### PR TITLE
feat(nav-item): support `tooltip` on NavItem

### DIFF
--- a/src/Nav/Nav.tsx
+++ b/src/Nav/Nav.tsx
@@ -66,15 +66,15 @@ const Nav: NavComponent = (React.forwardRef((props: NavProps, ref: React.Ref<HTM
   const hasWaterline = appearance !== 'default';
 
   const items = ReactChildren.mapCloneElement(children, item => {
-    const { eventKey, active, ...rest } = item.props;
+    const { eventKey, active, tooltip: itemTooltip, ...rest } = item.props;
     const displayName = item?.type?.displayName;
-    const hasTooltip = sidenav && !expanded;
+    const tooltip = typeof itemTooltip === 'undefined' ? sidenav && !expanded : itemTooltip;
 
     if (displayName === 'NavItem') {
       return {
         ...rest,
         onSelect,
-        hasTooltip,
+        tooltip,
         active: typeof activeKey === 'undefined' ? active : shallowEqual(activeKey, eventKey)
       };
     } else if (displayName === 'Dropdown') {
@@ -82,7 +82,7 @@ const Nav: NavComponent = (React.forwardRef((props: NavProps, ref: React.Ref<HTM
         ...rest,
         onSelect,
         activeKey,
-        showHeader: hasTooltip,
+        showHeader: tooltip,
         as: 'div'
       };
     }

--- a/src/Nav/NavItem.tsx
+++ b/src/Nav/NavItem.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Ripple from '../Ripple';
 import SafeAnchor from '../SafeAnchor';
 import { useClassNames, appendTooltip } from '../utils';
-import { WithAsProps, RsRefForwardingComponent } from '../@types/common';
+import { WithAsProps, RsRefForwardingComponent, TypeAttributes } from '../@types/common';
 import { IconProps } from '@rsuite/icons/lib/Icon';
 
 export interface NavItemProps<T = string>
@@ -28,7 +28,7 @@ export interface NavItemProps<T = string>
   eventKey?: T;
 
   /** Whether NavItem have a tooltip  */
-  hasTooltip?: boolean;
+  tooltip?: boolean | TypeAttributes.Placement;
 
   /** Providing a `href` will render an `<a>` element */
   href?: string;
@@ -56,7 +56,7 @@ const NavItem: RsRefForwardingComponent<'a', NavItemProps> = React.forwardRef(
       children,
       icon,
       tabIndex,
-      hasTooltip,
+      tooltip,
       divider,
       panel,
       onClick,
@@ -113,8 +113,13 @@ const NavItem: RsRefForwardingComponent<'a', NavItemProps> = React.forwardRef(
       </Component>
     );
 
-    return hasTooltip
-      ? appendTooltip({ children: item, message: children, placement: 'right' })
+    return tooltip
+      ? appendTooltip({
+          ref,
+          children: item,
+          message: children,
+          placement: typeof tooltip === 'boolean' ? 'right' : tooltip
+        })
       : item;
   }
 );
@@ -136,7 +141,7 @@ NavItem.propTypes = {
   children: PropTypes.node,
   eventKey: PropTypes.any,
   tabIndex: PropTypes.number,
-  hasTooltip: PropTypes.bool
+  tooltip: PropTypes.bool
 };
 
 export default NavItem;

--- a/src/Nav/test/NavItemSpec.js
+++ b/src/Nav/test/NavItemSpec.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
-import { getDOMNode, innerText } from '@test/testUtils';
+import { getDOMNode, createTestContainer, innerText } from '@test/testUtils';
 
 import NavItem from '../NavItem';
 
@@ -82,5 +83,24 @@ describe('NavItem', () => {
   it('Should have a custom className prefix', () => {
     const instance = getDOMNode(<NavItem classPrefix="custom-prefix" />);
     assert.ok(instance.className.match(/\bcustom-prefix\b/));
+  });
+
+  it('Should render a tooltip', () => {
+    const itemRef = React.createRef();
+
+    ReactTestUtils.act(() => {
+      ReactDOM.render(
+        <NavItem ref={itemRef} tooltip>
+          item
+        </NavItem>,
+        createTestContainer()
+      );
+    });
+
+    ReactTestUtils.act(() => {
+      ReactTestUtils.Simulate.focus(itemRef.current.root);
+    });
+
+    assert.equal(itemRef.current.overlay.getAttribute('role'), 'tooltip');
   });
 });

--- a/src/utils/appendTooltip.tsx
+++ b/src/utils/appendTooltip.tsx
@@ -4,11 +4,12 @@ import Whisper from '../Whisper';
 import { TypeAttributes } from '../@types/common';
 
 interface Props {
+  ref?: React.Ref<any>;
   message?: React.ReactNode;
   children?: React.ReactElement | ((props: any, ref) => React.ReactElement);
-  placement?: TypeAttributes.Placement | TypeAttributes.Placement4;
+  placement?: TypeAttributes.Placement;
 }
 
-export default function appendTooltip({ message, ...rest }: Props) {
-  return <Whisper speaker={<Tooltip>{message}</Tooltip>} {...rest} />;
+export default function appendTooltip({ message, ref, ...rest }: Props) {
+  return <Whisper ref={ref} speaker={<Tooltip>{message}</Tooltip>} {...rest} />;
 }


### PR DESCRIPTION
You can customize the rendering position of the tooltip on NavItem. When set to false, it will not render.

```tsx
<Sidenav>
  <Sidenav.Body>
    <Nav>
      <Nav.Item tooltip={false}> Dashboard </Nav.Item>
      <Nav.Item tooltip="top" > Dashboard </Nav.Item>
       ...
    </Nav>
  </Sidenav.Body>
</Sidenav>
```