### PR TITLE
fix(cascader): fixing childrenKey property not work when searching(#1568)

### DIFF
--- a/src/Cascader/Cascader.tsx
+++ b/src/Cascader/Cascader.tsx
@@ -143,7 +143,7 @@ const Cascader: PickerComponent<CascaderProps> = React.forwardRef((props: Cascad
 
   // Use component active state to support keyboard events.
   const [active, setActive] = useState(false);
-  const [flattenData, setFlattenData] = useState<ItemDataType[]>(flattenTree(data));
+  const [flattenData, setFlattenData] = useState<ItemDataType[]>(flattenTree(data, childrenKey));
 
   const triggerRef = useRef<OverlayTriggerInstance>();
   const overlayRef = useRef<HTMLDivElement>();
@@ -167,7 +167,7 @@ const Cascader: PickerComponent<CascaderProps> = React.forwardRef((props: Cascad
   });
 
   useEffect(() => {
-    setFlattenData(flattenTree(data));
+    setFlattenData(flattenTree(data, childrenKey));
   }, [data]);
 
   usePublicMethods(ref, { triggerRef, overlayRef, targetRef });

--- a/src/Cascader/Cascader.tsx
+++ b/src/Cascader/Cascader.tsx
@@ -168,7 +168,7 @@ const Cascader: PickerComponent<CascaderProps> = React.forwardRef((props: Cascad
 
   useEffect(() => {
     setFlattenData(flattenTree(data, childrenKey));
-  }, [data]);
+  }, [data, childrenKey]);
 
   usePublicMethods(ref, { triggerRef, overlayRef, targetRef });
 

--- a/src/Cascader/test/CascaderSpec.js
+++ b/src/Cascader/test/CascaderSpec.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 import Cascader from '../Cascader';
 import Button from '../../Button';
-import { getDOMNode, getInstance } from '@test/testUtils';
+import { getDOMNode, getInstance, createTestContainer } from '@test/testUtils';
 
 const items = [
   {
@@ -330,6 +330,65 @@ describe('Cascader', () => {
       ref.current.picker.overlay.querySelector('.rs-picker-cascader-menu-item').innerText,
       'test'
     );
+  });
+
+  it('Should show search items with childrenKey', () => {
+    const itemsWithChildrenKey = {
+      childrenKey: 'sub',
+      data: [
+        {
+          value: 't',
+          label: 't'
+        },
+        {
+          value: 'h',
+          label: 'h'
+        },
+        {
+          value: 'g',
+          label: 'g',
+          sub: [
+            {
+              value: 'g-m',
+              label: 'g-m'
+            },
+            {
+              value: 'g-b',
+              label: 'g-b'
+            }
+          ]
+        }
+      ]
+    };
+
+    const cascaderRef = React.createRef();
+
+    ReactTestUtils.act(() => {
+      ReactDOM.render(
+        <Cascader ref={cascaderRef} defaultOpen data={itemsWithChildrenKey.data} childrenKey={itemsWithChildrenKey.childrenKey}  />,
+        createTestContainer()
+      );
+    });
+
+    ReactTestUtils.act(() => {
+      const input = cascaderRef.current.overlay.querySelector('.rs-picker-search-bar-input');
+
+      ReactTestUtils.Simulate.focus(input);
+
+      input.value = 'g';
+      ReactTestUtils.Simulate.change(input);
+
+    });
+
+    ReactTestUtils.act(() => {
+      const searchResult = cascaderRef.current.overlay.querySelectorAll('.rs-picker-cascader-row');
+
+      assert.equal(
+        searchResult.length,
+        2
+      );
+
+    });
   });
 
   describe('ref testing', () => {

--- a/src/Cascader/test/CascaderSpec.js
+++ b/src/Cascader/test/CascaderSpec.js
@@ -365,7 +365,12 @@ describe('Cascader', () => {
 
     ReactTestUtils.act(() => {
       ReactDOM.render(
-        <Cascader ref={cascaderRef} defaultOpen data={itemsWithChildrenKey.data} childrenKey={itemsWithChildrenKey.childrenKey}  />,
+        <Cascader
+          ref={cascaderRef}
+          defaultOpen
+          data={itemsWithChildrenKey.data}
+          childrenKey={itemsWithChildrenKey.childrenKey}
+        />,
         createTestContainer()
       );
     });
@@ -377,17 +382,12 @@ describe('Cascader', () => {
 
       input.value = 'g';
       ReactTestUtils.Simulate.change(input);
-
     });
 
     ReactTestUtils.act(() => {
       const searchResult = cascaderRef.current.overlay.querySelectorAll('.rs-picker-cascader-row');
 
-      assert.equal(
-        searchResult.length,
-        2
-      );
-
+      assert.equal(searchResult.length, 2);
     });
   });
 


### PR DESCRIPTION
Fixing childrenKey property of the Cascader component does not work when searching  and Increase the corresponding unit test