### PR TITLE
docs(v5): fix typo and add missing Form.ErrorMessage in title

### DIFF
--- a/docs/pages/components/form/en-US/index.md
+++ b/docs/pages/components/form/en-US/index.md
@@ -6,7 +6,8 @@ A set of components and models that process form data.
 - `<Form.Group>` Define form groups, used for form layout.
 - `<Form.Control>` Define form-control.
 - `<Form.ControlLabel>` title of form-control.
-- `<Form.HelpText>` help infomation of form-controll
+- `<Form.HelpText>` help infomation of form-control.
+- `<Form.ErrorMessage>` error infomation of form-control.
 
 ## Import
 
@@ -201,7 +202,7 @@ cleanErrorForField: (fieldName: keyof E, callback?: () => void) => void;
 | htmlFor     | string                      | Attribute of the html label tag, defaults to the controlId of the Form.Group |
 | tooltip     | boolean                     | Whether to show through the Tooltip component                                |
 
-### `<Form.ErrorMessge>`
+### `<Form.ErrorMessage>`
 
 | Property    | Type`(default)`                   | Description                           |
 | ----------- | --------------------------------- | ------------------------------------- |

--- a/docs/pages/components/form/zh-CN/index.md
+++ b/docs/pages/components/form/zh-CN/index.md
@@ -190,7 +190,7 @@ cleanErrorForField: (fieldName: keyof E, callback?: () => void) => void;
 | htmlFor     | string                      | 对应 html label 标签的 for 属性，默认为 Form.Group 的 controlId |
 | tooltip     | boolean                     | 是否通过 Tooltip 组件显示                                       |
 
-### `<Form.ErrorMessge>`
+### `<Form.ErrorMessage>`
 
 | 属性名称    | 类型`(默认值)`                    | 描述              |
 | ----------- | --------------------------------- | ----------------- |


### PR DESCRIPTION
Hi, I've found some typos when I make some experiments with your library.
Lemme know if additional stuff needs to be done.

And thanks for the job 👏 