### PR TITLE
fix(toggle): improve a11y (keyboard focusable + keyboard events)

### DIFF
--- a/src/Toggle/Toggle.tsx
+++ b/src/Toggle/Toggle.tsx
@@ -78,7 +78,7 @@ const Toggle = React.forwardRef((props: ToggleProps, ref) => {
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<Element>) => {
-      if (event.code !== 'Space') {
+      if (event.key !== ' ') {
         return;
       }
       handleChange(event);

--- a/src/Toggle/test/ToggleSpec.js
+++ b/src/Toggle/test/ToggleSpec.js
@@ -78,11 +78,17 @@ describe('Toggle', () => {
     assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
-  it('Should toggle with the space key', () => {
-    const instance = getDOMNode(<Toggle defaultChecked />);
-    assert.equal(instance.getAttribute('aria-checked'), 'true');
+  it('Should toggle with the space key', done => {
+    const doneOp = checked => {
+      try {
+        assert.isTrue(checked);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    };
 
-    ReactTestUtils.Simulate.keyDown(instance, { code: 'Space' });
-    assert.equal(instance.getAttribute('aria-checked'), 'false');
+    const instance = getDOMNode(<Toggle onChange={doneOp} />);
+    ReactTestUtils.Simulate.keyDown(instance, { key: ' ' });
   });
 });


### PR DESCRIPTION
Hi, I noticed the switch button is not fully accessible. The component is not "keyboard focusable" and we can't "toggle" with the spacebar. I tried to cover this usecase with a test 

Read also: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Switch_role

Be gentle with my test, it's the first time I use the `@test/testUtils` library ;)
