### PR TITLE
fix(sidenav): trigger `<Nav onSelect>` on click `<Nav.Item>`

### DIFF
--- a/src/Sidenav/SidenavItem.tsx
+++ b/src/Sidenav/SidenavItem.tsx
@@ -2,11 +2,11 @@ import React, { useContext, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import isNil from 'lodash/isNil';
 import { useClassNames, shallowEqual } from '../utils';
-import { SidenavContext } from './Sidenav';
 import { WithAsProps, RsRefForwardingComponent } from '../@types/common';
 import { IconProps } from '@rsuite/icons/lib/Icon';
 import Ripple from '../Ripple';
 import SafeAnchor from '../SafeAnchor';
+import NavContext from '../Nav/NavContext';
 
 export interface SidenavItemProps<T = any>
   extends WithAsProps,
@@ -56,7 +56,7 @@ const SidenavItem: RsRefForwardingComponent<'li', SidenavItemProps> = React.forw
     ...rest
   } = props;
 
-  const { activeKey, onSelect: onSelectFromSidenav } = useContext(SidenavContext);
+  const { activeKey, onSelect: onSelectFromNav } = useContext(NavContext);
 
   const { merge, withClassPrefix, prefix } = useClassNames(classPrefix);
 
@@ -67,10 +67,10 @@ const SidenavItem: RsRefForwardingComponent<'li', SidenavItemProps> = React.forw
       if (disabled) return;
 
       onSelect?.(eventKey, event);
-      onSelectFromSidenav?.(eventKey, event);
+      onSelectFromNav?.(eventKey, event);
       onClick?.(event);
     },
-    [disabled, onSelect, onSelectFromSidenav, eventKey, onClick]
+    [disabled, onSelect, onSelectFromNav, eventKey, onClick]
   );
 
   if (divider) {

--- a/src/Sidenav/test/SidenavSpec.js
+++ b/src/Sidenav/test/SidenavSpec.js
@@ -184,11 +184,14 @@ describe('<Sidenav>', () => {
     expect(getByTestId('dropdown-item')).to.have.class('rs-dropdown-item-active');
   });
 
-  it('Should call <Nav onSelect> with correct eventKey from <Dropdown.Item>', () => {
+  it('Should call <Nav onSelect> with correct eventKey', () => {
     const onSelectSpy = sinon.spy();
     const { getByTestId } = render(
       <Sidenav>
-        <Nav activeKey="2-1" onSelect={onSelectSpy}>
+        <Nav onSelect={onSelectSpy}>
+          <Nav.Item eventKey="1-1" data-testid="nav-item">
+            Nav item
+          </Nav.Item>
           <Dropdown title="Dropdown" data-testid="dropdown">
             <Dropdown.Item eventKey="2-1" data-testid="dropdown-item">
               Dropdown item
@@ -198,10 +201,17 @@ describe('<Sidenav>', () => {
       </Sidenav>
     );
 
+    userEvent.click(getByTestId('nav-item'));
+    expect(onSelectSpy, 'Works with <Nav.Item>').to.have.been.calledWith('1-1', sinon.match.any);
+
+    onSelectSpy.resetHistory();
     // opens the dropdown
     userEvent.click(getByTestId('dropdown'));
 
     userEvent.click(getByTestId('dropdown-item'));
-    expect(onSelectSpy).to.have.been.calledWith('2-1', sinon.match.any);
+    expect(onSelectSpy, 'Works with <Dropdown.Item>').to.have.been.calledWith(
+      '2-1',
+      sinon.match.any
+    );
   });
 });


### PR DESCRIPTION
Top-level `<Nav.Item>` inside `<Sidenav>` was not triggering `onSelect` of `<Nav>` component.

https://user-images.githubusercontent.com/8225666/128141655-4401a2ce-b045-4038-9e23-d3ca0b22b58b.mp4

