### PR TITLE
Added onCreate prop for creatable inputPicker

### DIFF
--- a/src/InputPicker/InputPicker.tsx
+++ b/src/InputPicker/InputPicker.tsx
@@ -141,6 +141,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
       onExited,
       onChange,
       onClean,
+      onCreate,
       onSearch,
       onSelect,
       onOpen,
@@ -313,10 +314,11 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
 
         if (creatable && item.create) {
           delete item.create;
+          onCreate?.(value, item, event);
           setNewData(newData.concat(item));
         }
       },
-      [creatable, newData, onSelect]
+      [creatable, newData, onSelect, onCreate]
     );
 
     /**
@@ -762,6 +764,7 @@ InputPicker.propTypes = {
   renderMenu: PropTypes.func,
   renderMenuItem: PropTypes.func,
   renderMenuGroup: PropTypes.func,
+  onCreate: PropTypes.func,
   onSelect: PropTypes.func,
   onGroupTitleClick: PropTypes.func,
   onSearch: PropTypes.func,

--- a/src/InputPicker/test/InputPickerSpec.js
+++ b/src/InputPicker/test/InputPickerSpec.js
@@ -330,4 +330,18 @@ describe('InputPicker', () => {
     const instance = getDOMNode(<InputPicker tabIndex={10} />);
     assert.equal(instance.querySelector('.rs-picker-search-input').getAttribute('tabindex'), '10');
   });
+
+  it('Should call `onCreate` by keyCode=13 ', done => {
+    const doneOp = (value, item) => {
+      if (!(data.includes(value) || data.includes(item.value))) {
+        done();
+      }
+    };
+    const instance = getInstance(
+      <InputPicker defaultOpen data={data} onCreate={doneOp} defaultValue={'Kariane'} creatable />
+    );
+
+    ReactTestUtils.Simulate.keyDown(instance.target, { keyCode: 40 });
+    ReactTestUtils.Simulate.keyDown(instance.target, { keyCode: 13 });
+  });
 });

--- a/src/SelectPicker/SelectPicker.tsx
+++ b/src/SelectPicker/SelectPicker.tsx
@@ -83,6 +83,9 @@ export interface SelectProps<T = ValueType> {
   /** Called when the option is selected */
   onSelect?: (value: any, item: ItemDataType, event: React.SyntheticEvent) => void;
 
+  /** Called when the option is created */
+  onCreate?: (value: any, item: ItemDataType, event: React.SyntheticEvent) => void;
+
   /** Called after clicking the group title */
   onGroupTitleClick?: (event: React.SyntheticEvent) => void;
 


### PR DESCRIPTION
This feature will help when trying to do something with a value not previously on the data list. Use case involves, fetching an array of data as data list and adding a created value to the database so that the user does not have to create it again.
Created from ISSUE #1567 

The onCreate prop is a function that fires when the `creatable` `inputPicker` has a new created value that is not in the list. The function passes values as the onSelect prop does:
`onCreate={(value, item, event) => null}`

### Example:
```
<InputPicker
creatable
onCreate={(value, item, event) => addToDatabase(value)} />
```