### PR TITLE
Reconsidered onChange prop for controlled components

### DIFF
--- a/src/@types/common.ts
+++ b/src/@types/common.ts
@@ -119,6 +119,29 @@ export interface PickerBaseProps<LocaleType = any> extends WithAsProps, Animatio
   renderExtraFooter?: () => React.ReactNode;
 }
 
+export interface ControlledComponentProps<ValueType = any> {
+  /** Initial value */
+  defaultValue?: ValueType;
+
+  /** Current value of the component. Creates a controlled component */
+  value?: ValueType;
+
+  /** Called after the value has been changed */
+  onChange?: (event: React.ChangeEvent) => void;
+
+  /** Make the control readonly */
+  readOnly?: boolean;
+}
+
+export interface FormControlComponentProps<ValueType = any>
+  extends ControlledComponentProps<ValueType> {
+  /** Set the component to be disabled and cannot be entered */
+  disabled?: boolean;
+
+  /** Render the control as plain text */
+  plaintext?: boolean;
+}
+
 export interface FormControlBaseProps<ValueType = any> {
   /** Initial value */
   defaultValue?: ValueType;

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -2,24 +2,15 @@ import React, { useContext, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useControlled, partitionHTMLProps, useClassNames, TypeChecker } from '../utils';
 import { CheckboxGroupContext } from '../CheckboxGroup';
-import { WithAsProps, RsRefForwardingComponent } from '../@types/common';
+import { WithAsProps, RsRefForwardingComponent, FormControlComponentProps } from '../@types/common';
 
 export type ValueType = string | number;
-export interface CheckboxProps<V = ValueType> extends WithAsProps {
+export interface CheckboxProps<V = ValueType> extends WithAsProps, FormControlComponentProps<V> {
   /** HTML title */
   title?: string;
 
   /** Inline layout */
   inline?: boolean;
-
-  /** A checkbox can appear disabled and be unable to change states */
-  disabled?: boolean;
-
-  /** Make the control readonly */
-  readOnly?: boolean;
-
-  /** Render the control as plain text */
-  plaintext?: boolean;
 
   /** Whether or not checkbox is checked. */
   checked?: boolean;
@@ -31,13 +22,10 @@ export interface CheckboxProps<V = ValueType> extends WithAsProps {
   indeterminate?: boolean;
 
   /** Attributes applied to the input element. */
-  inputProps?: React.HTMLAttributes<HTMLInputElement>;
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 
   /** Pass a ref to the input element. */
   inputRef?: React.Ref<any>;
-
-  /** The HTML input value. */
-  value?: V;
 
   /** A checkbox can receive focus. */
   tabIndex?: number;
@@ -47,9 +35,6 @@ export interface CheckboxProps<V = ValueType> extends WithAsProps {
 
   /** Used for the name of the form */
   name?: string;
-
-  /** Called when the user attempts to change the checked state. */
-  onChange?: (value: V, checked: boolean, event: React.SyntheticEvent<HTMLInputElement>) => void;
 
   /** Called when the checkbox or label is clicked. */
   onClick?: (event: React.SyntheticEvent<HTMLElement>) => void;
@@ -122,7 +107,7 @@ const Checkbox: RsRefForwardingComponent<'div', CheckboxProps> = React.forwardRe
     }
 
     const handleChange = useCallback(
-      (event: React.SyntheticEvent<HTMLInputElement>) => {
+      (event: React.ChangeEvent<HTMLInputElement>) => {
         const nextChecked = !checked;
 
         if (disabled || readOnly) {
@@ -130,7 +115,7 @@ const Checkbox: RsRefForwardingComponent<'div', CheckboxProps> = React.forwardRe
         }
 
         setChecked(nextChecked);
-        onChange?.(value, nextChecked, event);
+        onChange?.(event);
         onGroupChange?.(value, nextChecked, event);
       },
       [checked, disabled, readOnly, setChecked, onChange, value, onGroupChange]

--- a/src/Checkbox/test/CheckboxSpec.js
+++ b/src/Checkbox/test/CheckboxSpec.js
@@ -49,20 +49,17 @@ describe('Checkbox', () => {
     assert.equal(input.tagName, 'INPUT');
   });
 
-  it('Should call onChange callback', done => {
+  it('Should call onChange callback with correct value', () => {
     const value = 'Test';
-    const doneOp = data => {
-      if (data === value) {
-        done();
-      }
-    };
+    const onChangeSpy = sinon.spy();
 
     const instance = getDOMNode(
-      <Checkbox onChange={doneOp} value={value}>
+      <Checkbox onChange={onChangeSpy} value={value}>
         Title
       </Checkbox>
     );
     ReactTestUtils.Simulate.change(instance.querySelector('input'));
+    assert.equal(onChangeSpy.getCall(0).args[0].target.value, value);
   });
 
   it('Should call onClick callback', done => {
@@ -89,32 +86,28 @@ describe('Checkbox', () => {
     ReactTestUtils.Simulate.focus(instance.querySelector('input'));
   });
 
-  it('Should be checked with change', done => {
-    const doneOp = (value, checked) => {
-      if (checked) {
-        done();
-      }
-    };
+  it('Should be checked with change', () => {
+    const onChangeSpy = sinon.spy();
 
-    const instance = getDOMNode(<Checkbox onChange={doneOp}>Title</Checkbox>);
-
-    ReactTestUtils.Simulate.change(instance.querySelector('input'));
+    const instance = getDOMNode(<Checkbox onChange={onChangeSpy}>Title</Checkbox>);
+    const input = instance.querySelector('input');
+    input.checked = true;
+    ReactTestUtils.Simulate.change(input);
+    assert.equal(onChangeSpy.getCall(0).args[0].target.checked, true);
   });
 
-  it('Should be unchecked with change', done => {
-    const doneOp = checked => {
-      if (!checked) {
-        done();
-      }
-    };
+  it('Should be unchecked with change', () => {
+    const onChangeSpy = sinon.spy();
 
     const instance = getDOMNode(
-      <Checkbox onChange={doneOp} checked>
+      <Checkbox onChange={onChangeSpy} checked>
         Title
       </Checkbox>
     );
-
-    ReactTestUtils.Simulate.change(instance.querySelector('input'));
+    const input = instance.querySelector('input');
+    input.checked = false;
+    ReactTestUtils.Simulate.change(input);
+    assert.equal(onChangeSpy.getCall(0).args[0].target.checked, false);
   });
 
   it('Should have a custom className', () => {

--- a/src/FormControl/FormControl.tsx
+++ b/src/FormControl/FormControl.tsx
@@ -106,10 +106,20 @@ const FormControl: RsRefForwardingComponent<'div', FormControlProps> = React.for
     const { withClassPrefix, prefix, merge } = useClassNames(classPrefix);
     const classes = merge(className, withClassPrefix('wrapper'));
 
-    const handleFieldChange = (value: any, event: React.SyntheticEvent<any>) => {
-      handleFieldCheck(value, trigger === 'change');
-      onFieldChange?.(name, value, event);
-      onChange?.(value, event);
+    const handleFieldChange = (
+      value: React.ChangeEvent | any,
+      event: React.SyntheticEvent<any>
+    ) => {
+      // React.ChangeEvent
+      if ('target' in value) {
+        handleFieldCheck(value.target.value, trigger === 'change');
+        onFieldChange?.(name ?? value.target.name, value.target.value, value);
+        onChange?.(value.target.value, value);
+      } else {
+        handleFieldCheck(value, trigger === 'change');
+        onFieldChange?.(name, value, event);
+        onChange?.(value, event);
+      }
     };
 
     const handleFieldBlur = (event: React.FocusEvent<HTMLFormElement>) => {

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -8,7 +8,7 @@ import {
   WithAsProps,
   RsRefForwardingComponent,
   TypeAttributes,
-  FormControlBaseProps
+  FormControlComponentProps
 } from '../@types/common';
 
 export interface LocaleType {
@@ -18,7 +18,7 @@ export interface LocaleType {
 export interface InputProps
   extends WithAsProps,
     Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'size'>,
-    FormControlBaseProps<string | number | ReadonlyArray<string>> {
+    FormControlComponentProps<string | number | ReadonlyArray<string>> {
   /** The HTML input type */
   type?: string;
 
@@ -74,13 +74,6 @@ const Input: RsRefForwardingComponent<'input', InputProps> = React.forwardRef(
       [onPressEnter, onKeyDown]
     );
 
-    const handleChange = useCallback(
-      (event: React.ChangeEvent<HTMLInputElement>) => {
-        onChange?.(event.target?.value, event);
-      },
-      [onChange]
-    );
-
     const { withClassPrefix, merge } = useClassNames(classPrefix);
     const classes = merge(className, withClassPrefix(size, { plaintext }));
     const inputGroupContext = useContext(InputGroupContext);
@@ -97,10 +90,10 @@ const Input: RsRefForwardingComponent<'input', InputProps> = React.forwardRef(
     }
 
     const operable = !disabled && !readOnly;
-    const eventProps: React.HTMLAttributes<HTMLInputElement> = {};
+    const eventProps: React.InputHTMLAttributes<HTMLInputElement> = {};
 
     if (operable) {
-      eventProps.onChange = handleChange;
+      eventProps.onChange = onChange;
       eventProps.onKeyDown = handleKeyDown;
       eventProps.onFocus = createChainedFunction(onFocus, inputGroupContext?.onFocus);
       eventProps.onBlur = createChainedFunction(onBlur, inputGroupContext?.onBlur);

--- a/src/InputNumber/InputNumber.tsx
+++ b/src/InputNumber/InputNumber.tsx
@@ -209,7 +209,10 @@ const InputNumber = React.forwardRef((props: InputNumberProps, ref) => {
   );
 
   const handleChange = useCallback(
-    (value: any, event: React.SyntheticEvent<any>) => {
+    (event: React.ChangeEvent<any>) => {
+      const {
+        target: { value }
+      } = event;
       if (!/^-?(?:\d+)?(\.)?(\d+)*$/.test(value) && value !== '') {
         return;
       }

--- a/src/Radio/Radio.tsx
+++ b/src/Radio/Radio.tsx
@@ -2,12 +2,13 @@ import React, { useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { RadioContext } from '../RadioGroup/RadioGroup';
 import { useClassNames, useControlled, partitionHTMLProps, TypeChecker } from '../utils';
-import { WithAsProps } from '../@types/common';
+import { FormControlComponentProps, WithAsProps } from '../@types/common';
 
 export type ValueType = string | number;
 export interface RadioProps<T = ValueType>
   extends WithAsProps,
-    Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
+    Omit<React.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'>,
+    FormControlComponentProps<T> {
   /** HTML title */
   title?: string;
 
@@ -22,9 +23,6 @@ export interface RadioProps<T = ValueType>
 
   /** Specifies whether the radio is selected */
   checked?: boolean;
-
-  /** Specifies the initial state: whether or not the radio is selected */
-  defaultChecked?: boolean;
 
   /** Attributes applied to the input element. */
   inputProps?: React.HTMLAttributes<HTMLInputElement>;
@@ -43,9 +41,6 @@ export interface RadioProps<T = ValueType>
 
   /** Primary content */
   children?: React.ReactNode;
-
-  /** Callback function with value changed */
-  onChange?: (value: T, checked: boolean, event: React.SyntheticEvent<HTMLInputElement>) => void;
 }
 
 const defaultProps: Partial<RadioProps> = {
@@ -105,8 +100,8 @@ const Radio = React.forwardRef((props: RadioProps, ref) => {
       }
 
       setChecked(true);
-      onGroupChange?.(value, event);
-      onChange?.(value, true, event);
+      onGroupChange?.(event);
+      onChange?.(event);
     },
     [disabled, onChange, onGroupChange, readOnly, setChecked, value]
   );

--- a/src/Radio/test/RadioSpec.js
+++ b/src/Radio/test/RadioSpec.js
@@ -63,10 +63,9 @@ describe('Radio', () => {
 
   it('Should call onChange callback', done => {
     const value = 'Test';
-    const doneOp = data => {
-      if (data === value) {
-        done();
-      }
+    const doneOp = event => {
+      assert.equal(event.target.value, value);
+      done();
     };
 
     const instance = getDOMNode(
@@ -94,8 +93,8 @@ describe('Radio', () => {
   });
 
   it('Should be checked with change', done => {
-    const doneOp = checked => {
-      if (checked === '100') {
+    const doneOp = event => {
+      if (event.target.value === '100') {
         done();
       }
     };

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useClassNames, useControlled } from '../utils';
-import { WithAsProps, FormControlBaseProps, RsRefForwardingComponent } from '../@types/common';
+import { WithAsProps, RsRefForwardingComponent, FormControlComponentProps } from '../@types/common';
 import { ValueType } from '../Radio';
 import Plaintext from '../Plaintext';
 
@@ -13,10 +13,10 @@ export interface RadioContextProps {
   disabled?: boolean;
   readOnly?: boolean;
   plaintext?: boolean;
-  onChange?: (value: ValueType, event: React.SyntheticEvent<HTMLInputElement>) => void;
+  onChange?: FormControlComponentProps['onChange'];
 }
 
-export interface RadioGroupProps<T = ValueType> extends WithAsProps, FormControlBaseProps<T> {
+export interface RadioGroupProps<T = ValueType> extends WithAsProps, FormControlComponentProps<T> {
   /** A radio group can have different appearances */
   appearance?: 'default' | 'picker';
 
@@ -55,14 +55,14 @@ const RadioGroup: RsRefForwardingComponent<'div', RadioGroupProps> = React.forwa
     const [value, setValue, isControlled] = useControlled(valueProp, defaultValue);
 
     const handleChange = useCallback(
-      (nextValue: ValueType, event: React.ChangeEvent<HTMLInputElement>) => {
-        setValue(nextValue);
-        onChange?.(nextValue, event);
+      (event: React.ChangeEvent<HTMLInputElement>) => {
+        setValue(event.target.value);
+        onChange?.(event);
       },
       [onChange, setValue]
     );
 
-    const contextValue = useMemo(
+    const contextValue = useMemo<RadioContextProps>(
       () => ({
         inline,
         name,

--- a/src/RadioGroup/test/RadioGroupSpec.js
+++ b/src/RadioGroup/test/RadioGroupSpec.js
@@ -75,15 +75,10 @@ describe('RadioGroup', () => {
     assert.ok(radios[1].className.match(/\bradio-checked\b/));
   });
 
-  it('Should call onChange callback', done => {
+  it('Should call onChange callback with correct value', () => {
+    const onChangeSpy = sinon.spy();
     const instance = getDOMNode(
-      <RadioGroup
-        onChange={value => {
-          if (value === 3) {
-            done();
-          }
-        }}
-      >
+      <RadioGroup onChange={onChangeSpy}>
         <Radio value={1}>Test1</Radio>
         <Radio value={2}>Test2</Radio>
         <Radio value={3}>Test2</Radio>
@@ -93,9 +88,10 @@ describe('RadioGroup', () => {
 
     const radios = instance.querySelectorAll('.rs-radio');
     ReactTestUtils.Simulate.change(radios[2].querySelector('input'));
+    assert.equal(onChangeSpy.getCall(0).args[0].target.value, 3);
   });
 
-  it('Should call onChange callback', done => {
+  it('Should call Radio onChange callback', done => {
     let count = 0;
 
     function onDone() {
@@ -120,16 +116,10 @@ describe('RadioGroup', () => {
     ReactTestUtils.Simulate.change(radios[2].querySelector('input'));
   });
 
-  it('Should call onChange callback and return correct parameters', done => {
+  it('Should call onChange callback and return correct parameters', () => {
+    const onChangeSpy = sinon.spy();
     const instance = getDOMNode(
-      <RadioGroup
-        name="test"
-        onChange={(value, event) => {
-          if (value === 3 && event.target.name === 'test') {
-            done();
-          }
-        }}
-      >
+      <RadioGroup name="test" onChange={onChangeSpy}>
         <Radio value={1}>Test1</Radio>
         <Radio value={2}>Test2</Radio>
         <Radio value={3}>Test2</Radio>
@@ -139,6 +129,9 @@ describe('RadioGroup', () => {
 
     const radios = instance.querySelectorAll('.rs-radio');
     ReactTestUtils.Simulate.change(radios[2].querySelector('input'));
+    const event = onChangeSpy.getCall(0).args[0];
+    assert.equal(event.target.value, 3);
+    assert.equal(event.target.name, 'test');
   });
 
   it('Should be selected as false', () => {


### PR DESCRIPTION
Controlled components for forms is supposed to have `value` and `onChange` props. In past versions, controlled components like `<Input>` calls its `onChange` callback with the updated value as the first argument:

```jsx
const [inputValue, setInputValue] = useState('');

<Input value={inputValue} onChange={newValue => setInputValue(newValue)} />
```

This signature does not resemble the way native `<input onChange>` works, where first argument is a `React.ChangeEvent`. The problem it causes is that we cannot get the `name` attribute from the `onChange` callback, making form components less form-friendly.

In this PR, most controlled components will adopt the native style `onChange` props, and most of them will directly pass `onChange` down to the native form elements under the hood, making the mechanism straight-forward.

## ⚠️ BREAKING CHANGE

The `onChange(value)` signature will be no longer supported.

### Before
```jsx
const [inputValue, setInputValue] = useState('');

<Input value={inputValue} onChange={newValue => setInputValue(newValue)} />
```

### After
```jsx
const [inputValue, setInputValue] = useState('');

<Input value={inputValue} onChange={event => setInputValue(event.target.value)} />
```

## Checklist
- [ ] Checkbox
- [x] Radio
- [x] Input
- [ ] InputNumber
- [ ] AutoComplete
- [ ] Toggle
- [ ] InputPicker
- [ ] TagPicker
- [ ] SelectPicker
- [ ] CheckPicker
- [ ] TreePicker
- [ ] CheckTreePicker
- [ ] Cascader
- [ ] MultiCascader
- [ ] DatePicker
- [ ] DateRangePicker
- [ ] Slider
- [ ] Rate