### PR TITLE
Update rsuite-table to v3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "rsuite-notification": "^3.0.2",
     "rsuite-schema": "0.0.12",
     "rsuite-selectpicker": "^3.0.4",
-    "rsuite-table": "^3.0.1",
+    "rsuite-table": "^3.0.2",
     "rsuite-treepicker": "^3.0.5",
     "rsuite-utils": "^1.0.8"
   },


### PR DESCRIPTION
> 2018-6-10

- **Feature**:  Support `bodyRef` on `<Table>` ([#23])
- **Bugfix**: When the height of the content is updated, reset the scroll bar position ([#22])

[23]: https://github.com/rsuite/rsuite-table/pull/23
[22]: https://github.com/rsuite/rsuite-table/pull/22