### PR TITLE
fix(picker): adjust the verification rules for renderValue

### DIFF
--- a/src/Cascader/Cascader.tsx
+++ b/src/Cascader/Cascader.tsx
@@ -497,7 +497,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
      * 1.Have a value and the value is valid.
      * 2.Regardless of whether the value is valid, as long as renderValue is set, it is judged to have a value.
      */
-    const hasValue = activePaths.length > 0 || (!_.isNil(value) && _.isFunction(renderValue));
+    let hasValue = activePaths.length > 0 || (!_.isNil(value) && _.isFunction(renderValue));
 
     let activeItemLabel: any = placeholder;
 
@@ -518,6 +518,9 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
 
     if (!_.isNil(value) && _.isFunction(renderValue)) {
       activeItemLabel = renderValue(value, activePaths, activeItemLabel);
+      if (_.isNil(activeItemLabel)) {
+        hasValue = false;
+      }
     }
 
     const classes = getToggleWrapperClassName('cascader', this.addPrefix, this.props, hasValue);

--- a/src/Cascader/test/CascaderSpec.js
+++ b/src/Cascader/test/CascaderSpec.js
@@ -203,4 +203,14 @@ describe('Cascader', () => {
     const instance = getInstance(<Cascader open data={items} toggleComponentClass={Button} />);
     ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'rs-btn');
   });
+
+  it('Should call renderValue', () => {
+    const instance1 = getDOMNode(<Cascader value="Test" renderValue={() => '1'} />);
+    const instance2 = getDOMNode(<Cascader value="Test" renderValue={() => null} />);
+    const instance3 = getDOMNode(<Cascader value="Test" renderValue={() => undefined} />);
+
+    assert.equal(instance1.querySelector('.rs-picker-toggle-value').innerText, '1');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+  });
 });

--- a/src/CheckPicker/CheckPicker.tsx
+++ b/src/CheckPicker/CheckPicker.tsx
@@ -459,7 +459,7 @@ class CheckPicker extends React.Component<CheckPickerProps, CheckPickerState> {
      * 1.Have a value and the value is valid.
      * 2.Regardless of whether the value is valid, as long as renderValue is set, it is judged to have a value.
      */
-    const hasValue = selectedItems.length > 0 || (value?.length > 0 && _.isFunction(renderValue));
+    let hasValue = selectedItems.length > 0 || (value?.length > 0 && _.isFunction(renderValue));
 
     let selectedElement: React.ReactNode = placeholder;
 
@@ -477,6 +477,9 @@ class CheckPicker extends React.Component<CheckPickerProps, CheckPickerState> {
 
     if (value?.length > 0 && _.isFunction(renderValue)) {
       selectedElement = renderValue(value, selectedItems, selectedElement);
+      if (_.isNil(selectedElement)) {
+        hasValue = false;
+      }
     }
 
     const classes = getToggleWrapperClassName('check', this.addPrefix, this.props, hasValue);

--- a/src/CheckPicker/test/CheckPickerSpec.js
+++ b/src/CheckPicker/test/CheckPickerSpec.js
@@ -140,6 +140,16 @@ describe('CheckPicker', () => {
     assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
   });
 
+  it('Should call renderValue', () => {
+    const instance1 = getDOMNode(<Dropdown value="Test" renderValue={() => '1'} />);
+    const instance2 = getDOMNode(<Dropdown value="Test" renderValue={() => null} />);
+    const instance3 = getDOMNode(<Dropdown value="Test" renderValue={() => undefined} />);
+
+    assert.equal(instance1.querySelector('.rs-picker-toggle-value').innerText, '1');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+  });
+
   it('Should render a placeholder when value error', () => {
     const instance = getDOMNode(
       <Dropdown

--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -1165,13 +1165,8 @@ class CheckTreePicker extends React.Component<CheckTreePickerProps, CheckTreePic
       ...rest
     } = this.props;
     const { hasValue, selectedValues } = this.state;
-    const hasValidValue = hasValue || (selectedValues.length > 0 && _.isFunction(renderValue));
-    const classes = getToggleWrapperClassName(
-      'check-tree',
-      this.addPrefix,
-      this.props,
-      hasValidValue
-    );
+    let hasValidValue = hasValue || (selectedValues.length > 0 && _.isFunction(renderValue));
+
     const selectedItems = this.getSelectedItems(selectedValues);
     let selectedElement: React.ReactNode = placeholder;
 
@@ -1195,10 +1190,19 @@ class CheckTreePicker extends React.Component<CheckTreePickerProps, CheckTreePic
       }
       if (_.isFunction(renderValue)) {
         selectedElement = renderValue(selectedValues, selectedItems, selectedElement);
+        if (_.isNil(selectedElement)) {
+          hasValidValue = false;
+        }
       }
     }
 
     const unhandled = getUnhandledProps(CheckTreePicker, rest);
+    const classes = getToggleWrapperClassName(
+      'check-tree',
+      this.addPrefix,
+      this.props,
+      hasValidValue
+    );
     if (inline) {
       return this.renderCheckTree();
     }

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -371,4 +371,16 @@ describe('CheckTreePicker', () => {
     assert.equal(list.length, 1);
     assert.ok(list[0].innerText, 'Louisa');
   });
+
+  it('Should call renderValue', () => {
+    const instance1 = getDOMNode(<CheckTreePicker value={['test']} renderValue={() => '1'} />);
+    const instance2 = getDOMNode(<CheckTreePicker value={['test']} renderValue={() => null} />);
+    const instance3 = getDOMNode(
+      <CheckTreePicker value={['test']} renderValue={() => undefined} />
+    );
+
+    assert.equal(instance1.querySelector('.rs-picker-toggle-value').innerText, '1');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+  });
 });

--- a/src/InputPicker/InputPicker.tsx
+++ b/src/InputPicker/InputPicker.tsx
@@ -625,7 +625,7 @@ class InputPicker extends React.Component<InputPickerProps, InputPickerState> {
   }
 
   renderMultiValue() {
-    const { multi, disabled, tagProps = {}, renderValue } = this.props;
+    const { multi, disabled, tagProps = {}, renderValue, value } = this.props;
     if (!multi) {
       return null;
     }
@@ -657,7 +657,7 @@ class InputPicker extends React.Component<InputPickerProps, InputPickerState> {
       })
       .filter(item => item !== null);
 
-    if (tags.length > 0 && _.isFunction(renderValue)) {
+    if ((tags.length > 0 || !_.isNil(value)) && _.isFunction(renderValue)) {
       return renderValue(this.getValue(), items, tagElements);
     }
 
@@ -715,8 +715,9 @@ class InputPicker extends React.Component<InputPickerProps, InputPickerState> {
      * 1.Have a value and the value is valid.
      * 2.Regardless of whether the value is valid, as long as renderValue is set, it is judged to have a value.
      */
-    const hasSingleValue = !_.isNil(value) && _.isFunction(renderValue);
-    const hasMultiValue = _.isArray(value) && value.length > 0 && _.isFunction(renderValue);
+    const hasSingleValue = !_.isNil(value) && _.isFunction(renderValue) && !_.isNil(displayElement);
+    const hasMultiValue =
+      _.isArray(value) && value.length > 0 && _.isFunction(renderValue) && !_.isNil(tagElements);
     const hasValue = multi
       ? !!_.get(tagElements, 'length') || hasMultiValue
       : isValid || hasSingleValue;

--- a/src/InputPicker/test/InputPickerSpec.js
+++ b/src/InputPicker/test/InputPickerSpec.js
@@ -311,4 +311,14 @@ describe('InputPicker', () => {
     assert.equal(list.length, 1);
     assert.ok(list[0].innerText, 'Louisa');
   });
+
+  it('Should call renderValue', () => {
+    const instance1 = getDOMNode(<InputPicker value="Test" renderValue={() => '1'} />);
+    const instance2 = getDOMNode(<InputPicker value="Test" renderValue={() => null} />);
+    const instance3 = getDOMNode(<InputPicker value="Test" renderValue={() => undefined} />);
+
+    assert.equal(instance1.querySelector('.rs-picker-toggle-value').innerText, '1');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+  });
 });

--- a/src/MultiCascader/MultiCascader.tsx
+++ b/src/MultiCascader/MultiCascader.tsx
@@ -486,7 +486,7 @@ class MultiCascader extends React.Component<MultiCascaderProps, MultiCascaderSta
      * 1.Have a value and the value is valid.
      * 2.Regardless of whether the value is valid, as long as renderValue is set, it is judged to have a value.
      */
-    const hasValue =
+    let hasValue =
       selectedItems.length > 0 || (this.props.value?.length > 0 && _.isFunction(renderValue));
 
     let selectedElement: React.ReactNode = placeholder;
@@ -512,6 +512,9 @@ class MultiCascader extends React.Component<MultiCascaderProps, MultiCascaderSta
         selectedItems,
         selectedElement
       );
+      if (_.isNil(selectedElement)) {
+        hasValue = false;
+      }
     }
 
     const classes = getToggleWrapperClassName('cascader', this.addPrefix, this.props, hasValue);

--- a/src/MultiCascader/test/MultiCascaderSpec.js
+++ b/src/MultiCascader/test/MultiCascaderSpec.js
@@ -275,4 +275,14 @@ describe('MultiCascader', () => {
     const instance = getInstance(<Dropdown open data={items} toggleComponentClass={Button} />);
     ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'rs-btn');
   });
+
+  it('Should call renderValue', () => {
+    const instance1 = getDOMNode(<Dropdown value="Test" renderValue={() => '1'} />);
+    const instance2 = getDOMNode(<Dropdown value="Test" renderValue={() => null} />);
+    const instance3 = getDOMNode(<Dropdown value="Test" renderValue={() => undefined} />);
+
+    assert.equal(instance1.querySelector('.rs-picker-toggle-value').innerText, '1');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+  });
 });

--- a/src/SelectPicker/SelectPicker.tsx
+++ b/src/SelectPicker/SelectPicker.tsx
@@ -402,7 +402,7 @@ class SelectPicker extends React.Component<SelectPickerProps, SelectPickerState>
      * 1.Have a value and the value is valid.
      * 2.Regardless of whether the value is valid, as long as renderValue is set, it is judged to have a value.
      */
-    const hasValue = !!activeItem || (!_.isNil(value) && _.isFunction(renderValue));
+    let hasValue = !!activeItem || (!_.isNil(value) && _.isFunction(renderValue));
 
     let selectedElement: React.ReactNode = placeholder;
 
@@ -412,6 +412,9 @@ class SelectPicker extends React.Component<SelectPickerProps, SelectPickerState>
 
     if (!_.isNil(value) && _.isFunction(renderValue)) {
       selectedElement = renderValue(value, activeItem, selectedElement);
+      if (_.isNil(selectedElement)) {
+        hasValue = false;
+      }
     }
 
     const classes = getToggleWrapperClassName('select', this.addPrefix, this.props, hasValue);

--- a/src/TagPicker/test/TagPickerSpec.js
+++ b/src/TagPicker/test/TagPickerSpec.js
@@ -341,4 +341,14 @@ describe('TagPicker', () => {
     );
     assert.equal(instance.querySelector('.rs-tag').tagName, 'SPAN');
   });
+
+  it('Should call renderValue', () => {
+    const instance1 = getDOMNode(<TagPicker value={['Test']} renderValue={() => '1'} />);
+    const instance2 = getDOMNode(<TagPicker value={['Test']} renderValue={() => null} />);
+    const instance3 = getDOMNode(<TagPicker value={['Test']} renderValue={() => undefined} />);
+
+    assert.equal(instance1.querySelector('.rs-picker-tag-wrapper').innerText, '1');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+  });
 });

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -1073,9 +1073,8 @@ class TreePicker extends React.Component<TreePickerProps, TreePickerState> {
       ...rest
     } = this.props;
     const { selectedValue, activeNode } = this.state;
-    const hasValidValue =
+    let hasValidValue =
       !_.isNil(activeNode) || (!_.isNil(selectedValue) && _.isFunction(renderValue));
-    const classes = getToggleWrapperClassName('tree', this.addPrefix, this.props, hasValidValue);
 
     let selectedElement: React.ReactNode = placeholder;
     const hasValue = !!activeNode;
@@ -1091,10 +1090,15 @@ class TreePicker extends React.Component<TreePickerProps, TreePickerState> {
       if (_.isFunction(renderValue)) {
         const node = activeNode ?? {};
         selectedElement = renderValue(selectedValue, node, selectedElement);
+
+        if (_.isNil(selectedElement)) {
+          hasValidValue = false;
+        }
       }
     }
 
     const unhandled = getUnhandledProps(TreePicker, rest);
+    const classes = getToggleWrapperClassName('tree', this.addPrefix, this.props, hasValidValue);
 
     if (inline) {
       return this.renderTree();

--- a/src/TreePicker/test/TreePickerSpec.js
+++ b/src/TreePicker/test/TreePickerSpec.js
@@ -389,4 +389,14 @@ describe('TreePicker', () => {
     assert.equal(list.length, 1);
     assert.ok(list[0].innerText, 'Louisa');
   });
+
+  it('Should call renderValue', () => {
+    const instance1 = getDOMNode(<TreePicker value="Test" renderValue={() => '1'} />);
+    const instance2 = getDOMNode(<TreePicker value="Test" renderValue={() => null} />);
+    const instance3 = getDOMNode(<TreePicker value="Test" renderValue={() => undefined} />);
+
+    assert.equal(instance1.querySelector('.rs-picker-toggle-value').innerText, '1');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+  });
 });


### PR DESCRIPTION
When renderValue returns null or undefined, it is considered that there is no value.