### PR TITLE
feat(IntlProvider): Support `formatDate` on `<IntlProvider>`

### DIFF
--- a/docs/pages/guide/intl/en/index.md
+++ b/docs/pages/guide/intl/en/index.md
@@ -8,11 +8,29 @@ The language in the React Suite component defaults to English. If you need to se
 import { IntlProvider } from 'rsuite';
 import zhCN from 'rsuite/lib/IntlProvider/locales/zh_CN';
 
-ReactDOM.render(
+return (
   <IntlProvider locale={zhCN}>
     <App />
-  </IntlProvider>,
-  document.getElementById('root')
+  </IntlProvider>
+);
+```
+
+## Format date
+
+```jsx
+import { IntlProvider } from 'rsuite';
+import ruRU from 'rsuite/lib/IntlProvider/locales/ru_RU';
+import format from 'date-fns/format';
+import ru from 'date-fns/locale/ru';
+
+function formatDate(data, formatStr) {
+  return format(data, formatStr, { locale: ru });
+}
+
+return (
+  <IntlProvider locale={ruRU} formatDate={formatDate}>
+    <App />
+  </IntlProvider>
 );
 ```
 
@@ -41,17 +59,26 @@ You can refer to the configuration in the [default language](https://github.com/
 
 ```jsx
 import { IntlProvider } from 'react-intl';
-import { IntlProvider as RSIntlProvider } from 'rsuite';
+import LocaleProvider from 'rsuite/lib/IntlProvider';
 import zhCN from 'rsuite/lib/IntlProvider/locales/zh_CN';
 
-ReactDOM.render(
+return (
   <IntlProvider locale="zh">
-    <RSIntlProvider locale={zhCN}>
+    <LocaleProvider locale={zhCN}>
       <App />
-    </RSIntlProvider>
-  </IntlProvider>,
-  document.getElementById('root')
+    </LocaleProvider>
+  </IntlProvider>
 );
 ```
 
 More Configuration references: [react-intl](https://github.com/yahoo/react-intl)
+
+## Props
+
+### `<IntlProvider>`
+
+| Property   | Type`(Default)`                                                       | Description                                    |
+| ---------- | --------------------------------------------------------------------- | ---------------------------------------------- |
+| locale     | object`(rsuite/lib/IntlProvider/locales/en_GB)`                       | Configure Language Pack                        |
+| rtl        | boolean                                                               | Text and other elements go from left to right. |
+| formatDate | (date: Date ,format?: string, options?: {locale?: object;}) => string | Format date                                    |

--- a/docs/pages/guide/intl/index.md
+++ b/docs/pages/guide/intl/index.md
@@ -8,11 +8,29 @@ React Suite 组件中的语言默认为英语。 如果需要设置其他语言�
 import { IntlProvider } from 'rsuite';
 import zhCN from 'rsuite/lib/IntlProvider/locales/zh_CN';
 
-ReactDOM.render(
+return (
   <IntlProvider locale={zhCN}>
     <App />
-  </IntlProvider>,
-  document.getElementById('root')
+  </IntlProvider>
+);
+```
+
+## 日期格式化
+
+```jsx
+import { IntlProvider } from 'rsuite';
+import ruRU from 'rsuite/lib/IntlProvider/locales/ru_RU';
+import format from 'date-fns/format';
+import ru from 'date-fns/locale/ru';
+
+function formatDate(data, formatStr) {
+  return format(data, formatStr, { locale: ru });
+}
+
+return (
+  <IntlProvider locale={ruRU} formatDate={formatDate}>
+    <App />
+  </IntlProvider>
 );
 ```
 
@@ -41,17 +59,26 @@ ReactDOM.render(
 
 ```jsx
 import { IntlProvider } from 'react-intl';
-import RSIntlProvider from 'rsuite/lib/IntlProvider';
+import LocaleProvider from 'rsuite/lib/IntlProvider';
 import zhCN from 'rsuite/lib/IntlProvider/locales/zh_CN';
 
-ReactDOM.render(
+return (
   <IntlProvider locale="zh">
-    <RSIntlProvider locale={zhCN}>
+    <LocaleProvider locale={zhCN}>
       <App />
-    </RSIntlProvider>
-  </IntlProvider>,
-  document.getElementById('root')
+    </LocaleProvider>
+  </IntlProvider>
 );
 ```
 
 更多配置参考: [react-intl](https://github.com/yahoo/react-intl)
+
+## Props
+
+### `<IntlProvider>`
+
+| 属性名称   | 类型`(默认值)`                                                        | 描述                                     |
+| ---------- | --------------------------------------------------------------------- | ---------------------------------------- |
+| locale     | object`(rsuite/lib/IntlProvider/locales/en_GB)`                       | 语言包配置                               |
+| rtl        | boolean                                                               | 可设置文本和其他元素的默认方向是从左到右 |
+| formatDate | (date: Date ,format?: string, options?: {locale?: object;}) => string | 格式化日期                               |

--- a/src/@types/common.d.ts
+++ b/src/@types/common.d.ts
@@ -35,7 +35,7 @@ export interface AnimationEventProps {
 
 export interface PickerBaseProps extends StandardProps, AnimationEventProps {
   /** locale */
-  locale?: boolean;
+  locale?: any;
 
   /** A picker can have different appearances. */
   appearance?: 'default' | 'subtle';

--- a/src/Calendar/CalendarPanel.tsx
+++ b/src/Calendar/CalendarPanel.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { format } from 'date-fns';
 import classNames from 'classnames';
 
 import Calendar from './Calendar';
 import Button from '../Button';
-import IntlProvider from '../IntlProvider';
+import IntlContext from '../IntlProvider/IntlContext';
+import FormattedDate from '../IntlProvider/FormattedDate';
 import { defaultProps, prefix } from '../utils';
 import { CalendarPanelProps } from './CalendarPanel.d';
 
@@ -114,7 +114,7 @@ class CalendarPanel extends React.PureComponent<CalendarPanelProps, State> {
     });
 
     return (
-      <IntlProvider locale={locale}>
+      <IntlContext.Provider value={locale}>
         <Calendar
           className={classes}
           isoWeek={isoWeek}
@@ -122,7 +122,9 @@ class CalendarPanel extends React.PureComponent<CalendarPanelProps, State> {
           format="YYYY-MM-DD"
           calendarState={showMonth ? 'DROP_MONTH' : null}
           pageDate={value}
-          renderTitle={date => format(date, locale.formattedMonthPattern || 'MMMM  YYYY')}
+          renderTitle={date => (
+            <FormattedDate date={date} formatStr={locale.formattedMonthPattern || 'MMMM  YYYY'} />
+          )}
           renderToolbar={this.renderToolbar}
           renderCell={renderCell}
           onMoveForword={this.handleNextMonth}
@@ -132,7 +134,7 @@ class CalendarPanel extends React.PureComponent<CalendarPanelProps, State> {
           limitEndYear={1000}
           {...rest}
         />
-      </IntlProvider>
+      </IntlContext.Provider>
     );
   }
 }

--- a/src/Calendar/Header.tsx
+++ b/src/Calendar/Header.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { format } from 'date-fns';
 import { prefix, getUnhandledProps, defaultProps } from '../utils';
 import IntlContext from '../IntlProvider/IntlContext';
+import FormattedDate from '../IntlProvider/FormattedDate';
 
 export interface HeaderProps {
   date: Date;
@@ -93,7 +93,7 @@ class Header extends React.PureComponent<HeaderProps> {
       return renderTitle(date);
     }
 
-    return date && format(date, this.getDateFormat());
+    return date && <FormattedDate date={date} formatStr={this.getDateFormat()} />;
   }
   render() {
     const {
@@ -176,7 +176,7 @@ class Header extends React.PureComponent<HeaderProps> {
               className={timeTitleClasses}
               onClick={onToggleTimeDropdown}
             >
-              {date && format(date, this.getTimeFormat())}
+              {date && <FormattedDate date={date} formatStr={this.getTimeFormat()} />}
             </span>
 
             {showMeridian ? (
@@ -186,7 +186,7 @@ class Header extends React.PureComponent<HeaderProps> {
                 className={this.addPrefix('meridian')}
                 onClick={onToggleMeridian}
               >
-                {date && format(date, 'A')}
+                {date && <FormattedDate date={date} formatStr="A" />}
               </span>
             ) : null}
           </div>

--- a/src/Calendar/TableRow.tsx
+++ b/src/Calendar/TableRow.tsx
@@ -19,6 +19,7 @@ export interface TableRowProps {
 }
 
 class TableRow extends React.PureComponent<TableRowProps> {
+  static contextType = IntlContext;
   static propTypes = {
     weekendDate: PropTypes.instanceOf(Date),
     selected: PropTypes.instanceOf(Date),
@@ -47,8 +48,10 @@ class TableRow extends React.PureComponent<TableRowProps> {
     this.props.onSelect?.(date, event);
   };
 
-  renderDays(context) {
+  renderDays() {
     const { weekendDate, disabledDate, inSameMonth, selected, renderCell } = this.props;
+    const { formatDate, formattedDayPattern, today } = this.context || {};
+    const formatStr = formattedDayPattern || 'YYYY-MM-DD';
     const days = [];
 
     for (let i = 0; i < 7; i += 1) {
@@ -62,14 +65,14 @@ class TableRow extends React.PureComponent<TableRowProps> {
         [this.addPrefix('cell-disabled')]: disabled
       });
 
-      const title = format(thisDate, context?.formattedDayPattern || 'YYYY-MM-DD');
+      const title = formatDate ? formatDate(thisDate, formatStr) : format(thisDate, formatStr);
       days.push(
         <div
           key={title}
           className={classes}
           role="menu"
           tabIndex={-1}
-          title={isToday ? `${title} (${context?.today})` : title}
+          title={isToday ? `${title} (${today})` : title}
           onClick={this.handleSelect.bind(this, thisDate, disabled)}
         >
           <div className={this.addPrefix('cell-content')}>
@@ -99,11 +102,7 @@ class TableRow extends React.PureComponent<TableRowProps> {
     return (
       <div {...unhandled} className={classes}>
         {showWeekNumbers && this.renderWeekNumber()}
-        <IntlContext.Consumer>
-          {context => {
-            return this.renderDays(context);
-          }}
-        </IntlContext.Consumer>
+        {this.renderDays()}
       </div>
     );
   }

--- a/src/Carousel/test/CarouselStylesSpec.js
+++ b/src/Carousel/test/CarouselStylesSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Carousel from '../index';
-import { createTestContainer, getDOMNode, getStyle, toRGB, itChrome } from '@test/testUtils';
+import { createTestContainer, getDOMNode, getStyle, toRGB } from '@test/testUtils';
 
 import '../styles/index';
 

--- a/src/Cascader/Cascader.tsx
+++ b/src/Cascader/Cascader.tsx
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import shallowEqual from '../utils/shallowEqual';
 import { polyfill } from 'react-lifecycles-compat';
 import { findNodeOfTree } from '../utils/treeUtils';
-import IntlProvider from '../IntlProvider';
+import IntlContext from '../IntlProvider/IntlContext';
 import FormattedMessage from '../IntlProvider/FormattedMessage';
 import DropdownMenu, { dropdownMenuPropTypes } from './DropdownMenu';
 import stringToObject from '../utils/stringToObject';
@@ -557,7 +557,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
     const classes = getToggleWrapperClassName('cascader', this.addPrefix, this.props, hasValue);
 
     return (
-      <IntlProvider locale={locale}>
+      <IntlContext.Provider value={locale}>
         <div className={classes} style={style} tabIndex={-1} role="menu" ref={this.containerRef}>
           <PickerToggleTrigger
             pickerProps={this.props}
@@ -579,7 +579,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
             </PickerToggle>
           </PickerToggleTrigger>
         </div>
-      </IntlProvider>
+      </IntlContext.Provider>
     );
   }
 }

--- a/src/CheckPicker/CheckPicker.tsx
+++ b/src/CheckPicker/CheckPicker.tsx
@@ -12,7 +12,7 @@ import {
   getDataGroupBy
 } from '../utils';
 
-import IntlProvider from '../IntlProvider';
+import IntlContext from '../IntlProvider/IntlContext';
 import FormattedMessage from '../IntlProvider/FormattedMessage';
 import {
   DropdownMenuCheckItem as DropdownMenuItem,
@@ -523,7 +523,7 @@ class CheckPicker extends React.Component<CheckPickerProps, CheckPickerState> {
     const classes = getToggleWrapperClassName('check', this.addPrefix, this.props, hasValue);
 
     return (
-      <IntlProvider locale={locale}>
+      <IntlContext.Provider value={locale}>
         <PickerToggleTrigger
           pickerProps={this.props}
           ref={this.triggerRef}
@@ -548,7 +548,7 @@ class CheckPicker extends React.Component<CheckPickerProps, CheckPickerState> {
             </PickerToggle>
           </div>
         </PickerToggleTrigger>
-      </IntlProvider>
+      </IntlContext.Provider>
     );
   }
 }

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 import _ from 'lodash';
 import { polyfill } from 'react-lifecycles-compat';
 import {
-  format,
   getMinutes,
   getHours,
   isSameDay,
@@ -14,7 +13,8 @@ import {
   setSeconds
 } from 'date-fns';
 
-import IntlProvider from '../IntlProvider';
+import IntlContext from '../IntlProvider/IntlContext';
+import FormattedDate from '../IntlProvider/FormattedDate';
 import Calendar from '../Calendar/Calendar';
 import Toolbar from './Toolbar';
 
@@ -184,7 +184,11 @@ class DatePicker extends React.Component<DatePickerProps, DatePickerState> {
     const value = this.getValue();
 
     if (value) {
-      return renderValue ? renderValue(value, formatType) : format(value, formatType);
+      return renderValue ? (
+        renderValue(value, formatType)
+      ) : (
+        <FormattedDate date={value} formatStr={formatType} />
+      );
     }
 
     return placeholder || formatType;
@@ -443,11 +447,11 @@ class DatePicker extends React.Component<DatePickerProps, DatePickerState> {
 
     if (inline) {
       return (
-        <IntlProvider locale={locale}>
+        <IntlContext.Provider value={locale}>
           <div className={classNames(classPrefix, this.addPrefix('date-inline'), className)}>
             {calendar}
           </div>
-        </IntlProvider>
+        </IntlContext.Provider>
       );
     }
 
@@ -456,7 +460,7 @@ class DatePicker extends React.Component<DatePickerProps, DatePickerState> {
     });
 
     return (
-      <IntlProvider locale={locale}>
+      <IntlContext.Provider value={locale}>
         <div className={classes} style={style}>
           <PickerToggleTrigger
             pickerProps={this.props}
@@ -477,7 +481,7 @@ class DatePicker extends React.Component<DatePickerProps, DatePickerState> {
             </PickerToggle>
           </PickerToggleTrigger>
         </div>
-      </IntlProvider>
+      </IntlContext.Provider>
     );
   }
 }

--- a/src/DateRangePicker/Calendar/TableRow.tsx
+++ b/src/DateRangePicker/Calendar/TableRow.tsx
@@ -4,8 +4,8 @@ import classNames from 'classnames';
 import { addDays, isSameDay, isBefore, isAfter, getDate, format } from 'date-fns';
 
 import { getUnhandledProps, prefix, defaultProps } from '../../utils';
-import { TYPE } from '../utils';
 import IntlContext from '../../IntlProvider/IntlContext';
+import { TargetEnum } from '../DateRangePicker.d';
 
 export interface TableRowProps {
   weekendDate?: Date;
@@ -21,6 +21,7 @@ export interface TableRowProps {
 }
 
 class TableRow extends React.Component<TableRowProps> {
+  static contextType = IntlContext;
   static propTypes = {
     weekendDate: PropTypes.instanceOf(Date),
     selected: PropTypes.arrayOf(PropTypes.instanceOf(Date)),
@@ -49,6 +50,9 @@ class TableRow extends React.Component<TableRowProps> {
       onSelect
     } = this.props;
 
+    const { formatDate, formattedDayPattern, today } = this.context || {};
+    const formatStr = formattedDayPattern || 'YYYY-MM-DD';
+
     const days = [];
     const selectedStartDate = selected[0];
     const selectedEndDate = selected[1];
@@ -58,7 +62,7 @@ class TableRow extends React.Component<TableRowProps> {
     for (let i = 0; i < 7; i += 1) {
       const thisDate = addDays(weekendDate, i);
       const selectValue = [selectedStartDate, selectedEndDate];
-      const disabled = disabledDate?.(thisDate, selectValue, TYPE.CALENDAR);
+      const disabled = disabledDate?.(thisDate, selectValue, TargetEnum.CALENDAR);
       const isToday = isSameDay(thisDate, new Date());
       const unSameMonth = !inSameMonth?.(thisDate);
       const isStartSelected =
@@ -97,23 +101,20 @@ class TableRow extends React.Component<TableRowProps> {
         [this.addPrefix('cell-disabled')]: disabled
       });
 
-      const title = format(thisDate, 'YYYY-MM-DD');
+      const title = formatDate ? formatDate(thisDate, formatStr) : format(thisDate, formatStr);
 
       days.push(
-        <IntlContext.Consumer key={title}>
-          {context => (
-            <div
-              className={classes}
-              role="menu"
-              tabIndex={-1}
-              title={isToday ? `${title} (${context?.today})` : title}
-              onMouseEnter={!disabled && onMouseMove ? onMouseMove.bind(null, thisDate) : undefined}
-              onClick={!disabled ? onSelect?.bind(null, thisDate) : undefined}
-            >
-              <span className={this.addPrefix('cell-content')}>{getDate(thisDate)}</span>
-            </div>
-          )}
-        </IntlContext.Consumer>
+        <div
+          key={title}
+          className={classes}
+          role="menu"
+          tabIndex={-1}
+          title={isToday ? `${title} (${today})` : title}
+          onMouseEnter={!disabled && onMouseMove ? onMouseMove.bind(null, thisDate) : undefined}
+          onClick={!disabled ? onSelect?.bind(null, thisDate) : undefined}
+        >
+          <span className={this.addPrefix('cell-content')}>{getDate(thisDate)}</span>
+        </div>
       );
     }
     return days;

--- a/src/DateRangePicker/DateRangePicker.d.ts
+++ b/src/DateRangePicker/DateRangePicker.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { PickerBaseProps, FormControlBaseProps } from '../@types/common';
 
 export type ValueType = [Date?, Date?];
-export enum TargetDisabledDate {
+export enum TargetEnum {
   CALENDAR = 'CALENDAR',
   TOOLBAR_BUTTON_OK = 'TOOLBAR_BUTTON_OK',
   TOOLBAR_SHORTCUT = 'TOOLBAR_SHORTCUT'
@@ -19,7 +19,7 @@ export type DisabledDateFunction = (
    */
   selectedDone?: boolean,
   // Call the target of the `disabledDate` function
-  target?: TargetDisabledDate
+  target?: TargetEnum
 ) => boolean;
 
 export interface RangeType {
@@ -61,7 +61,7 @@ export interface DateRangePickerProps extends PickerBaseProps, FormControlBasePr
     date: Date,
     selectDate: ValueType,
     selectedDone: boolean,
-    target: TargetDisabledDate
+    target: TargetEnum
   ) => boolean;
 
   /** Called when the option is selected */

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 import _ from 'lodash';
 
 import {
-  format,
   addDays,
   isBefore,
   isAfter,
@@ -20,10 +19,11 @@ import {
   compareAsc
 } from 'date-fns';
 
-import IntlProvider from '../IntlProvider';
+import IntlContext from '../IntlProvider/IntlContext';
+import FormattedDate from '../IntlProvider/FormattedDate';
 import Toolbar from './Toolbar';
 import DatePicker from './DatePicker';
-import { setTimingMargin, getCalendarDate, TYPE } from './utils';
+import { setTimingMargin, getCalendarDate } from './utils';
 import { defaultProps, getUnhandledProps, prefix, createChainedFunction } from '../utils';
 
 import {
@@ -33,7 +33,7 @@ import {
   getToggleWrapperClassName
 } from '../Picker';
 
-import { DateRangePickerProps, ValueType } from './DateRangePicker.d';
+import { DateRangePickerProps, ValueType, TargetEnum } from './DateRangePicker.d';
 import { PLACEMENT } from '../constants';
 
 interface DateRangePickerState {
@@ -193,9 +193,14 @@ class DateRangePicker extends React.Component<DateRangePickerProps, DateRangePic
     if (startDate && endDate) {
       const displayValue: any = [startDate, endDate].sort(compareAsc);
 
-      return renderValue
-        ? renderValue(displayValue, formatType)
-        : `${format(displayValue[0], formatType)} ~ ${format(displayValue[1], formatType)}`;
+      return renderValue ? (
+        renderValue(displayValue, formatType)
+      ) : (
+        <>
+          <FormattedDate date={displayValue[0]} formatStr={formatType} /> ~{' '}
+          <FormattedDate date={displayValue[1]} formatStr={formatType} />
+        </>
+      );
     }
 
     return placeholder || `${formatType} ~ ${formatType}`;
@@ -449,7 +454,7 @@ class DateRangePicker extends React.Component<DateRangePickerProps, DateRangePic
     this.props.onClose?.();
   };
 
-  disabledByBetween(start: Date, end: Date, type: string) {
+  disabledByBetween(start: Date, end: Date, type: TargetEnum) {
     const { disabledDate } = this.props;
     const { selectValue, doneSelected } = this.state;
     const selectStartDate = selectValue[0];
@@ -475,7 +480,7 @@ class DateRangePicker extends React.Component<DateRangePickerProps, DateRangePic
       return true;
     }
 
-    return this.disabledByBetween(selectValue[0], selectValue[1], TYPE.TOOLBAR_BUTTON_OK);
+    return this.disabledByBetween(selectValue[0], selectValue[1], TargetEnum.TOOLBAR_BUTTON_OK);
   };
 
   disabledShortcutButton = (value: ValueType = []) => {
@@ -483,10 +488,10 @@ class DateRangePicker extends React.Component<DateRangePickerProps, DateRangePic
       return true;
     }
 
-    return this.disabledByBetween(value[0], value[1], TYPE.TOOLBAR_SHORTCUT);
+    return this.disabledByBetween(value[0], value[1], TargetEnum.TOOLBAR_SHORTCUT);
   };
 
-  handleDisabledDate = (date: Date, values: ValueType, type: string) => {
+  handleDisabledDate = (date: Date, values: ValueType, type: TargetEnum) => {
     const { disabledDate } = this.props;
     const { doneSelected } = this.state;
     if (disabledDate) {
@@ -573,7 +578,7 @@ class DateRangePicker extends React.Component<DateRangePickerProps, DateRangePic
     const classes = getToggleWrapperClassName('daterange', this.addPrefix, this.props, hasValue);
 
     return (
-      <IntlProvider locale={locale}>
+      <IntlContext.Provider value={locale}>
         <div className={classes} style={style}>
           <PickerToggleTrigger
             pickerProps={this.props}
@@ -595,7 +600,7 @@ class DateRangePicker extends React.Component<DateRangePickerProps, DateRangePic
             </PickerToggle>
           </PickerToggleTrigger>
         </div>
-      </IntlProvider>
+      </IntlContext.Provider>
     );
   }
 }

--- a/src/DateRangePicker/utils.ts
+++ b/src/DateRangePicker/utils.ts
@@ -12,9 +12,3 @@ export function getCalendarDate(value: any = []): ValueType {
   }
   return [new Date(), addMonths(new Date(), 1)];
 }
-
-export enum TYPE {
-  CALENDAR = 'CALENDAR',
-  TOOLBAR_BUTTON_OK = 'TOOLBAR_BUTTON_OK',
-  TOOLBAR_SHORTCUT = 'TOOLBAR_SHORTCUT'
-}

--- a/src/IntlProvider/FormattedDate.tsx
+++ b/src/IntlProvider/FormattedDate.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import IntlContext from './IntlContext';
+import format from 'date-fns/format';
+
+interface FormattedDateProps {
+  date: Date;
+  formatStr: string;
+}
+
+function FormattedDate({ date, formatStr }: FormattedDateProps) {
+  return (
+    <IntlContext.Consumer>
+      {options => {
+        const formatDate = options?.formatDate || format;
+        return formatDate(date, formatStr);
+      }}
+    </IntlContext.Consumer>
+  );
+}
+
+export default FormattedDate;

--- a/src/IntlProvider/IntlContext.ts
+++ b/src/IntlProvider/IntlContext.ts
@@ -1,3 +1,3 @@
 import createContext from '../utils/createContext';
 
-export default createContext(null);
+export default createContext<any>(null);

--- a/src/IntlProvider/IntlProvider.d.ts
+++ b/src/IntlProvider/IntlProvider.d.ts
@@ -8,8 +8,16 @@ export interface IntlProviderProps {
   locale?: object;
 
   /** Support right-to-left */
-
   rtl?: boolean;
+
+  /** Date Formatting API */
+  formatDate?: (
+    date: Date | string | number,
+    format?: string,
+    options?: {
+      locale?: object;
+    }
+  ) => string;
 }
 
 declare const IntlProvider: React.ComponentType<IntlProviderProps>;

--- a/src/IntlProvider/IntlProvider.tsx
+++ b/src/IntlProvider/IntlProvider.tsx
@@ -1,10 +1,15 @@
 import * as React from 'react';
-import IntlContext from './IntlContext';
-
+import createContext from '../utils/createContext';
 import { IntlProviderProps } from './IntlProvider.d';
 
-const IntlProvider = ({ locale, rtl, children }: IntlProviderProps) => {
-  return <IntlContext.Provider value={{ ...locale, rtl }}>{children}</IntlContext.Provider>;
+export const IntlGlobalContext = createContext<IntlProviderProps>(null);
+
+const IntlProvider = ({ locale, rtl, children, formatDate }: IntlProviderProps) => {
+  return (
+    <IntlGlobalContext.Provider value={{ ...locale, rtl, formatDate }}>
+      {children}
+    </IntlGlobalContext.Provider>
+  );
 };
 
 export default IntlProvider;

--- a/src/IntlProvider/test/FormattedDateSpec.js
+++ b/src/IntlProvider/test/FormattedDateSpec.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import IntlContext from '../IntlContext';
+import FormattedDate from '../FormattedDate';
+import { getDOMNode } from '@test/testUtils';
+import format from 'date-fns/format';
+import ru from 'date-fns/locale/ru';
+
+function formatDate(data, formatStr) {
+  return format(data, formatStr, {
+    locale: ru
+  });
+}
+
+describe('FormattedDate', () => {
+  it('Should render formatted date ', () => {
+    const domNode = getDOMNode(
+      <div>
+        <IntlContext.Provider value={{ formatDate }}>
+          <div>
+            <FormattedDate date={new Date('2020-01-01')} formatStr="MMM DD, YYYY" />
+          </div>
+        </IntlContext.Provider>
+      </div>
+    );
+    assert.equal(domNode.innerText, 'янв. 01, 2020');
+  });
+
+  it('Should render default formatted date', () => {
+    const domNode = getDOMNode(
+      <div>
+        <FormattedDate date={new Date('2020-01-01')} formatStr="MMM DD, YYYY" />
+      </div>
+    );
+    assert.equal(domNode.innerText, 'Jan 01, 2020');
+  });
+});

--- a/src/IntlProvider/withLocale.tsx
+++ b/src/IntlProvider/withLocale.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import _ from 'lodash';
 import { setDisplayName, wrapDisplayName } from 'recompose';
+import format from 'date-fns/format';
 import defaultLocale from './locales/default';
-import IntlContext from './IntlContext';
 import extendReactStatics from '../utils/extendReactStatics';
+import { IntlGlobalContext } from './IntlProvider';
 
 const mergeObject = (list: any[]) =>
   list.reduce((a, b) => {
@@ -12,17 +13,17 @@ const mergeObject = (list: any[]) =>
   }, {});
 
 function withLocale<T>(combineKeys: string[] = []) {
-  return (BaseComponent: React.ComponentClass<any>) => {
+  return (BaseComponent: React.ComponentType<any>) => {
     const WithLocale = React.forwardRef((props: T, ref) => {
       return (
-        <IntlContext.Consumer>
-          {value => {
+        <IntlGlobalContext.Consumer>
+          {options => {
             const locale = mergeObject(
-              combineKeys.map(key => _.get(value || defaultLocale, `${key}`))
+              combineKeys.map(key => _.get(options || defaultLocale, `${key}`))
             );
 
-            if (value && typeof value.rtl !== undefined) {
-              locale.rtl = value.rtl;
+            if (options && typeof options.rtl !== undefined) {
+              locale.rtl = options.rtl;
             } else if (
               typeof window !== 'undefined' &&
               (document.body.getAttribute('dir') || document.dir) === 'rtl'
@@ -30,13 +31,15 @@ function withLocale<T>(combineKeys: string[] = []) {
               locale.rtl = true;
             }
 
+            locale.formatDate = options?.formatDate || format;
+
             return React.createElement(BaseComponent, {
               ref,
               locale,
               ...props
             });
           }}
-        </IntlContext.Consumer>
+        </IntlGlobalContext.Consumer>
       );
     });
 

--- a/src/Uploader/Uploader.tsx
+++ b/src/Uploader/Uploader.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import _ from 'lodash';
 import compose from 'recompose/compose';
 
-import IntlProvider from '../IntlProvider';
+import IntlContext from '../IntlProvider/IntlContext';
 import withLocale from '../IntlProvider/withLocale';
 import FileItem from './UploadFileItem';
 import UploadTrigger from './UploadTrigger';
@@ -378,11 +378,11 @@ class Uploader extends React.Component<UploaderProps, UploaderState> {
     }
 
     return (
-      <IntlProvider locale={locale}>
+      <IntlContext.Provider value={locale}>
         <div className={classes} style={style}>
           {renderList}
         </div>
-      </IntlProvider>
+      </IntlContext.Provider>
     );
   }
 }

--- a/src/utils/createContext.ts
+++ b/src/utils/createContext.ts
@@ -7,7 +7,7 @@ export default function createContext<T = any>(defaultValue: any) {
   };
 
   const ReactContext: React.Context<T> = React.createContext
-    ? React.createContext(defaultValue)
+    ? React.createContext<T>(defaultValue)
     : context;
 
   return ReactContext;


### PR DESCRIPTION
```tsx
import format from 'date-fns/format';
import ru from 'date-fns/locale/ru';

function formatDate(data, formatStr) {
  return format(data, formatStr, {
    locale: ru
  });
}
```

```tsx
<IntlProvider formatDate={formatDate} >
  <App />
</IntlProvider>
```

Fix: https://github.com/rsuite/rsuite/issues/1034
