### PR TITLE
fix(Picker): make `searchBy` param optional in ts definition file

### DIFF
--- a/src/SelectPicker/SelectPicker.d.ts
+++ b/src/SelectPicker/SelectPicker.d.ts
@@ -44,7 +44,7 @@ export interface SelectProps<ValueType = any> {
   virtualized?: boolean;
 
   /** Custom search rules. */
-  searchBy: (keyword: string, label: React.ReactNode, item: ItemDataType) => boolean;
+  searchBy?: (keyword: string, label: React.ReactNode, item: ItemDataType) => boolean;
 }
 
 export interface SelectPickerProps extends FormControlPickerProps<any>, SelectProps<any> {}

--- a/src/Tree/TreeBase.d.ts
+++ b/src/Tree/TreeBase.d.ts
@@ -39,5 +39,5 @@ export interface TreeBaseProps extends StandardProps {
   onClean?: (event: React.SyntheticEvent<HTMLElement>) => void;
 
   /** Custom search rules. */
-  searchBy: (keyword: string, label: React.ReactNode, item: any) => boolean;
+  searchBy?: (keyword: string, label: React.ReactNode, item: any) => boolean;
 }


### PR DESCRIPTION
在上一个commit中，`SelectPicker.d.ts` 和 `TreeBase.d.ts` 的searchBy参数 变成了必填项