### PR TITLE
[DateRangePicker] Update broken types and add enum for target

### DIFF
--- a/src/DateRangePicker/DateRangePicker.d.ts
+++ b/src/DateRangePicker/DateRangePicker.d.ts
@@ -2,19 +2,24 @@ import * as React from 'react';
 import { PickerBaseProps, FormControlBaseProps } from '../@types/common';
 
 export type ValueType = [Date?, Date?];
+export enum TargetDisabledDate {
+  CALENDAR = 'CALENDAR',
+  TOOLBAR_BUTTON_OK = 'TOOLBAR_BUTTON_OK',
+  TOOLBAR_SHORTCUT = 'TOOLBAR_SHORTCUT',
+};
 
 export type DisabledDateFunction = (
   /** Date used to determine if disabling is required. */
   date: Date,
   /** Date selected. */
-  selectValue?: ValueType,
+  selectDate?: ValueType,
   /**
    Whether to choose to finish now.
    If `false`, only the start date is selected, waiting for the selection end date.
    */
   selectedDone?: boolean,
   // Call the target of the `disabledDate` function
-  target?: 'CALENDAR' | 'TOOLBAR_BUTTON_OK' | 'TOOLBAR_SHORTCUT'
+  target?: TargetDisabledDate
 ) => boolean;
 
 export interface RangeType {
@@ -54,9 +59,9 @@ export interface DateRangePickerProps extends PickerBaseProps, FormControlBasePr
   /** Disabled date */
   disabledDate?: (
     date: Date,
-    selectValue: ValueType,
-    doneSelected: boolean,
-    type: string
+    selectDate: ValueType,
+    selectedDone: boolean,
+    type: TargetDisabledDate
   ) => boolean;
 
   /** Called when the option is selected */

--- a/src/DateRangePicker/DateRangePicker.d.ts
+++ b/src/DateRangePicker/DateRangePicker.d.ts
@@ -61,7 +61,7 @@ export interface DateRangePickerProps extends PickerBaseProps, FormControlBasePr
     date: Date,
     selectDate: ValueType,
     selectedDone: boolean,
-    type: TargetDisabledDate
+    target: TargetDisabledDate
   ) => boolean;
 
   /** Called when the option is selected */

--- a/src/DateRangePicker/DateRangePicker.d.ts
+++ b/src/DateRangePicker/DateRangePicker.d.ts
@@ -5,8 +5,8 @@ export type ValueType = [Date?, Date?];
 export enum TargetDisabledDate {
   CALENDAR = 'CALENDAR',
   TOOLBAR_BUTTON_OK = 'TOOLBAR_BUTTON_OK',
-  TOOLBAR_SHORTCUT = 'TOOLBAR_SHORTCUT',
-};
+  TOOLBAR_SHORTCUT = 'TOOLBAR_SHORTCUT'
+}
 
 export type DisabledDateFunction = (
   /** Date used to determine if disabling is required. */


### PR DESCRIPTION
typing for daterange picker are inconsistent between DisabledDateFunction and DateRangePickerProps and doc