### PR TITLE
ci(codecov): mark reports with browser name as flags

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -53,3 +53,5 @@ jobs:
           BROWSER: ${{ matrix.browser }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
+        with:
+          flags: ${{ matrix.browser }}


### PR DESCRIPTION
Now you can view coverage reports for different browsers accordingly. 

Example:

https://codecov.io/gh/rsuite/rsuite/src/b0718240d7f15061ce65c01dc265e28e2b416e6a/src/Placeholder/PlaceholderGraph.tsx