### PR TITLE
 添加Form错误消息示列,用于需要有提示框效果的情况下,不使用Form的实现

### DIFF
--- a/docs/pages/components/form/en-US/error-message.md
+++ b/docs/pages/components/form/en-US/error-message.md
@@ -57,6 +57,13 @@ const App = () => {
           <div style={errorStyles(errorVisible)}>{errorMessage}</div>
         </FormGroup>
       </Form>
+      <hr/>
+      <div className={'rs-form-control-wrapper'} style={{width: 300}}>
+        <Input placeholder="Custom error messages"/>
+        <ErrorMessage show={errorVisible} placement={errorPlacement}>
+              {errorMessage}
+        </ErrorMessage>
+      </div>
       <hr />
       Show Error: <Toggle onChange={setErrorVisible} checked={errorVisible} />
       <SelectPicker

--- a/docs/pages/components/form/zh-CN/error-message.md
+++ b/docs/pages/components/form/zh-CN/error-message.md
@@ -57,6 +57,13 @@ const App = () => {
           <div style={errorStyles(errorVisible)}>{errorMessage}</div>
         </FormGroup>
       </Form>
+      <hr/>
+      <div className={'rs-form-control-wrapper'} style={{width: 300}}>
+        <Input placeholder="Custom error messages"/>
+        <ErrorMessage show={errorVisible} placement={errorPlacement}>
+              {errorMessage}
+        </ErrorMessage>
+      </div>
       <hr />
       Show Error: <Toggle onChange={setErrorVisible} checked={errorVisible} />
       <SelectPicker


### PR DESCRIPTION
场景：有些自定义错误的场景下，需要控件提示错误消息
![image](https://user-images.githubusercontent.com/22113151/87890170-ce4fcd00-ca67-11ea-9c5b-1a046b2f466b.png)

图中所示一样。
但是不需要使用Form嵌套，但是又需要以弹出框的方式展示。