### PR TITLE
feat(whisper): support `onClose` on the `speaker` prop of Whisper

### DIFF
--- a/docs/pages/components/popover/en-US/overlay.md
+++ b/docs/pages/components/popover/en-US/overlay.md
@@ -3,18 +3,23 @@
 <!--start-code-->
 
 ```js
-const Overlay = React.forwardRef(({ style, ...rest }, ref) => {
+const Overlay = React.forwardRef(({ style, onClose, ...rest }, ref) => {
   const styles = {
     ...style,
-    background: '#000',
-    padding: 20,
+    background: '#fff',
+    width: 200,
+    padding: 10,
     borderRadius: 4,
     position: 'absolute',
+    border: '1px solid #ddd',
     boxShadow: '0 3px 6px -2px rgba(0, 0, 0, 0.6)'
   };
+
   return (
     <div {...rest} style={styles} ref={ref}>
       Overlay
+      <hr />
+      <button onClick={onClose}>close</button>
     </div>
   );
 });
@@ -23,8 +28,8 @@ const App = () => (
   <Whisper
     trigger="click"
     speaker={(props, ref) => {
-      const { className, left, top } = props;
-      return <Overlay style={{ left, top }} className={className} ref={ref} />;
+      const { className, left, top, onClose } = props;
+      return <Overlay style={{ left, top }} onClose={onClose} className={className} ref={ref} />;
     }}
   >
     <Button>Test</Button>

--- a/docs/pages/components/popover/zh-CN/overlay.md
+++ b/docs/pages/components/popover/zh-CN/overlay.md
@@ -3,18 +3,23 @@
 <!--start-code-->
 
 ```js
-const Overlay = React.forwardRef(({ style, ...rest }, ref) => {
+const Overlay = React.forwardRef(({ style, onClose, ...rest }, ref) => {
   const styles = {
     ...style,
-    background: '#000',
-    padding: 20,
+    background: '#fff',
+    width: 200,
+    padding: 10,
     borderRadius: 4,
     position: 'absolute',
+    border: '1px solid #ddd',
     boxShadow: '0 3px 6px -2px rgba(0, 0, 0, 0.6)'
   };
+
   return (
     <div {...rest} style={styles} ref={ref}>
       Overlay
+      <hr />
+      <button onClick={onClose}>close</button>
     </div>
   );
 });
@@ -23,11 +28,11 @@ const App = () => (
   <Whisper
     trigger="click"
     speaker={(props, ref) => {
-      const { className, left, top } = props;
-      return <Overlay style={{ left, top }} className={className} ref={ref} />;
+      const { className, left, top, onClose } = props;
+      return <Overlay style={{ left, top }} onClose={onClose} className={className} ref={ref} />;
     }}
   >
-    <Button>click me</Button>
+    <Button>Test</Button>
   </Whisper>
 );
 

--- a/src/Overlay/OverlayTrigger.tsx
+++ b/src/Overlay/OverlayTrigger.tsx
@@ -211,7 +211,13 @@ class OverlayTrigger extends React.Component<OverlayTriggerProps, OverlayTrigger
     }
 
     if (typeof speaker === 'function') {
-      return <Overlay {...overlayProps}>{speaker}</Overlay>;
+      return (
+        <Overlay {...overlayProps}>
+          {(props, ref) => {
+            return speaker({ ...props, onClose: this.hide }, ref);
+          }}
+        </Overlay>
+      );
     }
 
     return <Overlay {...overlayProps}>{React.cloneElement(speaker, speakerProps)}</Overlay>;

--- a/src/Whisper/test/WhisperSpec.js
+++ b/src/Whisper/test/WhisperSpec.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
-import { getDOMNode } from '@test/testUtils';
+import { getDOMNode, createTestContainer } from '@test/testUtils';
 
 import Whisper from '../Whisper';
 import Tooltip from '../../Tooltip';
@@ -165,5 +166,38 @@ describe('Whisper', () => {
     );
 
     ReactTestUtils.Simulate.click(whisper);
+  });
+
+  it('Should Overlay be closed, after call onClose', done => {
+    const doneOp = () => {
+      done();
+    };
+    const triggerRef = React.createRef();
+    const btnRef = React.createRef();
+    const Overlay = React.forwardRef(({ style, onClose, ...rest }, ref) => {
+      return (
+        <div {...rest} style={style} ref={ref}>
+          <button onClick={onClose}>close</button>
+        </div>
+      );
+    });
+
+    Overlay.displayName = 'Overlay';
+
+    ReactTestUtils.act(() => {
+      ReactDOM.render(
+        <Whisper ref={triggerRef} onExited={doneOp} trigger="click" speaker={<Tooltip />}>
+          <button ref={btnRef}>button</button>
+        </Whisper>,
+        createTestContainer()
+      );
+    });
+    ReactTestUtils.act(() => {
+      ReactTestUtils.Simulate.click(btnRef.current);
+    });
+
+    ReactTestUtils.act(() => {
+      ReactTestUtils.Simulate.click(triggerRef.current.getOverlayTarget());
+    });
   });
 });


### PR DESCRIPTION
The `onClose` method can be called inside the speaker to close the Overlay, when the value of the speaker is a function.

```tsx
const Overlay = React.forwardRef(({ style, onClose, ...rest }, ref) => {
  const styles = {
    ...style,
    background: '#fff',
    width: 200,
    padding: 10,
    borderRadius: 4,
    position: 'absolute',
    border: '1px solid #ddd',
    boxShadow: '0 3px 6px -2px rgba(0, 0, 0, 0.6)'
  };

  return (
    <div {...rest} style={styles} ref={ref}>
      Overlay
      <hr />
      <button onClick={onClose}>close</button>
    </div>
  );
});

const App = () => (
  <Whisper
    trigger="click"
    speaker={(props, ref) => {
      const { className, left, top, onClose } = props;
      return <Overlay style={{ left, top }} onClose={onClose} className={className} ref={ref} />;
    }}
  >
    <Button>Test</Button>
  </Whisper>
);
```
close #1458