### PR TITLE
test: replace react-dom render with testing-library render

### DIFF
--- a/src/AutoComplete/test/AutoCompleteStylesSpec.js
+++ b/src/AutoComplete/test/AutoCompleteStylesSpec.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import tinycolor from 'tinycolor2';
 import AutoComplete from '../index';
-import { createTestContainer, getStyle, toRGB, getDefaultPalette, inChrome } from '@test/testUtils';
+import { getStyle, toRGB, getDefaultPalette, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
@@ -11,7 +11,7 @@ const { H100 } = getDefaultPalette();
 describe('AutoComplete styles', () => {
   it('Input should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<AutoComplete ref={instanceRef} />, createTestContainer());
+    render(<AutoComplete ref={instanceRef} />);
     const dom = instanceRef.current.root.querySelector('input');
     assert.equal(getStyle(dom, 'backgroundColor'), toRGB('#fff'), 'AutoComplete background-color');
     // @description Can't get border-radius value in other browser except chrome
@@ -23,10 +23,7 @@ describe('AutoComplete styles', () => {
 
   it('Should the correct styles when set `open` and `defaultValue`', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
-      <AutoComplete ref={instanceRef} data={['a', 'b', 'ab']} open defaultValue="a" />,
-      createTestContainer()
-    );
+    render(<AutoComplete ref={instanceRef} data={['a', 'b', 'ab']} open defaultValue="a" />);
     const dom = instanceRef.current.root.querySelector('input');
     const focusItemDom = document.querySelector('.rs-auto-complete-item-focus');
     const unFocusItemDom = document.querySelector(
@@ -47,7 +44,7 @@ describe('AutoComplete styles', () => {
 
   it('Disabled should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<AutoComplete ref={instanceRef} disabled />, createTestContainer());
+    render(<AutoComplete ref={instanceRef} disabled />);
     const dom = instanceRef.current.root.querySelector('input');
     assert.equal(
       getStyle(dom, 'backgroundColor'),

--- a/src/Avatar/test/AvatarStylesSpec.js
+++ b/src/Avatar/test/AvatarStylesSpec.js
@@ -1,20 +1,20 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Avatar from '../index';
-import { createTestContainer, getDOMNode, getStyle, toRGB, itChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, toRGB, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Avatar styles', () => {
   it('Should render the correct background', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Avatar ref={instanceRef} />, createTestContainer());
+    render(<Avatar ref={instanceRef} />);
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'backgroundColor'), toRGB('#d9d9d9'));
   });
 
   it('Should apply size class', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Avatar size="lg" ref={instanceRef} />, createTestContainer());
+    render(<Avatar size="lg" ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'width'), '60px');
     assert.equal(getStyle(dom, 'width'), getStyle(dom, 'height'));
@@ -24,7 +24,7 @@ describe('Avatar styles', () => {
   // @description Can't get border-radius value in other browser except chrome
   itChrome('Should render circle avatar', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Avatar ref={instanceRef} circle />, createTestContainer());
+    render(<Avatar ref={instanceRef} circle />);
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'borderRadius'), '50%');
   });
 });

--- a/src/Badge/test/BadgeStylesSpec.js
+++ b/src/Badge/test/BadgeStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Badge from '../index';
-import { createTestContainer, getStyle, itChrome, toRGB } from '@test/testUtils';
+import { getStyle, itChrome, toRGB } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Badge styles', () => {
   it('Independent should render correct style ', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Badge ref={instanceRef} />, createTestContainer());
+    render(<Badge ref={instanceRef} />);
     const dom = instanceRef.current;
     assert.equal(getStyle(dom, 'width'), '8px');
     assert.equal(getStyle(dom, 'width'), getStyle(dom, 'height'));
@@ -17,14 +17,14 @@ describe('Badge styles', () => {
   // @description Can't get border-radius value in other browser except chrome
   itChrome('Independent should render correct border-radius ', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Badge ref={instanceRef} />, createTestContainer());
+    render(<Badge ref={instanceRef} />);
     const dom = instanceRef.current;
     assert.equal(getStyle(dom, 'borderRadius'), '4px');
   });
 
   it('Should render correct color', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Badge ref={instanceRef} />, createTestContainer());
+    render(<Badge ref={instanceRef} />);
     const dom = instanceRef.current;
     assert.equal(getStyle(dom, 'color'), toRGB('#fff'));
   });
@@ -32,18 +32,17 @@ describe('Badge styles', () => {
   it('Should render correct background color', () => {
     const instanceRef = React.createRef();
     const background = '#4caf50';
-    ReactDOM.render(<Badge ref={instanceRef} style={{ background }} />, createTestContainer());
+    render(<Badge ref={instanceRef} style={{ background }} />);
     const dom = instanceRef.current;
     assert.equal(getStyle(dom, 'backgroundColor'), toRGB(background));
   });
 
   it('Color Badge content should render the correct color', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Badge color="cyan" ref={instanceRef}>
         Red
-      </Badge>,
-      createTestContainer()
+      </Badge>
     );
     const content = instanceRef.current.querySelector('.rs-badge-content');
     assert.equal(
@@ -55,7 +54,7 @@ describe('Badge styles', () => {
 
   it('Color Badge independent should render the correct color', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Badge color="cyan" ref={instanceRef} />, createTestContainer());
+    render(<Badge color="cyan" ref={instanceRef} />);
     const dom = instanceRef.current;
     assert.equal(
       getStyle(dom, 'backgroundColor'),

--- a/src/Breadcrumb/test/BreadcrumbItemStylesSpec.js
+++ b/src/Breadcrumb/test/BreadcrumbItemStylesSpec.js
@@ -1,19 +1,18 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Breadcrumb from '../index';
-import { createTestContainer, getStyle, toRGB, inChrome } from '@test/testUtils';
+import { getStyle, toRGB, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('BreadcrumbItem styles', () => {
   it('Should render correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Breadcrumb ref={instanceRef}>
         <Breadcrumb.Item>1</Breadcrumb.Item>
         <Breadcrumb.Item>2</Breadcrumb.Item>
-      </Breadcrumb>,
-      createTestContainer()
+      </Breadcrumb>
     );
     const dom = instanceRef.current;
     const itemDom = dom.querySelector('.rs-breadcrumb-item');
@@ -25,11 +24,10 @@ describe('BreadcrumbItem styles', () => {
 
   it('Active item should render correct color', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Breadcrumb ref={instanceRef}>
         <Breadcrumb.Item active>1</Breadcrumb.Item>
-      </Breadcrumb>,
-      createTestContainer()
+      </Breadcrumb>
     );
     const dom = instanceRef.current;
     const li = dom.querySelector('.rs-breadcrumb-item');

--- a/src/Breadcrumb/test/BreadcrumbStylesSpec.js
+++ b/src/Breadcrumb/test/BreadcrumbStylesSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Breadcrumb from '../index';
-import { createTestContainer, getStyle, itChrome } from '@test/testUtils';
+import { getStyle, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
@@ -9,7 +9,7 @@ describe('Breadcrumb styles', () => {
   itChrome('Should render correct padding', () => {
     const instanceRef = React.createRef();
 
-    ReactDOM.render(<Breadcrumb ref={instanceRef} />, createTestContainer());
+    render(<Breadcrumb ref={instanceRef} />);
     assert.equal(getStyle(instanceRef.current, 'padding'), '0px');
   });
 });

--- a/src/Button/test/ButtonStylesSpec.js
+++ b/src/Button/test/ButtonStylesSpec.js
@@ -1,15 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Button from '../Button';
 import ButtonToolbar from '../../ButtonToolbar';
-import {
-  createTestContainer,
-  getDOMNode,
-  getDefaultPalette,
-  toRGB,
-  getStyle,
-  itChrome
-} from '@test/testUtils';
+import { getDOMNode, getDefaultPalette, toRGB, getStyle, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
@@ -18,7 +11,7 @@ const { H500, H700, H900 } = getDefaultPalette();
 describe('Button styles', () => {
   it('Default button should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Button ref={instanceRef}>Title</Button>, createTestContainer());
+    render(<Button ref={instanceRef}>Title</Button>);
     assert.equal(
       getStyle(getDOMNode(instanceRef.current), 'backgroundColor'),
       toRGB('#f7f7fa'),
@@ -33,11 +26,10 @@ describe('Button styles', () => {
 
   it('Primary button should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Button appearance="primary" ref={instanceRef}>
         Title
-      </Button>,
-      createTestContainer()
+      </Button>
     );
     assert.equal(
       getStyle(getDOMNode(instanceRef.current), 'backgroundColor'),
@@ -53,22 +45,20 @@ describe('Button styles', () => {
 
   it('Link button should render the correct font color', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Button appearance="link" ref={instanceRef}>
         Title
-      </Button>,
-      createTestContainer()
+      </Button>
     );
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'color'), H700);
   });
 
   it('Subtle button should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Button appearance="subtle" ref={instanceRef}>
         Title
-      </Button>,
-      createTestContainer()
+      </Button>
     );
     assert.equal(
       getStyle(getDOMNode(instanceRef.current), 'color'),
@@ -84,25 +74,23 @@ describe('Button styles', () => {
 
   it('Ghost button should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Button appearance="ghost" ref={instanceRef}>
         Title
-      </Button>,
-      createTestContainer()
+      </Button>
     );
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'color'), H700);
   });
 
   itChrome('Button should render the correct padding', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <ButtonToolbar ref={instanceRef}>
         <Button size="lg">Large</Button>
         <Button size="md">Medium</Button>
         <Button size="sm">Small</Button>
         <Button size="xs">Xsmall</Button>
-      </ButtonToolbar>,
-      createTestContainer()
+      </ButtonToolbar>
     );
     const buttons = getDOMNode(instanceRef.current).children;
     const lg = buttons[0];
@@ -118,11 +106,10 @@ describe('Button styles', () => {
   describe('Colorful buttons', () => {
     it('Primary button should render the correct color', () => {
       const instanceRef = React.createRef();
-      ReactDOM.render(
+      render(
         <Button color="red" appearance="primary" ref={instanceRef}>
           Red
-        </Button>,
-        createTestContainer()
+        </Button>
       );
       const dom = getDOMNode(instanceRef.current);
       assert.equal(
@@ -135,11 +122,10 @@ describe('Button styles', () => {
 
     it('Subtle button should render the correct styles', () => {
       const instanceRef = React.createRef();
-      ReactDOM.render(
+      render(
         <Button color="red" appearance="subtle" ref={instanceRef}>
           Red
-        </Button>,
-        createTestContainer()
+        </Button>
       );
       assert.equal(
         getStyle(getDOMNode(instanceRef.current), 'color'),
@@ -156,11 +142,10 @@ describe('Button styles', () => {
 
   it('Button should render the correct display', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Button block ref={instanceRef}>
         Tittle
-      </Button>,
-      createTestContainer()
+      </Button>
     );
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'display'), 'block');
@@ -168,7 +153,7 @@ describe('Button styles', () => {
 
   it('Disabled button should render the correct opacity', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <ButtonToolbar ref={instanceRef}>
         <Button appearance="default" disabled>
           Default
@@ -185,8 +170,7 @@ describe('Button styles', () => {
         <Button appearance="ghost" disabled>
           Ghost
         </Button>
-      </ButtonToolbar>,
-      createTestContainer()
+      </ButtonToolbar>
     );
     const buttons = getDOMNode(instanceRef.current).children;
     const defaultButton = buttons[0];
@@ -204,11 +188,10 @@ describe('Button styles', () => {
 
   it('Default button should render the correct styles when set active', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Button ref={instanceRef} active>
         Title
-      </Button>,
-      createTestContainer()
+      </Button>
     );
     assert.equal(
       getStyle(getDOMNode(instanceRef.current), 'backgroundColor'),
@@ -224,11 +207,10 @@ describe('Button styles', () => {
 
   it('Primary button should render the correct styles when set active', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Button appearance="primary" ref={instanceRef} active>
         Title
-      </Button>,
-      createTestContainer()
+      </Button>
     );
     assert.equal(
       getStyle(getDOMNode(instanceRef.current), 'backgroundColor'),
@@ -244,22 +226,20 @@ describe('Button styles', () => {
 
   it('Link button should render the correct font color when set active', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Button appearance="link" ref={instanceRef} active>
         Title
-      </Button>,
-      createTestContainer()
+      </Button>
     );
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'color'), H900);
   });
 
   it('Subtle button should render the correct styles when set active', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Button appearance="subtle" ref={instanceRef} active>
         Title
-      </Button>,
-      createTestContainer()
+      </Button>
     );
     assert.equal(
       getStyle(getDOMNode(instanceRef.current), 'color'),
@@ -275,11 +255,10 @@ describe('Button styles', () => {
 
   it('Ghost button should render the correct styles when set active', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Button appearance="ghost" ref={instanceRef} active>
         Title
-      </Button>,
-      createTestContainer()
+      </Button>
     );
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'color'), H900);
   });

--- a/src/ButtonGroup/test/ButtonGroupStylesSpec.js
+++ b/src/ButtonGroup/test/ButtonGroupStylesSpec.js
@@ -1,20 +1,19 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ButtonGroup from '../index';
 import Button from '../../Button';
-import { createTestContainer, getDOMNode, getStyle, itChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Button Group styles', () => {
   it('Should render the correct width', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <ButtonGroup justified ref={instanceRef}>
         <Button>Text</Button>
         <Button>Text2</Button>
-      </ButtonGroup>,
-      createTestContainer()
+      </ButtonGroup>
     );
     const buttons = getDOMNode(instanceRef.current).children;
 
@@ -23,11 +22,10 @@ describe('Button Group styles', () => {
 
   itChrome('Should render the correct padding', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <ButtonGroup size="lg" ref={instanceRef}>
         <Button>Text</Button>
-      </ButtonGroup>,
-      createTestContainer()
+      </ButtonGroup>
     );
     const buttons = getDOMNode(instanceRef.current).children;
 

--- a/src/ButtonToolbar/test/ButtonToolbarStyleSpec.js
+++ b/src/ButtonToolbar/test/ButtonToolbarStyleSpec.js
@@ -1,27 +1,26 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ButtonToolbar from '../ButtonToolbar';
 import Button from '../../Button';
 
-import { createTestContainer, getDOMNode, getStyle } from '@test/testUtils';
+import { getDOMNode, getStyle } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('ButtonToolbar styles', () => {
   it('Should render the correct vertical align', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<ButtonToolbar ref={instanceRef} />, createTestContainer());
+    render(<ButtonToolbar ref={instanceRef} />);
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'line-height'), '0px');
   });
 
   it('Should render the correct margin left', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <ButtonToolbar ref={instanceRef}>
         <Button>Title</Button>
         <Button>Title</Button>
-      </ButtonToolbar>,
-      createTestContainer()
+      </ButtonToolbar>
     );
     assert.equal(getStyle(getDOMNode(instanceRef.current).children[1], 'marginLeft'), '5px');
   });

--- a/src/Calendar/test/CalendarHeaderSpec.js
+++ b/src/Calendar/test/CalendarHeaderSpec.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 
 import Header from '../Header';
 import CalendarContext from '../CalendarContext';
-import { createTestContainer } from '../../../test/testUtils';
 
 describe('Calendar-Header', () => {
   it('Should render a div with "calendar-header" class', () => {
@@ -50,11 +49,10 @@ describe('Calendar-Header', () => {
     };
     const ref = React.createRef();
 
-    ReactDOM.render(
+    render(
       <CalendarContext.Provider value={{ date: new Date(), format: 'HH:mm:ss' }}>
         <Header showTime onToggleTimeDropdown={doneOp} ref={ref} />
-      </CalendarContext.Provider>,
-      createTestContainer()
+      </CalendarContext.Provider>
     );
 
     ReactTestUtils.Simulate.click(ref.current.querySelector('.rs-calendar-header-title-time'));

--- a/src/Calendar/test/CalendarMonthDropdownItemSpec.js
+++ b/src/Calendar/test/CalendarMonthDropdownItemSpec.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import MonthDropdownItem from '../MonthDropdownItem';
 import { format } from '../../utils/dateUtils';
 import CalendarContext from '../CalendarContext';
-import { createTestContainer } from '../../../test/testUtils';
 
 describe('Calendar-MonthDropdownItem', () => {
   it('Should output a  `1` ', () => {
@@ -25,11 +24,10 @@ describe('Calendar-MonthDropdownItem', () => {
       }
     };
     const ref = React.createRef();
-    ReactDOM.render(
+    render(
       <CalendarContext.Provider value={{ date: new Date(), onChangePageDate }}>
         <MonthDropdownItem month={1} year={2017} ref={ref} />
-      </CalendarContext.Provider>,
-      createTestContainer()
+      </CalendarContext.Provider>
     );
 
     ReactTestUtils.Simulate.click(ref.current);

--- a/src/Calendar/test/CalendarMonthDropdownSpec.js
+++ b/src/Calendar/test/CalendarMonthDropdownSpec.js
@@ -1,23 +1,21 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import MonthDropdown from '../MonthDropdown';
 import CalendarContext from '../CalendarContext';
-import { createTestContainer } from '../../../test/testUtils';
 
 describe('Calendar-MonthDropdown', () => {
   it('Should output year and month ', () => {
     const ref = React.createRef();
-    ReactDOM.render(
+    render(
       <CalendarContext.Provider
         value={{
           date: new Date()
         }}
       >
         <MonthDropdown show ref={ref} />
-      </CalendarContext.Provider>,
-      createTestContainer()
+      </CalendarContext.Provider>
     );
     assert.equal(ref.current.querySelectorAll('.rs-calendar-month-dropdown-year').length, 8);
   });
@@ -27,18 +25,17 @@ describe('Calendar-MonthDropdown', () => {
       done();
     };
     const ref = React.createRef();
-    ReactDOM.render(
+    render(
       <CalendarContext.Provider value={{ onChangePageDate, date: new Date() }}>
         <MonthDropdown show ref={ref} />
-      </CalendarContext.Provider>,
-      createTestContainer()
+      </CalendarContext.Provider>
     );
     ReactTestUtils.Simulate.click(ref.current.querySelector('.rs-calendar-month-dropdown-cell'));
   });
 
   it('Should disable month', () => {
     const ref = React.createRef();
-    ReactDOM.render(
+    render(
       <CalendarContext.Provider value={{ date: new Date(2019, 8, 1) }}>
         <MonthDropdown
           show
@@ -49,8 +46,7 @@ describe('Calendar-MonthDropdown', () => {
           }}
           ref={ref}
         />
-      </CalendarContext.Provider>,
-      createTestContainer()
+      </CalendarContext.Provider>
     );
 
     const cells = ref.current

--- a/src/Calendar/test/CalendarPanelSpec.js
+++ b/src/Calendar/test/CalendarPanelSpec.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { parseISO } from '../../utils/dateUtils';
-import { getDOMNode, createTestContainer } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 import CalendarPanel from '../CalendarPanel';
 
 describe('Calendar - Panel', () => {
@@ -77,7 +77,6 @@ describe('Calendar - Panel', () => {
 
   it('Should be a controlled value', done => {
     const instanceRef = React.createRef();
-    const container = createTestContainer();
     const App = React.forwardRef((props, ref) => {
       const [value, setValue] = React.useState(new Date('6/10/2021'));
       const pickerRef = React.useRef();
@@ -90,7 +89,7 @@ describe('Calendar - Panel', () => {
       return <CalendarPanel value={value} ref={pickerRef} format="yyyy-MM-dd" />;
     });
 
-    ReactDOM.render(<App ref={instanceRef} />, container);
+    render(<App ref={instanceRef} />);
     instanceRef.current.setDate(new Date('7/11/2021'));
     const panel = instanceRef.current.panel;
 

--- a/src/Calendar/test/CalendarStyleSpec.js
+++ b/src/Calendar/test/CalendarStyleSpec.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Calendar from '../CalendarPanel';
 import {
-  createTestContainer,
   getDefaultPalette,
   getDOMNode,
   getStyle,
@@ -20,7 +19,7 @@ const { H500, H700 } = getDefaultPalette();
 describe('Calendar styles', () => {
   it('MonthToolbar should render correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Calendar ref={instanceRef} />, createTestContainer());
+    render(<Calendar ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
 
     const monthToolbarDom = dom.querySelector('.rs-calendar-header-month-toolbar');
@@ -31,7 +30,7 @@ describe('Calendar styles', () => {
 
   it('TodayButton should render correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Calendar ref={instanceRef} />, createTestContainer());
+    render(<Calendar ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
 
     const todayButtonDom = dom.querySelector('.rs-calendar-btn-today');
@@ -41,7 +40,7 @@ describe('Calendar styles', () => {
 
   it('Selected item should render correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Calendar ref={instanceRef} />, createTestContainer());
+    render(<Calendar ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
 
     const selectedDom = dom.querySelector(
@@ -60,7 +59,7 @@ describe('Calendar styles', () => {
 
   it('Click date title button should render correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Calendar ref={instanceRef} />, createTestContainer());
+    render(<Calendar ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
 
     const dateTitleDom = dom.querySelector('.rs-calendar-header-title-date');
@@ -98,7 +97,7 @@ describe('Calendar styles', () => {
 
   itChrome('Should be bordered on cell', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Calendar bordered ref={instanceRef} />, createTestContainer());
+    render(<Calendar bordered ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     const tableCellDom = dom.querySelector('.rs-calendar-table-cell');
     assert.equal(
@@ -110,10 +109,7 @@ describe('Calendar styles', () => {
 
   itChrome('Should be bordered on month row', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
-      <Calendar calendarState={CalendarState.DROP_MONTH} bordered ref={instanceRef} />,
-      createTestContainer()
-    );
+    render(<Calendar calendarState={CalendarState.DROP_MONTH} bordered ref={instanceRef} />);
     const dom = instanceRef.current;
 
     // click month dropdown button
@@ -129,7 +125,7 @@ describe('Calendar styles', () => {
 
   it('Should render compact calendar', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Calendar compact ref={instanceRef} />, createTestContainer());
+    render(<Calendar compact ref={instanceRef} />);
     const tableCellContentDom = getDOMNode(instanceRef.current).querySelector(
       '.rs-calendar-table-row:not(.rs-calendar-table-header-row) .rs-calendar-table-cell-content'
     );

--- a/src/Calendar/test/CalendarTableHeaderRowSpec.js
+++ b/src/Calendar/test/CalendarTableHeaderRowSpec.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import { getDOMNode } from '@test/testUtils';
 import TableHeaderRow from '../TableHeaderRow';
 import CalendarContext from '../CalendarContext';
-import { createTestContainer } from '../../../test/testUtils';
 
 describe('Calendar-TableHeaderRow', () => {
   it('Should render a div with "table-header-row" class', () => {
@@ -31,11 +30,10 @@ describe('Calendar-TableHeaderRow', () => {
 
   it('Should render an empty cell for a week number column', () => {
     const ref = React.createRef();
-    ReactDOM.render(
+    render(
       <CalendarContext.Provider value={{ showWeekNumbers: true }}>
         <TableHeaderRow ref={ref} />
-      </CalendarContext.Provider>,
-      createTestContainer()
+      </CalendarContext.Provider>
     );
     assert.equal(ref.current.childNodes.length, 8);
   });

--- a/src/Calendar/test/CalendarTableRowSpec.js
+++ b/src/Calendar/test/CalendarTableRowSpec.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import TableRow from '../TableRow';
 import { getDate, format } from '../../utils/dateUtils';
 import CalendarContext from '../CalendarContext';
-import { createTestContainer } from '../../../test/testUtils';
 
 describe('Calendar-TableRow', () => {
   it('Should render a div with `table-row` class', () => {
@@ -28,11 +27,10 @@ describe('Calendar-TableRow', () => {
       done();
     };
     const ref = React.createRef();
-    ReactDOM.render(
+    render(
       <CalendarContext.Provider value={{ onSelect: doneOp }}>
         <TableRow ref={ref} />
-      </CalendarContext.Provider>,
-      createTestContainer()
+      </CalendarContext.Provider>
     );
     ReactTestUtils.Simulate.click(
       ref.current.querySelector('.rs-calendar-table-cell .rs-calendar-table-cell-content')
@@ -57,11 +55,10 @@ describe('Calendar-TableRow', () => {
 
   it('Should render a week number', () => {
     const ref = React.createRef();
-    ReactDOM.render(
+    render(
       <CalendarContext.Provider value={{ showWeekNumbers: true }}>
         <TableRow ref={ref} />
-      </CalendarContext.Provider>,
-      createTestContainer()
+      </CalendarContext.Provider>
     );
     assert.equal(
       ref.current.querySelector('.rs-calendar-table-cell-week-number').innerText,
@@ -71,11 +68,10 @@ describe('Calendar-TableRow', () => {
 
   it('Should render a ISO week number', () => {
     const ref = React.createRef();
-    ReactDOM.render(
+    render(
       <CalendarContext.Provider value={{ showWeekNumbers: true, isoWeek: true }}>
         <TableRow ref={ref} />
-      </CalendarContext.Provider>,
-      createTestContainer()
+      </CalendarContext.Provider>
     );
     assert.equal(
       ref.current.querySelector('.rs-calendar-table-cell-week-number').innerText,

--- a/src/Calendar/test/CalendarTimeDropdownSpec.js
+++ b/src/Calendar/test/CalendarTimeDropdownSpec.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import TimeDropdown from '../TimeDropdown';
 import CalendarContext from '../CalendarContext';
-import { createTestContainer } from '../../../test/testUtils';
 
 describe('Calendar - TimeDropdown', () => {
   it('Should render a div with `time-dropdown` class', () => {
@@ -16,11 +15,10 @@ describe('Calendar - TimeDropdown', () => {
 
   it('Should render 3 column', () => {
     const ref = React.createRef();
-    ReactDOM.render(
+    render(
       <CalendarContext.Provider value={{ format: 'HH:mm:ss' }}>
         <TimeDropdown ref={ref} />
-      </CalendarContext.Provider>,
-      createTestContainer()
+      </CalendarContext.Provider>
     );
 
     assert.equal(ref.current.querySelectorAll('.rs-calendar-time-dropdown-column').length, 3);
@@ -28,11 +26,10 @@ describe('Calendar - TimeDropdown', () => {
 
   it('Should render 2 column', () => {
     const ref = React.createRef();
-    ReactDOM.render(
+    render(
       <CalendarContext.Provider value={{ format: 'HH:mm' }}>
         <TimeDropdown ref={ref} />
-      </CalendarContext.Provider>,
-      createTestContainer()
+      </CalendarContext.Provider>
     );
 
     assert.equal(ref.current.querySelectorAll('.rs-calendar-time-dropdown-column').length, 2);
@@ -40,11 +37,10 @@ describe('Calendar - TimeDropdown', () => {
 
   it('Should render 1 column', () => {
     const ref = React.createRef();
-    ReactDOM.render(
+    render(
       <CalendarContext.Provider value={{ format: 'HH' }}>
         <TimeDropdown ref={ref} />
-      </CalendarContext.Provider>,
-      createTestContainer()
+      </CalendarContext.Provider>
     );
 
     assert.equal(ref.current.querySelectorAll('.rs-calendar-time-dropdown-column').length, 1);
@@ -55,11 +51,10 @@ describe('Calendar - TimeDropdown', () => {
       done();
     };
     const ref = React.createRef();
-    ReactDOM.render(
+    render(
       <CalendarContext.Provider value={{ onChangePageTime, date: new Date(), format: 'HH' }}>
         <TimeDropdown ref={ref} />
-      </CalendarContext.Provider>,
-      createTestContainer()
+      </CalendarContext.Provider>
     );
 
     ReactTestUtils.Simulate.click(ref.current.querySelector('[data-key="hours-1"]'));
@@ -67,7 +62,7 @@ describe('Calendar - TimeDropdown', () => {
 
   it('Should be disabled', () => {
     const ref = React.createRef();
-    ReactDOM.render(
+    render(
       <CalendarContext.Provider value={{ format: 'HH' }}>
         <TimeDropdown
           disabledHours={h => {
@@ -75,8 +70,7 @@ describe('Calendar - TimeDropdown', () => {
           }}
           ref={ref}
         />
-      </CalendarContext.Provider>,
-      createTestContainer()
+      </CalendarContext.Provider>
     );
 
     assert.equal(
@@ -87,7 +81,7 @@ describe('Calendar - TimeDropdown', () => {
 
   it('Should be hide', () => {
     const ref = React.createRef();
-    ReactDOM.render(
+    render(
       <CalendarContext.Provider value={{ format: 'HH' }}>
         <TimeDropdown
           hideHours={h => {
@@ -95,8 +89,7 @@ describe('Calendar - TimeDropdown', () => {
           }}
           ref={ref}
         />
-      </CalendarContext.Provider>,
-      createTestContainer()
+      </CalendarContext.Provider>
     );
 
     assert.equal(ref.current.querySelectorAll('li').length, 11);

--- a/src/Carousel/test/CarouselStylesSpec.js
+++ b/src/Carousel/test/CarouselStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Carousel from '../index';
-import { createTestContainer, getDOMNode, getStyle, toRGB } from '@test/testUtils';
+import { getDOMNode, getStyle, toRGB } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Carousel styles', () => {
   it('Should render correct style ', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Carousel ref={instanceRef} />, createTestContainer());
+    render(<Carousel ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'backgroundColor'), toRGB('#8e8e93'), 'Carousel background-color');
   });

--- a/src/Cascader/test/CascaderSpec.js
+++ b/src/Cascader/test/CascaderSpec.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import Cascader from '../Cascader';
 import Button from '../../Button';
-import { getDOMNode, getInstance, createTestContainer } from '@test/testUtils';
+import { getDOMNode, getInstance } from '@test/testUtils';
 
 const items = [
   {
@@ -29,18 +29,6 @@ const items = [
     ]
   }
 ];
-
-let container;
-
-beforeEach(() => {
-  container = document.createElement('div');
-  document.body.appendChild(container);
-});
-
-afterEach(() => {
-  document.body.removeChild(container);
-  container = null;
-});
 
 describe('Cascader', () => {
   it('Should output a picker', () => {
@@ -312,9 +300,7 @@ describe('Cascader', () => {
     TestApp.displayName = 'TestApp';
 
     const ref = React.createRef();
-    ReactTestUtils.act(() => {
-      ReactDOM.render(<TestApp ref={ref} />, container);
-    });
+    render(<TestApp ref={ref} />);
 
     assert.equal(ref.current.picker.root.querySelector('.rs-picker-toggle-value').innerText, '2');
     assert.equal(
@@ -347,9 +333,7 @@ describe('Cascader', () => {
     TestApp.displayName = 'TestApp';
 
     const ref = React.createRef();
-    ReactTestUtils.act(() => {
-      ReactDOM.render(<TestApp ref={ref} />, container);
-    });
+    render(<TestApp ref={ref} />);
 
     assert.equal(
       ref.current.picker.overlay.querySelectorAll('.rs-picker-cascader-menu-item').length,
@@ -401,17 +385,14 @@ describe('Cascader', () => {
 
     const cascaderRef = React.createRef();
 
-    ReactTestUtils.act(() => {
-      ReactDOM.render(
-        <Cascader
-          ref={cascaderRef}
-          defaultOpen
-          data={itemsWithChildrenKey.data}
-          childrenKey={itemsWithChildrenKey.childrenKey}
-        />,
-        createTestContainer()
-      );
-    });
+    render(
+      <Cascader
+        ref={cascaderRef}
+        defaultOpen
+        data={itemsWithChildrenKey.data}
+        childrenKey={itemsWithChildrenKey.childrenKey}
+      />
+    );
 
     ReactTestUtils.act(() => {
       const input = cascaderRef.current.overlay.querySelector('.rs-picker-search-bar-input');
@@ -462,9 +443,7 @@ describe('Cascader', () => {
       return <Cascader {...props} ref={pickerRef} data={data} open />;
     });
     const ref = React.createRef();
-    ReactTestUtils.act(() => {
-      ReactDOM.render(<TestApp ref={ref} />, container);
-    });
+    render(<TestApp ref={ref} />);
 
     const overlay = ref.current.picker.overlay;
 

--- a/src/Cascader/test/CascaderStylesSpec.js
+++ b/src/Cascader/test/CascaderStylesSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Cascader from '../index';
-import { createTestContainer, getStyle, inChrome } from '@test/testUtils';
+import { getStyle, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
@@ -25,10 +25,7 @@ const data = [
 describe('Cascader styles', () => {
   it('Should render the correct caret', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
-      <Cascader ref={instanceRef} data={data} menuClassName="rs-cascader-styles-test" open />,
-      createTestContainer()
-    );
+    render(<Cascader ref={instanceRef} data={data} menuClassName="rs-cascader-styles-test" open />);
 
     const menuItemDom = document.body.querySelector(
       '.rs-cascader-styles-test .rs-picker-cascader-menu-item'

--- a/src/CheckPicker/test/CheckPickerStylesSpec.js
+++ b/src/CheckPicker/test/CheckPickerStylesSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import CheckPicker from '../index';
-import { createTestContainer, getStyle, inChrome } from '@test/testUtils';
+import { getStyle, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
@@ -26,7 +26,7 @@ const data = [
 describe('CheckPicker styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<CheckPicker data={data} ref={instanceRef} open />, createTestContainer());
+    render(<CheckPicker data={data} ref={instanceRef} open />);
     const menuItemLabel = document.body.querySelector(
       '.rs-picker-check-menu-items .rs-checkbox-checker label'
     );

--- a/src/CheckTree/test/CheckTreeStylesSpec.js
+++ b/src/CheckTree/test/CheckTreeStylesSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import CheckTree from '../index';
-import { createTestContainer, getStyle, inChrome } from '@test/testUtils';
+import { getStyle, inChrome } from '@test/testUtils';
 
 const data = [
   {
@@ -33,10 +33,7 @@ const data = [
 describe('CheckTree styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
-      <CheckTree virtualized={false} data={data} ref={instanceRef} />,
-      createTestContainer()
-    );
+    render(<CheckTree virtualized={false} data={data} ref={instanceRef} />);
     const itemLabel = document.body.querySelector('.rs-check-tree .rs-check-tree-node');
     inChrome && assert.equal(getStyle(itemLabel, 'padding'), '0px 0px 0px 12px');
   });

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode, getInstance } from '@test/testUtils';
 import CheckTreePicker from '../CheckTreePicker';
@@ -35,18 +35,6 @@ const data = [
     value: 'disabled'
   }
 ];
-
-let container;
-
-beforeEach(() => {
-  container = document.createElement('div');
-  document.body.appendChild(container);
-});
-
-afterEach(() => {
-  document.body.removeChild(container);
-  container = null;
-});
 
 describe('CheckTreePicker', () => {
   it('Should render default value', () => {
@@ -379,25 +367,22 @@ describe('CheckTreePicker', () => {
     ];
 
     const ref = React.createRef();
-    ReactTestUtils.act(() => {
-      ReactDOM.render(
-        <CheckTreePicker
-          ref={ref}
-          data={data}
-          value={['Master']}
-          open
-          cascade={false}
-          defaultExpandAll
-          getChildren={() => [
-            {
-              label: 'children1',
-              value: 'children1'
-            }
-          ]}
-        />,
-        container
-      );
-    });
+    render(
+      <CheckTreePicker
+        ref={ref}
+        data={data}
+        value={['Master']}
+        open
+        cascade={false}
+        defaultExpandAll
+        getChildren={() => [
+          {
+            label: 'children1',
+            value: 'children1'
+          }
+        ]}
+      />
+    );
 
     ReactTestUtils.act(() => {
       ReactTestUtils.Simulate.click(
@@ -536,9 +521,7 @@ describe('CheckTreePicker', () => {
       expandItemValues = values;
     };
     const ref = React.createRef();
-    ReactTestUtils.act(() => {
-      ReactDOM.render(<TestApp ref={ref} onExpand={mockOnExpand} />, container);
-    });
+    render(<TestApp ref={ref} onExpand={mockOnExpand} />);
 
     assert.ok(ref.current.picker.overlay.querySelector('.rs-check-tree-node-expanded'));
 

--- a/src/CheckTreePicker/test/CheckTreePickerStylesSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerStylesSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import CheckTreePicker from '../index';
-import { createTestContainer, getStyle, itChrome } from '@test/testUtils';
+import { getStyle, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
@@ -35,7 +35,7 @@ const data = [
 describe('CheckTreePicker styles', () => {
   itChrome('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<CheckTreePicker data={data} ref={instanceRef} open />, createTestContainer());
+    render(<CheckTreePicker data={data} ref={instanceRef} open />);
     const itemLabel = document.body.querySelector('.rs-check-tree .rs-checkbox-checker label');
     assert.equal(getStyle(itemLabel, 'padding'), '8px 12px 8px 58px');
   });

--- a/src/Checkbox/test/CheckboxStylesSpec.js
+++ b/src/Checkbox/test/CheckboxStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Checkbox from '../Checkbox';
-import { createTestContainer, getDOMNode, toRGB, itChrome } from '@test/testUtils';
+import { getDOMNode, toRGB, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Checkbox styles', () => {
   itChrome('Should render the correct border', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Checkbox ref={instanceRef} />, createTestContainer());
+    render(<Checkbox ref={instanceRef} />);
     const innerDom = getDOMNode(instanceRef.current).querySelector('.rs-checkbox-inner');
     assert.equal(
       window.getComputedStyle(innerDom, '::before').border,

--- a/src/CheckboxGroup/test/CheckboxGroupStylesSpec.js
+++ b/src/CheckboxGroup/test/CheckboxGroupStylesSpec.js
@@ -1,20 +1,19 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import CheckboxGroup from '../CheckboxGroup';
 import Checkbox from '../../Checkbox';
-import { getStyle, createTestContainer, getDOMNode } from '@test/testUtils';
+import { getStyle, getDOMNode } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('CheckboxGroup styles', () => {
   it('Should render the correct margin', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <CheckboxGroup inline ref={instanceRef}>
         <Checkbox />
         <Checkbox />
-      </CheckboxGroup>,
-      createTestContainer()
+      </CheckboxGroup>
     );
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'margin-left'), '-10px');
   });

--- a/src/Col/test/ColStylesSpec.js
+++ b/src/Col/test/ColStylesSpec.js
@@ -1,17 +1,16 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Col from '../index';
-import { createTestContainer, getDOMNode, getStyle, itChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, itChrome } from '@test/testUtils';
 import '../../Grid/styles/index.less';
 
 describe('Col styles', () => {
   itChrome('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Col ref={instanceRef} md={1}>
         Title
-      </Col>,
-      createTestContainer()
+      </Col>
     );
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'padding'), '0px 5px');
   });

--- a/src/Container/test/ContainerStylesSpec.js
+++ b/src/Container/test/ContainerStylesSpec.js
@@ -1,18 +1,17 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Container from '../index';
-import { createTestContainer, getDOMNode, getStyle } from '@test/testUtils';
+import { getDOMNode, getStyle } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Container styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Container ref={instanceRef}>
         <span>Title</span>
-      </Container>,
-      createTestContainer()
+      </Container>
     );
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'display'), 'flex');
   });

--- a/src/Content/test/ContentStylesSpec.js
+++ b/src/Content/test/ContentStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Content from '../index';
-import { createTestContainer, getDOMNode, getStyle, itChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Content styles', () => {
   itChrome('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Content ref={instanceRef}>Title</Content>, createTestContainer());
+    render(<Content ref={instanceRef}>Title</Content>);
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'flex'), '1 1 auto');
   });
 });

--- a/src/DatePicker/test/DatePickerStylesSpec.js
+++ b/src/DatePicker/test/DatePickerStylesSpec.js
@@ -1,21 +1,20 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import DatePicker from '../index';
-import { createTestContainer } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('DatePicker styles', () => {
   it('Should render the calendar icon', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<DatePicker ref={instanceRef} open />, createTestContainer());
+    render(<DatePicker ref={instanceRef} open />);
     const toggleDom = instanceRef.current.root.querySelector('.rs-picker-toggle');
     assert.isNotNull(toggleDom.querySelector('[aria-label="calendar"]'));
   });
 
   it('Should render the clock icon', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<DatePicker ref={instanceRef} format="HH:mm:ss" open />, createTestContainer());
+    render(<DatePicker ref={instanceRef} format="HH:mm:ss" open />);
     const toggleDom = instanceRef.current.root.querySelector('.rs-picker-toggle');
     assert.isNotNull(toggleDom.querySelector('[aria-label="clock o"]'));
   });

--- a/src/DateRangePicker/test/DateRangePickerStylesSpec.js
+++ b/src/DateRangePicker/test/DateRangePickerStylesSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import DateRangePicker from '../index';
-import { createTestContainer, getInstance } from '@test/testUtils';
+import { getInstance } from '@test/testUtils';
 import { getWidth } from 'dom-lib';
 
 import '../styles/index.less';
@@ -9,7 +9,7 @@ import '../styles/index.less';
 describe('DateRangePicker styles', () => {
   it('Should render the correct styles', call => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<DateRangePicker ref={instanceRef} open />, createTestContainer());
+    render(<DateRangePicker ref={instanceRef} open />);
 
     const toggleDom = instanceRef.current.target;
     assert.isNotNull(toggleDom.querySelector('[aria-label="calendar"]'));

--- a/src/Divider/test/DividerPickerStylesSpec.js
+++ b/src/Divider/test/DividerPickerStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Divider from '../index';
-import { createTestContainer, getStyle, toRGB, inChrome } from '@test/testUtils';
+import { getStyle, toRGB, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Divider styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Divider ref={instanceRef} />, createTestContainer());
+    render(<Divider ref={instanceRef} />);
 
     const element = instanceRef.current;
     assert.equal(getStyle(element, 'backgroundColor'), toRGB('#e5e5ea'), 'Divider background');

--- a/src/Dropdown/test/DropdownStylesSpec.js
+++ b/src/Dropdown/test/DropdownStylesSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Dropdown from '../index';
-import { createTestContainer, getStyle, inChrome } from '@test/testUtils';
+import { getStyle, inChrome } from '@test/testUtils';
 
 import '../../Button/styles/index.less';
 import '../styles/index.less';
@@ -9,12 +9,11 @@ import '../styles/index.less';
 describe('Dropdown styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Dropdown title="Default" ref={instanceRef}>
         <Dropdown.Item>1</Dropdown.Item>
         <Dropdown.Item>2</Dropdown.Item>
-      </Dropdown>,
-      createTestContainer()
+      </Dropdown>
     );
     const dom = instanceRef.current;
     const toggleDom = dom.querySelector('.rs-dropdown-toggle');

--- a/src/FlexboxGrid/test/FlexboxStylesSpec.js
+++ b/src/FlexboxGrid/test/FlexboxStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Flexbox from '../index';
-import { createTestContainer, getDOMNode, getStyle, inChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Flexbox styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Flexbox ref={instanceRef} />, createTestContainer());
+    render(<Flexbox ref={instanceRef} />);
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'display'), 'flex', 'Flexbox display');
     inChrome &&
       assert.equal(
@@ -20,7 +20,7 @@ describe('Flexbox styles', () => {
 
   it('Should render the correct aligned', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Flexbox ref={instanceRef} align="top" />, createTestContainer());
+    render(<Flexbox ref={instanceRef} align="top" />);
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'alignItems'), 'flex-start');
   });
 });

--- a/src/Footer/test/FooterStylesSpec.js
+++ b/src/Footer/test/FooterStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Footer from '../index';
-import { createTestContainer, getDOMNode, getStyle, itChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Footer styles', () => {
   itChrome('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Footer ref={instanceRef} />, createTestContainer());
+    render(<Footer ref={instanceRef} />);
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'flex'), '0 0 auto');
   });
 });

--- a/src/Form/test/FormSpec.js
+++ b/src/Form/test/FormSpec.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import _isNil from 'lodash/isNil';
 import _omit from 'lodash/omit';
-import { getDOMNode, getInstance, createTestContainer } from '@test/testUtils';
+import { getDOMNode, getInstance } from '@test/testUtils';
 
 import Form from '../Form';
 import FormControl from '../../FormControl';
@@ -643,14 +643,11 @@ describe('Form', () => {
 
     const formRef = React.createRef();
 
-    ReactTestUtils.act(() => {
-      ReactDOM.render(
-        <Form formDefaultValue={values} onError={doneOp} model={model} ref={formRef}>
-          <FormControl name="items" accepter={Field} />
-        </Form>,
-        createTestContainer()
-      );
-    });
+    render(
+      <Form formDefaultValue={values} onError={doneOp} model={model} ref={formRef}>
+        <FormControl name="items" accepter={Field} />
+      </Form>
+    );
     ReactTestUtils.act(() => {
       formRef.current.check();
     });

--- a/src/Form/test/FormStylesSpec.js
+++ b/src/Form/test/FormStylesSpec.js
@@ -1,21 +1,20 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Form from '../index';
 import Button from '../../Button';
 import FormControlLabel from '../../FormControlLabel';
-import { createTestContainer, getStyle } from '@test/testUtils';
+import { getStyle } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Form styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Form ref={instanceRef} layout="inline">
         <Button>Text</Button>
         <FormControlLabel>Text</FormControlLabel>
-      </Form>,
-      createTestContainer()
+      </Form>
     );
     const dom = instanceRef.current.root;
     const buttonDom = dom.children[0];

--- a/src/FormControl/test/FormControlStylesSpec.js
+++ b/src/FormControl/test/FormControlStylesSpec.js
@@ -1,19 +1,18 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import FormControl from '../index';
 import Form from '../../Form';
-import { createTestContainer, getDOMNode, getStyle, toRGB, inChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, toRGB, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Form control styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Form>
         <FormControl ref={instanceRef} name="name" />
-      </Form>,
-      createTestContainer()
+      </Form>
     );
     const dom = getDOMNode(instanceRef.current);
     const inputDom = dom.querySelector('.rs-input');

--- a/src/FormControlLabel/test/FormControlLabelStylesSpec.js
+++ b/src/FormControlLabel/test/FormControlLabelStylesSpec.js
@@ -1,17 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import FormControlLabel from '../index';
-import { createTestContainer, getDOMNode, getStyle } from '@test/testUtils';
+import { getDOMNode, getStyle } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('FormControlLabel styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
-      <FormControlLabel ref={instanceRef}>Title</FormControlLabel>,
-      createTestContainer()
-    );
+    render(<FormControlLabel ref={instanceRef}>Title</FormControlLabel>);
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'marginBottom'), '4px');
   });
 });

--- a/src/FormErrorMessage/test/FormErrorMessageStylesSpec.js
+++ b/src/FormErrorMessage/test/FormErrorMessageStylesSpec.js
@@ -1,20 +1,19 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import FormErrorMessage from '../index';
-import { createTestContainer, getStyle, getDOMNode, toRGB, inChrome } from '@test/testUtils';
+import { getStyle, getDOMNode, toRGB, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('FormErrorMessage styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <div className="rs-form-control-wrapper">
         <FormErrorMessage show ref={instanceRef}>
           Text
         </FormErrorMessage>
-      </div>,
-      createTestContainer()
+      </div>
     );
     const dom = getDOMNode(instanceRef.current);
     const errorMessageDom = dom.querySelector('.rs-form-error-message');

--- a/src/FormGroup/test/FormGroupStylesSpec.js
+++ b/src/FormGroup/test/FormGroupStylesSpec.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import FormGroup from '../index';
 
-import { createTestContainer, getStyle } from '@test/testUtils';
+import { getStyle } from '@test/testUtils';
 
 import '../styles/index.less';
 import FormControl from '../../FormControl/index';
@@ -11,13 +11,12 @@ import Form from '../../Form/index';
 describe('FormGroup styles', () => {
   it('Form layout horizontal Should render the correct styles', () => {
     const inputInstanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Form layout="horizontal" ref={inputInstanceRef}>
         <FormGroup>
           <FormControl name="name" />
         </FormGroup>
-      </Form>,
-      createTestContainer()
+      </Form>
     );
     const dom = inputInstanceRef.current.root;
     const formControlWrapperDom = dom.querySelector('.rs-form-control-wrapper');

--- a/src/FormHelpText/test/FormHelpTextStylesSpec.js
+++ b/src/FormHelpText/test/FormHelpTextStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import FormHelpText from '../index';
-import { createTestContainer, getDOMNode, getStyle, toRGB } from '@test/testUtils';
+import { getDOMNode, getStyle, toRGB } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('FormHelpText styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<FormHelpText ref={instanceRef} />, createTestContainer());
+    render(<FormHelpText ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'display'), 'block', 'FormHelpText display');
     assert.equal(getStyle(dom, 'color'), toRGB('#8e8e93'), 'FormHelpText color');

--- a/src/Grid/test/GridStylesSpec.js
+++ b/src/Grid/test/GridStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Grid from '../index';
-import { createTestContainer, getDOMNode, getStyle, itChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Grid styles', () => {
   itChrome('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Grid ref={instanceRef} />, createTestContainer());
+    render(<Grid ref={instanceRef} />);
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'padding'), '0px 5px');
   });
 });

--- a/src/Header/test/HeaderStylesSpec.js
+++ b/src/Header/test/HeaderStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Header from '../index';
-import { createTestContainer, getDOMNode, getStyle, itChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Header styles', () => {
   itChrome('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Header ref={instanceRef} />, createTestContainer());
+    render(<Header ref={instanceRef} />);
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'flex'), '0 0 auto');
   });
 });

--- a/src/IconButton/test/IconButtonStylesSpec.js
+++ b/src/IconButton/test/IconButtonStylesSpec.js
@@ -1,21 +1,21 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import IconButton from '../index';
-import { createTestContainer, getDOMNode, getStyle, inChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('IconButton styles', () => {
   it('Should render the correct width and height', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<IconButton ref={instanceRef} />, createTestContainer());
+    render(<IconButton ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'width'), getStyle(dom, 'height'));
   });
 
   it('Should render the correct border-raidus', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<IconButton circle ref={instanceRef} />, createTestContainer());
+    render(<IconButton circle ref={instanceRef} />);
     inChrome && assert.equal(getStyle(getDOMNode(instanceRef.current), 'borderRadius'), '50%');
   });
 });

--- a/src/Input/test/InputStylesSpec.js
+++ b/src/Input/test/InputStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Input from '../index';
-import { createTestContainer, getDOMNode, getStyle, toRGB, inChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, toRGB, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Input styles', () => {
   it('Input should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Input ref={instanceRef} />, createTestContainer());
+    render(<Input ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     inChrome &&
       assert.equal(getStyle(dom, 'border'), `1px solid ${toRGB('#e5e5ea')}`, 'Input border');

--- a/src/InputNumber/test/InputNumberStylesSpec.js
+++ b/src/InputNumber/test/InputNumberStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import InputNumber from '../index';
-import { createTestContainer, getDOMNode, getStyle, toRGB, inChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, toRGB, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('InputNumber styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<InputNumber ref={instanceRef} />, createTestContainer());
+    render(<InputNumber ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'backgroundColor'), toRGB('#fff'), 'InputNumber background-color');
     inChrome &&

--- a/src/InputPicker/test/InputPickerSpec.js
+++ b/src/InputPicker/test/InputPickerSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
-import { getDOMNode, getInstance, createTestContainer } from '@test/testUtils';
+import { getDOMNode, getInstance } from '@test/testUtils';
 
 import InputPicker from '../InputPicker';
 import Button from '../../Button';
@@ -75,15 +75,12 @@ describe('InputPicker', () => {
     const input1Ref = React.createRef();
     const input2Ref = React.createRef();
 
-    ReactTestUtils.act(() => {
-      ReactDOM.render(
-        <div>
-          <InputPicker ref={input1Ref} />
-          <InputPicker ref={input2Ref} readOnly />
-        </div>,
-        createTestContainer()
-      );
-    });
+    render(
+      <div>
+        <InputPicker ref={input1Ref} />
+        <InputPicker ref={input2Ref} readOnly />
+      </div>
+    );
 
     ReactTestUtils.act(() => {
       ReactTestUtils.Simulate.focus(
@@ -400,12 +397,7 @@ describe('InputPicker', () => {
 
     const inputRef = React.createRef();
 
-    ReactTestUtils.act(() => {
-      ReactDOM.render(
-        <InputPicker ref={inputRef} defaultOpen data={data} onCreate={doneOp} creatable />,
-        createTestContainer()
-      );
-    });
+    render(<InputPicker ref={inputRef} defaultOpen data={data} onCreate={doneOp} creatable />);
 
     ReactTestUtils.act(() => {
       ReactTestUtils.Simulate.focus(inputRef.current.root);

--- a/src/InputPicker/test/InputPickerStylesSpec.js
+++ b/src/InputPicker/test/InputPickerStylesSpec.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import InputPicker from '../index';
 import Button from '../../Button';
-import { createTestContainer, getStyle, toRGB, getDefaultPalette, inChrome } from '@test/testUtils';
+import { getStyle, toRGB, getDefaultPalette, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
@@ -29,7 +29,7 @@ const { H500 } = getDefaultPalette();
 describe('InputPicker styles', () => {
   it('Should render correct toggle styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<InputPicker ref={instanceRef} data={data} />, createTestContainer());
+    render(<InputPicker ref={instanceRef} data={data} />);
     const dom = instanceRef.current.root;
     const toggleDom = dom.querySelector('.rs-picker-toggle');
     const toggleInputDom = dom.querySelector('.rs-picker-search-input');
@@ -44,40 +44,28 @@ describe('InputPicker styles', () => {
 
   it('Should render correct large size', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
-      <InputPicker toggleAs={Button} size="lg" ref={instanceRef} data={data} />,
-      createTestContainer()
-    );
+    render(<InputPicker toggleAs={Button} size="lg" ref={instanceRef} data={data} />);
     const dom = instanceRef.current.root;
     assert.equal(getStyle(dom, 'height'), '42px', 'Toggle height');
   });
 
   it('Should render correct middle size ', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
-      <InputPicker toggleAs={Button} size="md" ref={instanceRef} data={data} />,
-      createTestContainer()
-    );
+    render(<InputPicker toggleAs={Button} size="md" ref={instanceRef} data={data} />);
     const dom = instanceRef.current.root;
     assert.equal(getStyle(dom, 'height'), '36px', 'Toggle height');
   });
 
   it('Should render correct small size ', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
-      <InputPicker toggleAs={Button} size="sm" ref={instanceRef} data={data} />,
-      createTestContainer()
-    );
+    render(<InputPicker toggleAs={Button} size="sm" ref={instanceRef} data={data} />);
     const dom = instanceRef.current.root;
     assert.equal(getStyle(dom, 'height'), '30px', 'Toggle height');
   });
 
   it('Should render correct xsmall size ', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
-      <InputPicker toggleAs={Button} size="xs" ref={instanceRef} data={data} />,
-      createTestContainer()
-    );
+    render(<InputPicker toggleAs={Button} size="xs" ref={instanceRef} data={data} />);
     const dom = instanceRef.current.root;
     assert.equal(getStyle(dom, 'height'), '24px', 'Toggle height');
   });
@@ -85,7 +73,7 @@ describe('InputPicker styles', () => {
   it('Should render correct toggle styles when open', done => {
     const instanceRef = React.createRef();
     let dom;
-    ReactDOM.render(
+    render(
       <InputPicker
         ref={instanceRef}
         data={data}
@@ -96,8 +84,7 @@ describe('InputPicker styles', () => {
         }}
         // For the test set transition to none.
         style={{ transition: 'none' }}
-      />,
-      createTestContainer()
+      />
     );
     dom = instanceRef.current.root;
     instanceRef.current.open();
@@ -105,7 +92,7 @@ describe('InputPicker styles', () => {
 
   it('Should have correct height when disabled', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<InputPicker ref={instanceRef} data={data} disabled />, createTestContainer());
+    render(<InputPicker ref={instanceRef} data={data} disabled />);
     const dom = instanceRef.current.root;
 
     assert.equal(getStyle(dom, 'height'), '36px', 'InputPicker height');

--- a/src/List/test/ListItemStyleSpec.js
+++ b/src/List/test/ListItemStyleSpec.js
@@ -1,17 +1,16 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import List from '../index';
-import { createTestContainer, getStyle } from '@test/testUtils';
+import { getStyle } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('ListItem styles', () => {
   it('Should render correct toggle styles', () => {
-    ReactDOM.render(
+    render(
       <List className="rs-list-styles-test">
         <List.Item index={1} />
-      </List>,
-      createTestContainer()
+      </List>
     );
     const dom = document.querySelector('.rs-list-styles-test .rs-list-item');
     assert.equal(getStyle(dom, 'position'), 'relative', 'List item position');

--- a/src/List/test/ListSpec.js
+++ b/src/List/test/ListSpec.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import List from '../List';
-import { getDOMNode, createTestContainer } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 
 describe('List', () => {
   it('Should render a List', () => {
@@ -66,15 +66,12 @@ describe('List', () => {
   it('should call onSortStart', done => {
     const callback = () => done();
     const ref = React.createRef();
-    ReactTestUtils.act(() => {
-      ReactDOM.render(
-        <List ref={ref} sortable onSortStart={callback}>
-          <List.Item index={1}>item1</List.Item>
-          <List.Item index={2}>item2</List.Item>
-        </List>,
-        createTestContainer()
-      );
-    });
+    render(
+      <List ref={ref} sortable onSortStart={callback}>
+        <List.Item index={1}>item1</List.Item>
+        <List.Item index={2}>item2</List.Item>
+      </List>
+    );
 
     ReactTestUtils.Simulate.mouseDown(ref.current.firstChild);
   });
@@ -83,20 +80,17 @@ describe('List', () => {
     const callback = () => done();
     const mousemoveEvent = new Event('mousemove', { bubbles: true });
     const ref = React.createRef();
-    ReactTestUtils.act(() => {
-      ReactDOM.render(
-        <List
-          sortable
-          ref={ref}
-          onSortStart={() => window.dispatchEvent(mousemoveEvent)}
-          onSortMove={callback}
-        >
-          <List.Item index={1}>item1</List.Item>
-          <List.Item index={2}>item2</List.Item>
-        </List>,
-        createTestContainer()
-      );
-    });
+    render(
+      <List
+        sortable
+        ref={ref}
+        onSortStart={() => window.dispatchEvent(mousemoveEvent)}
+        onSortMove={callback}
+      >
+        <List.Item index={1}>item1</List.Item>
+        <List.Item index={2}>item2</List.Item>
+      </List>
+    );
 
     ReactTestUtils.Simulate.mouseDown(ref.current.firstChild);
   });
@@ -106,21 +100,18 @@ describe('List', () => {
     const callback = () => ++count > 1 && done();
     const mouseupEvent = new Event('mouseup', { bubbles: true });
     const ref = React.createRef();
-    ReactTestUtils.act(() => {
-      ReactDOM.render(
-        <List
-          sortable
-          ref={ref}
-          onSortStart={() => window.dispatchEvent(mouseupEvent)}
-          onSortEnd={callback}
-          onSort={callback}
-        >
-          <List.Item index={1}>item1</List.Item>
-          <List.Item index={2}>item2</List.Item>
-        </List>,
-        createTestContainer()
-      );
-    });
+    render(
+      <List
+        sortable
+        ref={ref}
+        onSortStart={() => window.dispatchEvent(mouseupEvent)}
+        onSortEnd={callback}
+        onSort={callback}
+      >
+        <List.Item index={1}>item1</List.Item>
+        <List.Item index={2}>item2</List.Item>
+      </List>
+    );
 
     ReactTestUtils.Simulate.mouseDown(ref.current.firstChild);
   });

--- a/src/List/test/ListStyleSpec.js
+++ b/src/List/test/ListStyleSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import List from '../index';
-import { createTestContainer, getDOMNode, getStyle } from '@test/testUtils';
+import { getDOMNode, getStyle } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('List styles', () => {
   it('Should render correct toggle styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<List ref={instanceRef} />, createTestContainer());
+    render(<List ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
 
     assert.equal(getStyle(dom, 'position'), 'relative', 'List position');

--- a/src/Loader/test/LoaderStyleSpec.js
+++ b/src/Loader/test/LoaderStyleSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Loader from '../index';
-import { createTestContainer, getDOMNode, getStyle, toRGB, inChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, toRGB, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Loader styles', () => {
   it('Should render correct toggle styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Loader ref={instanceRef} />, createTestContainer());
+    render(<Loader ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     const spinDom = dom.querySelector('.rs-loader-spin');
 

--- a/src/Message/test/MessageStylesSpec.js
+++ b/src/Message/test/MessageStylesSpec.js
@@ -1,26 +1,20 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Message from '../index';
-import { createTestContainer, getDOMNode, getStyle, toRGB } from '@test/testUtils';
+import { getDOMNode, getStyle, toRGB } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Message styles', () => {
   it('Should render the correct background color', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
-      <Message description="Informational" ref={instanceRef} />,
-      createTestContainer()
-    );
+    render(<Message description="Informational" ref={instanceRef} />);
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'backgroundColor'), toRGB('#f0f9ff'));
   });
 
   it('Icon should render the correct color', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
-      <Message showIcon type="info" description="Informational" ref={instanceRef} />,
-      createTestContainer()
-    );
+    render(<Message showIcon type="info" description="Informational" ref={instanceRef} />);
     const icon = getDOMNode(instanceRef.current).querySelector('.rs-icon');
     assert.equal(getStyle(icon, 'color'), toRGB('#2196f3'));
   });

--- a/src/Modal/test/ModalStyleSpec.js
+++ b/src/Modal/test/ModalStyleSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Modal from '../index';
-import { createTestContainer, getStyle } from '@test/testUtils';
+import { getStyle } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Modal styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Modal ref={instanceRef} open />, createTestContainer());
+    render(<Modal ref={instanceRef} open />);
     const dom = instanceRef.current;
     const drawerDom = dom.querySelector('.rs-modal');
     assert.equal(getStyle(dom, 'position'), 'fixed', 'Modal wrapper position');
@@ -28,7 +28,7 @@ describe('Modal styles', () => {
 
   it('Should have correct margin-x: 60px in `full` size', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Modal ref={instanceRef} open full />, createTestContainer());
+    render(<Modal ref={instanceRef} open full />);
     const dom = instanceRef.current;
     const dialog = dom.querySelector('.rs-modal-dialog');
     const { left, right } = dialog.getBoundingClientRect();

--- a/src/MultiCascader/test/MultiCascaderStylesSpec.js
+++ b/src/MultiCascader/test/MultiCascaderStylesSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import MultiCascader from '../index';
-import { createTestContainer, getStyle, inChrome } from '@test/testUtils';
+import { getStyle, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
@@ -25,14 +25,13 @@ const data = [
 describe('MultiCascader styles', () => {
   it('Should render the correct caret', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <MultiCascader
         ref={instanceRef}
         data={data}
         menuClassName="rs-multi-cascader-styles-test"
         open
-      />,
-      createTestContainer()
+      />
     );
 
     const menuItemDom = instanceRef.current.overlay;

--- a/src/Nav/test/NavItemSpec.js
+++ b/src/Nav/test/NavItemSpec.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getByTestId, screen } from '@testing-library/react';
-import { getDOMNode, createTestContainer, innerText } from '@test/testUtils';
+import { getDOMNode, innerText } from '@test/testUtils';
 
 import NavItem from '../NavItem';
 import Sidenav from '../../Sidenav';
@@ -104,18 +104,14 @@ describe('<Nav.Item>', () => {
   });
 
   it('Should render a tooltip when used inside a collapsed <Sidenav>', async () => {
-    const container = createTestContainer();
-    ReactTestUtils.act(() => {
-      ReactDOM.render(
-        <Sidenav expanded={false}>
-          <NavItem data-testid="nav-item">item</NavItem>
-        </Sidenav>,
-        container
-      );
-    });
+    const { getByTestId } = render(
+      <Sidenav expanded={false}>
+        <NavItem data-testid="nav-item">item</NavItem>
+      </Sidenav>
+    );
 
     ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.focus(getByTestId(container, 'nav-item'));
+      ReactTestUtils.Simulate.focus(getByTestId('nav-item'));
     });
 
     expect(screen.getByRole('tooltip'), 'Tooltip').not.to.be.null;

--- a/src/Nav/test/NavItemStylesSpec.js
+++ b/src/Nav/test/NavItemStylesSpec.js
@@ -1,14 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Nav from '../index';
-import {
-  createTestContainer,
-  getDOMNode,
-  getStyle,
-  toRGB,
-  getDefaultPalette,
-  inChrome
-} from '@test/testUtils';
+import { getDOMNode, getStyle, toRGB, getDefaultPalette, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
@@ -17,11 +10,10 @@ const { H700 } = getDefaultPalette();
 describe('NavItem styles', () => {
   it('Default NavItem should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Nav>
         <Nav.Item ref={instanceRef}>Text</Nav.Item>
-      </Nav>,
-      createTestContainer()
+      </Nav>
     );
     const navItemContentDom = getDOMNode(instanceRef.current);
     inChrome && assert.equal(getStyle(navItemContentDom, 'padding'), '8px 12px', 'NavItem padding');
@@ -30,13 +22,12 @@ describe('NavItem styles', () => {
 
   it('Default NavItem should render the correct styles when active', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Nav>
         <Nav.Item ref={instanceRef} active>
           Active
         </Nav.Item>
-      </Nav>,
-      createTestContainer()
+      </Nav>
     );
     const navItemContentDom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(navItemContentDom, 'color'), H700, 'NavItem color');
@@ -44,13 +35,12 @@ describe('NavItem styles', () => {
 
   it('Default NavItem should render the correct styles when disabled', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Nav>
         <Nav.Item ref={instanceRef} disabled>
           Disabled
         </Nav.Item>
-      </Nav>,
-      createTestContainer()
+      </Nav>
     );
     const navItemContentDom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(navItemContentDom, 'color'), toRGB('#c5c6c7'), 'NavItem color');

--- a/src/Nav/test/NavStylesSpec.js
+++ b/src/Nav/test/NavStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Nav from '../index';
-import { createTestContainer, getDOMNode, getStyle } from '@test/testUtils';
+import { getDOMNode, getStyle } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Nav styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Nav ref={instanceRef} />, createTestContainer());
+    render(<Nav ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'position'), 'relative', 'Nav position');
   });

--- a/src/Navbar/test/NavbarStylesSpec.js
+++ b/src/Navbar/test/NavbarStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import NavBar from '../index';
-import { createTestContainer, getDOMNode, getStyle, toRGB } from '@test/testUtils';
+import { getDOMNode, getStyle, toRGB } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Navbar styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<NavBar ref={instanceRef} />, createTestContainer());
+    render(<NavBar ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'backgroundColor'), toRGB('#f7f7fa'), 'NavBar background-color');
   });

--- a/src/Panel/test/PanelStylesSpec.js
+++ b/src/Panel/test/PanelStylesSpec.js
@@ -1,21 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Panel from '../index';
-import {
-  createTestContainer,
-  getDOMNode,
-  getStyle,
-  toRGB,
-  inChrome,
-  itChrome
-} from '@test/testUtils';
+import { getDOMNode, getStyle, toRGB, inChrome, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Panel styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Panel ref={instanceRef} />, createTestContainer());
+    render(<Panel ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     inChrome && assert.equal(getStyle(dom, 'borderRadius'), '6px', 'Panel border-radius');
     assert.equal(getStyle(dom, 'overflow'), 'hidden', 'Panel overflow');
@@ -23,7 +16,7 @@ describe('Panel styles', () => {
 
   itChrome('Should render the correct border', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Panel ref={instanceRef} bordered />, createTestContainer());
+    render(<Panel ref={instanceRef} bordered />);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'border'), `1px solid ${toRGB('#e5e5ea')}`);
   });

--- a/src/PanelGroup/test/PanelGroupStylesSpec.js
+++ b/src/PanelGroup/test/PanelGroupStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import PanelGroup from '../index';
-import { createTestContainer, getDOMNode, getStyle, itChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('PanelGroup styles', () => {
   itChrome('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<PanelGroup ref={instanceRef} />, createTestContainer());
+    render(<PanelGroup ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'borderRadius'), '6px', 'Panel border-radius');
   });

--- a/src/Placeholder/test/PlaceholderGraphStylesSpec.js
+++ b/src/Placeholder/test/PlaceholderGraphStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import PlaceholderGraph from '../PlaceholderGraph';
-import { createTestContainer, getDOMNode, getStyle, toRGB } from '@test/testUtils';
+import { getDOMNode, getStyle, toRGB } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('PlaceholderGraph styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<PlaceholderGraph ref={instanceRef} />, createTestContainer());
+    render(<PlaceholderGraph ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'display'), 'inline-block', 'PlaceholderGraph display');
     assert.equal(

--- a/src/Placeholder/test/PlaceholderGridStylesSpec.js
+++ b/src/Placeholder/test/PlaceholderGridStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import PlaceholderGrid from '../PlaceholderGrid';
-import { createTestContainer, getDOMNode, getStyle, inChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('PlaceholderGrid styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<PlaceholderGrid ref={instanceRef} />, createTestContainer());
+    render(<PlaceholderGrid ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     const theFirstColDom = dom.querySelector('.rs-placeholder-grid-col:first-child');
     const theSecondColDom = dom.querySelector('.rs-placeholder-grid-col:nth-child(2)');

--- a/src/Popover/test/PopoverStylesSpec.js
+++ b/src/Popover/test/PopoverStylesSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Popover from '../index';
-import { createTestContainer, getStyle, toRGB } from '@test/testUtils';
+import { getStyle, toRGB } from '@test/testUtils';
 
 import '../styles/index.less';
 import Whisper from '../../Whisper/index';
@@ -10,11 +10,10 @@ import Button from '../../Button/index';
 describe('Popover styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Popover ref={instanceRef} visible>
         Text
-      </Popover>,
-      createTestContainer()
+      </Popover>
     );
     const dom = instanceRef.current;
 
@@ -22,7 +21,7 @@ describe('Popover styles', () => {
   });
 
   it('Should render top start', () => {
-    ReactDOM.render(
+    render(
       <Whisper
         trigger="click"
         open
@@ -34,8 +33,7 @@ describe('Popover styles', () => {
         }
       >
         <Button appearance="subtle">Test</Button>
-      </Whisper>,
-      createTestContainer()
+      </Whisper>
     );
     const dom = document.querySelector('.popover-top-start');
     assert.equal(getStyle(dom, 'marginTop'), '-8px', 'Popover margin value');

--- a/src/Progress/test/ProgressLineStylesSpec.js
+++ b/src/Progress/test/ProgressLineStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ProgressLine from '../ProgressLine';
-import { createTestContainer, getDOMNode, getStyle, toRGB, inChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, toRGB, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('ProgressLine styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<ProgressLine ref={instanceRef} />, createTestContainer());
+    render(<ProgressLine ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     const outerDom = dom.querySelector('.rs-progress-line-outer');
     const innerDom = dom.querySelector('.rs-progress-line-inner');

--- a/src/Radio/test/RadioStylesSpec.js
+++ b/src/Radio/test/RadioStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Radio from '../index';
-import { createTestContainer, getDOMNode, toRGB, itChrome } from '@test/testUtils';
+import { getDOMNode, toRGB, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Radio styles', () => {
   itChrome('Should render the correct border', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Radio ref={instanceRef} />, createTestContainer());
+    render(<Radio ref={instanceRef} />);
     const innerDom = getDOMNode(instanceRef.current).querySelector('.rs-radio-inner');
     assert.equal(
       window.getComputedStyle(innerDom, '::before').border,
@@ -18,7 +18,7 @@ describe('Radio styles', () => {
 
   it('Should render checked style even in disabled state', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Radio ref={instanceRef} checked disabled />, createTestContainer());
+    render(<Radio ref={instanceRef} checked disabled />);
     const innerDom = getDOMNode(instanceRef.current).querySelector('.rs-radio-inner');
     assert.equal(window.getComputedStyle(innerDom, '::before').backgroundColor, toRGB('#3498ff'));
   });

--- a/src/Rate/test/RateSpec.js
+++ b/src/Rate/test/RateSpec.js
@@ -1,22 +1,10 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import CameraRetro from '@rsuite/icons/legacy/CameraRetro';
 import Star from '@rsuite/icons/legacy/Star';
 import Rate from '../Rate';
-
-let container;
-
-beforeEach(() => {
-  container = document.createElement('div');
-  document.body.appendChild(container);
-});
-
-afterEach(() => {
-  document.body.removeChild(container);
-  container = null;
-});
 
 describe('Rate', () => {
   it('Should render a default Rate', () => {
@@ -31,9 +19,7 @@ describe('Rate', () => {
 
   it('Should allow clean full value', () => {
     const ref = React.createRef();
-    ReactTestUtils.act(() => {
-      ReactDOM.render(<Rate defaultValue={1} ref={ref} />, container);
-    });
+    render(<Rate defaultValue={1} ref={ref} />);
 
     ReactTestUtils.act(() => {
       ReactTestUtils.Simulate.click(ref.current.querySelector('.rs-rate-character-full'));
@@ -122,9 +108,7 @@ describe('Rate', () => {
     };
 
     const ref = React.createRef();
-    ReactTestUtils.act(() => {
-      ReactDOM.render(<Rate ref={ref} defaultValue={1} onChange={doneOp} />, container);
-    });
+    render(<Rate ref={ref} defaultValue={1} onChange={doneOp} />);
 
     ReactTestUtils.act(() => {
       ReactTestUtils.Simulate.mouseMove(
@@ -149,9 +133,7 @@ describe('Rate', () => {
 
     const ref = React.createRef();
 
-    ReactTestUtils.act(() => {
-      ReactDOM.render(<Rate ref={ref} defaultValue={1} onChange={doneOp} />, container);
-    });
+    render(<Rate ref={ref} defaultValue={1} onChange={doneOp} />);
 
     ReactTestUtils.act(() => {
       ReactTestUtils.Simulate.keyDown(ref.current.querySelectorAll('.rs-rate-character')[1], {
@@ -208,9 +190,7 @@ describe('Rate', () => {
     TestApp.displayName = 'TestApp';
 
     const ref = React.createRef();
-    ReactTestUtils.act(() => {
-      ReactDOM.render(<TestApp ref={ref} />, container);
-    });
+    render(<TestApp ref={ref} />);
 
     assert.equal(
       ref.current.root.querySelector('[aria-checked="true"]').getAttribute('aria-posinset'),

--- a/src/Ripple/test/RippleSpec.js
+++ b/src/Ripple/test/RippleSpec.js
@@ -1,20 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import Ripple from '../Ripple';
-
-let container;
-
-beforeEach(() => {
-  container = document.createElement('div');
-  document.body.appendChild(container);
-});
-
-afterEach(() => {
-  document.body.removeChild(container);
-  container = null;
-});
 
 describe('Ripple', () => {
   it('Should render a Ripple', () => {
@@ -27,14 +15,11 @@ describe('Ripple', () => {
       done();
     };
     const ref = React.createRef();
-    ReactTestUtils.act(() => {
-      ReactDOM.render(
-        <div ref={ref} style={{ width: 100, height: 100 }}>
-          <Ripple onMouseDown={doneOp} />
-        </div>,
-        container
-      );
-    });
+    render(
+      <div ref={ref} style={{ width: 100, height: 100 }}>
+        <Ripple onMouseDown={doneOp} />
+      </div>
+    );
 
     ReactTestUtils.act(() => {
       const event = new Event('mousedown');

--- a/src/Row/test/RowStylesSpec.js
+++ b/src/Row/test/RowStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Row from '../index';
-import { createTestContainer, getDOMNode, getStyle, itChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Row styles', () => {
   itChrome('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Row ref={instanceRef} />, createTestContainer());
+    render(<Row ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'margin'), '0px -5px', 'Row margin');
   });

--- a/src/SelectPicker/test/SelectPickerSpec.js
+++ b/src/SelectPicker/test/SelectPickerSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
-import { getDOMNode, getInstance, createTestContainer } from '@test/testUtils';
+import { getDOMNode, getInstance } from '@test/testUtils';
 
 import Dropdown from '../SelectPicker';
 import SelectPicker from '../SelectPicker';
@@ -338,9 +338,7 @@ describe('SelectPicker', () => {
 
   it('Should focus the search box', () => {
     const pickerRef = React.createRef();
-    ReactTestUtils.act(() => {
-      ReactDOM.render(<Dropdown ref={pickerRef} data={data} />, createTestContainer());
-    });
+    render(<Dropdown ref={pickerRef} data={data} />);
 
     ReactTestUtils.act(() => {
       ReactTestUtils.Simulate.click(pickerRef.current.target);

--- a/src/SelectPicker/test/SelectPickerStylesSpec.js
+++ b/src/SelectPicker/test/SelectPickerStylesSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import SelectPicker from '../index';
-import { createTestContainer, getStyle, toRGB, inChrome, itChrome } from '@test/testUtils';
+import { getStyle, toRGB, inChrome, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
@@ -26,7 +26,7 @@ const data = [
 describe('SelectPicker styles', () => {
   it('Default select picker should render correct toggle styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<SelectPicker ref={instanceRef} open />, createTestContainer());
+    render(<SelectPicker ref={instanceRef} open />);
 
     const pickerNoneDom = document.body.querySelector('.rs-picker-none');
     inChrome &&
@@ -45,7 +45,7 @@ describe('SelectPicker styles', () => {
 
   it('Subtle select picker should render correct toggle styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<SelectPicker appearance="subtle" ref={instanceRef} />, createTestContainer());
+    render(<SelectPicker appearance="subtle" ref={instanceRef} />);
 
     inChrome &&
       assert.equal(getStyle(instanceRef.current.target, 'borderWidth'), '0px', 'Toggle border');
@@ -73,7 +73,7 @@ describe('SelectPicker styles', () => {
       </div>
     );
 
-    ReactDOM.render(instance, createTestContainer());
+    render(instance);
     const pickerToggles = instanceRef.current.querySelectorAll('.rs-picker-toggle');
     assert.equal(getStyle(pickerToggles[0], 'padding'), '9px 36px 9px 15px');
     assert.equal(getStyle(pickerToggles[1], 'padding'), '7px 32px 7px 11px');
@@ -92,7 +92,7 @@ describe('SelectPicker styles', () => {
       </div>
     );
 
-    ReactDOM.render(instance, createTestContainer());
+    render(instance);
     const pickerToggles = instanceRef.current.querySelectorAll('.rs-picker-toggle');
     assert.equal(getStyle(pickerToggles[0], 'padding'), '10px 36px 10px 16px');
     assert.equal(getStyle(pickerToggles[1], 'padding'), '8px 32px 8px 12px');
@@ -102,15 +102,14 @@ describe('SelectPicker styles', () => {
 
   it('Block select picker should render correct toggle styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<SelectPicker ref={instanceRef} block data={data} />, createTestContainer());
+    render(<SelectPicker ref={instanceRef} block data={data} />);
     assert.equal(getStyle(instanceRef.current.root, 'display'), 'block');
   });
 
   it('Select picker group should render correct styles', () => {
     const ref = React.createRef();
-    ReactDOM.render(
-      <SelectPicker ref={ref} groupBy="role" data={data} menuClassName="group-test-menu" open />,
-      createTestContainer()
+    render(
+      <SelectPicker ref={ref} groupBy="role" data={data} menuClassName="group-test-menu" open />
     );
 
     const secondItemGroup = ref.current.overlay.querySelectorAll(
@@ -123,7 +122,7 @@ describe('SelectPicker styles', () => {
 
   it('Disabled select picker should render correct toggle styles', () => {
     const ref = React.createRef();
-    ReactDOM.render(<SelectPicker disabled ref={ref} />, createTestContainer());
+    render(<SelectPicker disabled ref={ref} />);
     const defaultDom = ref.current.root;
     assert.equal(getStyle(defaultDom, 'opacity'), 0.3);
     assert.equal(
@@ -132,10 +131,7 @@ describe('SelectPicker styles', () => {
     );
 
     const ref2 = React.createRef();
-    ReactDOM.render(
-      <SelectPicker appearance="subtle" disabled ref={ref2} />,
-      createTestContainer()
-    );
+    render(<SelectPicker appearance="subtle" disabled ref={ref2} />);
     assert.equal(
       getStyle(ref2.current.root.querySelector('.rs-picker-toggle'), 'backgroundColor'),
       toRGB('#0000')

--- a/src/Sidebar/test/SidebarStylesSpec.js
+++ b/src/Sidebar/test/SidebarStylesSpec.js
@@ -1,17 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Sidebar from '../index';
-import { createTestContainer, getDOMNode, getStyle, itChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Sidebar styles', () => {
   itChrome('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
-      <Sidebar ref={instanceRef} className="rs-sidebar-collapse" />,
-      createTestContainer()
-    );
+    render(<Sidebar ref={instanceRef} className="rs-sidebar-collapse" />);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(
       getStyle(dom, 'transition'),

--- a/src/Sidenav/test/SidenavStylesSpec.js
+++ b/src/Sidenav/test/SidenavStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Sidenav from '../index';
-import { createTestContainer, getDOMNode, getStyle } from '@test/testUtils';
+import { getDOMNode, getStyle } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Sidenav styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Sidenav ref={instanceRef} expanded={false} />, createTestContainer());
+    render(<Sidenav ref={instanceRef} expanded={false} />);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'width'), '56px', 'Sidenav width');
   });

--- a/src/Slider/test/SliderStylesSpec.js
+++ b/src/Slider/test/SliderStylesSpec.js
@@ -1,14 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Slider from '../index';
-import {
-  createTestContainer,
-  getDOMNode,
-  getStyle,
-  toRGB,
-  getDefaultPalette,
-  inChrome
-} from '@test/testUtils';
+import { getDOMNode, getStyle, toRGB, getDefaultPalette, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
@@ -17,7 +10,7 @@ const { H500 } = getDefaultPalette();
 describe('Slider styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Slider ref={instanceRef} />, createTestContainer());
+    render(<Slider ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     const barDom = dom.querySelector('.rs-slider-bar');
     const handleDom = dom.querySelector('.rs-slider-handle');

--- a/src/Steps/test/StepItemStylesSpec.js
+++ b/src/Steps/test/StepItemStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import StepItem from '../StepItem';
-import { createTestContainer, getDOMNode, getStyle, itChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('StepItem styles', () => {
   itChrome('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<StepItem ref={instanceRef} />, createTestContainer());
+    render(<StepItem ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'paddingLeft'), '40px', 'StepItem padding-left');
   });

--- a/src/Steps/test/StepsStylesSpec.js
+++ b/src/Steps/test/StepsStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Steps from '../index';
-import { createTestContainer, getDOMNode, getStyle } from '@test/testUtils';
+import { getDOMNode, getStyle } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Steps styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Steps ref={instanceRef} />, createTestContainer());
+    render(<Steps ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'display'), 'flex', 'Steps flex');
   });

--- a/src/Table/test/TableStylesSpec.js
+++ b/src/Table/test/TableStylesSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Table from '../index';
-import { createTestContainer, getStyle } from '@test/testUtils';
+import { getStyle } from '@test/testUtils';
 
 import '../styles/index.less';
 
@@ -18,14 +18,13 @@ const { Column, HeaderCell, Cell } = Table;
 
 describe('Table styles', () => {
   it('Should render the correct styles', () => {
-    ReactDOM.render(
+    render(
       <Table data={data}>
         <Column>
           <HeaderCell>ID</HeaderCell>
           <Cell dataKey="id" />
         </Column>
-      </Table>,
-      createTestContainer()
+      </Table>
     );
     const dom = document.querySelector('.rs-table');
     // assert.equal(getStyle(dom, 'backgroundColor'), toRGB('#fff'), 'Table background-color');

--- a/src/Tag/test/TagStylesSpec.js
+++ b/src/Tag/test/TagStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Tag from '../index';
-import { createTestContainer, getDOMNode, getStyle, toRGB, inChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, toRGB, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Tag styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Tag ref={instanceRef}>Text</Tag>, createTestContainer());
+    render(<Tag ref={instanceRef}>Text</Tag>);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'backgroundColor'), toRGB('#f7f7fa'), 'Tag background-color');
     inChrome && assert.equal(getStyle(dom, 'padding'), '2px 8px', 'Tag padding');

--- a/src/TagGroup/test/TagGroupStylesSpec.js
+++ b/src/TagGroup/test/TagGroupStylesSpec.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import TagGroup from '../index';
-import { createTestContainer, getStyle, itChrome } from '@test/testUtils';
+import { getStyle, itChrome } from '@test/testUtils';
 
 describe('TagGroup styles', () => {
   itChrome('Should render the correct styles', () => {
     const instanceRef = React.createRef();
 
-    ReactDOM.render(<TagGroup ref={instanceRef} />, createTestContainer());
+    render(<TagGroup ref={instanceRef} />);
     assert.equal(getStyle(instanceRef.current, 'margin'), '-10px 0px 0px -10px', 'TagGroup margin');
   });
 });

--- a/src/TagPicker/test/TagPickerStylesSpec.js
+++ b/src/TagPicker/test/TagPickerStylesSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import TagPicker from '../index';
-import { createTestContainer, getStyle, inChrome } from '@test/testUtils';
+import { getStyle, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
@@ -25,8 +25,7 @@ const data = [
 
 describe('TagPicker styles', () => {
   it('Should render the correct styles', () => {
-    const containerDom = createTestContainer();
-    ReactDOM.render(<TagPicker data={data} open />, containerDom);
+    render(<TagPicker data={data} open />);
     const itemLabel = document.body.querySelector(
       '.rs-picker-check-menu-items .rs-checkbox-checker label'
     );

--- a/src/Timeline/test/TimelineStylesSpec.js
+++ b/src/Timeline/test/TimelineStylesSpec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Timeline from '../index';
-import { createTestContainer, getDOMNode, getStyle } from '@test/testUtils';
+import { getDOMNode, getStyle } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Timeline styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(<Timeline ref={instanceRef} />, createTestContainer());
+    render(<Timeline ref={instanceRef} />);
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'listStyleType'), 'none', 'Timeline list-style');
   });

--- a/src/Tooltip/test/TooltipStylesSpec.js
+++ b/src/Tooltip/test/TooltipStylesSpec.js
@@ -1,18 +1,17 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Tooltip from '../Tooltip';
-import { createTestContainer, getDOMNode, getStyle, toRGB, inChrome } from '@test/testUtils';
+import { getDOMNode, getStyle, toRGB, inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Tooltip styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
+    render(
       <Tooltip ref={instanceRef} visible>
         Text
-      </Tooltip>,
-      createTestContainer()
+      </Tooltip>
     );
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'fontSize'), '12px', 'Tooltip font-size');

--- a/src/Tree/test/TreeStylesSpec.js
+++ b/src/Tree/test/TreeStylesSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import Tree from '../index';
-import { createTestContainer, getStyle, inChrome } from '@test/testUtils';
+import { getStyle, inChrome } from '@test/testUtils';
 
 const data = [
   {
@@ -33,10 +33,7 @@ const data = [
 describe('CheckTree styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    ReactDOM.render(
-      <Tree virtualized={false} data={data} ref={instanceRef} />,
-      createTestContainer()
-    );
+    render(<Tree virtualized={false} data={data} ref={instanceRef} />);
     const itemLabel = document.body.querySelector('.rs-tree .rs-tree-node-label');
     inChrome && assert.equal(getStyle(itemLabel, 'padding'), '0px 0px 0px 16px');
   });

--- a/src/Whisper/test/WhisperSpec.js
+++ b/src/Whisper/test/WhisperSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
-import { getDOMNode, getInstance, createTestContainer } from '@test/testUtils';
+import { getDOMNode, getInstance } from '@test/testUtils';
 
 import Whisper from '../Whisper';
 import Tooltip from '../../Tooltip';
@@ -185,24 +185,21 @@ describe('Whisper', () => {
 
     Overlay.displayName = 'Overlay';
 
-    ReactTestUtils.act(() => {
-      ReactDOM.render(
-        <Whisper
-          ref={ref}
-          onExited={doneOp}
-          trigger="click"
-          speaker={(props, ref) => {
-            const { className, left, top, onClose } = props;
-            return (
-              <Overlay style={{ left, top }} onClose={onClose} className={className} ref={ref} />
-            );
-          }}
-        >
-          <button ref={btnRef}>button</button>
-        </Whisper>,
-        createTestContainer()
-      );
-    });
+    render(
+      <Whisper
+        ref={ref}
+        onExited={doneOp}
+        trigger="click"
+        speaker={(props, ref) => {
+          const { className, left, top, onClose } = props;
+          return (
+            <Overlay style={{ left, top }} onClose={onClose} className={className} ref={ref} />
+          );
+        }}
+      >
+        <button ref={btnRef}>button</button>
+      </Whisper>
+    );
     ReactTestUtils.act(() => {
       ReactTestUtils.Simulate.click(ref.current.root);
     });


### PR DESCRIPTION
Replace all

```js
ReactDOM.render(ui, createTestContainer());
```

with

```js
import { render } from '@testing-library/react';

render(ui)
``` 

to get rid of manual creation of container elements and risks of forgetting to cleanup.

Coverage decrease is acceptable.