### PR TITLE
Add support for `renderItem` on the navigation component

### DIFF
--- a/src/Breadcrumb/BreadcrumbItem.d.ts
+++ b/src/Breadcrumb/BreadcrumbItem.d.ts
@@ -20,6 +20,9 @@ export interface BreadcrumbItemProps extends StandardProps {
 
   /** Primary content */
   children?: React.ReactNode;
+
+  /** Custom rendering item */
+  renderItem?: (item: React.ReactNode) => React.ReactNode;
 }
 
 declare const BreadcrumbItem: React.ComponentType<BreadcrumbItemProps>;

--- a/src/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/Breadcrumb/BreadcrumbItem.tsx
@@ -15,7 +15,8 @@ class BreadcrumbItem extends React.Component<BreadcrumbItemProps> {
     title: PropTypes.string,
     target: PropTypes.string,
     classPrefix: PropTypes.string,
-    componentClass: PropTypes.elementType
+    componentClass: PropTypes.elementType,
+    renderItem: PropTypes.func
   };
   render() {
     const {
@@ -27,6 +28,7 @@ class BreadcrumbItem extends React.Component<BreadcrumbItemProps> {
       className,
       style,
       active,
+      renderItem,
       ...rest
     } = this.props;
 
@@ -37,9 +39,14 @@ class BreadcrumbItem extends React.Component<BreadcrumbItemProps> {
       [addPrefix('active')]: active
     });
 
+    let item: React.ReactNode = <Component {...rest} {...linkProps} />;
+    if (renderItem) {
+      item = renderItem(item);
+    }
+
     return (
       <li style={style} className={classes}>
-        {active ? <span {...rest} /> : <Component {...rest} {...linkProps} />}
+        {active ? <span {...rest} /> : item}
       </li>
     );
   }

--- a/src/Breadcrumb/test/BreadcrumbItemSpec.js
+++ b/src/Breadcrumb/test/BreadcrumbItemSpec.js
@@ -111,6 +111,17 @@ describe('Breadcrumb.Item', () => {
     assert.equal(linkNode.target, '_blank');
   });
 
+  it('Should output a custom item', () => {
+    let instance = getDOMNode(
+      <Breadcrumb.Item
+        renderItem={() => {
+          return <span>custom</span>;
+        }}
+      />
+    );
+    assert.include(instance.querySelector('span').innerText, 'custom');
+  });
+
   it('Should have a custom className', () => {
     const instance = getDOMNode(<Breadcrumb.Item className="custom" />);
     assert.include(instance.className, 'custom');

--- a/src/Dropdown/DropdownMenuItem.d.ts
+++ b/src/Dropdown/DropdownMenuItem.d.ts
@@ -30,6 +30,9 @@ export interface DropdownMenuItemProps<T = any> extends StandardProps {
 
   /** Select the callback function for the current option  */
   onSelect?: (eventKey: T, event: React.SyntheticEvent<HTMLElement>) => void;
+
+  /** Custom rendering item */
+  renderItem?: (item: React.ReactNode) => React.ReactNode;
 }
 
 declare const DropdownMenuItem: React.ComponentType<DropdownMenuItemProps>;

--- a/src/Dropdown/DropdownMenuItem.tsx
+++ b/src/Dropdown/DropdownMenuItem.tsx
@@ -34,7 +34,8 @@ class DropdownMenuItem extends React.Component<DropdownMenuItemProps, DropdownMe
     children: PropTypes.node,
     classPrefix: PropTypes.string,
     tabIndex: PropTypes.number,
-    componentClass: PropTypes.elementType
+    componentClass: PropTypes.elementType,
+    renderItem: PropTypes.func
   };
   static defaultProps = {
     tabIndex: -1,
@@ -98,6 +99,7 @@ class DropdownMenuItem extends React.Component<DropdownMenuItemProps, DropdownMe
       trigger,
       expanded,
       componentClass: Component,
+      renderItem,
       ...rest
     } = this.props;
 
@@ -145,17 +147,21 @@ class DropdownMenuItem extends React.Component<DropdownMenuItemProps, DropdownMe
       );
     }
 
+    const item = (
+      <Component
+        {...unhandled}
+        {...itemToggleProps}
+        className={addPrefix('content')}
+        tabIndex={tabIndex}
+      >
+        {icon && React.cloneElement(icon, { className: addPrefix('menu-icon') })}
+        {children}
+      </Component>
+    );
+
     return (
       <li {...itemProps} style={style} role="presentation" className={classes}>
-        <Component
-          {...unhandled}
-          {...itemToggleProps}
-          className={addPrefix('content')}
-          tabIndex={tabIndex}
-        >
-          {icon && React.cloneElement(icon, { className: addPrefix('menu-icon') })}
-          {children}
-        </Component>
+        {renderItem ? renderItem(item) : item}
       </li>
     );
   }

--- a/src/Dropdown/test/DropdownMenuItemSpec.js
+++ b/src/Dropdown/test/DropdownMenuItemSpec.js
@@ -1,82 +1,77 @@
 import React from 'react';
-import { findDOMNode } from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 
 import DropdownMenuItem from '../DropdownMenuItem';
 import Sidenav from '../../Sidenav';
 import Icon from '../../Icon';
 
-import { innerText } from '@test/testUtils';
+import { innerText, getDOMNode, getInstance } from '@test/testUtils';
 
 describe('DropdownMenuItem', () => {
   it('Should render a li', () => {
     const title = 'Test';
-    const instance = ReactTestUtils.renderIntoDocument(
-      <DropdownMenuItem>{title}</DropdownMenuItem>
-    );
-    assert.equal(findDOMNode(instance).tagName, 'LI');
-    assert.equal(innerText(findDOMNode(instance)), title);
+    const instance = getDOMNode(<DropdownMenuItem>{title}</DropdownMenuItem>);
+    assert.equal(instance.tagName, 'LI');
+    assert.equal(innerText(instance), title);
   });
 
   it('Should render a Button', () => {
     const title = 'Test';
-    const instance = ReactTestUtils.renderIntoDocument(
+    const instance = getDOMNode(
       <DropdownMenuItem componentClass="button">{title}</DropdownMenuItem>
     );
-    assert.equal(findDOMNode(instance).children[0].tagName, 'BUTTON');
-    assert.equal(innerText(findDOMNode(instance)), title);
+    assert.equal(instance.children[0].tagName, 'BUTTON');
+    assert.equal(innerText(instance), title);
   });
 
   it('Should render a divider', () => {
-    const instance = ReactTestUtils.renderIntoDocument(<DropdownMenuItem divider />);
-    assert.equal(findDOMNode(instance).className, 'rs-dropdown-item-divider');
+    const instance = getDOMNode(<DropdownMenuItem divider />);
+    assert.equal(instance.className, 'rs-dropdown-item-divider');
   });
 
   it('Should render a panel', () => {
-    const instance = ReactTestUtils.renderIntoDocument(<DropdownMenuItem panel />);
-    assert.equal(findDOMNode(instance).className, 'rs-dropdown-item-panel');
+    const instance = getDOMNode(<DropdownMenuItem panel />);
+    assert.equal(instance.className, 'rs-dropdown-item-panel');
   });
 
   it('Should be active', () => {
-    const instance = ReactTestUtils.renderIntoDocument(<DropdownMenuItem active />);
-    assert.include(findDOMNode(instance).className, 'rs-dropdown-item-active');
+    const instance = getDOMNode(<DropdownMenuItem active />);
+    assert.include(instance.className, 'rs-dropdown-item-active');
   });
 
   it('Should be open', () => {
-    const instance = ReactTestUtils.renderIntoDocument(<DropdownMenuItem open />);
-    assert.include(findDOMNode(instance).className, 'rs-dropdown-item-open');
+    const instance = getDOMNode(<DropdownMenuItem open />);
+    assert.include(instance.className, 'rs-dropdown-item-open');
   });
 
   it('Should be submenu', () => {
-    const instance = ReactTestUtils.renderIntoDocument(<DropdownMenuItem submenu />);
-    assert.include(findDOMNode(instance).className, 'rs-dropdown-item-submenu');
+    const instance = getDOMNode(<DropdownMenuItem submenu />);
+    assert.include(instance.className, 'rs-dropdown-item-submenu');
   });
 
   it('Should be expanded in `Sidenav`', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const instance = getDOMNode(
       <Sidenav>
         <DropdownMenuItem expanded submenu />
       </Sidenav>
     );
-    const Item = findDOMNode(instance).querySelector('.rs-dropdown-item');
+    const Item = instance.querySelector('.rs-dropdown-item');
     assert.include(Item.className, 'rs-dropdown-item-expand');
   });
 
   it('Should be disabled', () => {
-    const instance = ReactTestUtils.renderIntoDocument(<DropdownMenuItem disabled />);
-    assert.include(findDOMNode(instance).className, 'rs-dropdown-item-disabled');
+    const instance = getDOMNode(<DropdownMenuItem disabled />);
+    assert.include(instance.className, 'rs-dropdown-item-disabled');
   });
 
   it('Should be `pullLeft`', () => {
-    const instance = ReactTestUtils.renderIntoDocument(<DropdownMenuItem pullLeft />);
-    assert.include(findDOMNode(instance).className, 'rs-dropdown-item-pull-left');
+    const instance = getDOMNode(<DropdownMenuItem pullLeft />);
+    assert.include(instance.className, 'rs-dropdown-item-pull-left');
   });
 
   it('Should render a icon', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
-      <DropdownMenuItem icon={<Icon icon="user" />} />
-    );
-    assert.ok(findDOMNode(instance).querySelector('.rs-icon-user'));
+    const instance = getDOMNode(<DropdownMenuItem icon={<Icon icon="user" />} />);
+    assert.ok(instance.querySelector('.rs-icon-user'));
   });
 
   it('Should call onSelect callback', done => {
@@ -85,39 +80,46 @@ describe('DropdownMenuItem', () => {
         done();
       }
     };
-    const instance = ReactTestUtils.renderIntoDocument(
+    const instance = getDOMNode(
       <DropdownMenuItem onSelect={doneOp} eventKey="ABC">
         Title
       </DropdownMenuItem>
     );
-    ReactTestUtils.Simulate.click(findDOMNode(instance).children[0]);
+    ReactTestUtils.Simulate.click(instance.children[0]);
   });
 
   it('Should call onClick callback', done => {
     const doneOp = () => {
       done();
     };
-    const instance = ReactTestUtils.renderIntoDocument(
-      <DropdownMenuItem onClick={doneOp}>Title</DropdownMenuItem>
+    const instance = getDOMNode(<DropdownMenuItem onClick={doneOp}>Title</DropdownMenuItem>);
+    ReactTestUtils.Simulate.click(instance.children[0]);
+  });
+
+  it('Should output a custom item', () => {
+    let instance = getDOMNode(
+      <DropdownMenuItem
+        renderItem={() => {
+          return <span>custom</span>;
+        }}
+      />
     );
-    ReactTestUtils.Simulate.click(findDOMNode(instance).children[0]);
+    assert.include(instance.querySelector('span').innerText, 'custom');
   });
 
   it('Should have a custom className', () => {
-    const instance = ReactTestUtils.renderIntoDocument(<DropdownMenuItem className="custom" />);
-    assert.include(findDOMNode(instance).className, 'custom');
+    const instance = getDOMNode(<DropdownMenuItem className="custom" />);
+    assert.include(instance.className, 'custom');
   });
 
   it('Should have a custom style', () => {
     const fontSize = '12px';
-    const instance = ReactTestUtils.renderIntoDocument(<DropdownMenuItem style={{ fontSize }} />);
-    assert.equal(findDOMNode(instance).style.fontSize, fontSize);
+    const instance = getDOMNode(<DropdownMenuItem style={{ fontSize }} />);
+    assert.equal(instance.style.fontSize, fontSize);
   });
 
   it('Should have a custom className prefix', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
-      <DropdownMenuItem classPrefix="custom-prefix" />
-    );
-    assert.ok(findDOMNode(instance).className.match(/\bcustom-prefix\b/));
+    const instance = getDOMNode(<DropdownMenuItem classPrefix="custom-prefix" />);
+    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Nav/NavItem.d.ts
+++ b/src/Nav/NavItem.d.ts
@@ -32,6 +32,9 @@ export interface NavItemProps<T = any> extends StandardProps {
 
   /** Select the callback function that the event triggers. */
   onSelect?: (eventKey: T, event: React.SyntheticEvent<any>) => void;
+
+  /** Custom rendering item */
+  renderItem?: (item: React.ReactNode) => React.ReactNode;
 }
 
 declare const NavItem: React.ComponentType<NavItemProps>;

--- a/src/Nav/NavItem.tsx
+++ b/src/Nav/NavItem.tsx
@@ -33,7 +33,8 @@ class NavItem extends React.Component<NavItemProps> {
     eventKey: PropTypes.any,
     tabIndex: PropTypes.number,
     hasTooltip: PropTypes.bool,
-    componentClass: PropTypes.elementType
+    componentClass: PropTypes.elementType,
+    renderItem: PropTypes.func
   };
   static defaultProps = {
     tabIndex: 0
@@ -61,6 +62,7 @@ class NavItem extends React.Component<NavItemProps> {
       divider,
       panel,
       componentClass: Component,
+      renderItem,
       ...rest
     } = this.props;
 
@@ -89,20 +91,27 @@ class NavItem extends React.Component<NavItemProps> {
       );
     }
 
-    const item = (
+    if (Component === SafeAnchor) {
+      unhandled.disabled = disabled;
+    }
+
+    let item: React.ReactNode = (
       <Component
         {...unhandled}
         role="button"
         tabIndex={tabIndex}
         className={addPrefix('content')}
-        disabled={disabled}
         onClick={createChainedFunction(onClick, this.handleClick)}
       >
         {icon}
-        <span className={addPrefix('text')}>{children}</span>
+        {children}
         <Ripple />
       </Component>
     );
+
+    if (renderItem) {
+      item = renderItem(item);
+    }
 
     return (
       <li role="presentation" className={classes} style={style}>

--- a/src/Nav/test/NavItemSpec.js
+++ b/src/Nav/test/NavItemSpec.js
@@ -68,6 +68,17 @@ describe('NavItem', () => {
     assert.ok(!onHideSpy.calledOnce);
   });
 
+  it('Should output a custom item', () => {
+    let instance = getDOMNode(
+      <NavItem
+        renderItem={() => {
+          return <span>custom</span>;
+        }}
+      />
+    );
+    assert.include(instance.querySelector('span').innerText, 'custom');
+  });
+
   it('Should have a custom className', () => {
     let instance = getDOMNode(<NavItem className="custom" />);
     assert.include(instance.className, 'custom');

--- a/src/Pagination/PaginationButton.d.ts
+++ b/src/Pagination/PaginationButton.d.ts
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { StandardProps } from '../@types/common';
+
+export interface PaginationButtonProps extends StandardProps {
+  /** The value of the current option */
+  eventKey?: any;
+
+  /** Called when the button is clicked. */
+  onClick?: React.MouseEventHandler;
+
+  /** A button can show it is currently unable to be interacted with */
+  disabled?: boolean;
+
+  /** A button can show it is currently the active user selection */
+  active?: boolean;
+
+  /** You can use a custom element for this component */
+  componentClass: React.ElementType;
+
+  /** Primary content */
+  children?: React.ReactNode;
+
+  /** Select the callback function for the current option  */
+  onSelect?: (eventKey: any, event: React.MouseEvent) => void;
+
+  /** Custom rendering item */
+  renderItem?: (item: React.ReactNode) => React.ReactNode;
+}
+
+declare const PaginationButton: React.ComponentType<PaginationButtonProps>;
+
+export default PaginationButton;

--- a/src/Pagination/PaginationButton.tsx
+++ b/src/Pagination/PaginationButton.tsx
@@ -6,18 +6,7 @@ import SafeAnchor from '../SafeAnchor';
 import Ripple from '../Ripple';
 import { prefix, defaultProps, getUnhandledProps, createChainedFunction } from '../utils';
 
-export interface PaginationButtonProps {
-  classPrefix?: string;
-  eventKey?: any;
-  onClick?: React.MouseEventHandler;
-  disabled?: boolean;
-  active?: boolean;
-  className?: string;
-  componentClass: React.ElementType;
-  children?: React.ReactNode;
-  style?: React.CSSProperties;
-  onSelect?: (eventKey: any, event: React.MouseEvent) => void;
-}
+import { PaginationButtonProps } from './PaginationButton.d';
 
 class PaginationButton extends React.Component<PaginationButtonProps> {
   static propTypes = {
@@ -30,7 +19,8 @@ class PaginationButton extends React.Component<PaginationButtonProps> {
     className: PropTypes.string,
     componentClass: PropTypes.elementType,
     children: PropTypes.node,
-    style: PropTypes.object
+    style: PropTypes.object,
+    renderItem: PropTypes.func
   };
   handleClick = (event: React.MouseEvent) => {
     const { disabled, onSelect, eventKey } = this.props;
@@ -51,6 +41,7 @@ class PaginationButton extends React.Component<PaginationButtonProps> {
       style,
       componentClass: Component,
       children,
+      renderItem,
       ...rest
     } = this.props;
 
@@ -60,17 +51,20 @@ class PaginationButton extends React.Component<PaginationButtonProps> {
       [addPrefix('active')]: active,
       [addPrefix('disabled')]: disabled
     });
+    const item = (
+      <Component
+        {...unhandled}
+        disabled={disabled}
+        onClick={createChainedFunction(onClick, this.handleClick)}
+      >
+        {children}
+        <Ripple />
+      </Component>
+    );
 
     return (
       <li className={classes} style={style}>
-        <Component
-          {...unhandled}
-          disabled={disabled}
-          onClick={createChainedFunction(onClick, this.handleClick)}
-        >
-          {children}
-          <Ripple />
-        </Component>
+        {renderItem ? renderItem(item) : item}
       </li>
     );
   }

--- a/src/Pagination/test/PaginationButtonSpec.js
+++ b/src/Pagination/test/PaginationButtonSpec.js
@@ -39,6 +39,17 @@ describe('PaginationButton', () => {
     ReactTestUtils.Simulate.click(instance.querySelector('a'));
   });
 
+  it('Should output a custom item', () => {
+    let instance = getDOMNode(
+      <PaginationButton
+        renderItem={() => {
+          return <span>custom</span>;
+        }}
+      />
+    );
+    assert.include(instance.querySelector('span').innerText, 'custom');
+  });
+
   it('Should have a custom className', () => {
     const instance = getDOMNode(<PaginationButton className="custom" />);
     assert.ok(instance.className.match(/\bcustom\b/));

--- a/src/SafeAnchor/SafeAnchor.d.ts
+++ b/src/SafeAnchor/SafeAnchor.d.ts
@@ -11,11 +11,13 @@ export interface SafeAnchorProps {
   tabIndex?: number | string;
 
   /** You can use a custom element for this component */
-  componentClass?: React.ElementType;
+  componentClass?: React.ElementType<any>;
 
   onClick?: (event: React.MouseEvent) => void;
+
+  [key: string]: any;
 }
 
-declare const SafeAnchor: React.ComponentType<SafeAnchorProps>;
+declare const SafeAnchor: React.FunctionComponent<SafeAnchorProps>;
 
 export default SafeAnchor;

--- a/src/SafeAnchor/SafeAnchor.tsx
+++ b/src/SafeAnchor/SafeAnchor.tsx
@@ -1,46 +1,37 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-
 import { SafeAnchorProps } from './SafeAnchor.d';
 
-const isTrivialHref = (href: string) => !href || href.trim() === '#';
+const SafeAnchor: React.FunctionComponent = React.forwardRef<'SafeAnchor', SafeAnchorProps>(
+  (props, ref) => {
+    const { componentClass: Component = 'a', disabled, ...rest } = props;
+    const handleClick = (event: React.MouseEvent) => {
+      const { onClick } = rest;
 
-class SafeAnchor extends React.Component<SafeAnchorProps> {
-  static propTypes = {
-    href: PropTypes.string,
-    disabled: PropTypes.bool,
-    tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    componentClass: PropTypes.elementType,
-    onClick: PropTypes.func
-  };
+      if (disabled) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
 
-  static defaultProps = {
-    componentClass: 'a'
-  };
-
-  handleClick = (event: React.MouseEvent) => {
-    let { disabled, href, onClick } = this.props;
-    if (disabled || isTrivialHref(href)) {
-      event.preventDefault();
-    }
+      onClick && onClick(event);
+    };
 
     if (disabled) {
-      event.stopPropagation();
-      return;
+      rest.tabIndex = -1;
+      rest['aria-disabled'] = true;
     }
 
-    onClick && onClick(event);
-  };
-
-  render() {
-    let { componentClass: Component, tabIndex, disabled, ...props } = this.props;
-
-    if (disabled) {
-      tabIndex = -1;
-    }
-
-    return <Component {...props} tabIndex={tabIndex} onClick={this.handleClick} />;
+    return <Component ref={ref} {...rest} onClick={handleClick} />;
   }
-}
+);
+
+SafeAnchor.displayName = 'SafeAnchor';
+SafeAnchor.propTypes = {
+  disabled: PropTypes.bool,
+
+  /** @default 'a' */
+  componentClass: PropTypes.elementType
+};
 
 export default SafeAnchor;

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -27,7 +27,8 @@ export function getInstance(children) {
 
   if (
     displayName === 'withStyleProps(DefaultPropsComponent)' ||
-    displayName === 'withLocale(DefaultPropsComponent)'
+    displayName === 'withLocale(DefaultPropsComponent)' ||
+    displayName === 'SafeAnchor'
   ) {
     return ReactTestUtils.renderIntoDocument(<TestWrapper>{children}</TestWrapper>);
   }


### PR DESCRIPTION
Fix: https://github.com/rsuite/rsuite/issues/711

```js

import Link from "next/link";

<Nav>
  <Nav.Item
    renderItem={item => {
      return <Link href="/home">{item}</Link>;
    }}
  >
    link
  </Nav.Item>
</Nav>
```