### PR TITLE
feat(AutoComplete): Support `filterBy` param

### DIFF
--- a/docs/pages/components/auto-complete/en/index.md
+++ b/docs/pages/components/auto-complete/en/index.md
@@ -22,6 +22,8 @@ import { AutoComplete } from 'rsuite';
 | data \*       | string[], Array&lt;[DataItemType](#types)&gt;        | The data of component                                                            |
 | defaultValue  | string                                               | Default value                                                                    |
 | disabled      | boolean                                              | Whether disabled select                                                          |
+| filterBy      | (value: string, item: [DataItemType](#types)) => boolean       | Custom filter rules (will only display items that value is a substring of which by default)|
+| menuClassName | string                                               | A css class to apply to the Menu DOM                                   |
 | onChange      | (value:string, event) => void                        | Called when select an option or input value change, or value of input is changed |
 | onClose       | () => void                                           | Callback fired when hidden                                                       |
 | onEnter       | () => void                                           | Callback fired before the overlay transitions in                                 |

--- a/docs/pages/components/auto-complete/index.md
+++ b/docs/pages/components/auto-complete/index.md
@@ -22,6 +22,7 @@ import { AutoComplete } from 'rsuite';
 | data \*       | string[], Array&lt;[DataItemType](#types)&gt;                  | 组件数据                                |
 | defaultValue  | string                                                         | 设置默认值 `非受控`                     |
 | disabled      | boolean                                                        | 禁用组件                                |
+| filterBy      | (value: string, item: [DataItemType](#types)) => boolean       | 自定义每个item是否显示（默认只会显示data中value是它的子字符串的项）|
 | menuClassName | string                                                         | 选项菜单的 className                    |
 | onChange      | (value:string, event) => void                                  | `value` 发生改变时的回调函数            |
 | onClose       | () => void                                                     | 隐藏时的回调函数                        |

--- a/src/AutoComplete/AutoComplete.d.ts
+++ b/src/AutoComplete/AutoComplete.d.ts
@@ -15,6 +15,9 @@ export interface AutoCompleteProps extends StandardProps {
   /** Initial value */
   defaultValue?: string;
 
+  /** Custom filter function to determine whether the item will be displayed */
+  filterBy?: (value: string, item: ItemDataType) => boolean;
+
   /** Current value of the input. Creates a controlled component */
   value?: string;
 

--- a/src/AutoComplete/AutoComplete.tsx
+++ b/src/AutoComplete/AutoComplete.tsx
@@ -41,6 +41,7 @@ class AutoComplete extends React.Component<AutoCompleteProps, State> {
     style: PropTypes.object,
     open: PropTypes.bool,
     selectOnEnter: PropTypes.bool,
+    filterBy: PropTypes.func,
     onEnter: PropTypes.func,
     onEntering: PropTypes.func,
     onEntered: PropTypes.func,
@@ -116,7 +117,13 @@ class AutoComplete extends React.Component<AutoCompleteProps, State> {
   }
 
   shouldDisplay = (item: any) => {
+    const { filterBy } = this.props;
     const value = this.getValue();
+
+    if (typeof filterBy === 'function') {
+      return filterBy(value, item);
+    }
+
     if (!_.trim(value)) {
       return false;
     }

--- a/src/AutoComplete/test/AutoCompleteSpec.js
+++ b/src/AutoComplete/test/AutoCompleteSpec.js
@@ -229,4 +229,41 @@ describe('AutoComplete', () => {
     const instance = getDOMNode(<AutoComplete classPrefix="custom-prefix" />);
     assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
+
+  it('Should have a custom filter function', () => {
+    const instance1 = getInstance(
+      <AutoComplete data={['a', 'b', 'ab']} open defaultValue="a" filterBy={() => true} />
+    );
+
+    assert.equal(findDOMNode(instance1.menuContainerRef.current).querySelectorAll('li').length, 3);
+
+    const instance2 = getInstance(
+      <AutoComplete data={['a', 'b', 'ab']} open defaultValue="a" filterBy={() => false} />
+    );
+
+    assert.equal(findDOMNode(instance2.menuContainerRef.current).querySelectorAll('li').length, 0);
+
+    const instance3 = getInstance(
+      <AutoComplete
+        data={['a', 'b', 'ab']}
+        open
+        defaultValue="a"
+        // filterBy value only, so all item will be displayed
+        filterBy={value => value === 'a'}
+      />
+    );
+
+    assert.equal(findDOMNode(instance3.menuContainerRef.current).querySelectorAll('li').length, 3);
+
+    const instance4 = getInstance(
+      <AutoComplete
+        data={['a', 'b', 'ab']}
+        open
+        defaultValue="a"
+        filterBy={(_, item) => item.label && item.label.length >= 2}
+      />
+    );
+
+    assert.equal(findDOMNode(instance4.menuContainerRef.current).querySelectorAll('li').length, 1);
+  });
 });


### PR DESCRIPTION
Currently, <code>AutoComplete</code> will do this check `item.label.toLocaleLowerCase().indexOf(keyword) >= 0` to determine whether item in data array will be displayed.

I add `filterBy` param so we can use this param to determine whether to display an item in data array.

It this param present, the component will not use the default `shouldDisplay` logic any more. It's up to developer to control that logic.