### PR TITLE
Fixed multiple picker count label vertical align issue when set `size=lg`.

### DIFF
--- a/src/Picker/styles/common.less
+++ b/src/Picker/styles/common.less
@@ -114,6 +114,10 @@
     .tag-picker-search-input-lg;
     .date-picker-button-caret-lg;
     .date-picker-button-size(large);
+
+    .@{ns}picker-value-count {
+      line-height: @line-height-large-computed;
+    }
   }
 
   &-md {


### PR DESCRIPTION
FIxed #726