### PR TITLE
[FIX] Build error: import from es module to commonjs react-virtualized

### DIFF
--- a/src/Calendar/MonthDropdown.js
+++ b/src/Calendar/MonthDropdown.js
@@ -3,8 +3,8 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import moment from 'moment';
-import List from 'react-virtualized/dist/es/List';
-import AutoSizer from 'react-virtualized/dist/es/AutoSizer';
+import List from 'react-virtualized/dist/commonjs/List';
+import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
 import { prefix, getUnhandledProps, defaultProps } from '../utils';
 import MonthDropdownItem from './MonthDropdownItem';
 


### PR DESCRIPTION
Webpack(configuration cra/razzle/next, SSR) does not transpile files in node_modules by babel, only application folder.

`/es/` folder contains ES modules and throws error, when you try build your application. We need import commonjs file, it does not require babel for build process.

Build on SSR shows error:

![image](https://user-images.githubusercontent.com/31767378/51098627-abe54f80-17f1-11e9-8dc9-217a997ad57c.png)
