### PR TITLE
build(deps): bump rsuite-table from 5.0.0-alpha.5 to 5.0.0-alpha.8

### DIFF
--- a/docs/pages/components/table/en-US/index.md
+++ b/docs/pages/components/table/en-US/index.md
@@ -364,12 +364,13 @@ scrollLeft: (left: number) => void;
 
 ### `<Table.ColumnGroup>`
 
-| Property      | Type `(Default)`                | Description        |
-| ------------- | ------------------------------- | ------------------ |
-| align         | enum: 'left','center','right'   | Alignment          |
-| fixed         | boolean, 'left', 'right'        | Fixed column group |
-| header        | ReactNode                       | Group header       |
-| verticalAlign | enum: 'top', 'middle', 'bottom' | Vertical alignment |
+| Property          | Type `(Default)`                | Description                                                                                             |
+| ----------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| align             | enum: 'left','center','right'   | Alignment                                                                                               |
+| fixed             | boolean, 'left', 'right'        | Fixed column group                                                                                      |
+| groupHeaderHeight | number                          | The height of the header of the merged cell group. The default value is 50% of the table `headerHeight` |
+| header            | ReactNode                       | Group header                                                                                            |
+| verticalAlign     | enum: 'top', 'middle', 'bottom' | Vertical alignment                                                                                      |
 
 ### `<Table.Cell>`
 

--- a/docs/pages/components/table/zh-CN/index.md
+++ b/docs/pages/components/table/zh-CN/index.md
@@ -360,12 +360,13 @@ scrollLeft: (left: number) => void;
 
 ### `<Table.ColumnGroup>`
 
-| 属性名称      | 类型 `(默认值)`                 | 描述         |
-| ------------- | ------------------------------- | ------------ |
-| align         | enum: 'left','center','right'   | 对齐方式     |
-| fixed         | boolean, 'left', 'right'        | 固定列组     |
-| header        | ReactNode                       | 分组表头     |
-| verticalAlign | enum: 'top', 'middle', 'bottom' | 垂直对齐方式 |
+| 属性名称          | 类型 `(默认值)`                 | 描述                                                            |
+| ----------------- | ------------------------------- | --------------------------------------------------------------- |
+| align             | enum: 'left','center','right'   | 对齐方式                                                        |
+| fixed             | boolean, 'left', 'right'        | 固定列组                                                        |
+| groupHeaderHeight | number                          | 合并单元格组的标题高度。 默认值是 Table 属性 `headerHeight` 50% 的值。 |
+| header            | ReactNode                       | 分组表头                                                        |
+| verticalAlign     | enum: 'top', 'middle', 'bottom' | 垂直对齐方式                                                    |
 
 ### `<Table.Cell>`
 

--- a/docs/pages/guide/v5-features/en-US/index.md
+++ b/docs/pages/guide/v5-features/en-US/index.md
@@ -134,6 +134,36 @@ The difference between `onChangeCommitted` and `onChange` is that `onChange` is 
 <Badge color="yellow">Yellow</Badge>
 ```
 
+### 6. Refactor Table
+
+Use react hooks to refactor the Table and improve the performance when the table scrolls. [The `onDataUpdated` and `bodyRef` props are deprecated](https://github.com/rsuite/rsuite-table/pull/232).
+
+For some components to be rendered inside the table, the body container of the table can be obtained through `bodyRef` before. Now we can get the container directly through the `ref` of `Table`.
+
+```js
+// v4
+const ref = uesRef();
+return (
+  <>
+    <Table
+      bodyRef={body => {
+        ref.current = body;
+      }}
+    />
+    <CheckPicker container={() => bodyRef.current} />
+  </>
+);
+
+// v5
+const ref = uesRef();
+return (
+  <>
+    <Table ref={tableRef} />
+    <CheckPicker container={() => ref.current.body} />
+  </>
+);
+```
+
 ---
 
 ## To v5 from v4

--- a/docs/pages/guide/v5-features/zh-CN/index.md
+++ b/docs/pages/guide/v5-features/zh-CN/index.md
@@ -137,6 +137,36 @@ checkResult 返回的数据结构:
 <Badge color="yellow">Yellow</Badge>
 ```
 
+### 6. 重构 Table
+
+使用 react hooks 重构了 Table， 并改进了表格滚动时的性能。 [废弃了 `onDataUpdated` 和 `bodyRef` 属性](https://github.com/rsuite/rsuite-table/pull/232)。
+
+对于一些要在表格内部渲染的组件，之前可以通过 `bodyRef` 获取表格的 body 容器。 现在我们可以通过 `Table` 的 `ref` 直接获取容器。
+
+```js
+// v4
+const ref = uesRef();
+return (
+  <>
+    <Table
+      bodyRef={body => {
+        ref.current = body;
+      }}
+    />
+    <CheckPicker container={() => bodyRef.current} />
+  </>
+);
+
+// v5
+const ref = uesRef();
+return (
+  <>
+    <Table ref={tableRef} />
+    <CheckPicker container={() => ref.current.body} />
+  </>
+);
+```
+
 ---
 
 ## 从 v4 升级到 v5 🚀

--- a/package-lock.json
+++ b/package-lock.json
@@ -7510,7 +7510,8 @@
     "eslint-plugin-react-hooks": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
-      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ=="
+      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
+      "dev": true
     },
     "eslint-rule-composer": {
       "version": "0.3.0",
@@ -16488,16 +16489,15 @@
       }
     },
     "rsuite-table": {
-      "version": "5.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.0.0-alpha.5.tgz",
-      "integrity": "sha512-qwJJKjuEvwvVvu4TfPVfP30tRU3mlFD8m7T8TqINfV38FF9hV6cHhUggcIjKOTWKk5MEAZbCoqTliHUPVzmx+w==",
+      "version": "5.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.0.0-alpha.6.tgz",
+      "integrity": "sha512-Mo0N9Jvrrr6hADXKzCODzBe+ONvjxRIkkgDIhxjRi1Hpthi9RNqV7aiaVfO5M2TaPLzPtjWI3TumxsXm+cgnFg==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@rsuite/icons": "^1.0.0",
         "classnames": "^2.2.5",
         "dom-lib": "^2.0.3",
         "element-resize-event": "^3.0.6",
-        "eslint-plugin-react-hooks": "^4.2.0",
         "lodash": "^4.17.20"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16489,9 +16489,9 @@
       }
     },
     "rsuite-table": {
-      "version": "5.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.0.0-alpha.6.tgz",
-      "integrity": "sha512-Mo0N9Jvrrr6hADXKzCODzBe+ONvjxRIkkgDIhxjRi1Hpthi9RNqV7aiaVfO5M2TaPLzPtjWI3TumxsXm+cgnFg==",
+      "version": "5.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.0.0-alpha.8.tgz",
+      "integrity": "sha512-Svw1DP0AN5VQvkznWPgTSeOwuyJuHIpdeqXWD+WgCuBOS15KhmaKWolKkPl+ipIcfFE7MhF13ehpcWcfmoZZQQ==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@rsuite/icons": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "prop-types": "^15.7.2",
     "react-text-mask": "^5.4.3",
     "react-virtualized": "^9.22.3",
-    "rsuite-table": "^5.0.0-alpha.5",
+    "rsuite-table": "^5.0.0-alpha.6",
     "schema-typed": "^2.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "prop-types": "^15.7.2",
     "react-text-mask": "^5.4.3",
     "react-virtualized": "^9.22.3",
-    "rsuite-table": "^5.0.0-alpha.6",
+    "rsuite-table": "^5.0.0-alpha.8",
     "schema-typed": "^2.0.0"
   },
   "peerDependencies": {

--- a/src/Table/styles/index.less
+++ b/src/Table/styles/index.less
@@ -337,7 +337,6 @@
 
       &-content {
         display: table-cell;
-        padding: 10px;
       }
     }
   }


### PR DESCRIPTION
## CHANGELOG
- https://github.com/rsuite/rsuite-table/pull/232
- https://github.com/rsuite/rsuite-table/pull/234
- https://github.com/rsuite/rsuite-table/pull/235
- https://github.com/rsuite/rsuite-table/pull/236
- https://github.com/rsuite/rsuite-table/pull/237
- https://github.com/rsuite/rsuite-table/pull/238

## Breaking change

Use react hooks to refactor the Table and improve the performance when the table scrolls. [The `onDataUpdated` and `bodyRef` props are deprecated](https://github.com/rsuite/rsuite-table/pull/232).

For some components to be rendered inside the table, the body container of the table can be obtained through `bodyRef` before. Now we can get the container directly through the `ref` of `Table`.

```js
// v4
const ref = uesRef();
return (
  <>
    <Table
      bodyRef={body => {
        ref.current = body;
      }}
    />
    <CheckPicker container={() => bodyRef.current} />
  </>
);
// v5
const ref = uesRef();
return (
  <>
    <Table ref={tableRef} />
    <CheckPicker container={() => ref.current.body} />
  </>
);
```