### PR TITLE
fix(Panel): Missing panel border inside PanelGroup

### DIFF
--- a/src/PanelGroup/styles/common.less
+++ b/src/PanelGroup/styles/common.less
@@ -16,12 +16,12 @@
   }
 
   // Panel in Panel group haven't border.
-  &-group & {
+  &-group > & {
     border: none;
   }
 
   // Draw a split line for panel
-  &-group & + & {
+  &-group > & + & {
     position: relative;
 
     &::before {


### PR DESCRIPTION
在 `<PanelGroup>` 中使用 `<Panel>` 组件充当 "Card" 时，边框缺失。

```tsx
<PanelGroup>
  <Panel header="Products">
    {products.map((product, index) => (
      <Panel key={index} bordered> // borders missing
        <img src={proudct.thumbUrl} />
      </Panel>
    )}
  </Panel>
  // <Panel> ...
</PanelGroup>
```

对 `<PanelGroup>` 下的 `<Panel>` 进行 `border: none` 处理时，应当仅选中其直接子元素的 `<Panel>`。