### PR TITLE
fix(Steps): Children with Fragments

### DIFF
--- a/src/Steps/Steps.tsx
+++ b/src/Steps/Steps.tsx
@@ -43,7 +43,7 @@ class Steps extends React.Component<StepsProps> {
       [addPrefix('horizontal')]: horizontal
     });
 
-    const count = _.get(children, 'length');
+    const count = _.get(_.flatten(children), 'length');
     const items = ReactChildren.mapCloneElement(children, (item, index) => {
       const itemStyles = {
         [isIE10() ? 'msFlexPreferredSize' : 'flexBasis']:


### PR DESCRIPTION
`<Steps>` counts a `<Fragment>` in its children as one item, and applies styles incorrectly. 

```tsx
<Steps>
  {stages.map((stage, index) => (
    <Steps.Item key={index} title={stage.name} />
  )}
  <Steps.Item icon={<Icon icon="plus-circle" />} />
</Steps>
```

![image](https://user-images.githubusercontent.com/8225666/90358587-078c5480-e089-11ea-936b-9d98f6de2d65.png)
