### PR TITLE
Implement an option for showing week numbers in the Datepickers

### DIFF
--- a/src/Calendar/Calendar.tsx
+++ b/src/Calendar/Calendar.tsx
@@ -25,6 +25,7 @@ export interface CalendarProps {
   limitEndYear?: number;
   className?: string;
   classPrefix?: string;
+  showWeekNumbers?: boolean;
   disabledDate?: (date: Date) => boolean;
   disabledHours?: (hour: number, date: Date) => boolean;
   disabledMinutes?: (minute: number, date: Date) => boolean;
@@ -110,6 +111,7 @@ class Calendar extends React.Component<CalendarProps> {
       renderTitle,
       renderToolbar,
       renderCell,
+      showWeekNumbers,
       ...rest
     } = this.props;
 
@@ -155,6 +157,7 @@ class Calendar extends React.Component<CalendarProps> {
             isoWeek={isoWeek}
             disabledDate={this.disabledDate}
             renderCell={renderCell}
+            showWeekNumbers={showWeekNumbers}
           />
         )}
         {showMonth && (

--- a/src/Calendar/Table.tsx
+++ b/src/Calendar/Table.tsx
@@ -12,6 +12,7 @@ export interface TableProps {
   selected?: Date;
   className?: string;
   classPrefix?: string;
+  showWeekNumbers?: boolean;
   onSelect?: (date: Date, event: React.MouseEvent<HTMLDivElement>) => void;
   disabledDate?: (date: Date) => boolean;
   inSameMonth?: (date: Date) => boolean;
@@ -44,6 +45,7 @@ class Table extends React.PureComponent<TableProps> {
       classPrefix,
       isoWeek,
       renderCell,
+      showWeekNumbers,
       ...rest
     } = this.props;
 
@@ -51,7 +53,7 @@ class Table extends React.PureComponent<TableProps> {
 
     return (
       <div {...rest} className={classes}>
-        <TableHeaderRow isoWeek={isoWeek} />
+        <TableHeaderRow isoWeek={isoWeek} showWeekNumbers={showWeekNumbers} />
 
         {rows.map((week, index) => (
           <TableRow
@@ -63,6 +65,7 @@ class Table extends React.PureComponent<TableProps> {
             inSameMonth={inSameMonth}
             disabledDate={disabledDate}
             renderCell={renderCell}
+            showWeekNumbers={showWeekNumbers}
           />
         ))}
       </div>

--- a/src/Calendar/TableHeaderRow.tsx
+++ b/src/Calendar/TableHeaderRow.tsx
@@ -9,6 +9,7 @@ export interface TableHeaderRowProps {
   isoWeek?: boolean;
   className?: string;
   classPrefix?: string;
+  showWeekNumbers?: boolean;
 }
 
 const weekKeys = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
@@ -20,7 +21,7 @@ class TableHeaderRow extends React.PureComponent<TableHeaderRowProps> {
     classPrefix: PropTypes.string
   };
   render() {
-    const { className, classPrefix, isoWeek, ...props } = this.props;
+    const { className, classPrefix, isoWeek, showWeekNumbers, ...props } = this.props;
     const addPrefix = prefix(classPrefix);
     const classes = classNames(addPrefix('row'), addPrefix('header-row'), className);
     let items = weekKeys;
@@ -31,6 +32,7 @@ class TableHeaderRow extends React.PureComponent<TableHeaderRowProps> {
 
     return (
       <div {...props} className={classes}>
+        {showWeekNumbers && <div className={addPrefix('cell')} />}
         {items.map(key => (
           <div key={key} className={addPrefix('cell')}>
             <span className={addPrefix('cell-content')}>

--- a/src/Calendar/TableRow.tsx
+++ b/src/Calendar/TableRow.tsx
@@ -12,6 +12,7 @@ export interface TableRowProps {
   selected?: Date;
   className?: string;
   classPrefix?: string;
+  showWeekNumbers?: boolean;
   onSelect?: (date: Date, event: React.MouseEvent<HTMLDivElement>) => void;
   disabledDate?: (date: Date) => boolean;
   inSameMonth?: (date: Date) => boolean;
@@ -87,14 +88,23 @@ class TableRow extends React.PureComponent<TableRowProps> {
     return days;
   }
 
+  renderWeekNumber() {
+    return (
+      <div className={this.addPrefix('cell-week-number')}>
+        {format(this.props.weekendDate, 'W')}
+      </div>
+    );
+  }
+
   render() {
-    const { className, ...rest } = this.props;
+    const { className, showWeekNumbers, ...rest } = this.props;
 
     const classes = classNames(this.addPrefix('row'), className);
     const unhandled = getUnhandledProps(TableRow, rest);
 
     return (
       <div {...unhandled} className={classes}>
+        {showWeekNumbers && this.renderWeekNumber()}
         {this.renderDays()}
       </div>
     );

--- a/src/Calendar/View.tsx
+++ b/src/Calendar/View.tsx
@@ -12,6 +12,7 @@ export interface ViewProps {
   isoWeek?: boolean;
   className?: string;
   classPrefix?: string;
+  showWeekNumbers?: boolean;
   onSelect?: (date: Date, event: React.MouseEvent<HTMLDivElement>) => void;
   disabledDate?: (date: Date) => boolean;
   renderCell?: (date: Date) => React.ReactNode;
@@ -43,6 +44,7 @@ class View extends React.PureComponent<ViewProps> {
       classPrefix,
       isoWeek,
       renderCell,
+      showWeekNumbers,
       ...rest
     } = this.props;
 
@@ -59,6 +61,7 @@ class View extends React.PureComponent<ViewProps> {
           inSameMonth={this.inSameThisMonthDate}
           disabledDate={disabledDate}
           renderCell={renderCell}
+          showWeekNumbers={showWeekNumbers}
         />
       </div>
     );

--- a/src/Calendar/style/index.less
+++ b/src/Calendar/style/index.less
@@ -425,6 +425,32 @@
   }
 }
 
+.@{clpns}-table-cell-week-number {
+  display: table-cell;
+  width: 1%;
+  padding: @calendar-table-cell-padding;
+  text-align: center;
+  vertical-align: middle;
+  color: @calendar-table-cell-week-number-color;
+  background: @calendar-table-cell-week-number-bg;
+  font-size: @font-size-small;
+}
+
+.@{clpns}-table-row {
+  &:nth-child(2) {
+    .@{clpns}-table-cell-week-number {
+      border-top-left-radius: @calendar-panel-border-radius;
+      border-top-right-radius: @calendar-panel-border-radius;
+    }
+  }
+  &:last-child {
+    .@{clpns}-table-cell-week-number {
+      border-bottom-left-radius: @calendar-panel-border-radius;
+      border-bottom-right-radius: @calendar-panel-border-radius;
+    }
+  }
+}
+
 // Calendar month dropdown
 .@{clpns}-month-dropdown {
   display: none;

--- a/src/Calendar/test/CalendarTableHeaderRowSpec.js
+++ b/src/Calendar/test/CalendarTableHeaderRowSpec.js
@@ -29,4 +29,9 @@ describe('Calendar-TableHeaderRow', () => {
     );
     assert.ok(findDOMNode(instance).className.match(/\bcustom-prefix\b/));
   });
+
+  it('Should render an empty cell for a week number column', () => {
+    const instance = ReactTestUtils.renderIntoDocument(<TableHeaderRow showWeekNumbers />);
+    assert.equal(findDOMNode(instance).childNodes.length, 8);
+  });
 });

--- a/src/Calendar/test/CalendarTableRowSpec.js
+++ b/src/Calendar/test/CalendarTableRowSpec.js
@@ -3,7 +3,7 @@ import { findDOMNode } from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 
 import TableRow from '../TableRow';
-import { getDate } from 'date-fns';
+import { getDate, format } from 'date-fns';
 
 describe('Calendar-TableRow', () => {
   it('Should render a div with `table-row` class', () => {
@@ -45,5 +45,13 @@ describe('Calendar-TableRow', () => {
   it('Should have a custom className prefix', () => {
     const instance = ReactTestUtils.renderIntoDocument(<TableRow classPrefix="custom-prefix" />);
     assert.ok(findDOMNode(instance).className.match(/\bcustom-prefix\b/));
+  });
+
+  it('Should render a week number', () => {
+    const instance = ReactTestUtils.renderIntoDocument(<TableRow showWeekNumbers />);
+    assert.equal(
+      findDOMNode(instance).querySelector('.rs-calendar-table-cell-week-number').innerText,
+      format(new Date(), 'W')
+    );
   });
 });

--- a/src/DatePicker/DatePicker.d.ts
+++ b/src/DatePicker/DatePicker.d.ts
@@ -27,6 +27,9 @@ export interface DatePickerProps extends PickerBaseProps, FormControlBaseProps<D
   /** Set the lower limit of the available year relative to the current selection date */
   limitEndYear?: number;
 
+  /** Whether to show week numbers */
+  showWeekNumbers?: boolean;
+
   /** Disabled date */
   disabledDate?: (date?: Date) => boolean;
 

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -75,6 +75,7 @@ class DatePicker extends React.Component<DatePickerProps, DatePickerState> {
     style: PropTypes.object,
     oneTap: PropTypes.bool,
     preventOverflow: PropTypes.bool,
+    showWeekNumbers: PropTypes.bool,
     disabledDate: PropTypes.func,
     disabledHours: PropTypes.func,
     disabledMinutes: PropTypes.func,
@@ -374,13 +375,14 @@ class DatePicker extends React.Component<DatePickerProps, DatePickerState> {
   addPrefix = (name: string) => prefix(this.props.classPrefix)(name);
 
   renderCalendar() {
-    const { format, isoWeek, limitEndYear, disabledDate } = this.props;
+    const { format, isoWeek, limitEndYear, disabledDate, showWeekNumbers } = this.props;
     const { calendarState, pageDate } = this.state;
     const calendarProps = _.pick(this.props, calendarOnlyProps);
 
     return (
       <Calendar
         {...calendarProps}
+        showWeekNumbers={showWeekNumbers}
         disabledDate={disabledDate}
         limitEndYear={limitEndYear}
         format={format}

--- a/src/DateRangePicker/Calendar/Calendar.tsx
+++ b/src/DateRangePicker/Calendar/Calendar.tsx
@@ -19,6 +19,7 @@ export interface CalendarProps {
   className?: string;
   classPrefix?: string;
   limitEndYear?: number;
+  showWeekNumbers?: boolean;
   disabledDate?: (date: Date, selectValue: Date[], type: string) => boolean;
   onMoveForword?: (nextPageDate: Date) => void;
   onMoveBackward?: (nextPageDate: Date) => void;
@@ -134,6 +135,7 @@ class Calendar extends React.Component<CalendarProps> {
       isoWeek,
       limitEndYear,
       classPrefix,
+      showWeekNumbers,
       ...rest
     } = this.props;
 
@@ -166,6 +168,7 @@ class Calendar extends React.Component<CalendarProps> {
           onMouseMove={onMouseMove}
           disabledDate={disabledDate}
           isoWeek={isoWeek}
+          showWeekNumbers={showWeekNumbers}
         />
 
         <MonthDropdown

--- a/src/DateRangePicker/Calendar/Table.tsx
+++ b/src/DateRangePicker/Calendar/Table.tsx
@@ -13,6 +13,7 @@ export interface TableProps {
   hoverValue?: Date[];
   className?: string;
   classPrefix?: string;
+  showWeekNumbers?: boolean;
   onSelect?: (date: Date) => void;
   onMouseMove?: (date: Date) => void;
   disabledDate?: (date: Date, selectValue: Date[], type: string) => boolean;
@@ -48,6 +49,7 @@ class Table extends React.Component<TableProps> {
       className,
       classPrefix,
       isoWeek,
+      showWeekNumbers,
       ...rest
     } = this.props;
 
@@ -55,7 +57,7 @@ class Table extends React.Component<TableProps> {
 
     return (
       <div {...rest} className={classes}>
-        <TableHeaderRow isoWeek={isoWeek} />
+        <TableHeaderRow isoWeek={isoWeek} showWeekNumbers={showWeekNumbers} />
         {rows.map((week, index) => (
           <TableRow
             /* eslint-disable */
@@ -67,6 +69,7 @@ class Table extends React.Component<TableProps> {
             onMouseMove={onMouseMove}
             inSameMonth={inSameMonth}
             disabledDate={disabledDate}
+            showWeekNumbers={showWeekNumbers}
           />
         ))}
       </div>

--- a/src/DateRangePicker/Calendar/TableRow.tsx
+++ b/src/DateRangePicker/Calendar/TableRow.tsx
@@ -14,6 +14,7 @@ export interface TableRowProps {
   hoverValue: Date[];
   className?: string;
   classPrefix?: string;
+  showWeekNumbers?: boolean;
   onSelect?: (date: Date) => void;
   disabledDate?: (date: Date, selectValue: Date[], type: string) => boolean;
   inSameMonth?: (date: Date) => boolean;
@@ -125,13 +126,22 @@ class TableRow extends React.Component<TableRowProps> {
     return days;
   }
 
+  renderWeekNumber() {
+    return (
+      <div className={this.addPrefix('cell-week-number')}>
+        {format(this.props.weekendDate, 'W')}
+      </div>
+    );
+  }
+
   render() {
-    const { className, ...rest } = this.props;
+    const { className, showWeekNumbers, ...rest } = this.props;
     const classes = classNames(this.addPrefix('row'), className);
     const unhandled = getUnhandledProps(TableRow, rest);
 
     return (
       <div {...unhandled} className={classes}>
+        {showWeekNumbers && this.renderWeekNumber()}
         {this.renderDays()}
       </div>
     );

--- a/src/DateRangePicker/Calendar/View.tsx
+++ b/src/DateRangePicker/Calendar/View.tsx
@@ -16,6 +16,7 @@ export interface ViewProps {
   isoWeek?: boolean;
   className?: string;
   classPrefix?: string;
+  showWeekNumbers?: boolean;
 }
 
 class View extends React.Component<ViewProps> {
@@ -49,6 +50,7 @@ class View extends React.Component<ViewProps> {
       className,
       isoWeek,
       classPrefix,
+      showWeekNumbers,
       ...rest
     } = this.props;
 
@@ -66,6 +68,7 @@ class View extends React.Component<ViewProps> {
           inSameMonth={this.inSameThisMonthDate}
           disabledDate={disabledDate}
           hoverValue={hoverValue}
+          showWeekNumbers={showWeekNumbers}
         />
       </div>
     );

--- a/src/DateRangePicker/DatePicker.tsx
+++ b/src/DateRangePicker/DatePicker.tsx
@@ -14,6 +14,7 @@ export interface DatePickerProps {
   isoWeek?: boolean;
   limitEndYear?: number;
   classPrefix?: string;
+  showWeekNumbers?: boolean;
   disabledDate?: (date: Date, selectValue: ValueType, type: string) => boolean;
   onSelect?: (date: Date, event?: React.SyntheticEvent<any>) => void;
   onMouseMove?: (date: Date) => void;
@@ -91,7 +92,8 @@ class DatePicker extends React.Component<DatePickerProps, DatePickerState> {
       disabledDate,
       isoWeek,
       limitEndYear,
-      classPrefix
+      classPrefix,
+      showWeekNumbers
     } = this.props;
 
     const { calendarState } = this.state;
@@ -114,6 +116,7 @@ class DatePicker extends React.Component<DatePickerProps, DatePickerState> {
         onToggleMonthDropdown={this.toggleMonthDropdown}
         onChangePageDate={this.handleChangePageDate}
         limitEndYear={limitEndYear}
+        showWeekNumbers={showWeekNumbers}
       />
     );
   }

--- a/src/DateRangePicker/DateRangePicker.d.ts
+++ b/src/DateRangePicker/DateRangePicker.d.ts
@@ -42,6 +42,9 @@ export interface DateRangePickerProps extends PickerBaseProps, FormControlBasePr
   /** Set the lower limit of the available year relative to the current selection date */
   limitEndYear?: number;
 
+  /** Whether to show week numbers */
+  showWeekNumbers?: boolean;
+
   /** Disabled date */
   disabledDate?: (
     date: Date,

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -89,6 +89,7 @@ class DateRangePicker extends React.Component<DateRangePickerProps, DateRangePic
     defaultOpen: PropTypes.bool,
     placement: PropTypes.oneOf(PLACEMENT),
     preventOverflow: PropTypes.bool,
+    showWeekNumbers: PropTypes.bool,
     onChange: PropTypes.func,
     onOk: PropTypes.func,
     disabledDate: PropTypes.func,
@@ -499,7 +500,7 @@ class DateRangePicker extends React.Component<DateRangePickerProps, DateRangePic
   addPrefix = (name: string) => prefix(this.props.classPrefix)(name);
 
   renderDropdownMenu() {
-    const { menuClassName, ranges, isoWeek, limitEndYear, oneTap } = this.props;
+    const { menuClassName, ranges, isoWeek, limitEndYear, oneTap, showWeekNumbers } = this.props;
     const { calendarDate, selectValue, hoverValue, doneSelected } = this.state;
 
     const classes = classNames(this.addPrefix('daterange-menu'), menuClassName);
@@ -510,6 +511,7 @@ class DateRangePicker extends React.Component<DateRangePickerProps, DateRangePic
       hoverValue,
       calendarDate,
       limitEndYear,
+      showWeekNumbers,
       value: selectValue,
       disabledDate: this.handleDisabledDate,
       onSelect: this.handleChangeSelectValue,

--- a/src/style/variables.less
+++ b/src/style/variables.less
@@ -1143,6 +1143,8 @@
 @calendar-table-cell-content-disabled-color: @B400;
 @calendar-table-cell-content-selected-font-color: @B000;
 @calendar-table-cell-header-color: @B600;
+@calendar-table-cell-week-number-color: @B600;
+@calendar-table-cell-week-number-bg: @B050;
 @calendar-month-dropdown-row-border-color: @B200;
 @calendar-month-dropdown-year-active-color: @H700;
 @calendar-dropdown-top: 40px; // @calendar-picker-padding + content-height + gap


### PR DESCRIPTION
The same as #523 but on top of the Typescript version.

![image](https://user-images.githubusercontent.com/488812/61723959-4ad4a080-ad6d-11e9-9e03-de8df322b610.png)

Note: I can't verify `<DateRangePicker />` since the `next` version of docs even without my changes is not working for it (it's crashing and messages are pretty useless) and unfortunately I can't invest more time into debugging it right now.