### PR TITLE
feat: added translations for Spanish (Argentina & Spain)

### DIFF
--- a/docs/pages/guide/intl/en/index.md
+++ b/docs/pages/guide/intl/en/index.md
@@ -42,6 +42,8 @@ return (
 | da_DK         | Danish              |
 | en_GB         | English             |
 | en_US         | American English    |
+| es_AR         | Spanish (Argentina) |
+| es_ES         | Spanish (Spain)     |
 | fi_FI         | Finnish             |
 | it_IT         | Italian             |
 | ko_KR         | Korean              |

--- a/src/IntlProvider/locales/es_AR.d.ts
+++ b/src/IntlProvider/locales/es_AR.d.ts
@@ -1,0 +1,3 @@
+declare const locale: object;
+
+export default locale;

--- a/src/IntlProvider/locales/es_AR.ts
+++ b/src/IntlProvider/locales/es_AR.ts
@@ -1,0 +1,65 @@
+const Calendar = {
+  sunday: 'Do',
+  monday: 'Lu',
+  tuesday: 'Ma',
+  wednesday: 'Mi',
+  thursday: 'Ju',
+  friday: 'Vi',
+  saturday: 'Sá',
+  ok: 'Aceptar',
+  today: 'Hoy',
+  yesterday: 'Ayer',
+  hours: 'Horas',
+  minutes: 'Minutos',
+  seconds: 'Segundos',
+  /**
+   * Format of the string is based on Unicode Technical Standard #35:
+   * https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
+   **/
+  formattedMonthPattern: 'MMM YYYY',
+  formattedDayPattern: 'DD MMM YYYY'
+};
+
+export default {
+  Pagination: {
+    more: 'Más',
+    prev: 'Anterior',
+    next: 'Siguiente',
+    first: 'Primero',
+    last: 'Último'
+  },
+  Table: {
+    emptyMessage: 'Sin datos',
+    loading: 'Cargando...'
+  },
+  TablePagination: {
+    lengthMenuInfo: '{0} / páginas',
+    totalInfo: 'Total: {0}'
+  },
+  Calendar,
+  DatePicker: {
+    ...Calendar
+  },
+  DateRangePicker: {
+    ...Calendar,
+    last7Days: 'Últimos 7 días'
+  },
+  Picker: {
+    noResultsText: 'No se encontraron resultados',
+    placeholder: 'Seleccionar',
+    searchPlaceholder: 'Buscar',
+    checkAll: 'Todos'
+  },
+  InputPicker: {
+    newItem: 'Nuevo',
+    createOption: 'Crear opción "{0}"'
+  },
+  Uploader: {
+    inited: 'Inicial',
+    progress: 'Subiendo',
+    error: 'Error',
+    complete: 'Terminado',
+    emptyFile: 'Vacío',
+    upload: 'Subir'
+  }
+};

--- a/src/IntlProvider/locales/es_ES.d.ts
+++ b/src/IntlProvider/locales/es_ES.d.ts
@@ -1,0 +1,3 @@
+declare const locale: object;
+
+export default locale;

--- a/src/IntlProvider/locales/es_ES.ts
+++ b/src/IntlProvider/locales/es_ES.ts
@@ -1,0 +1,65 @@
+const Calendar = {
+  sunday: 'Do',
+  monday: 'Lu',
+  tuesday: 'Ma',
+  wednesday: 'Mi',
+  thursday: 'Ju',
+  friday: 'Vi',
+  saturday: 'Sá',
+  ok: 'Aceptar',
+  today: 'Hoy',
+  yesterday: 'Ayer',
+  hours: 'Horas',
+  minutes: 'Minutos',
+  seconds: 'Segundos',
+  /**
+   * Format of the string is based on Unicode Technical Standard #35:
+   * https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
+   **/
+  formattedMonthPattern: 'MMM YYYY',
+  formattedDayPattern: 'DD MMM YYYY'
+};
+
+export default {
+  Pagination: {
+    more: 'Más',
+    prev: 'Anterior',
+    next: 'Siguiente',
+    first: 'Primero',
+    last: 'Último'
+  },
+  Table: {
+    emptyMessage: 'Sin datos',
+    loading: 'Cargando...'
+  },
+  TablePagination: {
+    lengthMenuInfo: '{0} / páginas',
+    totalInfo: 'Total: {0}'
+  },
+  Calendar,
+  DatePicker: {
+    ...Calendar
+  },
+  DateRangePicker: {
+    ...Calendar,
+    last7Days: 'Últimos 7 días'
+  },
+  Picker: {
+    noResultsText: 'No se encontraron resultados',
+    placeholder: 'Seleccionar',
+    searchPlaceholder: 'Buscar',
+    checkAll: 'Todos'
+  },
+  InputPicker: {
+    newItem: 'Nuevo',
+    createOption: 'Crear opción "{0}"'
+  },
+  Uploader: {
+    inited: 'Inicial',
+    progress: 'Subiendo',
+    error: 'Error',
+    complete: 'Terminado',
+    emptyFile: 'Vacío',
+    upload: 'Subir'
+  }
+};

--- a/src/IntlProvider/locales/index.d.ts
+++ b/src/IntlProvider/locales/index.d.ts
@@ -3,6 +3,8 @@ export const azAZ: object;
 export const daDK: object;
 export const enGB: object;
 export const enUS: object;
+export const esAR: object;
+export const esES: object;
 export const fiFI: object;
 export const itIT: object;
 export const koKR: object;

--- a/src/IntlProvider/locales/index.ts
+++ b/src/IntlProvider/locales/index.ts
@@ -2,6 +2,8 @@ export { default as arEG } from './ar_EG';
 export { default as daDK } from './da_DK';
 export { default as enGB } from './en_GB';
 export { default as enUS } from './en_US';
+export { default as esAR } from './es_AR';
+export { default as esES } from './es_ES';
 export { default as fiFI } from './fi_FI';
 export { default as itIT } from './it_IT';
 export { default as koKR } from './ko_KR';


### PR DESCRIPTION
Added translations for Spanish (Argentina `es_AR` & Spain `es_ES`)