### PR TITLE
Prevent notice for overlay

### DIFF
--- a/src/Overlay/Overlay.tsx
+++ b/src/Overlay/Overlay.tsx
@@ -32,7 +32,7 @@ const Overlay = ({ animation = true, children, transition = Fade, ...rest }: Ove
 
 Overlay.propTypes = {
   animation: PropTypes.bool,
-  container: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  container: PropTypes.any,
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   onRendered: PropTypes.func,
   className: PropTypes.string,


### PR DESCRIPTION
```container``` should contain an HTML Element as stated in the interface. 

This ```PropType``` is incorrect and causes notices. Updated to ```any``` like in ```next```-branch.