### PR TITLE
Display correct name for the WrappedComponent

### DIFF
--- a/src/utils/defaultProps.ts
+++ b/src/utils/defaultProps.ts
@@ -10,7 +10,7 @@ function getComponentName(Component) {
   return (
     Component.displayName ||
     Component.name ||
-    typeof Component === 'string' ? Component : undefined
+    (typeof Component === 'string' ? Component : undefined)
   );
 }
 

--- a/src/utils/defaultProps.ts
+++ b/src/utils/defaultProps.ts
@@ -6,11 +6,21 @@ export interface Props {
   componentClass?: React.ElementType;
 }
 
+function getComponentName(Component) {
+  return (
+    Component.displayName ||
+    Component.name ||
+    typeof Component === 'string' ? Component : undefined
+  );
+}
+
 function defaultProps<T>(props: Props) {
   const { classPrefix, ...rest } = props;
 
   return (WrappedComponent: React.ComponentClass<any>): React.ComponentClass<T> => {
     class DefaultPropsComponent extends WrappedComponent {
+      static displayName = getComponentName(WrappedComponent) || 'DefaultPropsComponent';
+
       // for IE9 & IE10 support
       static contextTypes = WrappedComponent.contextTypes;
       static childContextTypes = WrappedComponent.childContextTypes;


### PR DESCRIPTION
As you can see from below, I have `FlexboxGrid` but instead of the name of it, it displays `DefaultPropsComponent`. I don't know how can I affirm this one as I don't know how will I test this lib. I just saw that instead of putting name for every component, why not get it when using `defaultProps` util.

![Screenshot from 2020-01-04 21-28-52](https://user-images.githubusercontent.com/32805276/71766527-9eadfd00-2f3b-11ea-87f7-393bf5545376.png)


In case, it didn't work. Maybe, we need to start putting `displayName` for every component that uses `defaultProps` util