### PR TITLE
Bugfix: IE error, object doesn't support property or method 'getDerivedStateFromProps'

### DIFF
--- a/src/utils/defaultProps.js
+++ b/src/utils/defaultProps.js
@@ -15,6 +15,7 @@ export default (props: Props): any => {
       // for IE9 & IE10 support
       static contextTypes = WrappedComponent.contextTypes;
       static childContextTypes = WrappedComponent.childContextTypes;
+      static getDerivedStateFromProps = WrappedComponent.getDerivedStateFromProps;
 
       static defaultProps = {
         ...WrappedComponent.defaultProps,


### PR DESCRIPTION
fix: https://github.com/reactjs/react-lifecycles-compat/issues/32