### PR TITLE
fix(dropdown-menu): remove unrecognizable activeKey from dom

### DIFF
--- a/src/Dropdown/DropdownMenu.tsx
+++ b/src/Dropdown/DropdownMenu.tsx
@@ -67,7 +67,16 @@ const DropdownMenu = React.forwardRef(
     props: DropdownMenuProps & Omit<React.HTMLAttributes<HTMLUListElement>, 'title' | 'onSelect'>,
     ref
   ) => {
-    const { onToggle, eventKey, title, onSelect, classPrefix, children, ...rest } = props;
+    const {
+      onToggle,
+      eventKey,
+      title,
+      activeKey,
+      onSelect,
+      classPrefix,
+      children,
+      ...rest
+    } = props;
 
     const dropdown = useContext(DropdownContext);
     const sidenav = useContext(SidenavContext);
@@ -97,7 +106,7 @@ const DropdownMenu = React.forwardRef(
       const classes = merge(props.className, withClassPrefix());
 
       return (
-        <DropdownContext.Provider value={{ activeKey: rest.activeKey, onSelect }}>
+        <DropdownContext.Provider value={{ activeKey, onSelect }}>
           <Menubar
             vertical
             onActivateItem={event => {


### PR DESCRIPTION
Prevent warning when setting `activeKey` prop of `<Dropdown.Menu>`

    Warning: React does not recognize the `activeKey` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `activekey` instead. If you accidentally passed it from a parent component, remove it from the DOM element.