### PR TITLE
build(deps): bump rsuite-table from 5.0.0 to 5.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17689,9 +17689,9 @@
       }
     },
     "rsuite-table": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.0.0.tgz",
-      "integrity": "sha512-HPVikMU1z7L/h4BAfDp25CFmInwZEqOLYL30EjrDbUbPZgPjhRPC4Yi1i40kMSxBI7Q9oONSdxD95TI5wenwVQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.0.1.tgz",
+      "integrity": "sha512-jtAa5o/UU62DG1SOyrR6LaPYX6WPK4s5U3UkQnrFWNfSrpy8umb00Rn2orU3eK+IvL8e7R2a1RM8QGcXIIZThg==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@rsuite/icons": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "prop-types": "^15.7.2",
     "react-text-mask": "^5.4.3",
     "react-virtualized": "^9.22.3",
-    "rsuite-table": "^5.0.0",
+    "rsuite-table": "^5.0.1",
     "schema-typed": "^2.0.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
## [rsuite-table@5.0.1](https://github.com/rsuite/rsuite-table/compare/5.0.0...5.0.1) (2021-10-20)


### Bug Fixes

* 🐛 Add the `children` type definition for Column ([#254](https://github.com/rsuite/rsuite-table/issues/254)) ([6b7a69e](https://github.com/rsuite/rsuite-table/commit/6b7a69e2e6d267231b8848017abbfe98d5b0e08a))
* 🐛 fix scrollbar is not updated after tree node is expanded ([#253](https://github.com/rsuite/rsuite-table/issues/253)) ([323110c](https://github.com/rsuite/rsuite-table/commit/323110c8b0779e245fa67de2f96a12fbc4ff8bb4)), closes [#249](https://github.com/rsuite/rsuite-table/issues/249)


### Features

* **a11y:** add aria-busy attribute to loading table ([#251](https://github.com/rsuite/rsuite-table/issues/251)) ([e41e2cf](https://github.com/rsuite/rsuite-table/commit/e41e2cf7a6814e7c1e32a5a6acc044d87aeb0b4b))

