### PR TITLE
feat(carousel): support `onSelect`, `onSlideEnd`, `onSlideStart` on `<Carousel>`

### DIFF
--- a/docs/pages/components/carousel/en-US/index.md
+++ b/docs/pages/components/carousel/en-US/index.md
@@ -24,12 +24,15 @@ Display a set of elements in a carousel
 
 ### `<Carousel>`
 
-| Property         | Type `(Default)`                                | Description                                    |
-| ---------------- | ----------------------------------------------- | ---------------------------------------------- |
-| as               | ElementType `('div')`                           | Custom element type                            |
-| autoplay         | boolean                                         | Automatic carousel element.                    |
-| autoplayInterval | number (`4000`)                                 | Delay in ms until navigating to the next item. |
-| children         | ReactNode                                       | Carousel elements                              |
-| classPrefix      | string `('carousel')`                           | Component CSS class prefix                     |
-| placement        | enum:'top','bottom','left','right' `('bottom')` | Button placement                               |
-| shape            | enum:'dot','bar' `('dot')`                      | Button shape                                   |
+| Property         | Type `(Default)`                                       | Description                                    |
+| ---------------- | ------------------------------------------------------ | ---------------------------------------------- |
+| as               | ElementType `('div')`                                  | Custom element type                            |
+| autoplay         | boolean                                                | Automatic carousel element.                    |
+| autoplayInterval | number (`4000`)                                        | Delay in ms until navigating to the next item. |
+| children         | ReactNode                                              | Carousel elements                              |
+| classPrefix      | string `('carousel')`                                  | Component CSS class prefix                     |
+| onSelect         | (index: number, event?: React.ChangeEvent) => void     | Callback fired when the active item changes    |
+| onSlideEnd       | (index: number, event?: React.TransitionEvent) => void | Callback fired when a slide transition ends    |
+| onSlideStart     | (index: number, event?: React.ChangeEvent) => void     | Callback fired when a slide transition starts  |
+| placement        | enum:'top','bottom','left','right' `('bottom')`        | Button placement                               |
+| shape            | enum:'dot','bar' `('dot')`                             | Button shape                                   |

--- a/docs/pages/components/carousel/zh-CN/index.md
+++ b/docs/pages/components/carousel/zh-CN/index.md
@@ -24,14 +24,14 @@
 
 ### `<Carousel>`
 
-| 属性名称     | 类型`(默认值)`                                         | 描述                                          |
-| ------------ | ------------------------------------------------------ | --------------------------------------------- |
-| as           | ElementType `('div')`                                  | 自定义元素类型                                |
-| autoplay     | boolean                                                | 自动轮播                                      |
-| children     | ReactNode                                              | 轮播的元素                                    |
-| classPrefix  | string `('carousel')`                                  | 组件 CSS 类的前缀                             |
-| onSelect     | (index: number, event?: React.ChangeEvent) => void     | Callback fired when the active item changes   |
-| onSlideEnd   | (index: number, event?: React.TransitionEvent) => void | Callback fired when a slide transition ends   |
-| onSlideStart | (index: number, event?: React.ChangeEvent) => void     | Callback fired when a slide transition starts |
-| placement    | enum:'top','bottom','left','right' `('bottom')`        | 按钮的位置                                    |
-| shape        | enum:'dot','bar' `('dot')`                             | 按钮的形状                                    |
+| 属性名称     | 类型`(默认值)`                                         | 描述                       |
+| ------------ | ------------------------------------------------------ | -------------------------- |
+| as           | ElementType `('div')`                                  | 自定义元素类型             |
+| autoplay     | boolean                                                | 自动轮播                   |
+| children     | ReactNode                                              | 轮播的元素                 |
+| classPrefix  | string `('carousel')`                                  | 组件 CSS 类的前缀          |
+| onSelect     | (index: number, event?: React.ChangeEvent) => void     | 活动项更改时触发的回调     |
+| onSlideEnd   | (index: number, event?: React.TransitionEvent) => void | 幻灯片过渡结束时触发的回调 |
+| onSlideStart | (index: number, event?: React.ChangeEvent) => void     | 幻灯片过渡开始时触发的回调 |
+| placement    | enum:'top','bottom','left','right' `('bottom')`        | 按钮的位置                 |
+| shape        | enum:'dot','bar' `('dot')`                             | 按钮的形状                 |

--- a/docs/pages/components/carousel/zh-CN/index.md
+++ b/docs/pages/components/carousel/zh-CN/index.md
@@ -24,11 +24,14 @@
 
 ### `<Carousel>`
 
-| 属性名称    | 类型`(默认值)`                                  | 描述              |
-| ----------- | ----------------------------------------------- | ----------------- |
-| as          | ElementType `('div')`                           | 自定义元素类型    |
-| autoplay    | boolean                                         | 自动轮播          |
-| children    | ReactNode                                       | 轮播的元素        |
-| classPrefix | string `('carousel')`                           | 组件 CSS 类的前缀 |
-| placement   | enum:'top','bottom','left','right' `('bottom')` | 按钮的位置        |
-| shape       | enum:'dot','bar' `('dot')`                      | 按钮的形状        |
+| 属性名称     | 类型`(默认值)`                                         | 描述                                          |
+| ------------ | ------------------------------------------------------ | --------------------------------------------- |
+| as           | ElementType `('div')`                                  | 自定义元素类型                                |
+| autoplay     | boolean                                                | 自动轮播                                      |
+| children     | ReactNode                                              | 轮播的元素                                    |
+| classPrefix  | string `('carousel')`                                  | 组件 CSS 类的前缀                             |
+| onSelect     | (index: number, event?: React.ChangeEvent) => void     | Callback fired when the active item changes   |
+| onSlideEnd   | (index: number, event?: React.TransitionEvent) => void | Callback fired when a slide transition ends   |
+| onSlideStart | (index: number, event?: React.ChangeEvent) => void     | Callback fired when a slide transition starts |
+| placement    | enum:'top','bottom','left','right' `('bottom')`        | 按钮的位置                                    |
+| shape        | enum:'dot','bar' `('dot')`                             | 按钮的形状                                    |

--- a/src/Carousel/test/CarouselSpec.js
+++ b/src/Carousel/test/CarouselSpec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import Carousel from '../Carousel';
 
@@ -39,5 +40,55 @@ describe('Carousel', () => {
   it('Should have a custom className prefix', () => {
     const instance = getDOMNode(<Carousel classPrefix="custom-prefix" md={1} />);
     assert.ok(instance.className.match(/\bcustom-prefix\b/));
+  });
+
+  it('Should be autoplay', done => {
+    const style = { height: 20 };
+    getDOMNode(
+      <Carousel
+        autoplay
+        autoplayInterval={500}
+        onSlideStart={() => done()}
+        style={{ width: 200, height: 20 }}
+      >
+        <div style={style}>1</div>
+        <div style={style}>2</div>
+      </Carousel>
+    );
+  });
+
+  it('Should call `onSlideStart` callback', done => {
+    const instance = getDOMNode(
+      <Carousel onSlideStart={() => done()}>
+        <div>1</div>
+        <div>2</div>
+      </Carousel>
+    );
+
+    const input = instance.querySelectorAll('.rs-carousel-label-wrapper')[1].querySelector('input');
+    ReactTestUtils.Simulate.change(input);
+  });
+
+  it('Should call `onSelect` callback', done => {
+    const instance = getDOMNode(
+      <Carousel onSelect={() => done()}>
+        <div>1</div>
+        <div>2</div>
+      </Carousel>
+    );
+
+    const input = instance.querySelectorAll('.rs-carousel-label-wrapper')[1].querySelector('input');
+    ReactTestUtils.Simulate.change(input);
+  });
+
+  it('Should call `onSlideEnd` callback', done => {
+    const instance = getDOMNode(
+      <Carousel onSlideEnd={() => done()}>
+        <div>1</div>
+        <div>2</div>
+      </Carousel>
+    );
+
+    ReactTestUtils.Simulate.transitionEnd(instance.querySelector('.rs-carousel-slider'));
   });
 });


### PR DESCRIPTION
| Property         | Type `(Default)`                                       | Description                                    |
| ---------------- | ------------------------------------------------------ | ---------------------------------------------- |
| onSelect         | (index: number, event?: React.ChangeEvent) => void     | Callback fired when the active item changes    |
| onSlideEnd       | (index: number, event?: React.TransitionEvent) => void | Callback fired when a slide transition ends    |
| onSlideStart     | (index: number, event?: React.ChangeEvent) => void     | Callback fired when a slide transition starts  |
