### PR TITLE
test(tree): add tests for Tree and CheckTree

### DIFF
--- a/src/CheckTree/index.tsx
+++ b/src/CheckTree/index.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { FormControlPickerProps, RsRefForwardingComponent } from '../@types/common';
 import CheckTreePicker, { ValueType } from '../CheckTreePicker';
 
 import { TreeBaseProps } from '../Tree/Tree';
+import TreeContext from '../Tree/TreeContext';
 
 export interface CheckTreeProps
   extends TreeBaseProps<ValueType>,
@@ -11,12 +12,16 @@ export interface CheckTreeProps
   cascade?: boolean;
 }
 
-const CheckTree: RsRefForwardingComponent<
-  'div',
-  CheckTreeProps
-> = React.forwardRef((props: CheckTreeProps, ref: React.Ref<any>) => (
-  <CheckTreePicker ref={ref} inline {...props} />
-));
+const CheckTree: RsRefForwardingComponent<'div', CheckTreeProps> = React.forwardRef(
+  (props: CheckTreeProps, ref: React.Ref<any>) => {
+    const dragNodeRef = useRef();
+    return (
+      <TreeContext.Provider value={{ inline: true, dragNodeRef }}>
+        <CheckTreePicker ref={ref} {...props} />
+      </TreeContext.Provider>
+    );
+  }
+);
 
 CheckTree.displayName = 'CheckTree';
 

--- a/src/CheckTree/test/CheckTreeSpec.js
+++ b/src/CheckTree/test/CheckTreeSpec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Simulate } from 'react-dom/test-utils';
 import { getInstance } from '@test/testUtils';
 import CheckTree from '../index';
 

--- a/src/CheckTree/test/CheckTreeSpec.js
+++ b/src/CheckTree/test/CheckTreeSpec.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Simulate } from 'react-dom/test-utils';
+import { getInstance } from '@test/testUtils';
+import CheckTree from '../index';
+
+const data = [
+  {
+    label: 'Master',
+    value: 'Master',
+    children: [
+      {
+        label: 'tester0',
+        value: 'tester0'
+      },
+      {
+        label: 'tester1',
+        value: 'tester1',
+        children: [
+          {
+            label: 'tester2',
+            value: 'tester2'
+          }
+        ]
+      }
+    ]
+  },
+  {
+    label: 'Disabled node',
+    value: 'disabled'
+  }
+];
+
+describe('Tree', () => {
+  it('Should render a multi-selectable tree', () => {
+    const instance = getInstance(<CheckTree data={data} />);
+
+    assert.include(instance.className, 'rs-check-tree');
+    assert.equal(instance.getAttribute('role'), 'tree');
+    assert.equal(instance.getAttribute('aria-multiselectable'), 'true');
+  });
+});

--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect, useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { isNil, pick, isFunction, omit, cloneDeep, isUndefined } from 'lodash';
 import { List, AutoSizer, ListInstance, ListRowProps } from '../Picker/VirtualizedList';
 import CheckTreeNode from './CheckTreeNode';
+import TreeContext from '../Tree/TreeContext';
 import { PickerLocale } from '../locales';
 import {
   createChainedFunction,
@@ -123,7 +124,6 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
     toggleAs,
     searchKeyword,
     locale: overrideLocale,
-    inline,
     cascade,
     disabled,
     valueKey,
@@ -165,6 +165,8 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
     renderTreeNode,
     ...rest
   } = props;
+
+  const { inline } = useContext(TreeContext);
   const triggerRef = useRef<OverlayTriggerInstance>();
   const targetRef = useRef<HTMLButtonElement>();
   const listRef = useRef<ListInstance>();
@@ -507,7 +509,7 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
     ]
   );
 
-  usePublicMethods(ref, { triggerRef, overlayRef, targetRef });
+  usePublicMethods(ref, { triggerRef, overlayRef, targetRef }, inline);
 
   const handleClean = useCallback(
     (event: React.SyntheticEvent<any>) => {
@@ -776,7 +778,7 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
     return (
       <div
         id={id ? `${id}-listbox` : undefined}
-        ref={treeViewRef}
+        ref={inline ? mergeRefs(treeViewRef, ref as any) : treeViewRef}
         role="tree"
         aria-multiselectable
         className={classes}
@@ -916,7 +918,6 @@ CheckTreePicker.propTypes = {
   ...listPickerPropTypes,
   height: PropTypes.number,
   appearance: PropTypes.oneOf(['default', 'subtle']),
-  inline: PropTypes.bool,
   locale: PropTypes.any,
   cascade: PropTypes.bool,
   countable: PropTypes.bool,

--- a/src/Picker/utils.ts
+++ b/src/Picker/utils.ts
@@ -541,7 +541,11 @@ interface Refs {
  * @param ref
  * @param params
  */
-export function usePublicMethods(ref, { triggerRef, overlayRef, targetRef, rootRef }: Refs) {
+export function usePublicMethods(
+  ref,
+  { triggerRef, overlayRef, targetRef, rootRef }: Refs,
+  disabled?: boolean
+) {
   const handleOpen = useCallback(() => {
     triggerRef.current?.open();
   }, [triggerRef]);
@@ -554,18 +558,21 @@ export function usePublicMethods(ref, { triggerRef, overlayRef, targetRef, rootR
     triggerRef.current?.updatePosition();
   }, [triggerRef]);
 
-  useImperativeHandle(ref, () => ({
-    get root() {
-      return rootRef?.current ? rootRef?.current : triggerRef.current?.root;
-    },
-    get overlay() {
-      return overlayRef.current;
-    },
-    get target() {
-      return targetRef?.current;
-    },
-    updatePosition: handleUpdatePosition,
-    open: handleOpen,
-    close: handleClose
-  }));
+  if (!disabled) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useImperativeHandle(ref, () => ({
+      get root() {
+        return rootRef?.current ? rootRef?.current : triggerRef.current?.root;
+      },
+      get overlay() {
+        return overlayRef.current;
+      },
+      get target() {
+        return targetRef?.current;
+      },
+      updatePosition: handleUpdatePosition,
+      open: handleOpen,
+      close: handleClose
+    }));
+  }
 }

--- a/src/Tree/Tree.tsx
+++ b/src/Tree/Tree.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import TreePicker from '../TreePicker';
+import TreeContext from './TreeContext';
 import { StandardProps, ItemDataType, RsRefForwardingComponent } from '../@types/common';
 
 /**
@@ -57,9 +58,6 @@ export interface TreeBaseProps<ValueType = string | number, ItemDataType = Recor
   extends StandardProps {
   /** The height of Dropdown */
   height?: number;
-
-  /** Display inline */
-  inline?: boolean;
 
   /** Whether display search input box */
   searchable?: boolean;
@@ -136,12 +134,16 @@ export interface TreeProps<ValueType = string | number>
   defaultValue?: ValueType;
 }
 
-const Tree: RsRefForwardingComponent<
-  'div',
-  TreeProps
-> = React.forwardRef((props: TreeProps, ref: React.Ref<any>) => (
-  <TreePicker inline ref={ref} {...props} />
-));
+const Tree: RsRefForwardingComponent<'div', TreeProps> = React.forwardRef(
+  (props: TreeProps, ref: React.Ref<any>) => {
+    const dragNodeRef = useRef();
+    return (
+      <TreeContext.Provider value={{ inline: true, dragNodeRef }}>
+        <TreePicker ref={ref} {...props} />
+      </TreeContext.Provider>
+    );
+  }
+);
 
 Tree.displayName = 'Tree';
 export default Tree;

--- a/src/Tree/TreeContext.ts
+++ b/src/Tree/TreeContext.ts
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export interface TreeContextProps {
+  inline?: boolean;
+  dragNodeRef?: React.MutableRefObject<any>;
+}
+
+const TreeContext = React.createContext<TreeContextProps>({});
+
+export default TreeContext;

--- a/src/Tree/test/TreeSpec.js
+++ b/src/Tree/test/TreeSpec.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Simulate } from 'react-dom/test-utils';
+import { getInstance } from '@test/testUtils';
+import Tree from '../Tree';
+
+const data = [
+  {
+    label: 'Master',
+    value: 'Master',
+    children: [
+      {
+        label: 'tester0',
+        value: 'tester0'
+      },
+      {
+        label: 'tester1',
+        value: 'tester1',
+        children: [
+          {
+            label: 'tester2',
+            value: 'tester2'
+          }
+        ]
+      }
+    ]
+  },
+  {
+    label: 'Disabled node',
+    value: 'disabled'
+  }
+];
+
+describe('Tree', () => {
+  it('Should render a tree', () => {
+    const instance = getInstance(<Tree data={data} />);
+
+    assert.include(instance.className, 'rs-tree');
+    assert.equal(instance.getAttribute('role'), 'tree');
+  });
+
+  it('Should call `onDragStart` callback', () => {
+    const onDragStartSpy = sinon.spy();
+    const instance = getInstance(<Tree data={data} onDragStart={onDragStartSpy} draggable />);
+    const treeNode = instance.querySelector('.rs-tree-node');
+
+    Simulate.dragStart(treeNode);
+
+    assert.isTrue(onDragStartSpy.calledOnce);
+    assert.isNotNull(treeNode.querySelector('.rs-tree-node-dragging'));
+    assert.equal(onDragStartSpy.firstCall.firstArg.value, 'Master');
+  });
+
+  it('Should call `onDragEnter` callback', () => {
+    const onDragEnterSpy = sinon.spy();
+    const instance = getInstance(<Tree data={data} onDragEnter={onDragEnterSpy} draggable />);
+    const treeNode = instance.querySelector('.rs-tree-node');
+
+    Simulate.dragEnter(treeNode);
+    assert.isTrue(onDragEnterSpy.calledOnce);
+    assert.equal(onDragEnterSpy.firstCall.firstArg.value, 'Master');
+  });
+
+  it('Should call `onDragOver` callback', () => {
+    const onDragOverSpy = sinon.spy();
+    const instance = getInstance(<Tree data={data} onDragOver={onDragOverSpy} draggable />);
+    const treeNode = instance.querySelector('.rs-tree-node');
+
+    Simulate.dragOver(treeNode);
+    assert.isTrue(onDragOverSpy.calledOnce);
+    assert.equal(onDragOverSpy.firstCall.firstArg.value, 'Master');
+  });
+
+  it('Should call `onDragLeave` callback', () => {
+    const onDragLeaveSpy = sinon.spy();
+    const instance = getInstance(<Tree data={data} onDragLeave={onDragLeaveSpy} draggable />);
+    const treeNode = instance.querySelector('.rs-tree-node');
+
+    Simulate.dragLeave(treeNode);
+    assert.isTrue(onDragLeaveSpy.calledOnce);
+    assert.equal(onDragLeaveSpy.firstCall.firstArg.value, 'Master');
+  });
+
+  it('Should call `onDragEnd` callback', () => {
+    const onDragEndSpy = sinon.spy();
+    const instance = getInstance(<Tree data={data} onDragEnd={onDragEndSpy} draggable />);
+    const treeNode = instance.querySelector('.rs-tree-node');
+
+    Simulate.dragEnd(treeNode);
+    assert.isTrue(onDragEndSpy.calledOnce);
+    assert.equal(onDragEndSpy.firstCall.firstArg.value, 'Master');
+  });
+});

--- a/src/TreePicker/TreeNode.tsx
+++ b/src/TreePicker/TreeNode.tsx
@@ -1,9 +1,9 @@
-import React, { forwardRef, useCallback } from 'react';
+import React, { forwardRef, useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { hasClass } from 'dom-lib';
 import ArrowDown from '@rsuite/icons/legacy/ArrowDown';
 import Spinner from '@rsuite/icons/legacy/Spinner';
-
+import TreeContext from '../Tree/TreeContext';
 import reactToString from '../utils/reactToString';
 import { useClassNames, TREE_NODE_PADDING, TREE_NODE_ROOT_PADDING } from '../utils';
 import { WithAsProps, RsRefForwardingComponent } from '../@types/common';
@@ -82,6 +82,7 @@ const TreeNode: RsRefForwardingComponent<'div', TreeNodeProps> = forwardRef<
     ref
   ) => {
     const { prefix, merge, withClassPrefix } = useClassNames(classPrefix);
+    const { dragNodeRef } = useContext(TreeContext);
 
     const getTitle = useCallback(() => {
       if (typeof label === 'string') {
@@ -120,13 +121,14 @@ const TreeNode: RsRefForwardingComponent<'div', TreeNodeProps> = forwardRef<
 
     const handleDragStart = useCallback(
       (event: React.DragEvent) => {
-        const dragNode = document.getElementById('drag-node');
+        const dragNode = dragNodeRef?.current;
+
         if (dragNode) {
-          event.dataTransfer.setDragImage(dragNode, 0, 0);
+          event.dataTransfer?.setDragImage(dragNode, 0, 0);
         }
         onDragStart?.(nodeData, event);
       },
-      [nodeData, onDragStart]
+      [dragNodeRef, nodeData, onDragStart]
     );
 
     const handleDragEnter = useCallback(

--- a/src/TreePicker/test/TreeNodeSpec.js
+++ b/src/TreePicker/test/TreeNodeSpec.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Simulate } from 'react-dom/test-utils';
+import { getDOMNode } from '@test/testUtils';
+import TreeNode from '../TreeNode';
+
+describe('TreePicker - TreeNode', () => {
+  it('Should render tree node', () => {
+    const instance = getDOMNode(<TreeNode layer={0} />);
+
+    assert.include(instance.className, 'rs-tree-node');
+    assert.include(instance.getAttribute('role'), 'treeitem');
+  });
+
+  it('Should call `onDragStart` callback', () => {
+    const onDragStartSpy = sinon.spy();
+    const instance = getDOMNode(<TreeNode layer={0} onDragStart={onDragStartSpy} nodeData={1} />);
+
+    Simulate.dragStart(instance);
+
+    assert.isTrue(onDragStartSpy.calledOnce);
+    assert.equal(onDragStartSpy.firstCall.firstArg, 1);
+  });
+
+  it('Should call `onDragEnter` callback', () => {
+    const onDragEnterSpy = sinon.spy();
+    const instance = getDOMNode(<TreeNode layer={0} onDragEnter={onDragEnterSpy} nodeData={1} />);
+
+    Simulate.dragEnter(instance);
+
+    assert.isTrue(onDragEnterSpy.calledOnce);
+    assert.equal(onDragEnterSpy.firstCall.firstArg, 1);
+  });
+
+  it('Should call `onDragOver` callback', () => {
+    const onDragOverSpy = sinon.spy();
+    const instance = getDOMNode(<TreeNode layer={0} onDragOver={onDragOverSpy} nodeData={1} />);
+
+    Simulate.dragOver(instance);
+
+    assert.isTrue(onDragOverSpy.calledOnce);
+    assert.equal(onDragOverSpy.firstCall.firstArg, 1);
+  });
+
+  it('Should call `onDragEnd` callback', () => {
+    const onDragEndSpy = sinon.spy();
+    const instance = getDOMNode(<TreeNode layer={0} onDragEnd={onDragEndSpy} nodeData={1} />);
+
+    Simulate.dragEnd(instance);
+
+    assert.isTrue(onDragEndSpy.calledOnce);
+    assert.equal(onDragEndSpy.firstCall.firstArg, 1);
+  });
+});

--- a/src/TreePicker/test/TreePickerSpec.js
+++ b/src/TreePicker/test/TreePickerSpec.js
@@ -1,12 +1,8 @@
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
-import ReactDOM from 'react-dom';
-import { getDOMNode, getInstance } from '@test/testUtils';
+import { act, Simulate } from 'react-dom/test-utils';
+import { getDOMNode, getInstance, render } from '@test/testUtils';
 import TreePicker from '../TreePicker';
 import { KEY_VALUES } from '../../utils';
-
-const itemFocusClassName = '.rs-tree-node-focus';
-const itemExpandedClassName = '.rs-tree-node-expanded';
 
 const data = [
   {
@@ -35,18 +31,6 @@ const data = [
   }
 ];
 
-let container;
-
-beforeEach(() => {
-  container = document.createElement('div');
-  document.body.appendChild(container);
-});
-
-afterEach(() => {
-  document.body.removeChild(container);
-  container = null;
-});
-
 describe('TreePicker', () => {
   it('Should render default value', () => {
     const instance = getDOMNode(<TreePicker defaultOpen data={data} defaultValue={'Master'} />);
@@ -57,7 +41,7 @@ describe('TreePicker', () => {
   it('Should clean selected value', () => {
     const instance = getDOMNode(<TreePicker defaultOpen data={data} defaultValue={'Master'} />);
 
-    ReactTestUtils.Simulate.click(instance.querySelector('.rs-picker-toggle-clean'));
+    Simulate.click(instance.querySelector('.rs-picker-toggle-clean'));
     expect(instance.querySelector('.rs-picker-toggle').innerText).to.equal('Select');
   });
 
@@ -80,13 +64,13 @@ describe('TreePicker', () => {
   it('Should be disabled', () => {
     const instance = getDOMNode(<TreePicker disabled data={[]} />);
 
-    assert.ok(instance.className.match(/\bdisabled\b/));
+    assert.include(instance.className, 'disabled');
   });
 
   it('Should be block', () => {
     const instance = getDOMNode(<TreePicker block data={[]} />);
 
-    assert.ok(instance.className.match(/\bblock\b/));
+    assert.include(instance.className, 'block');
   });
 
   it('Should active one node by `value`', () => {
@@ -99,7 +83,7 @@ describe('TreePicker', () => {
       <TreePicker open cascade={false} data={data} value={['Master']} />
     );
 
-    ReactTestUtils.Simulate.click(
+    Simulate.click(
       instance.overlay.querySelector('div[data-ref="0-0"]  > .rs-tree-node-expand-icon')
     );
     assert.equal(instance.overlay.querySelectorAll('.rs-tree-open').length, 1);
@@ -174,57 +158,54 @@ describe('TreePicker', () => {
     assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'test');
   });
 
-  it('Should call `onChange` callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getInstance(<TreePicker open onChange={doneOp} data={data} />);
-    ReactTestUtils.Simulate.click(instance.overlay.querySelector('span[data-key="0-0"]'));
+  it('Should call `onChange` callback', () => {
+    const onChangeSpy = sinon.spy();
+    const instance = getInstance(<TreePicker open onChange={onChangeSpy} data={data} />);
+
+    Simulate.click(instance.overlay.querySelector('span[data-key="0-0"]'));
+    assert.isTrue(onChangeSpy.calledOnce);
   });
 
-  it('Should call `onClean` callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call `onClean` callback', () => {
+    const onCleanSpy = sinon.spy();
     const instance = getDOMNode(
-      <TreePicker defaultOpen data={data} defaultValue={'tester0'} onClean={doneOp} />
+      <TreePicker defaultOpen data={data} defaultValue={'tester0'} onClean={onCleanSpy} />
     );
 
-    ReactTestUtils.Simulate.click(instance.querySelector('.rs-picker-toggle-clean'));
+    Simulate.click(instance.querySelector('.rs-picker-toggle-clean'));
+    assert.isTrue(onCleanSpy.calledOnce);
   });
 
-  it('Should call `onOpen` callback', done => {
-    const cb = () => {
-      done();
-    };
+  it('Should call `onOpen` callback', () => {
+    const onOpenSpy = sinon.spy();
+    const instance = getDOMNode(<TreePicker onOpen={onOpenSpy} data={data} />);
 
-    const instance = getDOMNode(<TreePicker onOpen={cb} data={data} />);
-    ReactTestUtils.Simulate.click(instance.querySelector('.rs-picker-toggle'));
+    Simulate.click(instance.querySelector('.rs-picker-toggle'));
+    assert.isTrue(onOpenSpy.calledOnce);
   });
 
-  it('Should call `onClose` callback', done => {
-    const cb = () => {
-      done();
-    };
+  it('Should call `onClose` callback', () => {
+    const onCloseSpy = sinon.spy();
+    const instance = getDOMNode(<TreePicker onClose={onCloseSpy} data={data} />);
 
-    const instance = getDOMNode(<TreePicker onClose={cb} data={data} />);
-    ReactTestUtils.Simulate.click(instance.querySelector('.rs-picker-toggle'));
-    ReactTestUtils.Simulate.click(instance.querySelector('.rs-picker-toggle'));
+    Simulate.click(instance.querySelector('.rs-picker-toggle'));
+    Simulate.click(instance.querySelector('.rs-picker-toggle'));
+    assert.isTrue(onCloseSpy.calledOnce);
   });
 
   it('Should focus item by keyCode=40', () => {
     const instance = getInstance(<TreePicker open data={data} defaultExpandAll value="tester1" />);
-    ReactTestUtils.Simulate.keyDown(instance.target, { key: KEY_VALUES.DOWN });
+    Simulate.keyDown(instance.target, { key: KEY_VALUES.DOWN });
 
-    assert.equal(instance.overlay.querySelector(itemFocusClassName).innerText, 'Master');
+    assert.equal(instance.overlay.querySelector('.rs-tree-node-focus').innerText, 'Master');
   });
 
   it('Should focus item by keyCode=38 ', () => {
     const instance = getInstance(<TreePicker open data={data} defaultExpandAll value="tester1" />);
 
-    ReactTestUtils.Simulate.click(instance.overlay.querySelector('span[data-key="0-0-1"]'));
-    ReactTestUtils.Simulate.keyDown(instance.target, { key: KEY_VALUES.UP });
-    assert.equal(instance.overlay.querySelector(itemFocusClassName).innerText, 'tester0');
+    Simulate.click(instance.overlay.querySelector('span[data-key="0-0-1"]'));
+    Simulate.keyDown(instance.target, { key: KEY_VALUES.UP });
+    assert.equal(instance.overlay.querySelector('.rs-tree-node-focus').innerText, 'tester0');
   });
 
   it('Should focus item by keyCode=13 ', done => {
@@ -234,7 +215,7 @@ describe('TreePicker', () => {
     const instance = getInstance(
       <TreePicker defaultOpen data={data} onChange={doneOp} defaultExpandAll />
     );
-    ReactTestUtils.Simulate.click(instance.overlay.querySelector('span[data-key="0-0-1"]'));
+    Simulate.click(instance.overlay.querySelector('span[data-key="0-0-1"]'));
   });
 
   /**
@@ -243,10 +224,10 @@ describe('TreePicker', () => {
   it('Should fold children node by keyCode=37', () => {
     const tree = getInstance(<TreePicker defaultOpen data={data} defaultExpandAll />);
 
-    ReactTestUtils.Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
-    ReactTestUtils.Simulate.keyDown(tree.overlay, { key: KEY_VALUES.LEFT });
+    Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
+    Simulate.keyDown(tree.overlay, { key: KEY_VALUES.LEFT });
     assert.equal(
-      tree.overlay.querySelectorAll(`div[data-ref="0-0"] > ${itemExpandedClassName}`).length,
+      tree.overlay.querySelectorAll('div[data-ref="0-0"] > .rs-tree-node-expanded').length,
       0
     );
   });
@@ -257,12 +238,12 @@ describe('TreePicker', () => {
   it('Should change nothing when trigger on root node by keyCode=37', () => {
     const tree = getInstance(<TreePicker defaultOpen data={data} defaultExpandAll />);
 
-    ReactTestUtils.Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
-    ReactTestUtils.Simulate.keyDown(tree.overlay, { key: KEY_VALUES.LEFT });
-    assert.equal(tree.overlay.querySelector(itemFocusClassName).innerText, 'Master');
+    Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
+    Simulate.keyDown(tree.overlay, { key: KEY_VALUES.LEFT });
+    assert.equal(tree.overlay.querySelector('.rs-tree-node-focus').innerText, 'Master');
 
     assert.equal(
-      tree.overlay.querySelectorAll(`div[data-ref="0-0"] > ${itemExpandedClassName}`).length,
+      tree.overlay.querySelectorAll('div[data-ref="0-0"] > .rs-tree-node-expanded').length,
       0
     );
   });
@@ -273,9 +254,9 @@ describe('TreePicker', () => {
   it('Should focus on parentNode when trigger on leaf node by keyCode=37', () => {
     const tree = getInstance(<TreePicker defaultOpen data={data} defaultExpandAll />);
 
-    ReactTestUtils.Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
-    ReactTestUtils.Simulate.keyDown(tree.overlay, { key: KEY_VALUES.LEFT });
-    assert.equal(tree.overlay.querySelector(itemFocusClassName).innerText, 'Master');
+    Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
+    Simulate.keyDown(tree.overlay, { key: KEY_VALUES.LEFT });
+    assert.equal(tree.overlay.querySelector('.rs-tree-node-focus').innerText, 'Master');
   });
 
   /**
@@ -284,10 +265,10 @@ describe('TreePicker', () => {
   it('Should fold children node by keyCode=39', () => {
     const tree = getInstance(<TreePicker defaultOpen data={data} />);
 
-    ReactTestUtils.Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
-    ReactTestUtils.Simulate.keyDown(tree.overlay, { key: KEY_VALUES.RIGHT });
+    Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
+    Simulate.keyDown(tree.overlay, { key: KEY_VALUES.RIGHT });
     assert.equal(
-      tree.overlay.querySelectorAll(`div[data-ref="0-0"] > ${itemExpandedClassName}`).length,
+      tree.overlay.querySelectorAll('div[data-ref="0-0"] > .rs-tree-node-expanded').length,
       1
     );
   });
@@ -298,9 +279,9 @@ describe('TreePicker', () => {
   it('Should change nothing when trigger on leaf node by keyCode=39', () => {
     const tree = getInstance(<TreePicker defaultOpen data={data} defaultExpandAll />);
 
-    ReactTestUtils.Simulate.click(tree.overlay.querySelector('span[data-key="0-0-0"]'));
-    ReactTestUtils.Simulate.keyDown(tree.overlay, { key: KEY_VALUES.RIGHT });
-    assert.equal(tree.overlay.querySelector(itemFocusClassName).innerText, 'tester0');
+    Simulate.click(tree.overlay.querySelector('span[data-key="0-0-0"]'));
+    Simulate.keyDown(tree.overlay, { key: KEY_VALUES.RIGHT });
+    assert.equal(tree.overlay.querySelector('.rs-tree-node-focus').innerText, 'tester0');
   });
 
   /**
@@ -309,9 +290,9 @@ describe('TreePicker', () => {
   it('Should focus on first child node when node expanded by keyCode=39', () => {
     const tree = getInstance(<TreePicker defaultOpen data={data} defaultExpandAll />);
 
-    ReactTestUtils.Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
-    ReactTestUtils.Simulate.keyDown(tree.overlay, { key: KEY_VALUES.RIGHT });
-    assert.equal(tree.overlay.querySelector(itemFocusClassName).innerText, 'tester0');
+    Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
+    Simulate.keyDown(tree.overlay, { key: KEY_VALUES.RIGHT });
+    assert.equal(tree.overlay.querySelector('.rs-tree-node-focus').innerText, 'tester0');
   });
 
   it('Should have a custom className', () => {
@@ -344,8 +325,8 @@ describe('TreePicker', () => {
       }
     ];
     const ref = React.createRef();
-    ReactTestUtils.act(() => {
-      ReactDOM.render(
+    act(() => {
+      render(
         <TreePicker
           data={data}
           cascade={false}
@@ -358,13 +339,12 @@ describe('TreePicker', () => {
               value: 'children1'
             }
           ]}
-        />,
-        container
+        />
       );
     });
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.click(
+    act(() => {
+      Simulate.click(
         ref.current.overlay.querySelector('div[data-ref="0-1"]  > .rs-tree-node-expand-icon')
       );
     });
@@ -414,7 +394,7 @@ describe('TreePicker', () => {
     const instance = getInstance(
       <TreePicker defaultOpen data={data} expandItemValues={['Master']} />
     );
-    assert.equal(getDOMNode(instance.overlay).querySelectorAll(itemExpandedClassName).length, 1);
+    assert.equal(getDOMNode(instance.overlay).querySelectorAll('.rs-tree-node-expanded').length, 1);
   });
 
   it('Should fold all the node when toggle master node', () => {
@@ -445,19 +425,19 @@ describe('TreePicker', () => {
       expandItemValues = values;
     };
     const ref = React.createRef();
-    ReactTestUtils.act(() => {
-      ReactDOM.render(<TestApp ref={ref} onExpand={mockOnExpand} />, container);
+    act(() => {
+      render(<TestApp ref={ref} onExpand={mockOnExpand} />);
     });
 
     assert.ok(ref.current.picker.overlay.querySelector('.rs-tree-node-expanded'));
 
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.click(
+    act(() => {
+      Simulate.click(
         ref.current.picker.overlay.querySelector('div[data-ref="0-0"]  > .rs-tree-node-expand-icon')
       );
     });
 
-    ReactTestUtils.act(() => {
+    act(() => {
       ref.current.setExpandItemValues(expandItemValues);
     });
 
@@ -484,17 +464,17 @@ describe('TreePicker', () => {
     );
 
     const searchBar = instance.overlay.querySelector('.rs-picker-search-bar-input');
-    ReactTestUtils.Simulate.change(searchBar, {
+    Simulate.change(searchBar, {
       target: { value: 'Master' }
     });
 
     searchBar.focus();
-    ReactTestUtils.Simulate.keyDown(searchBar, {
+    Simulate.keyDown(searchBar, {
       key: KEY_VALUES.BACKSPACE
     });
     assert.equal(instance.root.querySelector('.rs-picker-toggle-value').innerText, 'Master');
 
-    ReactTestUtils.Simulate.keyDown(instance.overlay, {
+    Simulate.keyDown(instance.overlay, {
       key: KEY_VALUES.BACKSPACE
     });
 
@@ -507,7 +487,7 @@ describe('TreePicker', () => {
     assert.equal(instance.overlay.querySelectorAll('.rs-tree-node').length, 2);
 
     const searchBar = instance.overlay.querySelector('.rs-picker-search-bar-input');
-    ReactTestUtils.Simulate.change(searchBar, {
+    Simulate.change(searchBar, {
       target: { value: 'test' }
     });
 

--- a/src/TreePicker/test/TreePickerStylesSpec.js
+++ b/src/TreePicker/test/TreePickerStylesSpec.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import TreePicker from '../index';
-import { createTestContainer, getStyle, inChrome } from '@test/testUtils';
+import { render, getStyle, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
@@ -35,8 +34,7 @@ const data = [
 describe('TreePicker styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    const containerDom = createTestContainer();
-    ReactDOM.render(<TreePicker data={data} ref={instanceRef} open />, containerDom);
+    render(<TreePicker data={data} ref={instanceRef} open />);
     const pickerMenuDom = document.querySelector('.rs-picker-tree-menu');
     const treeWrapperDom = pickerMenuDom.querySelector('.rs-tree');
     const treeNodeDom = pickerMenuDom.querySelector('.rs-tree-node');


### PR DESCRIPTION
- Removed `inline` prop on Tree related components. Through context management.
- Removed the hard-coded id attribute on the drag element https://github.com/rsuite/rsuite/pull/1883/files#diff-e7f6213f721793e010931abb7589019403121edde27e935bf3fe07af27031037L762
- Fixed the inability to get element on `Tree` and `CheckTree` through `ref`.