### PR TITLE
refactor(PickerToggle): improve clear button

### DIFF
--- a/src/Picker/PickerToggle.tsx
+++ b/src/Picker/PickerToggle.tsx
@@ -159,7 +159,7 @@ const PickerToggle: RsRefForwardingComponent<
     );
   }
 
-  const cleanable = cleanableProp && hasValue && !readOnly;
+  const showCleanButton = cleanableProp && hasValue && !readOnly;
 
   // When the component is read-only or disabled, the input is not interactive.
   const inputFocused = readOnly || disabled ? false : input && activeState;
@@ -207,7 +207,14 @@ const PickerToggle: RsRefForwardingComponent<
         </span>
       ) : null}
 
-      {cleanable && <CloseButton className={prefix`clean`} tabIndex={-1} onClick={handleClean} />}
+      {showCleanButton && (
+        <CloseButton
+          className={prefix`clean`}
+          tabIndex={-1}
+          locale={{ closeLabel: 'Clear' }}
+          onClick={handleClean}
+        />
+      )}
       {caret && <Caret className={prefix`caret`} />}
     </Component>
   );

--- a/src/Picker/styles/index.less
+++ b/src/Picker/styles/index.less
@@ -218,7 +218,7 @@
     .ellipsis();
   }
 
-  .rs-picker-cleanable & {
+  .rs-picker-cleanable.rs-picker-has-value & {
     padding-right: (@dropdown-toggle-padding-right + @picker-toggle-clean-width);
 
     .rs-@{date-picker-prefix}&,

--- a/src/Picker/styles/mixin.less
+++ b/src/Picker/styles/mixin.less
@@ -122,7 +122,7 @@
     padding-right: (@padding-horizontal + @dropdown-caret-width + @dropdown-caret-padding);
   }
 
-  .rs-picker-cleanable & {
+  .rs-picker-has-value.rs-picker-cleanable & {
     padding-right: (
       @padding-horizontal + @dropdown-caret-width + @dropdown-caret-padding + @clean-btn-width +
         @clean-btn-margin

--- a/src/Picker/test/PickerToggleSpec.js
+++ b/src/Picker/test/PickerToggleSpec.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import Toggle from '../PickerToggle';
 import { getDOMNode } from '@test/testUtils';
 
-describe('Toggle', () => {
+describe('<PickerToggle>', () => {
   it('Should output a toggle', () => {
     const Title = 'Title';
     const instance = getDOMNode(<Toggle title="title">{Title}</Toggle>);
@@ -27,17 +29,30 @@ describe('Toggle', () => {
     assert.equal(instance.innerText, Title);
   });
 
-  it('Should call `onClean` callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(
-      <Toggle title="title" hasValue cleanable onClean={doneOp}>
-        Title
-      </Toggle>
-    );
+  describe('Cleanable (`cleanable`=true)', () => {
+    it('Should render a clear button when value is present', () => {
+      const { getByRole } = render(
+        <Toggle cleanable hasValue>
+          Title
+        </Toggle>
+      );
 
-    ReactTestUtils.Simulate.click(instance.querySelector('.rs-picker-toggle-clean'));
+      expect(getByRole('button', { name: /clear/i })).to.exist;
+    });
+
+    it('Should call `onClean` callback when clicking clear button', () => {
+      const onCleanSpy = sinon.spy();
+
+      const { getByRole } = render(
+        <Toggle cleanable hasValue onClean={onCleanSpy}>
+          Title
+        </Toggle>
+      );
+
+      userEvent.click(getByRole('button', { name: /clear/i }));
+
+      expect(onCleanSpy).to.have.been.called;
+    });
   });
 
   it('Should call onBlur callback', done => {

--- a/src/Picker/utils.ts
+++ b/src/Picker/utils.ts
@@ -97,10 +97,7 @@ export function usePickerClassName(props: PickerClassNameProps): [string, string
       [`placement-${kebabCase(placementPolyfill(placement))}`]: placement,
       'read-only': readOnly,
       'has-value': hasValue,
-      // fixme Bad implementation.
-      //       Should implement by modifying `.cleanable` styles according to `.has-value` class,
-      //       not by removing `.cleanable` class.
-      cleanable: hasValue && cleanable,
+      cleanable,
       block,
       disabled,
       countable,


### PR DESCRIPTION
- Rename clear button's label to 'Clear'.
- Add missing `-cleanable` className on cleanable pickers when value is empty.