### PR TITLE
Fix `create-react-app` command with yarn

### DIFF
--- a/docs/pages/guide/use-with-create-react-app/en-US/index.md
+++ b/docs/pages/guide/use-with-create-react-app/en-US/index.md
@@ -7,7 +7,7 @@
 Before all start, you may need install [yarn][yarn].
 
 ```bash
-$ yarn create-react-app test-app
+$ yarn create react-app test-app
 ```
 
 After execution, the tool will automatically generate a `react` development scaffold and install all dependencies necessary to develop `react`.


### PR DESCRIPTION
`yarn create-react-app test-app` is obsolete. 

`yarn create react-app test-app` is the way to go!