### PR TITLE
fix(Icon): custom svg icons in current color

### DIFF
--- a/styles/less/iconfont.less
+++ b/styles/less/iconfont.less
@@ -24,6 +24,10 @@
   //* Better Font Rendering =========== */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  //* Custom SVG icons */
+  & > svg {
+    fill: currentColor;
+  }
 }
 
 .rs-icon-500px {


### PR DESCRIPTION
Custom svg icons should apply current context's font color, for instance when used in `Nav.Item` and the nav is active.