### PR TITLE
Change button disabled styles

### DIFF
--- a/styles/button.less
+++ b/styles/button.less
@@ -122,7 +122,6 @@
   }
 
   &.@{ns}btn-disabled,
-  &[disabled],
   .@{ns}dropdown-disabled & {
     &,
     &:hover,

--- a/styles/dropdown.less
+++ b/styles/dropdown.less
@@ -45,6 +45,49 @@
     float: left;
     box-shadow: @dropdown-shadow;
   }
+
+  &-disabled &-toggle.@{ns}btn {
+    cursor: @cursor-disabled !important;
+
+    &.@{ns}btn-subtle {
+      &,
+      &:focus,
+      &:active {
+        color: @btn-subtle-disabled-color;
+        background: none;
+      }
+    }
+
+    &.@{ns}btn-primary {
+      &,
+      &:focus,
+      &:active {
+        opacity: 0.3;
+        background-color: @btn-primary-bg;
+      }
+    }
+
+    &.@{ns}btn-link {
+      &,
+      &:focus,
+      &:active {
+        opacity: 0.3;
+        text-decoration: none;
+      }
+    }
+
+    &.@{ns}btn-ghost {
+      &,
+      &:focus,
+      &:active {
+        opacity: 0.3;
+      }
+    }
+
+    .@{ns}ripple-pond {
+      display: none !important;
+    }
+  }
 }
 
 .@{ns}dropdown-toggle {
@@ -120,7 +163,9 @@
   // Set submenu icon
   &.@{ns}dropdown-menu-pull-right {
     > .@{ns}dropdown-item-content {
-      padding-right: @dropdown-item-content-padding-horizontal+@dropdown-item-content-submenu-icon-angle-spacing+@dropdown-item-content-submenu-icon-angle-width;
+      padding-right: @dropdown-item-content-padding-horizontal+
+        @dropdown-item-content-submenu-icon-angle-spacing+
+        @dropdown-item-content-submenu-icon-angle-width;
 
       > .@{ns}dropdown-menu-toggle .@{ns}icon {
         right: @dropdown-item-content-padding-horizontal;
@@ -134,7 +179,9 @@
 
   &.@{ns}dropdown-menu-pull-left {
     > .@{ns}dropdown-item-content {
-      padding-left: @dropdown-item-content-padding-horizontal+ @dropdown-item-content-submenu-icon-angle-spacing + @dropdown-item-content-submenu-icon-angle-width;
+      padding-left: @dropdown-item-content-padding-horizontal+
+        @dropdown-item-content-submenu-icon-angle-spacing +
+        @dropdown-item-content-submenu-icon-angle-width;
 
       > .@{ns}dropdown-menu-toggle .@{ns}icon {
         left: @dropdown-item-content-padding-horizontal;

--- a/styles/mixins/button.less
+++ b/styles/mixins/button.less
@@ -36,9 +36,7 @@
     background-image: none;
   }
 
-  &.@{ns}btn-disabled,
-  &[disabled],
-  .@{ns}dropdown-disabled & {
+  &.@{ns}btn-disabled {
     cursor: @cursor-disabled !important;
     opacity: 0.3;
 
@@ -80,9 +78,7 @@
   .btn-subtle-variant(@btn-subtle-hover-bg);
   .btn-loading-reset(@btn-subtle-color);
 
-  &.@{ns}btn-disabled,
-  &[disabled],
-  .@{ns}dropdown-disabled & {
+  &.@{ns}btn-disabled {
     &,
     &:hover,
     &:focus,
@@ -166,9 +162,7 @@
     background-image: none;
   }
 
-  &.@{ns}btn-disabled,
-  &[disabled],
-  .@{ns}dropdown-disabled & {
+  &.@{ns}btn-disabled {
     &:hover,
     &:focus,
     &.focus {
@@ -189,8 +183,7 @@
 
   &,
   &:active,
-  &.@{ns}btn-active,
-  &[disabled] {
+  &.@{ns}btn-active {
     background-color: transparent;
   }
 
@@ -219,7 +212,7 @@
     }
   }
 
-  &[disabled] {
+  &.@{ns}btn-disabled {
     &:hover,
     &:focus {
       color: @color;
@@ -259,9 +252,7 @@
     }
   }
 
-  &.@{ns}btn-disabled,
-  &[disabled],
-  .@{ns}dropdown-disabled & {
+  &.@{ns}btn-disabled {
     &,
     &:hover,
     &:focus,
@@ -312,9 +303,7 @@
     }
   }
 
-  &.@{ns}btn-disabled,
-  &[disabled],
-  .@{ns}dropdown-disabled & {
+  &.@{ns}btn-disabled {
     &:hover,
     &:focus,
     &.focus {
@@ -377,7 +366,6 @@
 
     // Defalut button spectrum button need set opacity.
     &.@{ns}btn-default.@{ns}btn-disabled,
-    &.@{ns}btn-default[disabled],
     .@{ns}dropdown-disabled &.@{ns}btn-default {
       opacity: 0.3;
     }

--- a/styles/mixins/button.less
+++ b/styles/mixins/button.less
@@ -39,10 +39,10 @@
   &.@{ns}btn-disabled,
   &[disabled],
   .@{ns}dropdown-disabled & {
-    cursor: @cursor-disabled;
-    .opacity(0.3);
+    cursor: @cursor-disabled !important;
+    opacity: 0.3;
 
-    &::after {
+    .@{ns}ripple-pond {
       display: none !important;
     }
   }


### PR DESCRIPTION
### Fixed
1. When `<Dropdown/>` is disabled , click it still trigger ripple animation and cursor is default.
### Refactor
1. Remove dropdown disabled styles to `dropdown.less`