### PR TITLE
build(deps): bump element-resieze-event from 3.0.3 to 3.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7352,9 +7352,9 @@
       "dev": true
     },
     "element-resize-event": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/element-resize-event/-/element-resize-event-3.0.3.tgz",
-      "integrity": "sha512-vhGNxT87PdZA6Ak4E0QhArwGzNcSPUwSN7n9wCFLeBlY2NNuuiwguQuQIp7P5oB65PLJ892yKcHiqz1xLWeiug=="
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/element-resize-event/-/element-resize-event-3.0.6.tgz",
+      "integrity": "sha512-sSeXY9rNDp86bJODW68pxLcy3A5FrPZfIgOrJHzqgYzX513Zq6/ytdBigp7KeJEpZZopBBSiO1cVuiRkZpNxLw=="
     },
     "elliptic": {
       "version": "6.5.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "classnames": ">=2.0.0",
     "date-fns": "^1.30.1",
     "dom-lib": "^1.2.1",
-    "element-resize-event": "^3.0.3",
+    "element-resize-event": "^3.0.6",
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "react-lifecycles-compat": "^3.0.4",


### PR DESCRIPTION
close  #1705 
