### PR TITLE
update:Some table loader styles bug

### DIFF
--- a/styles/mixins/hacks.less
+++ b/styles/mixins/hacks.less
@@ -207,3 +207,12 @@
 .ie10-visibility(@value) when (@ie-polyfill = true) {
   visibility: ~'@{value}@{ie-suffix}';
 }
+
+// Safari
+.safari-visibility(@value) {
+  @media not all and (min-resolution: 0.001dpcm) {
+    & {
+      visibility: @value;
+    }
+  }
+}

--- a/styles/table.less
+++ b/styles/table.less
@@ -120,6 +120,8 @@
     // Make sure events through loader
     pointer-events: none;
     .ie10-visibility(hidden);
+    // Fixed in safari, after multiple clicks , the loader still has not disappeared.
+    .safari-visibility(hidden);
   }
 
   &-loader {
@@ -147,6 +149,8 @@
     opacity: 1;
     animation: none;
     pointer-events: auto;
+    // When loading cover scrollbar.
+    z-index: 1;
   }
 
   &-cell {


### PR DESCRIPTION
1. In safari, after multiple clicks , the loader still has not disappeared.
2. Loader should above the scrollbar.