### PR TITLE
DatePicker: add missing less definition

### DIFF
--- a/src/Calendar/TimeDropdown.tsx
+++ b/src/Calendar/TimeDropdown.tsx
@@ -7,14 +7,7 @@ import classNames from 'classnames';
 
 import { prefix, getUnhandledProps, defaultProps } from '../utils';
 import scrollTopAnimation from '../utils/scrollTopAnimation';
-import {
-  getHours,
-  getMinutes,
-  getSeconds,
-  setSeconds,
-  setMinutes,
-  setHours
-} from 'date-fns';
+import { getHours, getMinutes, getSeconds, setSeconds, setMinutes, setHours } from 'date-fns';
 
 export interface TimeDropdownProps {
   date?: Date;

--- a/src/Calendar/styles/common.less
+++ b/src/Calendar/styles/common.less
@@ -181,6 +181,40 @@
   }
 }
 
+// In picker menu
+.@{ns}picker-menu .@{clpns} {
+  width: @calendar-header-width;
+  // To make sure <Calendar/> horizontal align at center when toolbar  width is so long.
+  display: block;
+  margin: 0 auto;
+
+  .@{clpns}-month-dropdown-cell-content,
+  .@{clpns}-table-cell-content {
+    width: @calendar-in-menu-content-side-length;
+    height: @calendar-in-menu-content-side-length;
+  }
+
+  .@{clpns}-table-header-row .@{clpns}-table-cell-content {
+    height: 24px;
+    padding-top: 0;
+  }
+
+  .@{clpns}-table-cell-content {
+    padding-left: 0;
+    padding-right: 0;
+    display: inline-block;
+  }
+
+  .@{clpns}-month-dropdown-scroll {
+    height: 227px;
+  }
+
+  .@{clpns}-time-dropdown-column > ul {
+    height: 214px;
+    padding-bottom: 184px;
+  }
+}
+
 // Show time dropdown
 .@{clpns}-show-time-dropdown {
   .@{clpns}-header-title-time {

--- a/src/DatePicker/styles/common.less
+++ b/src/DatePicker/styles/common.less
@@ -4,6 +4,7 @@
 
 // DatePicker Picker
 // ----------------------
+@clpns: ~'@{ns}@{calendar-picker-prefix}';
 
 // Change the <caret/> & <clean/> vertical position make it align middle.
 .@{ns}@{date-picker-prefix},

--- a/src/DatePicker/styles/common.less
+++ b/src/DatePicker/styles/common.less
@@ -4,7 +4,6 @@
 
 // DatePicker Picker
 // ----------------------
-@clpns: ~'@{ns}@{calendar-picker-prefix}';
 
 // Change the <caret/> & <clean/> vertical position make it align middle.
 .@{ns}@{date-picker-prefix},
@@ -82,40 +81,6 @@
   }
 }
 
-// In picker menu
-.@{ns}picker-menu .@{clpns} {
-  width: @calendar-header-width;
-  // To make sure <Calendar/> horizontal align at center when toolbar  width is so long.
-  display: block;
-  margin: 0 auto;
-
-  .@{clpns}-month-dropdown-cell-content,
-  .@{clpns}-table-cell-content {
-    width: @calendar-in-menu-content-side-length;
-    height: @calendar-in-menu-content-side-length;
-  }
-
-  .@{clpns}-table-header-row .@{clpns}-table-cell-content {
-    height: 24px;
-    padding-top: 0;
-  }
-
-  .@{clpns}-table-cell-content {
-    padding-left: 0;
-    padding-right: 0;
-    display: inline-block;
-  }
-
-  .@{clpns}-month-dropdown-scroll {
-    height: 227px;
-  }
-
-  .@{clpns}-time-dropdown-column > ul {
-    height: 214px;
-    padding-bottom: 184px;
-  }
-}
-
 // Picker date
 .@{ns}@{date-picker-prefix} {
   .@{ns}picker-toggle-caret::before {
@@ -133,7 +98,7 @@
   &-inline {
     height: 299px;
 
-    .@{clpns} {
+    .@{ns}@{calendar-picker-prefix} {
       height: 286px;
     }
   }


### PR DESCRIPTION
Right now it's crashing the build when used with `babel-preset-rsuite` like:
```
error  in ./node_modules/rsuite/lib/DatePicker/styles/index.less

Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
ModuleBuildError: Module build failed (from ./node_modules/less-loader/dist/cjs.js):


// In picker menu
.@{ns}picker-menu .@{clpns} {
                 ^
Variable @clpns is undefined
      in [cut]/node_modules/rsuite/lib/DatePicker/styles/common.less (line 85, column 19)
    at runLoaders ([cut]/node_modules/webpack/lib/NormalModule.js:302:20)
    at [cut]/node_modules/loader-runner/lib/LoaderRunner.js:367:11
    at [cut]/node_modules/loader-runner/lib/LoaderRunner.js:233:18
    at context.callback ([cut]/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at process._tickCallback (internal/process/next_tick.js:68:7)

 @ ./node_modules/rsuite/lib/DateRangePicker/styles/themes/default.js 9:0-48
 @ ./node_modules/rsuite/lib/DateRangePicker/styles/index.js
 @ ./src/Foo.tsx
```
