### PR TITLE
add form control wrapper

### DIFF
--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -8,6 +8,7 @@ import FormContext, { FormValueContext, FormErrorContext } from './FormContext';
 import LegacyFormControl from './_legacy/FormControl';
 
 import { getUnhandledProps, defaultProps, prefix } from './utils';
+import { mapProps, compose } from 'recompose';
 
 type PlacementEightPoints =
   | 'bottomLeft'
@@ -27,7 +28,8 @@ type Props = {
   onBlur?: (event: SyntheticEvent<*>) => void,
   classPrefix?: string,
   errorMessage?: React.Node,
-  errorPlacement?: PlacementEightPoints
+  errorPlacement?: PlacementEightPoints,
+  formValue: any
 };
 
 type State = {
@@ -65,8 +67,8 @@ class FormControl extends React.Component<Props, State> {
     return this.props.checkTrigger || checkTrigger;
   }
 
-  handleFieldChange = (formValue: Object, value: any, event: SyntheticEvent<*>) => {
-    const { name, onChange } = this.props;
+  handleFieldChange = (value: any, event: SyntheticEvent<*>) => {
+    const { name, onChange, formValue } = this.props;
     const { onFieldChange } = this.context;
     const checkTrigger = this.getCheckTrigger();
     const checkResult = this.handleFieldCheck(formValue, value, checkTrigger === 'change');
@@ -77,8 +79,8 @@ class FormControl extends React.Component<Props, State> {
     onChange && onChange(value, event);
   };
 
-  handleFieldBlur = (formValue: Object, event: SyntheticEvent<*>) => {
-    const { onBlur, name } = this.props;
+  handleFieldBlur = (event: SyntheticEvent<*>) => {
+    const { onBlur, name, formValue } = this.props;
     const checkTrigger = this.getCheckTrigger();
     const value = typeof formValue[name] === 'undefined' ? this.state.value : formValue[name];
 
@@ -142,16 +144,16 @@ class FormControl extends React.Component<Props, State> {
     );
   };
 
-  renderValue = (formValue: Object = {}) => {
-    const { name, accepter: Component, ...props } = this.props;
+  renderValue = () => {
+    const { name, accepter: Component, formValue, ...props } = this.props;
     const { formDefaultValue = {} } = this.context;
     const unhandled = getUnhandledProps(FormControl, props);
     return (
       <Component
         {...unhandled}
         name={name}
-        onChange={this.handleFieldChange.bind(this, formValue)}
-        onBlur={this.handleFieldBlur.bind(this, formValue)}
+        onChange={this.handleFieldChange}
+        onBlur={this.handleFieldBlur}
         defaultValue={formDefaultValue[name]}
         value={formValue[name]}
       />
@@ -161,15 +163,32 @@ class FormControl extends React.Component<Props, State> {
   render() {
     return (
       <div className={this.addPrefix('wrapper')}>
-        <FormValueContext.Consumer>{this.renderValue}</FormValueContext.Consumer>
+        {this.renderValue()}
         {this.checkErrorFromContext()}
       </div>
     );
   }
 }
 
+class FormControlWrapper extends React.Component {
+  render() {
+    return (
+      <FormValueContext.Consumer>
+        {formValue => {
+          return (
+            <FormControl
+              {...this.props}
+              formValue={formValue}
+            />
+          );
+        }}
+      </FormValueContext.Consumer>
+    );
+  }
+}
+
 const EnhancedFormControl = defaultProps({
   classPrefix: 'form-control'
-})(FormControl);
+})(FormControlWrapper);
 
 export default (React.createContext ? EnhancedFormControl : LegacyFormControl);

--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -8,7 +8,6 @@ import FormContext, { FormValueContext, FormErrorContext } from './FormContext';
 import LegacyFormControl from './_legacy/FormControl';
 
 import { getUnhandledProps, defaultProps, prefix } from './utils';
-import { mapProps, compose } from 'recompose';
 
 type PlacementEightPoints =
   | 'bottomLeft'
@@ -29,7 +28,7 @@ type Props = {
   classPrefix?: string,
   errorMessage?: React.Node,
   errorPlacement?: PlacementEightPoints,
-  formValue: any
+  formValue?: Object
 };
 
 type State = {
@@ -55,7 +54,6 @@ class FormControl extends React.Component<Props, State> {
 
     const { formValue = {}, formDefaultValue = {} } = context;
     const name = props.name;
-
     this.state = {
       checkResult: {},
       value: formValue[name] || formDefaultValue[name]
@@ -68,7 +66,7 @@ class FormControl extends React.Component<Props, State> {
   }
 
   handleFieldChange = (value: any, event: SyntheticEvent<*>) => {
-    const { name, onChange, formValue } = this.props;
+    const { name, onChange, formValue = {} } = this.props;
     const { onFieldChange } = this.context;
     const checkTrigger = this.getCheckTrigger();
     const checkResult = this.handleFieldCheck(formValue, value, checkTrigger === 'change');
@@ -80,7 +78,7 @@ class FormControl extends React.Component<Props, State> {
   };
 
   handleFieldBlur = (event: SyntheticEvent<*>) => {
-    const { onBlur, name, formValue } = this.props;
+    const { onBlur, name, formValue = {} } = this.props;
     const checkTrigger = this.getCheckTrigger();
     const value = typeof formValue[name] === 'undefined' ? this.state.value : formValue[name];
 
@@ -145,7 +143,7 @@ class FormControl extends React.Component<Props, State> {
   };
 
   renderValue = () => {
-    const { name, accepter: Component, formValue, ...props } = this.props;
+    const { name, accepter: Component, formValue = {}, ...props } = this.props;
     const { formDefaultValue = {} } = this.context;
     const unhandled = getUnhandledProps(FormControl, props);
     return (
@@ -174,14 +172,7 @@ class FormControlWrapper extends React.Component {
   render() {
     return (
       <FormValueContext.Consumer>
-        {formValue => {
-          return (
-            <FormControl
-              {...this.props}
-              formValue={formValue}
-            />
-          );
-        }}
+        {formValue => <FormControl {...this.props} formValue={formValue} />}
       </FormValueContext.Consumer>
     );
   }

--- a/test/FormSpec.js
+++ b/test/FormSpec.js
@@ -325,4 +325,14 @@ describe('Form', () => {
     const instance = ReactTestUtils.renderIntoDocument(<Form classPrefix="custom-prefix" />);
     assert.ok(findDOMNode(instance).className.match(/\bcustom-prefix\b/));
   });
+
+  it('Should render correctly when form value was null', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Form>
+        <FormControl name="name" />
+      </Form>
+    );
+
+    assert.equal(findDOMNode(instance).tagName, 'FORM');
+  });
 });


### PR DESCRIPTION
为了避免每次FormControl render时向内部组件传入新的handleFieldChange与handleFieldBlur方法，将formValue作为 FormControl 的props传入。