### PR TITLE
Fix CheckTreePicker and TreePicker value controlled

### DIFF
--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -195,11 +195,14 @@ class CheckTreePicker extends React.Component<CheckTreePickerProps, CheckTreePic
       nextState.value = value;
     }
 
-    if (compareArray(expandItemValues, prevState.expandItemValues)) {
+    if (compareArray(expandItemValues, prevState.expandItemValues) && _.isArray(expandItemValues)) {
       nextState.expandItemValues = expandItemValues;
     }
 
-    if (compareArray(uncheckableItemValues, prevState.uncheckableItemValues)) {
+    if (
+      compareArray(uncheckableItemValues, prevState.uncheckableItemValues) &&
+      _.isArray(uncheckableItemValues)
+    ) {
       nextState.uncheckableItemValues = uncheckableItemValues;
     }
 
@@ -258,7 +261,7 @@ class CheckTreePicker extends React.Component<CheckTreePickerProps, CheckTreePic
     const { value } = this.props;
     if (compareArray(value, prevState.value)) {
       this.unserializeLists({
-        check: value,
+        check: value ?? [],
         expand: expandItemValues
       });
       this.setState({
@@ -271,7 +274,7 @@ class CheckTreePicker extends React.Component<CheckTreePickerProps, CheckTreePic
 
   updateExpandItemValuesChange(prevState: CheckTreePickerState) {
     const { expandItemValues } = this.props;
-    if (compareArray(expandItemValues, prevState.expandItemValues)) {
+    if (compareArray(expandItemValues, prevState.expandItemValues) && _.isArray(expandItemValues)) {
       this.unserializeLists({
         expand: expandItemValues
       });
@@ -284,7 +287,10 @@ class CheckTreePicker extends React.Component<CheckTreePickerProps, CheckTreePic
   updateUncheckableItemValuesChange(prevState: CheckTreePickerState) {
     const { data, selectedValues, expandItemValues } = this.state;
     const { uncheckableItemValues } = this.props;
-    if (compareArray(uncheckableItemValues, prevState.uncheckableItemValues)) {
+    if (
+      compareArray(uncheckableItemValues, prevState.uncheckableItemValues) &&
+      _.isArray(uncheckableItemValues)
+    ) {
       this.flattenNodes(data);
       this.unserializeLists({
         check: selectedValues,

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -4,9 +4,22 @@ import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { getDOMNode, getInstance } from '@test/testUtils';
 import CheckTreePicker from '../CheckTreePicker';
-import { findDOMNode } from 'react-dom';
+import ReactDOM, { findDOMNode } from 'react-dom';
+import { assert } from 'chai';
 
 Enzyme.configure({ adapter: new Adapter() });
+
+let container;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  document.body.removeChild(container);
+  container = null;
+});
 
 const data = [
   {
@@ -383,5 +396,115 @@ describe('CheckTreePicker', () => {
     assert.equal(instance1.querySelector('.rs-picker-toggle-value').innerText, '1');
     assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
     assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+  });
+
+  it('Should controlled by value', () => {
+    const TestApp = React.forwardRef((props, ref) => {
+      const [value, setValue] = React.useState();
+      const pickerRef = React.useRef();
+      React.useImperativeHandle(ref, () => ({
+        picker: pickerRef.current,
+        setValue
+      }));
+
+      return <CheckTreePicker data={data} ref={pickerRef} value={value} defaultExpandAll open />;
+    });
+
+    TestApp.displayName = 'TestCheckTreePicker';
+
+    const ref = React.createRef();
+    ReactTestUtils.act(() => {
+      ReactDOM.render(<TestApp ref={ref} />, container);
+    });
+
+    assert.equal(
+      ref.current.picker.treeViewRef.current.querySelectorAll('.rs-checkbox-checked').length,
+      0
+    );
+
+    ReactTestUtils.act(() => {
+      ref.current.setValue(['Master']);
+    });
+    assert.equal(
+      ref.current.picker.treeViewRef.current.querySelectorAll('.rs-checkbox-checked').length,
+      4
+    );
+  });
+
+  it('Should controlled by expandItemValues', () => {
+    const TestApp = React.forwardRef((props, ref) => {
+      const [expandItemValues, setExpandItemValues] = React.useState();
+      const pickerRef = React.useRef();
+      React.useImperativeHandle(ref, () => ({
+        picker: pickerRef.current,
+        setExpandItemValues
+      }));
+
+      return (
+        <CheckTreePicker data={data} ref={pickerRef} expandItemValues={expandItemValues} open />
+      );
+    });
+
+    TestApp.displayName = 'TestCheckTreePicker';
+
+    const ref = React.createRef();
+    ReactTestUtils.act(() => {
+      ReactDOM.render(<TestApp ref={ref} />, container);
+    });
+
+    assert.equal(
+      ref.current.picker.treeViewRef.current.querySelectorAll('.rs-check-tree-node-expanded')
+        .length,
+      0
+    );
+
+    ReactTestUtils.act(() => {
+      ref.current.setExpandItemValues(['Master']);
+    });
+    assert.equal(
+      ref.current.picker.treeViewRef.current.querySelectorAll('.rs-check-tree-node-expanded')
+        .length,
+      1
+    );
+  });
+
+  it('Should controlled by uncheckableItemValues', () => {
+    const TestApp = React.forwardRef((props, ref) => {
+      const [uncheckableItemValues, setUncheckableItemValues] = React.useState();
+      const pickerRef = React.useRef();
+      React.useImperativeHandle(ref, () => ({
+        picker: pickerRef.current,
+        setUncheckableItemValues
+      }));
+
+      return (
+        <CheckTreePicker
+          data={data}
+          ref={pickerRef}
+          uncheckableItemValues={uncheckableItemValues}
+          open
+        />
+      );
+    });
+
+    TestApp.displayName = 'TestCheckTreePicker';
+
+    const ref = React.createRef();
+    ReactTestUtils.act(() => {
+      ReactDOM.render(<TestApp ref={ref} />, container);
+    });
+
+    assert.equal(
+      ref.current.picker.treeViewRef.current.querySelectorAll('.rs-checkbox-inner').length,
+      5
+    );
+
+    ReactTestUtils.act(() => {
+      ref.current.setUncheckableItemValues(['Master']);
+    });
+    assert.equal(
+      ref.current.picker.treeViewRef.current.querySelectorAll('.rs-checkbox-inner').length,
+      4
+    );
   });
 });

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -123,7 +123,10 @@ export function treeDeprecatedWarning(
  * @param b
  */
 export function compareArray(a: any[], b: any[]) {
-  return _.isArray(a) && _.isArray(b) && !shallowEqualArray(a, b);
+  if (!(_.isArray(a) && _.isArray(b))) {
+    return a !== b;
+  }
+  return !shallowEqualArray(a, b);
 }
 
 /**


### PR DESCRIPTION
Fix CheckTreePicker and TreePicker some controlled props is not working when props change `undefined` to `array`

About CheckTreePicker controlled props
* value
* uncheckableItemValues
* expandItemValues

About TreePicker controlled props
* expandItemValues