### PR TITLE
Use grab cursors for sortable List.Item

### DIFF
--- a/src/List/styles/common.less
+++ b/src/List/styles/common.less
@@ -21,8 +21,14 @@
 
   &-sortable .@{ns}list-item {
     cursor: move;
+    cursor: grab;
+    
+    &:active {
+      cursor: grabbing;
+    }
 
-    &-disabled {
+    &-disabled,
+    &-disabled:active {
       cursor: not-allowed;
     }
   }


### PR DESCRIPTION
Use [*Grab cursors*](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor) for draggable elements, which, in this case, are sortable `<List.Item>`s.

Specification of some `cursor`s for drag & drop:

| CSS Value | Description |
| -------------- | --------------- |
| `move` | Something is to be moved. |
| `grab` | Something can be grabbed (dragged to be moved). |
| `grabbing` | Something is being grabbed (dragged to be moved). |

As *Grab cursors* are [not supported until latest browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Browser_compatibility), keep `move` for compatibility.