### PR TITLE
Split FormControlAccepterProps from FormControlProps

### DIFF
--- a/src/FormControl/FormControl.d.ts
+++ b/src/FormControl/FormControl.d.ts
@@ -2,12 +2,33 @@ import * as React from 'react';
 
 import { TypeAttributes, StandardProps } from '../@types/common';
 
-export type FormControlProps<P = {}, ValueType = any> = StandardProps & {
-  /** Proxied components */
-  accepter?: React.ComponentType<P>;
+/**
+ * Props that FormControl passes to its accepter
+ */
+export interface FormControlAccepterProps<ValueType = any> {
+  /** The name of form-control */
+  name?: string;
+
+  defaultValue?: ValueType;
+
+  /** Value */
+  value?: ValueType;
 
   /** Callback fired when data changing */
-  onChange?: (value: ValueType, event: React.SyntheticEvent<HTMLElement>) => void;
+  onChange?(value: ValueType, event: React.SyntheticEvent<HTMLElement>): void;
+
+  /** Whether form-control readonly */
+  readOnly?: boolean;
+
+  onBlur?(event: React.SyntheticEvent<any>): void;
+}
+
+/**
+ * Props that <FormControl> itself takes
+ */
+export type FormControlProps<P = {}, ValueType = any> = StandardProps & {
+  /** Proxied components */
+  accepter?: React.ComponentType<P & FormControlAccepterProps<ValueType>>;
 
   /** The name of form-control */
   name?: string;
@@ -30,13 +51,11 @@ export type FormControlProps<P = {}, ValueType = any> = StandardProps & {
   /** Plain text when the control has no value */
   plaintextDefaultValue?: React.ReactNode;
 
-  /** Value */
-  value?: ValueType;
-
   /** Asynchronous check value */
   checkAsync?: boolean;
-} & P;
+};
 
-declare function FormControl<P = {}>(props: FormControlProps<P>): React.ReactElement;
+// FormControl also takes accepter's props and passes them down
+declare function FormControl<P = {}, ValueType = any>(props: FormControlProps<P, ValueType> & P): React.ReactElement;
 
 export default FormControl;

--- a/src/FormControl/FormControl.d.ts
+++ b/src/FormControl/FormControl.d.ts
@@ -56,6 +56,8 @@ export type FormControlProps<P = {}, ValueType = any> = StandardProps & {
 };
 
 // FormControl also takes accepter's props and passes them down
-declare function FormControl<P = {}, ValueType = any>(props: FormControlProps<P, ValueType> & P): React.ReactElement;
+declare function FormControl<P = {}, ValueType = any>(
+  props: FormControlProps<P, ValueType> & P
+): React.ReactElement;
 
 export default FormControl;

--- a/src/FormControl/FormControl.d.ts
+++ b/src/FormControl/FormControl.d.ts
@@ -33,6 +33,12 @@ export type FormControlProps<P = {}, ValueType = any> = StandardProps & {
   /** The name of form-control */
   name?: string;
 
+  /** Value */
+  value?: ValueType;
+
+  /** Callback fired when data changing */
+  onChange?(value: ValueType, event: React.SyntheticEvent<HTMLElement>): void;
+
   /** The data validation trigger type, and it wiill overrides the setting on <Form> */
   checkTrigger?: TypeAttributes.CheckTrigger;
 


### PR DESCRIPTION
当为 `<FormControl>` 编写自定义的 accepter 组件时，`FormControlProps` 可能被错误地用来为其 props 添加额外的字段。

```tsx
interface MyInputProps extends FormControlProps {
  myProp: string;
}

function MyInput({ value, onChange }: MyInputProps) {
  // do something with value and onChange
}

<FormControl accepter={MyInput} myProp="abc" />
```

而 `FormControlProps` 实际上是 `<FormControl>` 组件**自身**的 props 声明。如果需要一个 interface 来辅助编写 accepter 组件，应当另外声明如：

```ts
interface FormControlAccepterProps<ValueType = any> {
  value?: ValueType;
  onChange?(value: ValueType): void;
}
```

## Help Needed
在 `FormControlAccepterProps` 的用法上，我有一些尚未确定的考虑，希望可以听下其他人的意见。

我认为 accepter 组件的 props 本身不应 `extends FormControlAccepterProps`，而是组件接收 `Props & FormControlAccepterProps` 作为参数。

```tsx
interface MyInputProps {
  myProp: string;
}

function MyInput({ value, onChange }: MyInputProps & FormControlAccepterProps) {
  // do something with value and onChange
}

<FormControl accepter={MyInput} myProp="abc" />
```
这样一来，`MyInputProps` 中将不包含这个 `<MyInput>` 本身不对外接收的 props。尤其当有其他 interface 会 `extends MyInputProps` 时，可以避免引入多余的字段。在这个 PR 中，`<FormControl>` 继承 accepter 的 props 的方式也据此进行了调整。