### PR TITLE
Update rsuite-table to 3.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13732,9 +13732,9 @@
       }
     },
     "rsuite-table": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-3.4.11.tgz",
-      "integrity": "sha512-I1LkOopDlgTIyouy6co1zAFWPncOfAq/OJuf7c6kVbvMqoRasL9I63LlMFSbNk/yGmlps5dBDI1MBAGW1hirhQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-3.5.0.tgz",
+      "integrity": "sha512-NQCpNUH5f530tcOhz9esx0OJZ7t6+NZE4frPl874zjwbEYL5mXQGK0rRtZ4IqXJxRGjqVn+i0Qu/xcpxeDEsdQ==",
       "requires": {
         "classnames": "^2.2.5",
         "dom-lib": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "recompose": "^0.26.0",
     "rsuite-intl": "~1.0.4",
     "rsuite-notification": "^3.0.4",
-    "rsuite-table": "^3.4.11",
+    "rsuite-table": "^3.5.0",
     "rsuite-utils": "^1.6.0",
     "schema-typed": "~0.2.1"
   },

--- a/types/Table.d.ts
+++ b/types/Table.d.ts
@@ -98,6 +98,12 @@ export interface TableProps extends StandardProps {
 
   /** Customize what you can do to expand a zone */
   renderRowExpanded?: (rowDate?: object) => React.ReactNode;
+
+  /** Customize data is empty display content  */
+  renderEmpty?: (info: React.ReactNode) => React.ReactNode;
+
+  /** Customize the display content in the data load  */
+  renderLoading?: (loading: React.ReactNode) => React.ReactNode;
 }
 
 interface TableComponent extends React.ComponentClass<TableProps> {

--- a/types/TableColumn.d.ts
+++ b/types/TableColumn.d.ts
@@ -4,6 +4,9 @@ export interface TableColumnProps {
   /** Alignment */
   align?: 'left' | 'center' | 'right';
 
+  /** Vertical alignment */
+  verticalAlign?: 'top' | 'middle' | 'bottom';
+
   /** 	Column width */
   width?: number;
 


### PR DESCRIPTION
## 3.5.0
- Support `renderEmpty` and `renderLoading` on `<Table>`
- Support `verticalAlign` on `<Table.Column>`
- Fix: Unable to preventDefault inside passive event listener due to target being treated as passive
