### PR TITLE
build(dx): resolve react to root installation

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -30,6 +30,10 @@ module.exports = {
     DEV: __DEV__ ? 1 : 0,
     VERSION: pkg.version
   },
+  /**
+   *
+   * @param {import('webpack').Configuration} config
+   */
   webpack(config) {
     const originEntry = config.entry;
 
@@ -155,6 +159,15 @@ module.exports = {
       }
       return entries;
     };
+
+    // If we are building docs with local rsuite from src (local development and review builds),
+    // we should target `react` and `react-dom` imports to root node_modules
+    if (__LOCAL__) {
+      Object.assign(config.resolve.alias, {
+        react: path.resolve(__dirname, '../node_modules/react'),
+        'react-dom': path.resolve(__dirname, '../node_modules/react-dom')
+      });
+    }
 
     return config;
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "check:type": "tsc",
     "clear": "rimraf ./.next && rimraf ./out ",
-    "predev": "rimraf ./node_modules/react && rimraf ./node_modules/react-dom",
     "dev": "cross-env NODE_ENV=development ALIAS=locally node server.js",
     "dev:styles": "cross-env STYLE_DEBUG=STYLE npm run dev",
     "build": "npm run clear && ALIAS=locally next build && next export",


### PR DESCRIPTION
Resolve `react` and `react-dom` to root node_modules to prevent multiple react version error. `predev` script is not needed and also removed from Vercel build commands.

See discussion https://github.com/orgs/rsuite/teams/maintainer/discussions/1