### PR TITLE
feat(dropdown): support `renderToggle` on `<Dropdown>`

### DIFF
--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,3 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/docs/pages/components/button/fragments/icon-button.md
+++ b/docs/pages/components/button/fragments/icon-button.md
@@ -28,10 +28,10 @@ const instance = (
     </ButtonToolbar>
 
     <ButtonToolbar>
-      <IconButton icon={<FacebookOfficialIcon />} color="blue" circle />
-      <IconButton icon={<GooglePlusCircleIcon />} color="red" circle />
-      <IconButton icon={<TwitterIcon />} color="cyan" circle />
-      <IconButton icon={<LinkedinIcon />} color="blue" circle />
+      <IconButton icon={<FacebookOfficialIcon />} color="blue" appearance="primary" circle />
+      <IconButton icon={<GooglePlusCircleIcon />} color="red" appearance="primary" circle />
+      <IconButton icon={<TwitterIcon />} color="cyan" appearance="primary" circle />
+      <IconButton icon={<LinkedinIcon />} color="blue" appearance="primary" circle />
     </ButtonToolbar>
 
     <ButtonToolbar>

--- a/docs/pages/components/dropdown/en-US/index.md
+++ b/docs/pages/components/dropdown/en-US/index.md
@@ -38,7 +38,7 @@ You can disable the entire component or disable individual options by configurin
 
 <!--{include:`disabled.md`}-->
 
-### With Button
+### Extends button props
 
 The default value of the `toggleAs` property of`Dropdown` is `Button`. You can set the button-related props (eg. size, appearance) and display it in the style of a button.
 
@@ -71,6 +71,10 @@ The default value of the `toggleAs` property of`Dropdown` is `Button`. You can s
 
 <!--{include:`menu-items.md`}-->
 
+### Custom Toggle
+
+<!--{include:`custom-toggle.md`}-->
+
 ### Used with Popover
 
 <!--{include:`with-popover.md`}-->
@@ -90,24 +94,24 @@ The default value of the `toggleAs` property of`Dropdown` is `Button`. You can s
 
 ### `<Dropdown>`
 
-| Property        | Type`(default)`                     | Description                                                                             |
-| --------------- | ----------------------------------- | --------------------------------------------------------------------------------------- |
-| activeKey       | string                              | The option to activate the state, corresponding to the `eventkey` in the Dropdown.item. |
-| classPrefix     | string `('dropdown')`               | The prefix of the component CSS class                                                   |
-| disabled        | boolean                             | Whether or not component is disabled                                                    |
-| icon            | Element&lt;typeof Icon&gt;          | Set the icon                                                                            |
-| menuStyle       | CSSProperties                       | The style of the menu.                                                                  |
-| onClose         | () => void                          | The callback function that the menu closes                                              |
-| onOpen          | () => void                          | Menu Pop-up callback function                                                           |
-| onSelect        | (eventKey: string, event) => void   | Selected callback function                                                              |
-| onToggle        | (open?: boolean) => void            | Callback function for menu state switching.                                             |
-| open            | boolean                             | Controlled open state                                                                   |
-| placement       | Placement `('bottomStart')`         | The placement of Menu                                                                   |
-| renderTitle     | (children?: ReactNode) => ReactNode | Custom title                                                                            |
-| title           | ReactNode                           | Menu defaults to display content.                                                       |
-| toggleAs        | ElementType `(Button)`              | You can use a custom element for this component                                         |
-| toggleClassName | string                              | A css class to apply to the Toggle DOM node                                             |
-| trigger         | Trigger `('click')`                 | Triggering events                                                                       |
+| Property        | Type`(default)`                   | Description                                                                             |
+| --------------- | --------------------------------- | --------------------------------------------------------------------------------------- |
+| activeKey       | string                            | The option to activate the state, corresponding to the `eventkey` in the Dropdown.item. |
+| classPrefix     | string `('dropdown')`             | The prefix of the component CSS class                                                   |
+| disabled        | boolean                           | Whether or not component is disabled                                                    |
+| icon            | Element&lt;typeof Icon&gt;        | Set the icon                                                                            |
+| menuStyle       | CSSProperties                     | The style of the menu.                                                                  |
+| onClose         | () => void                        | The callback function that the menu closes                                              |
+| onOpen          | () => void                        | Menu Pop-up callback function                                                           |
+| onSelect        | (eventKey: string, event) => void | Selected callback function                                                              |
+| onToggle        | (open?: boolean) => void          | Callback function for menu state switching.                                             |
+| open            | boolean                           | Controlled open state                                                                   |
+| placement       | Placement `('bottomStart')`       | The placement of Menu                                                                   |
+| renderToggle    | (props, ref) => any;              | Custom Toggle                                                                           |
+| title           | ReactNode                         | Menu defaults to display content.                                                       |
+| toggleAs        | ElementType `(Button)`            | You can use a custom element for this component                                         |
+| toggleClassName | string                            | A css class to apply to the Toggle DOM node                                             |
+| trigger         | Trigger `('click')`               | Triggering events                                                                       |
 
 ### `<Dropdown.Item>`
 
@@ -126,7 +130,7 @@ The default value of the `toggleAs` property of`Dropdown` is `Button`. You can s
 
 ### `<Dropdown.Menu>`
 
-| Property | Type`(default)`            | Description                                                 |
-| -------- | -------------------------- | ----------------------------------------------------------- |
-| icon     | Element&lt;typeof Icon&gt; | Set the icon                                                |
-| title    | string                     | Define the title as a submenu                               |
+| Property | Type`(default)`            | Description                   |
+| -------- | -------------------------- | ----------------------------- |
+| icon     | Element&lt;typeof Icon&gt; | Set the icon                  |
+| title    | string                     | Define the title as a submenu |

--- a/docs/pages/components/dropdown/fragments/custom-toggle.md
+++ b/docs/pages/components/dropdown/fragments/custom-toggle.md
@@ -1,0 +1,48 @@
+<!--start-code-->
+
+```js
+/**
+ 
+import PlusIcon from '@rsuite/icons/Plus';
+import PageIcon from '@rsuite/icons/Page';
+import FolderFillIcon from '@rsuite/icons/FolderFill';
+import DetailIcon from '@rsuite/icons/Detail';
+import FileDownloadIcon from '@rsuite/icons/FileDownload';
+ 
+*/
+
+const renderIconButton = (props, ref) => {
+  return (
+    <IconButton {...props} ref={ref} icon={<PlusIcon />} circle color="blue" appearance="primary" />
+  );
+};
+
+const renderButton = (props, ref) => {
+  return (
+    <button {...props} ref={ref}>
+      New File
+    </button>
+  );
+};
+
+const App = () => (
+  <div>
+    <Dropdown renderToggle={renderIconButton}>
+      <Dropdown.Item icon={<PageIcon />}>New File</Dropdown.Item>
+      <Dropdown.Item icon={<FolderFillIcon />}>New File with Current Profile</Dropdown.Item>
+      <Dropdown.Item icon={<FileDownloadIcon />}>Download As...</Dropdown.Item>
+      <Dropdown.Item icon={<DetailIcon />}>Export PDF</Dropdown.Item>
+    </Dropdown>
+    <hr />
+    <Dropdown renderToggle={renderButton}>
+      <Dropdown.Item icon={<PageIcon />}>New File</Dropdown.Item>
+      <Dropdown.Item icon={<FolderFillIcon />}>New File with Current Profile</Dropdown.Item>
+      <Dropdown.Item icon={<FileDownloadIcon />}>Download As...</Dropdown.Item>
+      <Dropdown.Item icon={<DetailIcon />}>Export PDF</Dropdown.Item>
+    </Dropdown>
+  </div>
+);
+ReactDOM.render(<App />);
+```
+
+<!--end-code-->

--- a/docs/pages/components/dropdown/zh-CN/index.md
+++ b/docs/pages/components/dropdown/zh-CN/index.md
@@ -38,13 +38,13 @@
 
 <!--{include:`disabled.md`}-->
 
-### 与按钮组合
+### 继承按钮属性
 
 `Dropdown` 的 `toggleAs` 属性默认值为是 `Button`, 可以设置按钮相关的属性（例如: size, appearance）, 以按钮的样式展示。
 
 <!--{include:`toggle-as.md`}-->
 
-### 没有插入号
+### 没有箭头图标
 
 <!--{include:`no-caret.md`}-->
 
@@ -71,6 +71,10 @@
 
 <!--{include:`menu-items.md`}-->
 
+### 自定义 Toggle
+
+<!--{include:`custom-toggle.md`}-->
+
 ### 与 Popover 组合使用
 
 <!--{include:`with-popover.md`}-->
@@ -90,24 +94,24 @@
 
 ### `<Dropdown>`
 
-| 属性名称        | 类型 `(默认值)`                     | 描述                                             |
-| --------------- | ----------------------------------- | ------------------------------------------------ |
-| activeKey       | string                              | 激活状态的选项，对应 Dropdown.Item 中的 eventKey |
-| classPrefix     | string `('dropdown')`               | 组件 CSS 类的前缀                                |
-| disabled        | boolean                             | 禁用组件                                         |
-| icon            | Element&lt;typeof Icon&gt;          | 设置图标                                         |
-| menuStyle       | CSSProperties                       | 菜单样式                                         |
-| onClose         | () => void                          | 菜单关闭的回调函数                               |
-| onOpen          | () => void                          | 菜单弹出的回调函数                               |
-| onSelect        | (eventKey: string, event) => void   | 选择后的回调函数                                 |
-| onToggle        | (open?: boolean) => void            | 菜单状态切换的回调函数                           |
-| open            | boolean                             | 受控的打开状态                                   |
-| placement       | Placement `('bottomStart')`         | 菜单显示位置                                     |
-| renderTitle     | (children?: ReactNode) => ReactNode | 自定义 title                                     |
-| title           | ReactNode                           | 菜单默认显示内容                                 |
-| toggleAs        | ElementType `(Button)`              | 为组件自定义元素类型                             |
-| toggleClassName | string                              | 设置 Toggle 的 className                         |
-| trigger         | Trigger `('click')`                 | 触发事件                                         |
+| 属性名称        | 类型 `(默认值)`                   | 描述                                             |
+| --------------- | --------------------------------- | ------------------------------------------------ |
+| activeKey       | string                            | 激活状态的选项，对应 Dropdown.Item 中的 eventKey |
+| classPrefix     | string `('dropdown')`             | 组件 CSS 类的前缀                                |
+| disabled        | boolean                           | 禁用组件                                         |
+| icon            | Element&lt;typeof Icon&gt;        | 设置图标                                         |
+| menuStyle       | CSSProperties                     | 菜单样式                                         |
+| onClose         | () => void                        | 菜单关闭的回调函数                               |
+| onOpen          | () => void                        | 菜单弹出的回调函数                               |
+| onSelect        | (eventKey: string, event) => void | 选择后的回调函数                                 |
+| onToggle        | (open?: boolean) => void          | 菜单状态切换的回调函数                           |
+| open            | boolean                           | 受控的打开状态                                   |
+| placement       | Placement `('bottomStart')`       | 菜单显示位置                                     |
+| renderToggle    | (props, ref) => any;              | 自定义 Toggle                                    |
+| title           | ReactNode                         | 菜单默认显示内容                                 |
+| toggleAs        | ElementType `(Button)`            | 为组件自定义元素类型                             |
+| toggleClassName | string                            | 设置 Toggle 的 className                         |
+| trigger         | Trigger `('click')`               | 触发事件                                         |
 
 ### `<Dropdown.Item>`
 
@@ -126,7 +130,7 @@
 
 ### `<Dropdown.Menu>`
 
-| 属性名称 | 类型                       | 描述                             |
-| -------- | -------------------------- | -------------------------------- |
-| icon     | Element&lt;typeof Icon&gt; | 设置图标                         |
-| title    | string                     | 作为子菜单定义标题               |
+| 属性名称 | 类型                       | 描述               |
+| -------- | -------------------------- | ------------------ |
+| icon     | Element&lt;typeof Icon&gt; | 设置图标           |
+| title    | string                     | 作为子菜单定义标题 |

--- a/docs/pages/guide/v5-features/en-US/index.md
+++ b/docs/pages/guide/v5-features/en-US/index.md
@@ -475,3 +475,29 @@ import 'rsuite/styles/index.less'; // less
 import 'rsuite/dist/rsuite.min.css'; // or css
 import 'rsuite/dist/rsuite-rtl.min.css'; // or rtl css
 ```
+
+#### 2.12 Deprecate `renderTitle` property of `<Dropdown>`
+
+The `renderTitle` has been deprecated and replaced by `renderToggle`.
+
+```js
+//v4
+return (
+  <Dropdown
+    renderTitle={() => <IconButton appearance="primary" icon={<Icon icon="plus" />} circle />}
+  >
+    ...
+  </Dropdown>
+);
+
+//v5
+return (
+  <Dropdown
+    renderToggle={(props, ref) => (
+      <IconButton {...props} ref={ref} icon={<PlusIcon />} circle appearance="primary" />
+    )}
+  >
+    ...
+  </Dropdown>
+);
+```

--- a/docs/pages/guide/v5-features/zh-CN/index.md
+++ b/docs/pages/guide/v5-features/zh-CN/index.md
@@ -478,3 +478,29 @@ import 'rsuite/styles/index.less'; // less
 import 'rsuite/dist/rsuite.min.css'; // or css
 import 'rsuite/dist/rsuite-rtl.min.css'; // or rtl css
 ```
+
+#### 2.14 废弃 `<Dropdown>` 组件的 `renderTitle` 属性
+
+废弃 `renderTitle`，取而代之的是 `renderToggle`。
+
+```js
+//v4
+return (
+  <Dropdown
+    renderTitle={() => <IconButton appearance="primary" icon={<Icon icon="plus" />} circle />}
+  >
+    ...
+  </Dropdown>
+);
+
+//v5
+return (
+  <Dropdown
+    renderToggle={(props, ref) => (
+      <IconButton {...props} ref={ref} icon={<PlusIcon />} circle appearance="primary" />
+    )}
+  >
+    ...
+  </Dropdown>
+);
+```

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -62,8 +62,13 @@ export interface DropdownProps<T = any>
    */
   open?: boolean;
 
-  /** Custom title */
-  renderTitle?: (children?: React.ReactNode) => React.ReactNode;
+  /**
+   * @deprecated
+   */
+  renderTitle?: (children: React.ReactNode) => React.ReactNode;
+
+  /** Custom Toggle */
+  renderToggle?: (props: WithAsProps, ref: React.Ref<any>) => any;
 
   /** The callback function that the menu closes */
   onClose?: () => void;
@@ -107,7 +112,6 @@ const Dropdown: DropdownComponent = (React.forwardRef((props: DropdownProps, ref
     eventKey,
     trigger,
     placement,
-    renderTitle,
     toggleAs,
     toggleClassName,
     classPrefix,
@@ -116,7 +120,7 @@ const Dropdown: DropdownComponent = (React.forwardRef((props: DropdownProps, ref
     children,
     menuStyle,
     style,
-    ...menuProps
+    ...toggleProps
   } = rest;
 
   const { onSelect: onSelectFromNav } = useContext(NavContext);
@@ -194,12 +198,12 @@ const Dropdown: DropdownComponent = (React.forwardRef((props: DropdownProps, ref
                   {(buttonProps, buttonRef) => (
                     <DropdownToggle
                       ref={buttonRef}
-                      as={renderTitle ? 'span' : toggleAs}
+                      as={toggleAs}
                       className={toggleClassName}
                       placement={placement}
                       disabled={disabled}
                       {...omit(buttonProps, ['open'])}
-                      {...menuProps}
+                      {...toggleProps}
                     >
                       {title}
                     </DropdownToggle>
@@ -231,12 +235,12 @@ const Dropdown: DropdownComponent = (React.forwardRef((props: DropdownProps, ref
   let renderMenuButton = (menuButtonProps, menuButtonRef) => (
     <DropdownToggle
       ref={menuButtonRef}
-      as={renderTitle ? 'span' : toggleAs}
+      as={toggleAs}
       className={toggleClassName}
       placement={placement}
       disabled={disabled}
       {...omit(menuButtonProps, ['open'])}
-      {...menuProps}
+      {...toggleProps}
     >
       {title}
     </DropdownToggle>
@@ -249,7 +253,7 @@ const Dropdown: DropdownComponent = (React.forwardRef((props: DropdownProps, ref
           return (
             <DropdownToggle
               ref={mergeRefs(buttonRef, menuitemRef)}
-              as={renderTitle ? 'span' : toggleAs}
+              as={toggleAs}
               className={mergeNavItemClassNames(
                 toggleClassName,
                 withNavItemClassPrefix({
@@ -258,7 +262,7 @@ const Dropdown: DropdownComponent = (React.forwardRef((props: DropdownProps, ref
               )}
               {...menuButtonProps}
               {...omit(menuitemProps, ['onClick'])}
-              {...menuProps}
+              {...toggleProps}
             >
               {title}
             </DropdownToggle>
@@ -361,7 +365,7 @@ Dropdown.propTypes = {
   onMouseLeave: PropTypes.func,
   onContextMenu: PropTypes.func,
   onClick: PropTypes.func,
-  renderTitle: PropTypes.func
+  renderToggle: PropTypes.func
 };
 
 export default Dropdown;

--- a/src/Dropdown/DropdownToggle.tsx
+++ b/src/Dropdown/DropdownToggle.tsx
@@ -1,7 +1,5 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-
-import Ripple from '../Ripple';
 import Button from '../Button';
 import { useClassNames } from '../utils';
 import { IconProps } from '@rsuite/icons/lib/Icon';
@@ -12,7 +10,7 @@ import { SidenavContext } from '../Sidenav/Sidenav';
 export interface DropdownToggleProps extends WithAsProps {
   icon?: React.ReactElement<IconProps>;
   noCaret?: boolean;
-  renderTitle?: (children?: React.ReactNode) => React.ReactNode;
+  renderToggle?: (props: WithAsProps, ref: React.Ref<any>) => any;
   placement?: TypeAttributes.Placement8;
 }
 
@@ -29,7 +27,7 @@ const DropdownToggle: RsRefForwardingComponent<
     as: Component,
     className,
     classPrefix,
-    renderTitle,
+    renderToggle,
     children,
     icon,
     noCaret,
@@ -39,37 +37,23 @@ const DropdownToggle: RsRefForwardingComponent<
 
   const sidenav = useContext(SidenavContext);
   const { prefix, withClassPrefix, merge } = useClassNames(classPrefix);
-  const classes = merge(
-    className,
-    withClassPrefix({
-      'custom-title': typeof renderTitle === 'function',
-      'no-caret': noCaret
-    })
-  );
+  const classes = merge(className, withClassPrefix({ 'no-caret': noCaret }));
 
   const inSidenav = !!sidenav;
 
   // Caret icon is down by default, when Dropdown is used in Sidenav.
   const Caret = useToggleCaret(inSidenav ? 'bottomStart' : placement);
 
-  if (renderTitle) {
-    return (
-      <Component {...rest} ref={ref} className={classes}>
-        {renderTitle(children)}
-        <Ripple />
-      </Component>
-    );
-  }
-
   const buttonProps = Component === Button ? { appearance: 'subtle' } : null;
-
-  return (
+  const toggle = (
     <Component {...buttonProps} {...rest} ref={ref} className={classes}>
-      {icon}
+      <span className={prefix('icon')}>{icon}</span>
       {children}
       {noCaret ? null : <Caret className={prefix('caret')} />}
     </Component>
   );
+
+  return renderToggle ? renderToggle(rest, ref) : toggle;
 });
 
 DropdownToggle.displayName = 'DropdownToggle';
@@ -81,7 +65,17 @@ DropdownToggle.propTypes = {
   classPrefix: PropTypes.string,
   noCaret: PropTypes.bool,
   as: PropTypes.elementType,
-  renderTitle: PropTypes.func
+  renderToggle: PropTypes.func,
+  placement: PropTypes.oneOf([
+    'bottomStart',
+    'bottomEnd',
+    'topStart',
+    'topEnd',
+    'leftStart',
+    'rightStart',
+    'leftEnd',
+    'rightEnd'
+  ])
 };
 
 export default DropdownToggle;

--- a/src/Dropdown/styles/index.less
+++ b/src/Dropdown/styles/index.less
@@ -14,12 +14,11 @@
 .rs-dropdown {
   position: relative;
   display: inline-block;
-  font-size: 0;
   vertical-align: middle; // Make sure dropdown vertical alignment with button,button group and so on.
 
   // Dropdown button style
   .rs-btn {
-    > .rs-icon:not(.rs-dropdown-toggle-caret) {
+    > .rs-dropdown-toggle-icon {
       margin-right: 6px;
     }
 

--- a/src/Dropdown/styles/mixin.less
+++ b/src/Dropdown/styles/mixin.less
@@ -42,11 +42,6 @@
   // Rest `:focus` blue border.
   outline: none;
   cursor: pointer;
-
-  // Custom title toggle need reset padding.
-  &-custom-title {
-    padding: 0 !important;
-  }
 }
 
 // Horizontal dividers

--- a/src/Dropdown/test/DropdownSpec.js
+++ b/src/Dropdown/test/DropdownSpec.js
@@ -823,4 +823,24 @@ describe('<Dropdown>', () => {
       });
     });
   });
+
+  it('Should render a custom toggle', () => {
+    const renderToggle = (props, ref) => {
+      return (
+        <button {...props} ref={ref}>
+          new
+        </button>
+      );
+    };
+    const instance = getDOMNode(
+      <Dropdown renderToggle={renderToggle}>
+        <Dropdown.Item>item-1</Dropdown.Item>
+        <Dropdown.Item>item-2</Dropdown.Item>
+      </Dropdown>
+    );
+
+    assert.equal(instance.innerText, 'new');
+    ReactTestUtils.Simulate.click(instance.querySelector('[role="button"]'));
+    assert.equal(instance.innerText, 'new\nitem-1\nitem-2');
+  });
 });

--- a/src/Dropdown/test/DropdownToggleSpec.js
+++ b/src/Dropdown/test/DropdownToggleSpec.js
@@ -22,7 +22,7 @@ describe('DropdownToggle', () => {
 
   it('Should have a icon', () => {
     const instance = getDOMNode(<DropdownToggle icon={<User />}>abc</DropdownToggle>);
-    assert.ok(instance.querySelector('.rs-icon'));
+    assert.ok(instance.querySelector('.rs-dropdown-toggle-icon .rs-icon'));
   });
 
   it('Should render custom component', () => {
@@ -35,11 +35,16 @@ describe('DropdownToggle', () => {
     assert.ok(!instance.querySelector('.rs-dropdown-toggle-caret'));
   });
 
-  it('Should render a custom title', () => {
-    const instance = getDOMNode(
-      <DropdownToggle renderTitle={children => <b>{children}</b>}>abc</DropdownToggle>
-    );
-    assert.equal(instance.innerText, 'abc');
+  it('Should render a custom toggle', () => {
+    const renderToggle = (props, ref) => {
+      return (
+        <button {...props} ref={ref}>
+          new
+        </button>
+      );
+    };
+    const instance = getDOMNode(<DropdownToggle renderToggle={renderToggle}>abc</DropdownToggle>);
+    assert.equal(instance.innerText, 'new');
   });
 
   it('Should have a custom className', () => {


### PR DESCRIPTION
## Custom Toggle

```tsx
const renderIconButton = (props, ref) => {
  return (
    <IconButton {...props} ref={ref} icon={<PlusIcon />} circle color="blue" appearance="primary" />
  );
};

const App = () => (
  <Dropdown renderToggle={renderIconButton}>
      <Dropdown.Item icon={<PageIcon />}>New File</Dropdown.Item>
      <Dropdown.Item icon={<FolderFillIcon />}>New File with Current Profile</Dropdown.Item>
      <Dropdown.Item icon={<FileDownloadIcon />}>Download As...</Dropdown.Item>
      <Dropdown.Item icon={<DetailIcon />}>Export PDF</Dropdown.Item>
  </Dropdown>
);
```
![image](https://user-images.githubusercontent.com/1203827/129559566-145c9abd-a4c4-4688-89b0-8d63964d1a90.png)


## Breaking change

The `renderTitle` has been deprecated and replaced by `renderToggle: (props, ref) => ReactNode`.

```tsx
//v4
return (
  <Dropdown
    renderTitle={() => <IconButton appearance="primary" icon={<Icon icon="plus" />} circle />}
  >
    ...
  </Dropdown>
);

//v5
return (
  <Dropdown
    renderToggle={(props, ref) => (
      <IconButton {...props} ref={ref} icon={<PlusIcon />} circle appearance="primary" />
    )}
  >
    ...
  </Dropdown>
);
```
