### PR TITLE
build(deps): bump schema-typed from 2.0.0 to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16579,9 +16579,9 @@
       }
     },
     "schema-typed": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.0.0.tgz",
-      "integrity": "sha512-Ed8doSm1QAIC32TjJ3G+ar8wA1ewZwvWkx/ET+3UKYKYsQTTFzL47hrGn2naecaKsm0Zv5gzYjE+dhunIgAnqQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.0.1.tgz",
+      "integrity": "sha512-9sz07HVMxcHjCQ3jtT0mfGtHcSqcmUmBIf6OcJkWDcrl4wQsIIv3mCn+CE/Xb6+VpFWpnPY3nSFby5VxawHEfQ=="
     },
     "schema-utils": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react-text-mask": "^5.4.3",
     "react-virtualized": "^9.22.3",
     "rsuite-table": "^5.0.0-alpha.8",
-    "schema-typed": "^2.0.0"
+    "schema-typed": "^2.0.1"
   },
   "peerDependencies": {
     "react": ">=16.8.0",


### PR DESCRIPTION
## Changelog

- https://github.com/rsuite/schema-typed/pull/36
- https://github.com/rsuite/schema-typed/pull/35
