### PR TITLE
MultiCascader: don't throw on a non-present selected value

### DIFF
--- a/src/MultiCascader/utils.js
+++ b/src/MultiCascader/utils.js
@@ -60,6 +60,9 @@ export default function(props: Object) {
       }
 
       let item: any = flattenData.find(v => v[valueKey] === value[i]);
+      if (!item) {
+        continue;
+      }
       let sv = splitValue(item, true, value, uncheckableItemValues);
       tempRemovedValue = _.uniq(tempRemovedValue.concat(sv.removedValue));
 

--- a/test/MultiCascader/utilsSpec.js
+++ b/test/MultiCascader/utilsSpec.js
@@ -146,4 +146,9 @@ describe('MultiCascader - utils', () => {
     assert.equal(removedValue.toString(), '1-2,1-3');
     assert.equal(value.toString(), '1');
   });
+
+  it("transformValue - doesn't throw", () => {
+    const transformedValue = utils.transformValue(['1', '999'], [{ value: '1', label: '1' }]);
+    assert.equal(transformedValue.toString(), '1,999');
+  });
 });


### PR DESCRIPTION
Right now `MultiCascader` is throwing exceptions if it's rendered with a `value` containing references to a non-existent elements, eg:
```jsx
<MultiCascader 
  cascade                
  data={[{value: 5, label: 'any'}]}
  value={[1]}
/>
```

This change ignores not found items.