### PR TITLE
feat(AutoComplete): add 'selectOnEnter' prop

### DIFF
--- a/src/AutoComplete.js
+++ b/src/AutoComplete.js
@@ -46,7 +46,8 @@ type Props = {
   onClose?: () => void,
   renderItem?: (itemValue: string) => React.Node,
   style?: Object,
-  open?: boolean
+  open?: boolean,
+  selectOnEnter?: boolean
 };
 
 type State = {
@@ -58,7 +59,8 @@ type State = {
 class AutoComplete extends React.Component<Props, State> {
   static defaultProps = {
     data: [],
-    placement: 'bottomLeft'
+    placement: 'bottomLeft',
+    selectOnEnter: true
   };
 
   constructor(props: Props) {
@@ -209,7 +211,7 @@ class AutoComplete extends React.Component<Props, State> {
       return;
     }
 
-    const { onKeyDown } = this.props;
+    const { onKeyDown, selectOnEnter = true } = this.props;
 
     switch (event.keyCode) {
       // down
@@ -224,7 +226,7 @@ class AutoComplete extends React.Component<Props, State> {
         break;
       // enter
       case 13:
-        this.selectFocusMenuItem(event);
+        selectOnEnter && this.selectFocusMenuItem(event);
         event.preventDefault();
         break;
       // esc | tab

--- a/test/AutoCompleteSpec.js
+++ b/test/AutoCompleteSpec.js
@@ -126,6 +126,23 @@ describe('AutoComplete', () => {
     ReactTestUtils.Simulate.keyDown(findDOMNode(instance.menuContainer), { keyCode: 13 });
   });
 
+  it("Shouldn't call onSelect callback on Enter pressed if selectOnEnter=false", () => {
+    const onSelectSpy = sinon.spy();
+    const instance = getInstance(
+      <AutoComplete
+        defaultValue="a"
+        onSelect={onSelectSpy}
+        selectOnEnter={false}
+        data={['a', 'ab', 'ac']}
+        open
+      />
+    );
+    ReactTestUtils.Simulate.keyDown(findDOMNode(instance.menuContainer), { keyCode: 40 });
+    ReactTestUtils.Simulate.keyDown(findDOMNode(instance.menuContainer), { keyCode: 13 });
+
+    assert.ok(!onSelectSpy.calledOnce);
+  });
+
   it('Should call onClose callback when keyCode=27', done => {
     const doneOp = () => {
       done();


### PR DESCRIPTION
### New prop

| name | type(default) | description |
| ----- | ----- | ----- |
| selectOnEnter |bool(true) | whether to select the focused item on Enter key pressed |