### PR TITLE
docs(guide/intl): fix wrong link linking to default.js which has been renamed to default.ts

### DIFF
--- a/docs/pages/guide/intl/en/index.md
+++ b/docs/pages/guide/intl/en/index.md
@@ -34,7 +34,7 @@ ReactDOM.render(
 
 ## Expand or modify language
 
-You can refer to the configuration in the [default language](https://github.com/rsuite/rsuite/blob/master/src/IntlProvider/locales/default.js) file to make a new language pack passed to the `<IntlProvider>` component via the locale property.
+You can refer to the configuration in the [default language](https://github.com/rsuite/rsuite/blob/master/src/IntlProvider/locales/default.ts) file to make a new language pack passed to the `<IntlProvider>` component via the locale property.
 
 ## Used with react-intl
 

--- a/docs/pages/guide/intl/index.md
+++ b/docs/pages/guide/intl/index.md
@@ -34,7 +34,7 @@ ReactDOM.render(
 
 ## 扩展或者修改语言
 
-您可以参考 [默认语言文件](https://github.com/rsuite/rsuite/blob/master/src/IntlProvider/locales/default.js) 中的配置，做一个新的语言包通过 `locale` 属性传递给 `<IntlProvider>` 组件。
+您可以参考 [默认语言文件](https://github.com/rsuite/rsuite/blob/master/src/IntlProvider/locales/default.ts) 中的配置，做一个新的语言包通过 `locale` 属性传递给 `<IntlProvider>` 组件。
 
 ## 与 react-intl 同时使用
 


### PR DESCRIPTION
markdown的链接 指向了default.js，但是这个文件已经叫default.ts 了