### PR TITLE
[v4] aria-disabled for picker toggles

### DIFF
--- a/src/Cascader/Cascader.tsx
+++ b/src/Cascader/Cascader.tsx
@@ -543,6 +543,7 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
               cleanable={cleanable && !disabled}
               hasValue={hasValue}
               active={active}
+              aria-disabled={disabled}
             >
               {activeItemLabel || <FormattedMessage id="placeholder" />}
             </PickerToggle>

--- a/src/Cascader/test/CascaderSpec.js
+++ b/src/Cascader/test/CascaderSpec.js
@@ -41,6 +41,7 @@ describe('Cascader', () => {
     const instance = getDOMNode(<Cascader disabled />);
 
     assert.ok(instance.className.match(/\bdisabled\b/));
+    assert.equal(instance.querySelector('[role=combobox]').getAttribute('aria-disabled'), 'true');
   });
 
   it('Should be inline', () => {

--- a/src/CheckPicker/CheckPicker.tsx
+++ b/src/CheckPicker/CheckPicker.tsx
@@ -505,6 +505,7 @@ class CheckPicker extends React.Component<CheckPickerProps, CheckPickerState> {
               cleanable={cleanable && !disabled}
               hasValue={hasValue}
               active={this.state.active}
+              aria-disabled={disabled}
             >
               {selectedElement || <FormattedMessage id="placeholder" />}
             </PickerToggle>

--- a/src/CheckPicker/test/CheckPickerSpec.js
+++ b/src/CheckPicker/test/CheckPickerSpec.js
@@ -63,6 +63,7 @@ describe('CheckPicker', () => {
     const instance = getDOMNode(<Dropdown disabled />);
 
     assert.ok(instance.className.match(/\bdisabled\b/));
+    assert.equal(instance.querySelector('[role=combobox]').getAttribute('aria-disabled'), 'true');
   });
 
   it('Should be block', () => {

--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -1226,6 +1226,7 @@ class CheckTreePicker extends React.Component<CheckTreePickerProps, CheckTreePic
             cleanable={cleanable && !disabled}
             hasValue={hasValidValue}
             active={this.state.active}
+            aria-disabled={disabled}
           >
             {selectedElement || locale.placeholder}
           </PickerToggle>

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -72,6 +72,7 @@ describe('CheckTreePicker', () => {
     const instance = getDOMNode(<CheckTreePicker disabled data={[]} />);
 
     assert.ok(instance.className.match(/\bdisabled\b/));
+    assert.equal(instance.querySelector('[role=combobox]').getAttribute('aria-disabled'), 'true');
   });
 
   it('Should be block', () => {

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -442,6 +442,7 @@ class DatePicker extends React.Component<DatePickerProps, DatePickerState> {
               cleanable={cleanable && !disabled}
               hasValue={hasValue}
               active={this.state.active}
+              aria-disabled={disabled}
             >
               {this.getDateString()}
             </PickerToggle>

--- a/src/DatePicker/test/DatePickerSpec.js
+++ b/src/DatePicker/test/DatePickerSpec.js
@@ -15,6 +15,7 @@ describe('DatePicker', () => {
   it('Should be disabled', () => {
     const instance = getDOMNode(<DatePicker disabled />);
     assert.ok(instance.className.match(/\bdisabled\b/));
+    assert.equal(instance.querySelector('[role=combobox]').getAttribute('aria-disabled'), 'true');
   });
 
   it('Should be not cleanable', () => {

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -570,6 +570,7 @@ class DateRangePicker extends React.Component<DateRangePickerProps, DateRangePic
               cleanable={cleanable && !disabled}
               hasValue={hasValue}
               active={this.state.active}
+              aria-disabled={disabled}
             >
               {this.getDateString()}
             </PickerToggle>

--- a/src/DateRangePicker/test/DateRangePickerSpec.js
+++ b/src/DateRangePicker/test/DateRangePickerSpec.js
@@ -16,6 +16,7 @@ describe('DateRangePicker', () => {
   it('Should be disabled', () => {
     const instance = getDOMNode(<DateRangePicker disabled />);
     assert.ok(instance.className.match(/\bdisabled\b/));
+    assert.equal(instance.querySelector('[role=combobox]').getAttribute('aria-disabled'), 'true');
   });
 
   it('Should be disabled date', () => {

--- a/src/MultiCascader/MultiCascader.tsx
+++ b/src/MultiCascader/MultiCascader.tsx
@@ -536,6 +536,7 @@ class MultiCascader extends React.Component<MultiCascaderProps, MultiCascaderSta
             cleanable={cleanable && !disabled}
             hasValue={hasValue}
             active={this.state.active}
+            aria-disabled={disabled}
           >
             {selectedElement || locale.placeholder}
           </PickerToggle>

--- a/src/MultiCascader/test/MultiCascaderSpec.js
+++ b/src/MultiCascader/test/MultiCascaderSpec.js
@@ -108,6 +108,7 @@ describe('MultiCascader', () => {
     const instance = getDOMNode(<Dropdown disabled />);
 
     assert.ok(instance.className.match(/\bdisabled\b/));
+    assert.equal(instance.querySelector('[role=combobox]').getAttribute('aria-disabled'), 'true');
   });
 
   it('Should be inline', () => {

--- a/src/SelectPicker/SelectPicker.tsx
+++ b/src/SelectPicker/SelectPicker.tsx
@@ -438,6 +438,7 @@ class SelectPicker extends React.Component<SelectPickerProps, SelectPickerState>
             cleanable={cleanable && !disabled}
             hasValue={hasValue}
             active={this.state.active}
+            aria-disabled={disabled}
           >
             {selectedElement || locale.placeholder}
           </PickerToggle>

--- a/src/SelectPicker/test/SelectPickerSpec.js
+++ b/src/SelectPicker/test/SelectPickerSpec.js
@@ -60,6 +60,7 @@ describe('SelectPicker', () => {
     const instance = getDOMNode(<Dropdown disabled />);
     const instanceDom = instance;
     assert.ok(instanceDom.className.match(/\bdisabled\b/));
+    assert.equal(instance.querySelector('[role=combobox]').getAttribute('aria-disabled'), 'true');
   });
 
   it('Should output a button', () => {

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -1123,6 +1123,7 @@ class TreePicker extends React.Component<TreePickerProps, TreePickerState> {
             componentClass={toggleComponentClass}
             hasValue={hasValidValue}
             active={this.state.active}
+            aria-disabled={disabled}
           >
             {selectedElement || locale.placeholder}
           </PickerToggle>

--- a/src/TreePicker/test/TreePickerSpec.js
+++ b/src/TreePicker/test/TreePickerSpec.js
@@ -73,6 +73,7 @@ describe('TreePicker', () => {
     const instance = getDOMNode(<TreePicker disabled data={[]} />);
 
     assert.ok(instance.className.match(/\bdisabled\b/));
+    assert.equal(instance.querySelector('[role=combobox]').getAttribute('aria-disabled'), 'true');
   });
 
   it('Should be block', () => {


### PR DESCRIPTION
Add `aria-disabled=true` to pickers' toggles when they are disabled.

### Pickers with toggle
- [x] SelectPicker
- [x] CheckPicker
- [x] TreePicker
- [x] CheckTreePicker
- [x] Cascader
- [x] MultiCascader
- [x] DatePicker
- [x] DateRangePicker
