### PR TITLE
fix(pickers): fix `listProps` not working on picker

### DIFF
--- a/docs/pages/components/check-tree-picker/en-US/index.md
+++ b/docs/pages/components/check-tree-picker/en-US/index.md
@@ -72,6 +72,7 @@ Learn more in [Accessibility](/guide/accessibility).
 | getChildren             | (node: DataItemType) => Promise&lt;DataItemType&gt;                                           | load node children data asynchronously                                    |
 | height                  | number `(360px)`                                                                              | height of menu. When `virtualize` is true, you can set the height of menu |
 | labelKey                | string `('label')`                                                                            | set label key in data                                                     |
+| listProps               | [ListProps][listprops]                                                                        | List-related properties in `react-virtualized`                            |
 | locale                  | [PickerLocaleType](/guide/i18n/#pickers)                                                      | Locale text                                                               |
 | menuClassName           | string                                                                                        | className for Menu                                                        |
 | menuStyle               | CSSProperties                                                                                 | style for Menu                                                            |
@@ -110,3 +111,5 @@ Learn more in [Accessibility](/guide/accessibility).
 - [`<CheckTree>`](/components/check-tree)
 - [`<Tree>`](/components/tree)
 - [`<TreePicker>`](/components/tree-picker)
+
+[listprops]: https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#prop-types

--- a/docs/pages/components/check-tree-picker/zh-CN/index.md
+++ b/docs/pages/components/check-tree-picker/zh-CN/index.md
@@ -72,6 +72,7 @@
 | getChildren             | (node: DataItemType) => Promise&lt;DataItemType&gt;                                           | 异步加载节点数据                                                                |
 | height                  | number `(360px)`                                                                              | menu 的高度。当设置了 virtualized 为 true 时， 可以通过 height 控制 menu 的高度 |
 | labelKey                | string `('label')`                                                                            | tree 数据结构 label 属性名称                                                    |
+| listProps               | [ListProps][listprops]                                                                        | `react-virtualized` 中 List 的相关属性                                          |
 | locale                  | [PickerLocaleType](/zh/guide/i18n/#pickers)                                                   | 本地化的文本                                                                    |
 | menuClassName           | string                                                                                        | 选项菜单的 className                                                            |
 | menuStyle               | CSSProperties                                                                                 | 应用于菜单 DOM 节点的 style                                                     |
@@ -110,3 +111,5 @@
 - [`<CheckTree>`](/zh/components/check-tree) 用于展示一个树结构数据，同时支持 Checkbox 选择。
 - [`<Tree>`](/zh/components/tree) 用于展示一个树结构数据。
 - [`<TreePicker>`](/zh/components/tree-picker) 选择器组件，树形单项选择器。
+
+[listprops]: https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#prop-types

--- a/docs/pages/components/check-tree/en-US/index.md
+++ b/docs/pages/components/check-tree/en-US/index.md
@@ -38,13 +38,14 @@ The cascade attribute can set whether or not CheckTree can consider the cascade 
 | childKey                | string `('children')`                                                                         | Set childrenKey key in data                                               |
 | data \*                 | Array&lt;DataItemType&gt;                                                                     | Tree data                                                                 |
 | defaultExpandAll        | boolean                                                                                       | Expand all tree node                                                      |
-| defaultValue            | string[]                                                                                      | Default values of the selected tree node                                  |
 | defaultExpandItemValues | any []                                                                                        | Set the value of the default expanded node                                |
+| defaultValue            | string[]                                                                                      | Default values of the selected tree node                                  |
 | disabledItemValues      | string[]                                                                                      | Values of disabled tree node                                              |
 | expandItemValues        | any []                                                                                        | Set the value of the expanded node (controlled)                           |
 | getChildren             | (node: DataItemType) => Promise&lt;DataItemType&gt;                                           | load node children data asynchronously                                    |
 | height                  | number `(360px)`                                                                              | height of menu. When `virtualize` is true, you can set the height of menu |
 | labelKey                | string `('label')`                                                                            | Set label key in data                                                     |
+| listProps               | [ListProps][listprops]                                                                        | List-related properties in `react-virtualized`                            |
 | onChange                | (values:string[]) => void                                                                     | Callback fired when value change                                          |
 | onExpand                | (expandItemValues: any [], activeNode:DataItemType, concat:(data, children) => Array) => void | callback fired when tree node expand state changed                        |
 | onSelect                | (activeNode:string, value:any, event) => void                                                 | Callback fired when tree node is selected                                 |
@@ -61,3 +62,5 @@ The cascade attribute can set whether or not CheckTree can consider the cascade 
 - [`<Tree>`](/components/tree)
 - [`<TreePicker>`](/components/tree-picker)
 - [`<CheckTreePicker>`](/components/check-tree-picker)
+
+[listprops]: https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#prop-types

--- a/docs/pages/components/check-tree/zh-CN/index.md
+++ b/docs/pages/components/check-tree/zh-CN/index.md
@@ -38,13 +38,14 @@
 | childKey                | string `('children')`                                                                         | tree 数据结构 children 属性名称                                                 |
 | data \*                 | Array&lt;DataItemType&gt;                                                                     | tree 数据                                                                       |
 | defaultExpandAll        | boolean                                                                                       | 默认展开所有节点                                                                |
+| defaultExpandItemValues | any []                                                                                        | 设置默认展开节点的值                                                            |
 | defaultValue            | string[]                                                                                      | 默认选中的值                                                                    |
 | disabledItemValues      | string[]                                                                                      | 禁用节点列表                                                                    |
-| defaultExpandItemValues | any []                                                                                        | 设置默认展开节点的值                                                            |
 | expandItemValues        | any []                                                                                        | 设置展开节点的值（受控）                                                        |
 | getChildren             | (node: DataItemType) => Promise&lt;DataItemType&gt;                                           | 异步加载节点数据                                                                |
 | height                  | number `(360px)`                                                                              | menu 的高度。当设置了 virtualized 为 true 时， 可以通过 height 控制 menu 的高度 |
 | labelKey                | string `('label')`                                                                            | tree 数据结构 label 属性名称                                                    |
+| listProps               | [ListProps][listprops]                                                                        | `react-virtualized` 中 List 的相关属性                                          |
 | onChange                | (values:string[]) => void                                                                     | 数据改变的回调函数                                                              |
 | onExpand                | (expandItemValues: any [], activeNode:DataItemType, concat:(data, children) => Array) => void | 树节点展示时的回调                                                              |
 | onSelect                | (activeNode:DataItemType,value:any, event) => void                                            | 选择树节点后的回调函数                                                          |
@@ -61,3 +62,5 @@
 - [`<Tree>`](/zh/components/tree) 用于展示一个树结构数据。
 - [`<TreePicker>`](/zh/components/tree-picker) 选择器组件，树形单项选择器。
 - [`<CheckTreePicker>`](/zh/components/check-tree-picker) 选择器组件，在 TreePicker 节点上支持 Checkbox，用于多选 。
+
+[listprops]: https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#prop-types

--- a/docs/pages/components/tree-picker/en-US/index.md
+++ b/docs/pages/components/tree-picker/en-US/index.md
@@ -70,6 +70,7 @@ Learn more in [Accessibility](/guide/accessibility).
 | getChildren             | (node: DataItemType) => Promise&lt;DataItemType&gt;                                           | load node children data asynchronously                                    |
 | height                  | number `(360px)`                                                                              | height of menu. When `virtualize` is true, you can set the height of menu |
 | labelKey                | string `('label')`                                                                            | Tree data structure Label property name                                   |
+| listProps               | [ListProps][listprops]                                                                        | List-related properties in `react-virtualized`                            |
 | locale                  | [PickerLocaleType](/guide/i18n/#pickers)                                                      | Locale text                                                               |
 | menuClassName           | string                                                                                        | A css class to apply to the Menu DOM node                                 |
 | menuStyle               | CSSProperties                                                                                 | style for Menu                                                            |
@@ -106,3 +107,5 @@ Learn more in [Accessibility](/guide/accessibility).
 - [`<CheckTreePicker>`](/components/check-tree-picker) Selector component, which supports a Checkbox on the Treepicker node for multiple selections.
 - [`<Tree>`](/components/tree) Used to show a tree-structured data.
 - [`<CheckTree>`](/components/check-tree) Used to show a tree-structured data while supporting Checkbox selection.
+
+[listprops]: https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#prop-types

--- a/docs/pages/components/tree-picker/zh-CN/index.md
+++ b/docs/pages/components/tree-picker/zh-CN/index.md
@@ -70,8 +70,9 @@
 | getChildren             | (node: DataItemType) => Promise&lt;DataItemType&gt;                                           | 异步加载节点数据                                                                |
 | height                  | number `(360px)`                                                                              | menu 的高度。当设置了 virtualized 为 true 时， 可以通过 height 控制 menu 的高度 |
 | labelKey                | string `('label')`                                                                            | tree 数据结构 label 属性名称                                                    |
-| locale                  | object                                                                                        | 本地语言                                                                        |
+| listProps               | [ListProps][listprops]                                                                        | `react-virtualized` 中 List 的相关属性                                          |
 | locale                  | [PickerLocaleType](/zh/guide/i18n/#pickers)                                                   | 本地化的文本                                                                    |
+| locale                  | object                                                                                        | 本地语言                                                                        |
 | menuClassName           | string                                                                                        | 应用于菜单 DOM 节点的 css class                                                 |
 | menuStyle               | CSSProperties                                                                                 | 应用于菜单 DOM 节点的 style                                                     |
 | onChange                | (value:string) => void                                                                        | 数据改变的回调函数                                                              |
@@ -107,3 +108,5 @@
 - [`<CheckTreePicker>`](/zh/components/check-tree-picker) 选择器组件，在 TreePicker 节点上支持 Checkbox，用于多选 。
 - [`<Tree>`](/zh/components/tree) 用于展示一个树结构数据。
 - [`<CheckTree>`](/zh/components/check-tree) 用于展示一个树结构数据，同时支持 Checkbox 选择。
+
+[listprops]: https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#prop-types

--- a/docs/pages/components/tree/en-US/index.md
+++ b/docs/pages/components/tree/en-US/index.md
@@ -41,12 +41,13 @@
 | getChildren             | (node: DataItemType) => Promise&lt;DataItemType &gt;                                           | load node children data asynchronously                                    |
 | height                  | number `(360px)`                                                                               | Height of tree. When `virtualize` is true, you can set the height of tree |
 | labelKey                | string `('label')`                                                                             | Tree data structure Label property name                                   |
+| listProps               | [ListProps][listprops]                                                                         | List-related properties in `react-virtualized`                            |
 | onChange                | (value:string) => void                                                                         | Callback function for data change                                         |
-| onDragStart             | (nodeData:DataItemType, event) => void                                                         | Called when node drag start                                               |
-| onDragEnter             | (nodeData:DataItemType, event) => void                                                         | Called when node drag enter                                               |
-| onDragOver              | (nodeData:DataItemType, event) => void                                                         | Called when node drag over                                                |
-| onDragLeave             | (nodeData:DataItemType, event) => void                                                         | Called when node drag leave                                               |
 | onDragEnd               | (nodeData:DataItemType, event) => void                                                         | Called when node drag end                                                 |
+| onDragEnter             | (nodeData:DataItemType, event) => void                                                         | Called when node drag enter                                               |
+| onDragLeave             | (nodeData:DataItemType, event) => void                                                         | Called when node drag leave                                               |
+| onDragOver              | (nodeData:DataItemType, event) => void                                                         | Called when node drag over                                                |
+| onDragStart             | (nodeData:DataItemType, event) => void                                                         | Called when node drag start                                               |
 | onDrop                  | (dropData:DropDataType, event) => void                                                         | Called when node drop                                                     |
 | onExpand                | (expandItemValues: any [], activeNode: DataItemType, concat:(data, children) => Array) => void | Callback When tree node is displayed                                      |
 | onSelect                | (activeNode:DataItemType, value, event) => void                                                | Callback function after selecting tree node                               |
@@ -63,3 +64,5 @@
 - [`<CheckTree>`](/components/check-tree) Selector component, which supports a Checkbox on the TreePicker node for multiple selections.
 - [`<TreePicker>`](/components/tree-picker) Used to show a tree-structured data.
 - [`<CheckTreePicker>`](/components/check-tree-picker) Used to show a tree-structured data while supporting Checkbox selection.
+
+[listprops]: https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#prop-types

--- a/docs/pages/components/tree/zh-CN/index.md
+++ b/docs/pages/components/tree/zh-CN/index.md
@@ -33,23 +33,24 @@
 | classPrefix             | string`('picker')`                                                                            | 组件 CSS 类的前缀                                                               |
 | data \*                 | Array&lt;DataItemType&gt;                                                                     | tree 数据                                                                       |
 | defaultExpandAll        | boolean                                                                                       | 默认展开所有节点                                                                |
-| defaultValue            | string                                                                                        | 默认选中的值                                                                    |
 | defaultExpandItemValues | any []                                                                                        | 设置默认展开节点的值                                                            |
+| defaultValue            | string                                                                                        | 默认选中的值                                                                    |
 | disabledItemValues      | string[]                                                                                      | 禁用选项                                                                        |
 | draggable               | boolean                                                                                       | 是否可以拖拽                                                                    |
 | expandItemValues        | any []                                                                                        | 设置展开节点的值（受控）                                                        |
 | getChildren             | (node: DataItemType) => Promise&lt;DataItemType&gt;                                           | 异步加载节点数据                                                                |
 | height                  | number `(360px)`                                                                              | menu 的高度。当设置了 virtualized 为 true 时， 可以通过 height 控制 menu 的高度 |
 | labelKey                | string `('label')`                                                                            | tree 数据结构 label 属性名称                                                    |
+| listProps               | [ListProps][listprops]                                                                        | `react-virtualized` 中 List 的相关属性                                          |
 | onChange                | (value:string) => void                                                                        | 数据改变的回调函数                                                              |
+| onDragEnd               | (nodeData:DataItemType, event) => void                                                        | drag end 回调                                                                   |
+| onDragEnter             | (nodeData:DataItemType, event) => void                                                        | drag enter 回调                                                                 |
+| onDragLeave             | (nodeData:DataItemType, event) => void                                                        | drag leave 回调                                                                 |
+| onDragOver              | (nodeData:DataItemType, event) => void                                                        | drag over 回调                                                                  |
+| onDragStart             | (nodeData:DataItemType, event) => void                                                        | drag start 回调                                                                 |
+| onDrop                  | (dropData:DropDataType, event) => void                                                        | drop 回调                                                                       |
 | onExpand                | (expandItemValues: any [], activeNode:DataItemType, concat:(data, children) => Array) => void | 树节点展示时的回调                                                              |
 | onSelect                | (activeNode:DataItemType, value, event) => void                                               | 选择树节点后的回调函数                                                          |
-| onDragStart             | (nodeData:DataItemType, event) => void                                                        | drag start 回调                                                                 |
-| onDragEnter             | (nodeData:DataItemType, event) => void                                                        | drag enter 回调                                                                 |
-| onDragOver              | (nodeData:DataItemType, event) => void                                                        | drag over 回调                                                                  |
-| onDragLeave             | (nodeData:DataItemType, event) => void                                                        | drag leave 回调                                                                 |
-| onDragEnd               | (nodeData:DataItemType, event) => void                                                        | drag end 回调                                                                   |
-| onDrop                  | (dropData:DropDataType, event) => void                                                        | drop 回调                                                                       |
 | renderDragNode          | (nodeData:DataItemType) => ReactNode                                                          | 当 draggable 为 true 时，自定义渲染拖拽节点                                     |
 | renderTreeIcon          | (nodeData:DataItemType) => ReactNode                                                          | 自定义渲染 图标                                                                 |
 | renderTreeNode          | (nodeData:DataItemType) => ReactNode                                                          | 自定义渲染 tree 节点                                                            |
@@ -63,3 +64,5 @@
 - [`<CheckTree>`](/zh/components/check-tree) 用于展示一个树结构数据，同时支持 Checkbox 选择。
 - [`<TreePicker>`](/zh/components/tree-picker) 选择器组件，树形单项选择器。
 - [`<CheckTreePicker>`](/zh/components/check-tree-picker) 选择器组件，在 TreePicker 节点上支持 Checkbox，用于多选 。
+
+[listprops]: https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#prop-types

--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -147,6 +147,7 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
     menuAutoWidth,
     uncheckableItemValues,
     id,
+    listProps,
     renderMenu,
     getChildren,
     renderExtraFooter,
@@ -801,6 +802,7 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
                   rowCount={formattedNodes.length}
                   rowRenderer={renderVirtualListNode(formattedNodes)}
                   scrollToAlignment="center"
+                  {...listProps}
                 />
               )}
             </AutoSizer>

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -603,4 +603,13 @@ describe('CheckTreePicker', () => {
 
     assert.equal(instance.overlay.querySelectorAll('.rs-check-tree-node').length, 4);
   });
+
+  it('Should to reset the option height', () => {
+    const instance = getInstance(
+      <CheckTreePicker open virtualized data={data} listProps={{ rowHeight: 28 }} />
+    );
+
+    const node = instance.overlay.querySelector('.rs-check-tree-node');
+    assert.equal(node.style.height, '28px');
+  });
 });

--- a/src/Picker/DropdownMenu.tsx
+++ b/src/Picker/DropdownMenu.tsx
@@ -212,13 +212,13 @@ const DropdownMenu = React.forwardRef(
                 role="listbox"
                 containerRole={''}
                 aria-readonly={null}
-                {...listProps}
                 width={width}
                 height={height || maxHeight}
                 scrollToIndex={findIndex(data, item => item[valueKey] === activeItemValues?.[0])}
                 rowCount={rowCount}
                 rowHeight={getRowHeight.bind(this, filteredItems)}
                 rowRenderer={renderItem.bind(null, filteredItems)}
+                {...listProps}
               />
             )}
           </AutoSizer>

--- a/src/Picker/propTypes.ts
+++ b/src/Picker/propTypes.ts
@@ -30,7 +30,8 @@ export const pickerPropTypes = {
   renderValue: PropTypes.func,
   onOpen: PropTypes.func,
   onClose: PropTypes.func,
-  onClean: PropTypes.func
+  onClean: PropTypes.func,
+  listProps: PropTypes.object
 };
 
 export const listPickerPropTypes = {

--- a/src/Picker/test/DropdownMenuSpec.js
+++ b/src/Picker/test/DropdownMenuSpec.js
@@ -222,4 +222,20 @@ describe('picker -  DropdownMenu', () => {
 
     assert.equal(instance.querySelectorAll('[data-key="1"]').length, 1);
   });
+
+  it('Should to reset the option height', () => {
+    const instance = getDOMNode(
+      <DropdownMenu
+        data={items}
+        maxHeight={50}
+        dropdownMenuItemAs={DropdownMenuItem}
+        classPrefix={classPrefix}
+        virtualized
+        listProps={{ rowHeight: 28 }}
+      />
+    );
+
+    const option = instance.querySelector('[role="option"]');
+    assert.equal(option.style.height, '28px');
+  });
 });

--- a/src/Tree/Tree.tsx
+++ b/src/Tree/Tree.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react';
 import TreePicker from '../TreePicker';
 import TreeContext from './TreeContext';
 import { StandardProps, ItemDataType, RsRefForwardingComponent } from '../@types/common';
+import { ListProps } from 'react-virtualized/dist/commonjs/List';
 
 /**
  * Tree Node Drag Type
@@ -64,6 +65,12 @@ export interface TreeBaseProps<ValueType = string | number, ItemDataType = Recor
 
   /** Whether using virtualized list */
   virtualized?: boolean;
+
+  /**
+   * List-related properties in `react-virtualized`
+   * https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#prop-types
+   */
+  listProps?: ListProps;
 
   /** Expand all nodes By default */
   defaultExpandAll?: boolean;

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -148,6 +148,7 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
     expandItemValues: controlledExpandItemValues,
     defaultExpandItemValues,
     id,
+    listProps,
     getChildren,
     renderTreeIcon,
     renderTreeNode,
@@ -803,6 +804,7 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
                   rowCount={formattedNodes.length}
                   rowRenderer={renderVirtualListNode(formattedNodes)}
                   scrollToAlignment="center"
+                  {...listProps}
                 />
               )}
             </AutoSizer>

--- a/src/TreePicker/test/TreePickerSpec.js
+++ b/src/TreePicker/test/TreePickerSpec.js
@@ -493,4 +493,13 @@ describe('TreePicker', () => {
 
     assert.equal(instance.overlay.querySelectorAll('.rs-tree-node').length, 4);
   });
+
+  it('Should to reset the option height', () => {
+    const instance = getInstance(
+      <TreePicker open virtualized data={data} listProps={{ rowHeight: 28 }} />
+    );
+
+    const node = instance.overlay.querySelector('.rs-tree-node');
+    assert.equal(node.style.height, '28px');
+  });
 });


### PR DESCRIPTION
Set the [listProps](https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#prop-types) property for the option to reset the default properties of `react-virtualized`.

```tsx
<TreePicker virtualized  listProps={{ rowHeight: 28 }} />
```

close https://github.com/rsuite/rsuite/issues/1957
