### PR TITLE
Update Form's definition, fix #626

### DIFF
--- a/types/Form.d.ts
+++ b/types/Form.d.ts
@@ -37,6 +37,19 @@ export interface FormProps extends StandardProps {
   onCheck?: (formError: object) => void;
 }
 
-declare const Form: React.ComponentType<FormProps>;
+declare class Form extends React.Component<FormProps, any> {
+  /** Verify form data */
+  check(callback?: (formError: object) => void): boolean;
+
+  /** Check single field value */
+  checkForField(fieldName: string, callback?: (checkResult: object) => void): boolean;
+
+  /** Clean error message. */
+  cleanErrors(callback?: () => void): void;
+
+  cleanErrorForField(fieldName: string, callback?: () => void): void;
+
+  resetErrors(formError: object, callback?: () => void): void;
+}
 
 export default Form;


### PR DESCRIPTION
Declare `Form` as a class instead of const. Add method definitions.
 
![image](https://user-images.githubusercontent.com/8225666/65302122-b3dd6680-dbac-11e9-973e-490cefd0a350.png)
