### PR TITLE
test(Uploader): assert async results with waitFor

### DIFF
--- a/src/Uploader/UploadFileItem.tsx
+++ b/src/Uploader/UploadFileItem.tsx
@@ -24,7 +24,6 @@ export interface UploadFileItemProps extends WithAsProps {
   onCancel?: (fileKey: number | string, event: React.MouseEvent) => void;
   onPreview?: (file: FileType, event: React.MouseEvent) => void;
   onReupload?: (file: FileType, event: React.MouseEvent) => void;
-  onThumbnailCompleted?: (thumbnail: string) => void;
 }
 
 /**
@@ -68,7 +67,6 @@ const UploadFileItem = React.forwardRef(
       onPreview,
       onCancel,
       onReupload,
-      onThumbnailCompleted,
       ...rest
     } = props;
 
@@ -103,10 +101,9 @@ const UploadFileItem = React.forwardRef(
       if (!file.url) {
         getThumbnail((previewImage: any) => {
           setPreviewImage(previewImage);
-          onThumbnailCompleted?.(previewImage);
         });
       }
-    }, [file.url, getThumbnail, onThumbnailCompleted]);
+    }, [file.url, getThumbnail]);
 
     const handlePreview = useCallback(
       (event: React.MouseEvent) => {
@@ -307,8 +304,7 @@ UploadFileItem.propTypes = {
   renderThumbnail: PropTypes.func,
   onCancel: PropTypes.func,
   onPreview: PropTypes.func,
-  onReupload: PropTypes.func,
-  onThumbnailCompleted: PropTypes.func
+  onReupload: PropTypes.func
 };
 
 export default UploadFileItem;

--- a/src/Uploader/test/UploadFileItemSpec.js
+++ b/src/Uploader/test/UploadFileItemSpec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
+import { waitFor } from '@testing-library/react';
 import { getDOMNode } from '@test/testUtils';
 import UploadFileItem, { formatSize } from '../UploadFileItem';
 
@@ -172,7 +173,7 @@ describe('UploadFileItem', () => {
     assert.include(thumbnail.textContent, 'custom-thumbnail');
   });
 
-  it('Should call `onThumbnailCompleted` with rendered thumbnail src', done => {
+  it('Should render a thumbnail previewing the image to upload', async () => {
     const file = {
       name: 'image.png',
       fileKey: 1,
@@ -181,21 +182,12 @@ describe('UploadFileItem', () => {
       })
     };
 
-    const instance = getDOMNode(
-      <UploadFileItem
-        file={file}
-        listType="picture-text"
-        onThumbnailCompleted={img => {
-          const thumbnail = instance.querySelector('.rs-uploader-file-item-preview img');
-          try {
-            assert.equal(thumbnail.src, img);
-            done();
-          } catch (err) {
-            done(err);
-          }
-        }}
-      />
-    );
+    const instance = getDOMNode(<UploadFileItem file={file} listType="picture-text" />);
+
+    await waitFor(() => {
+      const thumbnail = instance.querySelector('.rs-uploader-file-item-preview img');
+      assert.equal(thumbnail.src, 'data:image/png;base64,MTA=');
+    });
   });
 });
 


### PR DESCRIPTION
Remove the internal `onThumbnailCompleted` prop (added in #1997) that was [only for testing purpose](https://github.com/rsuite/rsuite/pull/1997#discussion_r729473803).