### PR TITLE
Fixed alignment of Loader within its container

### DIFF
--- a/src/Loader.js
+++ b/src/Loader.js
@@ -52,7 +52,7 @@ class Loader extends React.Component<Props> {
     return (
       <div {...props} className={classes}>
         {backdrop && <div className={addPrefix('backdrop')} />}
-        <div className={classPrefix} ref={this.loaderRef}>
+        <div className={classPrefix}>
           <span className={addPrefix('spin')} />
           {hasContent && <span className={addPrefix('content')}>{content}</span>}
         </div>

--- a/src/Loader.js
+++ b/src/Loader.js
@@ -22,12 +22,6 @@ class Loader extends React.Component<Props> {
     speed: 'normal'
   };
 
-  loader = null;
-
-  loaderRef = ref => {
-    this.loader = ref;
-  };
-
   addPrefix(name: string) {
     return prefix(this.props.classPrefix)(name);
   }

--- a/src/Loader.js
+++ b/src/Loader.js
@@ -2,11 +2,9 @@
 
 import * as React from 'react';
 import classNames from 'classnames';
-import { getWidth, addStyle } from 'dom-lib';
 import compose from 'recompose/compose';
 
 import { withStyleProps, defaultProps, prefix } from './utils';
-import { isIE11, isEdge } from './utils/BrowserDetection';
 
 type Props = {
   className?: string,
@@ -23,18 +21,6 @@ class Loader extends React.Component<Props> {
   static defaultProps = {
     speed: 'normal'
   };
-
-  componentDidMount() {
-    const { center, backdrop } = this.props;
-
-    if (center || backdrop) {
-      const width = getWidth(this.loader);
-      addStyle(this.loader, {
-        display: isIE11() || isEdge() ? 'block' : 'table',
-        width: `${width}px`
-      });
-    }
-  }
 
   loader = null;
 


### PR DESCRIPTION
Several months ago was added some piece of code that brakes center alignment of Loader within its container. Removal of that inline styles fixes that issue. 
![center-is-not-in-center](https://user-images.githubusercontent.com/6840290/64497714-9fe25c80-d2b0-11e9-97ba-54e02d2e08f7.png)
