### PR TITLE
Fix character casing in the Sidebar definition

### DIFF
--- a/docs/pages/components/container/en/index.md
+++ b/docs/pages/components/container/en/index.md
@@ -6,7 +6,7 @@ The container layout can define the main frame of the page.
 * `<Header>` Container header.
 * `<Content>` Container content.
 * `<Footer>` Container footer.
-* `<Sidebar>` COntainer sidebar.
+* `<Sidebar>` Container sidebar.
 
 ## Usage
 


### PR DESCRIPTION
From "COntainer" to "Container"