### PR TITLE
chore(coverage): remove test scripts from coverage calculation

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -30,7 +30,7 @@ module.exports = (api, options) => {
           [
             'istanbul',
             {
-              exclude: ['src/utils/ajaxUpload.ts']
+              exclude: ['src/**/*Spec.js', 'test/**/*']
             }
           ]
         ]

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -41,9 +41,7 @@ module.exports = config => {
     logLevel: config.LOG_INFO,
     preprocessors: {
       'test/*.js': ['webpack'],
-      'src/**/*.js': ['webpack'],
-      'src/**/*.ts': ['coverage'],
-      'src/**/*.tsx': ['coverage']
+      'src/**/*.js': ['webpack', 'sourcemap']
     },
     webpack: require('./webpack.karma.js'),
     webpackMiddleware: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = config => {
   const { env } = process;
   const { M, F } = env;
 
-  let testFile = 'test/index.js';
+  let testFile = 'src/**/*Spec.js';
 
   if (M) {
     testFile = `src/${M}/test/*.js`;
@@ -40,8 +40,7 @@ module.exports = config => {
     reporters: ['mocha', 'coverage'],
     logLevel: config.LOG_INFO,
     preprocessors: {
-      'test/*.js': ['webpack'],
-      'src/**/*.js': ['webpack', 'sourcemap']
+      'src/**/*Spec.js': ['webpack']
     },
     webpack: require('./webpack.karma.js'),
     webpackMiddleware: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -41,7 +41,9 @@ module.exports = config => {
     logLevel: config.LOG_INFO,
     preprocessors: {
       'test/*.js': ['webpack'],
-      'src/**/*.js': ['webpack']
+      'src/**/*.js': ['webpack'],
+      'src/**/*.ts': ['coverage'],
+      'src/**/*.tsx': ['coverage']
     },
     webpack: require('./webpack.karma.js'),
     webpackMiddleware: {


### PR DESCRIPTION
Test scripts themselves were taken into count in coverage calculation, resulting in a misleading coverage output. Remove them by configuring karma and babel as [`babel-plugin-istanbul` documents](https://github.com/istanbuljs/babel-plugin-istanbul#ignoring-files).

Before: https://codecov.io/gh/rsuite/rsuite/tree/9f23d9c26f092cd49c73c89dfe4dd394716c2863
![image](https://user-images.githubusercontent.com/8225666/123380161-b363d200-d5c1-11eb-99a1-4e2a9eac6bc0.png)

After: https://codecov.io/gh/rsuite/rsuite/tree/fda8746b67d01a17f78719a206cd0611dab11b63
![image](https://user-images.githubusercontent.com/8225666/123380207-c24a8480-d5c1-11eb-84ad-f6dcc434ec68.png)


As this PR modified the coverage collecting scope, you may merge this PR regardless of possible coverage reduction.

Reference:
- https://github.com/ryanclark/karma-webpack/issues/21#issuecomment-249701814
- https://github.com/istanbuljs/babel-plugin-istanbul#ignoring-files
- https://github.com/karma-runner/karma-coverage#basic