### PR TITLE
fix: CheckTreePicker and TreePicker search problems

### DIFF
--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -512,6 +512,12 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
 
   const handleClean = useCallback(
     (event: React.SyntheticEvent<any>) => {
+      const target = event.target as Element;
+      // exclude searchBar
+      if (target.matches('div[role="searchbox"] > input')) {
+        return;
+      }
+
       setActiveNode(null);
       setValue([]);
       setFocusItemValue(null);

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -564,4 +564,30 @@ describe('CheckTreePicker', () => {
     assert.equal(list.length, 1);
     assert.ok(list[0].innerText, 'Louisa');
   });
+
+  it('Should only clean the searchKeyword', () => {
+    const instance = getInstance(
+      <CheckTreePicker defaultOpen defaultExpandAll data={data} defaultValue={['Master']} />
+    );
+
+    const searchBar = instance.overlay.querySelector('.rs-picker-search-bar-input');
+    ReactTestUtils.Simulate.change(searchBar, {
+      target: { value: 'Master' }
+    });
+
+    searchBar.focus();
+    ReactTestUtils.Simulate.keyDown(searchBar, {
+      key: KEY_VALUES.BACKSPACE
+    });
+    assert.equal(
+      instance.root.querySelector('.rs-picker-toggle-value .rs-picker-value-item').innerText,
+      'Master (All)'
+    );
+
+    ReactTestUtils.Simulate.keyDown(instance.overlay, {
+      key: KEY_VALUES.BACKSPACE
+    });
+
+    assert.ok(!instance.root.querySelector('.rs-picker-toggle-value .rs-picker-value-item'));
+  });
 });

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -590,4 +590,17 @@ describe('CheckTreePicker', () => {
 
     assert.ok(!instance.root.querySelector('.rs-picker-toggle-value .rs-picker-value-item'));
   });
+
+  it('Should display the search result when in virtualized mode', () => {
+    const instance = getInstance(<CheckTreePicker open virtualized data={data} />);
+
+    assert.equal(instance.overlay.querySelectorAll('.rs-check-tree-node').length, 2);
+
+    const searchBar = instance.overlay.querySelector('.rs-picker-search-bar-input');
+    ReactTestUtils.Simulate.change(searchBar, {
+      target: { value: 'test' }
+    });
+
+    assert.equal(instance.overlay.querySelectorAll('.rs-check-tree-node').length, 4);
+  });
 });

--- a/src/CheckTreePicker/utils.ts
+++ b/src/CheckTreePicker/utils.ts
@@ -12,7 +12,6 @@ export interface TreeNodeType {
   visible?: boolean;
   expand?: boolean;
   layer?: number;
-  showNode?: boolean;
   label?: string | React.ReactNode;
   value?: string | number;
   groupBy?: string;

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -36,7 +36,8 @@ import {
   focusToActiveTreeNode,
   leftArrowHandler,
   focusTreeNode,
-  rightArrowHandler
+  rightArrowHandler,
+  isSearching
 } from '../utils/treeUtils';
 
 import {
@@ -252,18 +253,23 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
     (render?: any) => {
       let formattedNodes = [];
       if (virtualized) {
-        formattedNodes = formatVirtualizedTreeData(
-          flattenNodes,
-          filteredData,
-          expandItemValues
-        ).filter(n => n.showNode && n.visible);
+        formattedNodes = formatVirtualizedTreeData(flattenNodes, filteredData, expandItemValues, {
+          searchKeyword: searchKeywordState
+        }).filter(n => n.visible);
       } else {
         formattedNodes = filteredData.map((dataItem, index) => render?.(dataItem, index, 1));
       }
 
       return formattedNodes;
     },
-    [expandItemValues, filteredData, flattenNodes, formatVirtualizedTreeData, virtualized]
+    [
+      searchKeywordState,
+      expandItemValues,
+      filteredData,
+      flattenNodes,
+      formatVirtualizedTreeData,
+      virtualized
+    ]
   );
 
   const focusActiveNode = useCallback(() => {
@@ -530,12 +536,16 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
 
   const handleFocusItem = useCallback(
     (key: string) => {
-      const focusableItems = getFocusableItems(filteredData, {
-        disabledItemValues,
-        valueKey,
-        childrenKey,
-        expandItemValues
-      });
+      const focusableItems = getFocusableItems(
+        filteredData,
+        {
+          disabledItemValues,
+          valueKey,
+          childrenKey,
+          expandItemValues
+        },
+        isSearching(searchKeywordState)
+      );
       const selector = `.${treePrefix('node-label')}`;
       const focusProps = {
         focusItemValue,
@@ -556,6 +566,7 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
       }
     },
     [
+      searchKeywordState,
       expandItemValues,
       filteredData,
       focusItemValue,
@@ -718,7 +729,7 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
 
   const renderVirtualListNode = (nodes: any[]) => ({ key, index, style }: ListRowProps) => {
     const node = nodes[index];
-    const { layer, showNode } = node;
+    const { layer, visible } = node;
 
     const expand = getExpandWhenSearching(
       searchKeywordState,
@@ -735,7 +746,7 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
     };
 
     return (
-      showNode && (
+      visible && (
         <TreeNode ref={ref => saveTreeNodeRef(node.refKey, ref)} key={key} {...nodeProps} />
       )
     );

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -620,6 +620,11 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
 
   const handleClean = useCallback(
     (event: React.SyntheticEvent<any>) => {
+      const target = event.target as Element;
+      // exclude searchBar
+      if (target.matches('div[role="searchbox"] > input')) {
+        return;
+      }
       setValue(null);
       onChange?.(null, event);
     },

--- a/src/TreePicker/test/TreePickerSpec.js
+++ b/src/TreePicker/test/TreePickerSpec.js
@@ -500,4 +500,17 @@ describe('TreePicker', () => {
 
     assert.ok(!instance.root.querySelector('.rs-picker-toggle-value .rs-picker-value-item'));
   });
+
+  it('Should display the search result when in virtualized mode', () => {
+    const instance = getInstance(<TreePicker open virtualized data={data} />);
+
+    assert.equal(instance.overlay.querySelectorAll('.rs-tree-node').length, 2);
+
+    const searchBar = instance.overlay.querySelector('.rs-picker-search-bar-input');
+    ReactTestUtils.Simulate.change(searchBar, {
+      target: { value: 'test' }
+    });
+
+    assert.equal(instance.overlay.querySelectorAll('.rs-tree-node').length, 4);
+  });
 });

--- a/src/TreePicker/test/TreePickerSpec.js
+++ b/src/TreePicker/test/TreePickerSpec.js
@@ -477,4 +477,27 @@ describe('TreePicker', () => {
     assert.equal(list.length, 1);
     assert.ok(list[0].innerText, 'Louisa');
   });
+
+  it('Should only clean the searchKeyword', () => {
+    const instance = getInstance(
+      <TreePicker defaultOpen defaultExpandAll data={data} defaultValue={'Master'} />
+    );
+
+    const searchBar = instance.overlay.querySelector('.rs-picker-search-bar-input');
+    ReactTestUtils.Simulate.change(searchBar, {
+      target: { value: 'Master' }
+    });
+
+    searchBar.focus();
+    ReactTestUtils.Simulate.keyDown(searchBar, {
+      key: KEY_VALUES.BACKSPACE
+    });
+    assert.equal(instance.root.querySelector('.rs-picker-toggle-value').innerText, 'Master');
+
+    ReactTestUtils.Simulate.keyDown(instance.overlay, {
+      key: KEY_VALUES.BACKSPACE
+    });
+
+    assert.ok(!instance.root.querySelector('.rs-picker-toggle-value .rs-picker-value-item'));
+  });
 });


### PR DESCRIPTION
* fix(tree): can't search in virtualized mode
* fix(tree): exclude searchBar backspace event from onPickerKeyDown