### PR TITLE
fix(modal): remove duplicated dialog role

### DIFF
--- a/src/Modal/BaseModal.tsx
+++ b/src/Modal/BaseModal.tsx
@@ -269,12 +269,7 @@ class BaseModal extends React.Component<BaseModalProps, BaseModalState> {
 
     return (
       <Portal ref={this.setMountNodeRef} container={container}>
-        <div
-          ref={this.modalNodeRef}
-          role={rest.role || 'dialog'}
-          style={style}
-          className={className}
-        >
+        <div ref={this.modalNodeRef} role={rest.role} style={style} className={className}>
           {backdrop && this.renderBackdrop()}
           <RefHolder ref={this.dialogRef}>{dialog}</RefHolder>
         </div>

--- a/src/Modal/test/ModalSpec.js
+++ b/src/Modal/test/ModalSpec.js
@@ -5,6 +5,19 @@ import { getInstance } from '@test/testUtils';
 import Modal from '../Modal';
 
 describe('Modal', () => {
+  it('Should render exactly one element with dialog role', () => {
+    const instance = getInstance(
+      <Modal show>
+        <p>message</p>
+      </Modal>
+    );
+
+    assert.notOk(
+      instance.modalRef.current.getDialogElement().parentNode.closest('[role="dialog"]')
+    );
+    assert.equal(instance.modalRef.current.getDialogElement().getAttribute('role'), 'dialog');
+  });
+
   it('Should render the modal content', () => {
     const instance = getInstance(
       <Modal show>


### PR DESCRIPTION
`Modal` was rendering duplicated `role=dialog` elements.

![image](https://user-images.githubusercontent.com/8225666/106349232-47798800-6307-11eb-9263-7c085bdc263a.png)

This PR removes the role on the outer div. 