### PR TITLE
fix(sidenav): fix nav item not activated in collapsed sidenav

### DIFF
--- a/src/Sidenav/SidenavItem.tsx
+++ b/src/Sidenav/SidenavItem.tsx
@@ -83,45 +83,28 @@ const SidenavItem: RsRefForwardingComponent<'li', SidenavItemProps> = React.forw
             withClassPrefix({ focus: active, active: selected, disabled })
           );
 
-          const item = (
-            <Component
-              ref={mergeRefs(ref, menuitemRef)}
-              disabled={Component === SafeAnchor ? disabled : undefined}
-              className={classes}
-              data-event-key={eventKey}
-              {...menuitem}
-              {...omit(rest, ['divider', 'panel'])}
-            >
-              {icon}
-              {children}
-              <Ripple />
-            </Component>
-          );
-
           // Show tooltip when inside a collapse <Sidenav>
-          return sidenav
-            ? appendTooltip({
-                children: (triggerProps, triggerRef) => {
-                  return (
-                    <Component
-                      ref={mergeRefs(mergeRefs(ref, menuitemRef), triggerRef as any)}
-                      disabled={Component === SafeAnchor ? disabled : undefined}
-                      className={classes}
-                      data-event-key={eventKey}
-                      {...menuitem}
-                      {...omit(rest, ['divider', 'panel'])}
-                      {...triggerProps}
-                    >
-                      {icon}
-                      {children}
-                      <Ripple />
-                    </Component>
-                  );
-                },
-                message: children,
-                placement: 'right'
-              })
-            : item;
+          return appendTooltip({
+            children: (triggerProps, triggerRef) => {
+              return (
+                <Component
+                  ref={mergeRefs(mergeRefs(ref, menuitemRef), triggerRef as any)}
+                  disabled={Component === SafeAnchor ? disabled : undefined}
+                  className={classes}
+                  data-event-key={eventKey}
+                  {...omit(rest, ['divider', 'panel'])}
+                  {...triggerProps}
+                  {...menuitem}
+                >
+                  {icon}
+                  {children}
+                  <Ripple />
+                </Component>
+              );
+            },
+            message: children,
+            placement: 'right'
+          });
         }}
       </MenuItem>
     );

--- a/src/Sidenav/styles/index.less
+++ b/src/Sidenav/styles/index.less
@@ -1,4 +1,5 @@
 @import '../../styles/common';
+@import '../../styles//mixins/menu';
 @import '../../Ripple/styles/mixins';
 @import 'mixin';
 
@@ -416,8 +417,16 @@
   }
 
   .rs-sidenav-item.rs-sidenav-item-active,
+  .rs-dropdown-item.rs-dropdown-item-active,
   .rs-dropdown.rs-dropdown-selected-within .rs-dropdown-toggle-icon {
     color: var(--rs-sidenav-default-selected-text);
+  }
+
+  // Collapsed
+  &.rs-sidenav-collapse-out {
+    .rs-dropdown-item.rs-dropdown-item-active {
+      .menuitem-active();
+    }
   }
 }
 

--- a/src/Sidenav/test/SidenavSpec.js
+++ b/src/Sidenav/test/SidenavSpec.js
@@ -215,6 +215,37 @@ describe('<Sidenav>', () => {
     );
   });
 
+  it('Should call <Nav onSelect> with correct eventKey when <Sidenav expanded={false}>', () => {
+    const onSelectSpy = sinon.spy();
+    const { getByTestId } = render(
+      <Sidenav expanded={false}>
+        <Nav onSelect={onSelectSpy}>
+          <Nav.Item eventKey="1-1" data-testid="nav-item">
+            Nav item
+          </Nav.Item>
+          <Dropdown title="Dropdown" data-testid="dropdown">
+            <Dropdown.Item eventKey="2-1" data-testid="dropdown-item">
+              Dropdown item
+            </Dropdown.Item>
+          </Dropdown>
+        </Nav>
+      </Sidenav>
+    );
+
+    userEvent.click(getByTestId('nav-item'));
+    expect(onSelectSpy, 'Works with <Nav.Item>').to.have.been.calledWith('1-1', sinon.match.any);
+
+    onSelectSpy.resetHistory();
+    // opens the dropdown
+    userEvent.click(getByTestId('dropdown'));
+
+    userEvent.click(getByTestId('dropdown-item'));
+    expect(onSelectSpy, 'Works with <Dropdown.Item>').to.have.been.calledWith(
+      '2-1',
+      sinon.match.any
+    );
+  });
+
   it('Should add "selected-within" className on <Dropdown> when some item inside is selected', () => {
     const { getByTestId } = render(
       <Sidenav>


### PR DESCRIPTION
`<Nav.Item>` inside collapsed `<Sidenav>` was not able to be activated by clicking on it.