### PR TITLE
test: replace innerText usage with textContent

### DIFF
--- a/src/Avatar/test/AvatarSpec.js
+++ b/src/Avatar/test/AvatarSpec.js
@@ -6,7 +6,7 @@ describe('Avatar', () => {
   it('Should render avatar', () => {
     const content = 'RS';
     const instance = getDOMNode(<Avatar>{content}</Avatar>);
-    assert.equal(instance.innerText, content);
+    assert.equal(instance.textContent, content);
   });
 
   it('Change background', () => {

--- a/src/Badge/test/BadgeSpec.js
+++ b/src/Badge/test/BadgeSpec.js
@@ -16,7 +16,7 @@ describe('Badge', () => {
   it('Should render content', () => {
     const content = 'NEW+';
     const instance = getDOMNode(<Badge content={content} />);
-    assert.equal(instance.innerText, content);
+    assert.equal(instance.textContent, content);
   });
 
   it('Should be invisible', () => {
@@ -31,18 +31,18 @@ describe('Badge', () => {
   it('MaxCount is invalid', () => {
     const content = '999';
     const instance = getDOMNode(<Badge content={content} />);
-    assert.equal(instance.innerText, content);
+    assert.equal(instance.textContent, content);
   });
 
   it('Should render default maxCount', () => {
     const instance = getDOMNode(<Badge content={999} />);
-    assert.equal(instance.innerText, '99+');
+    assert.equal(instance.textContent, '99+');
   });
 
   it('Should render customized maxCount', () => {
     const maxCount = 200;
     const instance = getDOMNode(<Badge content={999} maxCount={maxCount} />);
-    assert.equal(instance.innerText, `${maxCount}+`);
+    assert.equal(instance.textContent, `${maxCount}+`);
   });
 
   it('Should render wrapper button', () => {

--- a/src/Breadcrumb/test/BreadcrumbSpec.js
+++ b/src/Breadcrumb/test/BreadcrumbSpec.js
@@ -38,7 +38,7 @@ describe('Breadcrumb', () => {
     );
 
     assert.equal(instance.querySelectorAll('.rs-breadcrumb-item').length, 3);
-    assert.equal(instance.querySelectorAll('.rs-breadcrumb-item')[1].innerText, '...');
+    assert.equal(instance.querySelectorAll('.rs-breadcrumb-item')[1].textContent, '...');
   });
 
   it('Should call onExpand callback', done => {
@@ -69,7 +69,7 @@ describe('Breadcrumb', () => {
     );
 
     assert.equal(instance.childNodes[1].className, 'rs-breadcrumb-separator');
-    assert.equal(instance.childNodes[1].innerText, '/');
+    assert.equal(instance.childNodes[1].textContent, '/');
   });
 
   it('Should have a custom separator', () => {
@@ -82,7 +82,7 @@ describe('Breadcrumb', () => {
 
     assert.equal(instance.childNodes[1].className, 'rs-breadcrumb-separator');
     assert.equal(instance.childNodes[1].tagName, 'SPAN');
-    assert.equal(instance.childNodes[1].innerText, '-');
+    assert.equal(instance.childNodes[1].textContent, '-');
   });
 
   it('Should have a custom className', () => {

--- a/src/Button/test/ButtonSpec.js
+++ b/src/Button/test/ButtonSpec.js
@@ -6,7 +6,7 @@ import { getDOMNode, getInstance } from '@test/testUtils';
 describe('Button', () => {
   it('Should output a button', () => {
     const instance = getDOMNode(<Button>Title</Button>);
-    assert.equal(instance.innerText, 'Title');
+    assert.equal(instance.textContent, 'Title');
     assert.equal(instance.nodeName, 'BUTTON');
     assert.ok(instance.className.match(/\bbtn-default\b/));
   });

--- a/src/Calendar/test/CalendarMonthDropdownItemSpec.js
+++ b/src/Calendar/test/CalendarMonthDropdownItemSpec.js
@@ -11,7 +11,7 @@ describe('Calendar-MonthDropdownItem', () => {
     const instance = getDOMNode(<MonthDropdownItem month={1} date={new Date()} />);
 
     assert.equal(instance.nodeName, 'DIV');
-    assert.equal(instance.innerText, '1');
+    assert.equal(instance.textContent, '1');
   });
 
   it('Should call `onSelect` callback with correct date', done => {

--- a/src/Calendar/test/CalendarPanelSpec.js
+++ b/src/Calendar/test/CalendarPanelSpec.js
@@ -42,7 +42,7 @@ describe('Calendar - Panel', () => {
     assert.equal(
       instance
         .querySelectorAll('.rs-calendar-table-row')[1]
-        .querySelector('.rs-calendar-table-cell-content').innerText,
+        .querySelector('.rs-calendar-table-cell-content').textContent,
       '1'
     );
   });
@@ -93,11 +93,11 @@ describe('Calendar - Panel', () => {
     instanceRef.current.setDate(new Date('7/11/2021'));
     const panel = instanceRef.current.panel;
 
-    assert.equal(panel.querySelector('.rs-calendar-header-title').innerText, 'Jun 2021');
+    assert.equal(panel.querySelector('.rs-calendar-header-title').textContent, 'Jun 2021');
 
     setTimeout(() => {
       try {
-        assert.equal(panel.querySelector('.rs-calendar-header-title').innerText, 'Jul 2021');
+        assert.equal(panel.querySelector('.rs-calendar-header-title').textContent, 'Jul 2021');
         done();
       } catch (err) {
         done(err);

--- a/src/Calendar/test/CalendarSpec.js
+++ b/src/Calendar/test/CalendarSpec.js
@@ -19,7 +19,7 @@ describe('Calendar', () => {
     assert.equal(
       instance
         .querySelectorAll('.rs-calendar-table-row')[1]
-        .querySelector('.rs-calendar-table-cell-content').innerText,
+        .querySelector('.rs-calendar-table-cell-content').textContent,
       '1'
     );
   });

--- a/src/Calendar/test/CalendarTableRowSpec.js
+++ b/src/Calendar/test/CalendarTableRowSpec.js
@@ -17,7 +17,7 @@ describe('Calendar-TableRow', () => {
     const instance = getDOMNode(<TableRow />);
 
     assert.equal(
-      instance.querySelector('.rs-calendar-table-cell-is-today').innerText,
+      instance.querySelector('.rs-calendar-table-cell-is-today').textContent,
       getDate(new Date()) + ''
     );
   });
@@ -61,7 +61,7 @@ describe('Calendar-TableRow', () => {
       </CalendarContext.Provider>
     );
     assert.equal(
-      ref.current.querySelector('.rs-calendar-table-cell-week-number').innerText,
+      ref.current.querySelector('.rs-calendar-table-cell-week-number').textContent,
       format(new Date(), 'w')
     );
   });
@@ -74,7 +74,7 @@ describe('Calendar-TableRow', () => {
       </CalendarContext.Provider>
     );
     assert.equal(
-      ref.current.querySelector('.rs-calendar-table-cell-week-number').innerText,
+      ref.current.querySelector('.rs-calendar-table-cell-week-number').textContent,
       format(new Date(), 'I')
     );
   });

--- a/src/Cascader/test/CascaderSpec.js
+++ b/src/Cascader/test/CascaderSpec.js
@@ -60,7 +60,7 @@ describe('Cascader', () => {
     const placeholder = 'foobar';
     const instance = getDOMNode(<Cascader placeholder={placeholder} />);
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, placeholder);
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, placeholder);
   });
 
   it('Should output a button', () => {
@@ -90,19 +90,19 @@ describe('Cascader', () => {
     // Invalid value
     const instance3 = getDOMNode(<Cascader renderValue={v => [v, placeholder]} value={''} />);
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-value').innerText, `1${placeholder}`);
-    assert.equal(instance2.querySelector('.rs-picker-toggle-value').innerText, `2${placeholder}`);
-    assert.equal(instance3.querySelector('.rs-picker-toggle-value').innerText, placeholder);
+    assert.equal(instance.querySelector('.rs-picker-toggle-value').textContent, `1${placeholder}`);
+    assert.equal(instance2.querySelector('.rs-picker-toggle-value').textContent, `2${placeholder}`);
+    assert.equal(instance3.querySelector('.rs-picker-toggle-value').textContent, placeholder);
   });
 
   it('Should not be call renderValue()', () => {
     const instance = getDOMNode(<Cascader renderValue={() => 'value'} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
   });
 
   it('Should render a placeholder when value error', () => {
     const instance = getDOMNode(<Cascader value={2} placeholder={'test'} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'test');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'test');
   });
 
   it('Should be active by value', () => {
@@ -110,7 +110,7 @@ describe('Cascader', () => {
     const instance = getInstance(<Cascader defaultOpen data={items} value={value} />);
 
     assert.equal(
-      instance.overlay.querySelector('.rs-picker-cascader-menu-item-active').innerText,
+      instance.overlay.querySelector('.rs-picker-cascader-menu-item-active').textContent,
       value
     );
   });
@@ -120,7 +120,7 @@ describe('Cascader', () => {
     const instance = getInstance(<Cascader defaultOpen data={items} defaultValue={value} />);
 
     assert.equal(
-      instance.overlay.querySelector('.rs-picker-cascader-menu-item-active').innerText,
+      instance.overlay.querySelector('.rs-picker-cascader-menu-item-active').textContent,
       value
     );
   });
@@ -203,7 +203,7 @@ describe('Cascader', () => {
     const instance = getDOMNode(<Cascader defaultOpen data={items} defaultValue={'3-1'} />);
 
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-picker-toggle-clean'));
-    expect(instance.querySelector('.rs-picker-toggle-placeholder').innerText).to.equal('Select');
+    expect(instance.querySelector('.rs-picker-toggle-placeholder').textContent).to.equal('Select');
   });
 
   it('Should have a custom className', () => {
@@ -245,7 +245,7 @@ describe('Cascader', () => {
     );
 
     assert.equal(
-      instance.overlay.querySelectorAll('.rs-picker-cascader-menu-item')[1].innerText,
+      instance.overlay.querySelectorAll('.rs-picker-cascader-menu-item')[1].textContent,
       '2'
     );
   });
@@ -276,9 +276,9 @@ describe('Cascader', () => {
     const instance2 = getDOMNode(<Cascader value="Test" renderValue={() => null} />);
     const instance3 = getDOMNode(<Cascader value="Test" renderValue={() => undefined} />);
 
-    assert.equal(instance1.querySelector('.rs-picker-toggle-value').innerText, '1');
-    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
-    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance1.querySelector('.rs-picker-toggle-value').textContent, '1');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
 
     assert.include(instance1.className, 'rs-picker-has-value');
     assert.notInclude(instance2.className, 'rs-picker-has-value');
@@ -302,9 +302,9 @@ describe('Cascader', () => {
     const ref = React.createRef();
     render(<TestApp ref={ref} />);
 
-    assert.equal(ref.current.picker.root.querySelector('.rs-picker-toggle-value').innerText, '2');
+    assert.equal(ref.current.picker.root.querySelector('.rs-picker-toggle-value').textContent, '2');
     assert.equal(
-      ref.current.picker.overlay.querySelector('.rs-picker-cascader-menu-item-active').innerText,
+      ref.current.picker.overlay.querySelector('.rs-picker-cascader-menu-item-active').textContent,
       '2'
     );
 
@@ -313,7 +313,7 @@ describe('Cascader', () => {
     });
 
     assert.equal(
-      ref.current.picker.root.querySelector('.rs-picker-toggle-placeholder').innerText,
+      ref.current.picker.root.querySelector('.rs-picker-toggle-placeholder').textContent,
       'Select'
     );
   });
@@ -349,7 +349,7 @@ describe('Cascader', () => {
       1
     );
     assert.equal(
-      ref.current.picker.overlay.querySelector('.rs-picker-cascader-menu-item').innerText,
+      ref.current.picker.overlay.querySelector('.rs-picker-cascader-menu-item').textContent,
       'test'
     );
   });
@@ -454,6 +454,6 @@ describe('Cascader', () => {
     });
 
     assert.equal(overlay.querySelectorAll('.rs-picker-cascader-menu-item').length, 1);
-    assert.equal(overlay.querySelector('.rs-picker-cascader-menu-item').innerText, 'test');
+    assert.equal(overlay.querySelector('.rs-picker-cascader-menu-item').textContent, 'test');
   });
 });

--- a/src/CheckPicker/test/CheckPickerSpec.js
+++ b/src/CheckPicker/test/CheckPickerSpec.js
@@ -36,7 +36,7 @@ describe('CheckPicker', () => {
       <CheckPicker defaultOpen data={data} defaultValue={['Eugenia']} />
     );
     ReactTestUtils.Simulate.click(instance.root.querySelector(cleanClassName));
-    expect(instance.root.querySelector(placeholderClassName).innerText).to.equal('Select');
+    expect(instance.root.querySelector(placeholderClassName).textContent).to.equal('Select');
   });
 
   it('Should have "default" appearance by default', () => {
@@ -49,7 +49,7 @@ describe('CheckPicker', () => {
     const instance = getDOMNode(<CheckPicker defaultOpen data={data} value={['Eugenia']} />);
 
     ReactTestUtils.Simulate.click(instance.querySelector(cleanClassName));
-    expect(instance.querySelector(valueClassName).innerText).to.equal('Eugenia');
+    expect(instance.querySelector(valueClassName).textContent).to.equal('Eugenia');
   });
 
   it('Should output a dropdown', () => {
@@ -89,15 +89,15 @@ describe('CheckPicker', () => {
   it('Should active item by `value`', () => {
     const value = ['Louisa'];
     const instance = getInstance(<CheckPicker defaultOpen data={data} value={value} />);
-    assert.equal(instance.root.querySelector(valueClassName).innerText, 'Louisa');
-    assert.equal(instance.overlay.querySelector(itemActiveClassName).innerText, value);
+    assert.equal(instance.root.querySelector(valueClassName).textContent, 'Louisa');
+    assert.equal(instance.overlay.querySelector(itemActiveClassName).textContent, value);
   });
 
   it('Should active item by `defaultValue`', () => {
     const value = ['Louisa'];
     const instance = getInstance(<CheckPicker defaultOpen data={data} defaultValue={value} />);
-    assert.equal(instance.root.querySelector(valueClassName).innerText, 'Louisa');
-    assert.equal(instance.overlay.querySelector(itemActiveClassName).innerText, value);
+    assert.equal(instance.root.querySelector(valueClassName).textContent, 'Louisa');
+    assert.equal(instance.overlay.querySelector(itemActiveClassName).textContent, value);
   });
 
   it('Should render a group', () => {
@@ -108,7 +108,7 @@ describe('CheckPicker', () => {
   it('Should have a placeholder', () => {
     const instance = getDOMNode(<CheckPicker className="custom" placeholder="test" />);
 
-    assert.equal(instance.querySelector(placeholderClassName).innerText, 'test');
+    assert.equal(instance.querySelector(placeholderClassName).textContent, 'test');
   });
 
   it('Should render value by `renderValue`', () => {
@@ -124,7 +124,7 @@ describe('CheckPicker', () => {
       />
     );
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-value').innerText, '1,2');
+    assert.equal(instance.querySelector('.rs-picker-toggle-value').textContent, '1,2');
   });
 
   it('Should output a value by renderValue()', () => {
@@ -144,8 +144,8 @@ describe('CheckPicker', () => {
       <CheckPicker renderValue={v => [v, placeholder]} data={[]} value={[2]} />
     );
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-value').innerText, `1${placeholder}`);
-    assert.equal(instance2.querySelector('.rs-picker-toggle-value').innerText, `2${placeholder}`);
+    assert.equal(instance.querySelector('.rs-picker-toggle-value').textContent, `1${placeholder}`);
+    assert.equal(instance2.querySelector('.rs-picker-toggle-value').textContent, `2${placeholder}`);
   });
 
   it('Should render a placeholder when value error', () => {
@@ -160,7 +160,7 @@ describe('CheckPicker', () => {
       />
     );
 
-    assert.equal(instance.querySelector(placeholderClassName).innerText, 'test');
+    assert.equal(instance.querySelector(placeholderClassName).textContent, 'test');
   });
 
   it('Should call `onChange` callback', done => {
@@ -234,7 +234,7 @@ describe('CheckPicker', () => {
 
     ReactTestUtils.Simulate.keyDown(instance.target, { key: 'ArrowDown' });
 
-    assert.equal(instance.overlay.querySelector(itemFocusClassName).innerText, 'Kariane');
+    assert.equal(instance.overlay.querySelector(itemFocusClassName).textContent, 'Kariane');
   });
 
   it('Should focus item by key=ArrowUp ', () => {
@@ -244,7 +244,7 @@ describe('CheckPicker', () => {
 
     ReactTestUtils.Simulate.keyDown(instance.target, { key: 'ArrowUp' });
 
-    assert.equal(instance.overlay.querySelector(itemFocusClassName).innerText, 'Eugenia');
+    assert.equal(instance.overlay.querySelector(itemFocusClassName).textContent, 'Eugenia');
   });
 
   it('Should call `onChange` by key=Enter ', done => {
@@ -315,7 +315,7 @@ describe('CheckPicker', () => {
       />
     );
     const checkbox = instance.overlay.querySelector('.rs-checkbox-checked');
-    assert.equal(checkbox.innerText, '');
+    assert.equal(checkbox.textContent, '');
   });
 
   it('Should have a custom className prefix', () => {
@@ -330,7 +330,7 @@ describe('CheckPicker', () => {
 
     const menu = instance.overlay.querySelector('.rs-checkbox');
 
-    assert.equal(menu.innerText, 'Kariane');
+    assert.equal(menu.textContent, 'Kariane');
   });
 
   it('Should be render selected options be sticky', () => {
@@ -359,12 +359,12 @@ describe('CheckPicker', () => {
     );
     const list = instance.overlay.querySelectorAll('.rs-check-item');
     assert.equal(list.length, 1);
-    assert.ok(list[0].innerText, 'Louisa');
+    assert.ok(list[0].textContent, 'Louisa');
   });
 
   it('Should not be call renderValue()', () => {
     const instance = getDOMNode(<CheckPicker renderValue={() => 'value'} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
   });
 
   it('Should call renderValue', () => {
@@ -372,9 +372,9 @@ describe('CheckPicker', () => {
     const instance2 = getDOMNode(<CheckPicker value="Test" renderValue={() => null} />);
     const instance3 = getDOMNode(<CheckPicker value="Test" renderValue={() => undefined} />);
 
-    assert.equal(instance1.querySelector('.rs-picker-toggle-value').innerText, '1');
-    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
-    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance1.querySelector('.rs-picker-toggle-value').textContent, '1');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
 
     assert.include(instance1.className, 'rs-picker-has-value');
     assert.notInclude(instance2.className, 'rs-picker-has-value');

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -40,7 +40,7 @@ describe('CheckTreePicker', () => {
   it('Should render default value', () => {
     const instance = getDOMNode(<CheckTreePicker defaultOpen data={data} value={['Master']} />);
     expect(
-      instance.querySelector('.rs-picker-toggle-value .rs-picker-value-item').innerText
+      instance.querySelector('.rs-picker-toggle-value .rs-picker-value-item').textContent
     ).to.equal('Master (All)');
   });
 
@@ -56,7 +56,7 @@ describe('CheckTreePicker', () => {
     );
 
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-picker-toggle-clean'));
-    expect(instance.querySelector('.rs-picker-toggle').innerText).to.equal('Select');
+    expect(instance.querySelector('.rs-picker-toggle').textContent).to.equal('Select');
   });
 
   it('Should output a clean button', () => {
@@ -115,7 +115,7 @@ describe('CheckTreePicker', () => {
   it('Should have a placeholder', () => {
     const instance = getDOMNode(<CheckTreePicker data={data} placeholder="test" />);
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'test');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'test');
   });
 
   it('Should output a value by renderValue()', () => {
@@ -153,9 +153,9 @@ describe('CheckTreePicker', () => {
       />
     );
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-value').innerText, '1,2');
-    assert.equal(instance2.querySelector('.rs-picker-toggle-value').innerText, `2${placeholder}`);
-    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, placeholder);
+    assert.equal(instance.querySelector('.rs-picker-toggle-value').textContent, '1,2');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-value').textContent, `2${placeholder}`);
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').textContent, placeholder);
   });
 
   it('Should call renderValue', () => {
@@ -165,19 +165,19 @@ describe('CheckTreePicker', () => {
       <CheckTreePicker value={['test']} renderValue={() => undefined} />
     );
 
-    assert.equal(instance1.querySelector('.rs-picker-toggle-value').innerText, '1');
-    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
-    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance1.querySelector('.rs-picker-toggle-value').textContent, '1');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
   });
 
   it('Should not be call renderValue()', () => {
     const instance = getDOMNode(<CheckTreePicker data={[]} renderValue={() => 'value'} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
   });
 
   it('Should render a placeholder when value error', () => {
     const instance = getDOMNode(<CheckTreePicker placeholder="test" data={data} value={['4']} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'test');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'test');
   });
 
   it('Should call `onChange` callback with 1 values', () => {
@@ -237,7 +237,7 @@ describe('CheckTreePicker', () => {
     const tree = getInstance(<CheckTreePicker defaultOpen data={data} defaultExpandAll />);
     ReactTestUtils.Simulate.keyDown(tree.target, { key: KEY_VALUES.DOWN });
 
-    assert.equal(tree.overlay.querySelector(itemFocusClassName).innerText, 'Master');
+    assert.equal(tree.overlay.querySelector(itemFocusClassName).textContent, 'Master');
   });
 
   it('Should focus item by keyCode=38 ', () => {
@@ -246,7 +246,7 @@ describe('CheckTreePicker', () => {
     ReactTestUtils.Simulate.change(tree.overlay.querySelector('div[data-key="0-0-1"] input'));
     ReactTestUtils.Simulate.keyDown(tree.target, { key: KEY_VALUES.UP });
 
-    assert.equal(tree.overlay.querySelector(itemFocusClassName).innerText, 'tester0');
+    assert.equal(tree.overlay.querySelector(itemFocusClassName).textContent, 'tester0');
   });
 
   it('Should focus item by keyCode=13 ', done => {
@@ -281,7 +281,7 @@ describe('CheckTreePicker', () => {
 
     ReactTestUtils.Simulate.change(tree.overlay.querySelector('div[data-key="0-0"] input'));
     ReactTestUtils.Simulate.keyDown(tree.overlay, { key: KEY_VALUES.LEFT });
-    assert.equal(tree.overlay.querySelector(itemFocusClassName).innerText, 'Master');
+    assert.equal(tree.overlay.querySelector(itemFocusClassName).textContent, 'Master');
 
     assert.equal(
       tree.overlay.querySelectorAll(`div[data-ref="0-0"] > ${itemExpandedClassName}`).length,
@@ -297,7 +297,7 @@ describe('CheckTreePicker', () => {
 
     ReactTestUtils.Simulate.change(tree.overlay.querySelector('div[data-key="0-0-0"] input'));
     ReactTestUtils.Simulate.keyDown(tree.overlay, { key: KEY_VALUES.LEFT });
-    assert.equal(tree.overlay.querySelector(itemFocusClassName).innerText, 'Master');
+    assert.equal(tree.overlay.querySelector(itemFocusClassName).textContent, 'Master');
   });
 
   /**
@@ -322,7 +322,7 @@ describe('CheckTreePicker', () => {
 
     ReactTestUtils.Simulate.change(tree.overlay.querySelector('div[data-key="0-0-0"] input'));
     ReactTestUtils.Simulate.keyDown(tree.overlay, { key: KEY_VALUES.RIGHT });
-    assert.equal(tree.overlay.querySelector(itemFocusClassName).innerText, 'tester0');
+    assert.equal(tree.overlay.querySelector(itemFocusClassName).textContent, 'tester0');
   });
 
   /**
@@ -333,7 +333,7 @@ describe('CheckTreePicker', () => {
 
     ReactTestUtils.Simulate.change(tree.overlay.querySelector('div[data-key="0-0"] input'));
     ReactTestUtils.Simulate.keyDown(tree.overlay, { key: KEY_VALUES.RIGHT });
-    assert.equal(tree.overlay.querySelector(itemFocusClassName).innerText, 'tester0');
+    assert.equal(tree.overlay.querySelector(itemFocusClassName).textContent, 'tester0');
   });
 
   it('Should have a custom className', () => {
@@ -551,7 +551,7 @@ describe('CheckTreePicker', () => {
     );
     const list = getDOMNode(instance.overlay).querySelectorAll('.rs-check-tree-node');
     assert.equal(list.length, 1);
-    assert.ok(list[0].innerText, 'Louisa');
+    assert.ok(list[0].textContent, 'Louisa');
   });
 
   it('Should only clean the searchKeyword', () => {
@@ -569,7 +569,7 @@ describe('CheckTreePicker', () => {
       key: KEY_VALUES.BACKSPACE
     });
     assert.equal(
-      instance.root.querySelector('.rs-picker-toggle-value .rs-picker-value-item').innerText,
+      instance.root.querySelector('.rs-picker-toggle-value .rs-picker-value-item').textContent,
       'Master (All)'
     );
 

--- a/src/Container/test/ContainerSpec.js
+++ b/src/Container/test/ContainerSpec.js
@@ -13,7 +13,7 @@ describe('Container', () => {
       </Container>
     );
     assert.equal(instance.className, 'rs-container');
-    assert.equal(instance.innerText, title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should render a Container when children is false', () => {

--- a/src/Content/test/ContentSpec.js
+++ b/src/Content/test/ContentSpec.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
 import Content from '../Content';
-import { innerText } from '@test/testUtils';
 
 describe('Content', () => {
   it('Should render a Content', () => {
@@ -9,7 +8,7 @@ describe('Content', () => {
     const instance = getDOMNode(<Content>{title}</Content>);
 
     assert.equal(instance.className, 'rs-content');
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should have a custom className', () => {

--- a/src/CustomProvider/test/CustomProviderSpec.js
+++ b/src/CustomProvider/test/CustomProviderSpec.js
@@ -31,8 +31,8 @@ describe('CustomProvider', () => {
       </div>
     );
 
-    assert.equal(node.querySelectorAll('.rs-picker-toggle-placeholder')[0].innerText, '选择');
-    assert.equal(node.querySelectorAll('.rs-picker-toggle-placeholder')[1].innerText, '选择');
+    assert.equal(node.querySelectorAll('.rs-picker-toggle-placeholder')[0].textContent, '选择');
+    assert.equal(node.querySelectorAll('.rs-picker-toggle-placeholder')[1].textContent, '选择');
   });
 
   it('Should render formatted date', () => {
@@ -43,7 +43,7 @@ describe('CustomProvider', () => {
         </CustomProvider>
       </div>
     );
-    assert.equal(node.querySelector('.rs-calendar-header-title').innerText, 'мая, 2021');
+    assert.equal(node.querySelector('.rs-calendar-header-title').textContent, 'мая, 2021');
   });
 
   // TODO: This is a side-effect test, which will affect the style check test.

--- a/src/CustomProvider/test/FormattedDateSpec.js
+++ b/src/CustomProvider/test/FormattedDateSpec.js
@@ -23,7 +23,7 @@ describe('FormattedDate', () => {
         </CustomProvider>
       </div>
     );
-    assert.equal(domNode.innerText, 'янв. 01, 2020');
+    assert.equal(domNode.textContent, 'янв. 01, 2020');
   });
 
   it('Should render formatted date by formatDate', () => {
@@ -36,7 +36,7 @@ describe('FormattedDate', () => {
         </CustomProvider>
       </div>
     );
-    assert.equal(domNode.innerText, 'янв. 01, 2020');
+    assert.equal(domNode.textContent, 'янв. 01, 2020');
   });
 
   it('Should render default formatted date', () => {
@@ -45,6 +45,6 @@ describe('FormattedDate', () => {
         <FormattedDate date={new Date('2020-01-01')} formatStr="MMM dd, yyyy" />
       </div>
     );
-    assert.equal(domNode.innerText, 'Jan 01, 2020');
+    assert.equal(domNode.textContent, 'Jan 01, 2020');
   });
 });

--- a/src/DatePicker/test/DatePickerSpec.js
+++ b/src/DatePicker/test/DatePickerSpec.js
@@ -46,7 +46,7 @@ describe('DatePicker ', () => {
 
   it('Should output a date', () => {
     const instance = getDOMNode(<DatePicker defaultValue={parseISO('2017-08-14')} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-value').innerText, '2017-08-14');
+    assert.equal(instance.querySelector('.rs-picker-toggle-value').textContent, '2017-08-14');
   });
 
   it('Should output custom value', () => {
@@ -59,12 +59,12 @@ describe('DatePicker ', () => {
       />
     );
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-value').innerText, '08/14/2017');
+    assert.equal(instance.querySelector('.rs-picker-toggle-value').textContent, '08/14/2017');
   });
 
   it('Should output a date', () => {
     const instance = getDOMNode(<DatePicker value={parseISO('2017-08-14')} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-value').innerText, '2017-08-14');
+    assert.equal(instance.querySelector('.rs-picker-toggle-value').textContent, '2017-08-14');
   });
 
   it('Should get panel container ref', function () {
@@ -166,7 +166,7 @@ describe('DatePicker ', () => {
       ReactTestUtils.Simulate.blur(input);
     });
 
-    assert.equal(instance.root.querySelector('.rs-picker-toggle-value').innerText, '10:00:00');
+    assert.equal(instance.root.querySelector('.rs-picker-toggle-value').textContent, '10:00:00');
   });
 
   it('Should call `onClean` callback', () => {
@@ -347,7 +347,7 @@ describe('DatePicker ', () => {
     const doneOp = () => {
       try {
         assert.equal(
-          instance.target.querySelector('.rs-picker-toggle-value').innerText,
+          instance.target.querySelector('.rs-picker-toggle-value').textContent,
           '2018-01-05'
         );
         done();
@@ -420,13 +420,13 @@ describe('DatePicker ', () => {
     );
     const picker = instance.overlay;
 
-    assert.equal(picker.querySelector('.rs-calendar-header-meridian').innerText, 'PM');
-    assert.equal(picker.querySelector('.rs-calendar-header-title-time').innerText, '01:00:00');
+    assert.equal(picker.querySelector('.rs-calendar-header-meridian').textContent, 'PM');
+    assert.equal(picker.querySelector('.rs-calendar-header-title-time').textContent, '01:00:00');
     assert.equal(
       picker.querySelector('.rs-calendar-time-dropdown-column').querySelectorAll('li').length,
       12
     );
-    assert.equal(picker.querySelector('.rs-calendar-time-dropdown-column li').innerText, '12');
+    assert.equal(picker.querySelector('.rs-calendar-time-dropdown-column li').textContent, '12');
   });
 
   it('Should show dates that are not in the same month', () => {
@@ -434,9 +434,9 @@ describe('DatePicker ', () => {
     const picker = instance.overlay;
     const days = picker.querySelectorAll('.rs-calendar-table-cell-un-same-month');
 
-    assert.equal(days[0].innerText, '30');
-    assert.equal(days[1].innerText, '31');
-    assert.equal(days[2].innerText, '1');
+    assert.equal(days[0].textContent, '30');
+    assert.equal(days[1].textContent, '31');
+    assert.equal(days[2].textContent, '1');
   });
 
   it('Should be a controlled value', () => {
@@ -461,9 +461,9 @@ describe('DatePicker ', () => {
 
     const picker = instanceRef.current.picker;
 
-    assert.equal(picker.root.querySelector('.rs-picker-toggle-value').innerText, '2021-07-11');
+    assert.equal(picker.root.querySelector('.rs-picker-toggle-value').textContent, '2021-07-11');
     assert.equal(
-      picker.overlay.querySelector('.rs-calendar-header-title').innerText,
+      picker.overlay.querySelector('.rs-calendar-header-title').textContent,
       '11 Jul 2021'
     );
   });
@@ -485,9 +485,9 @@ describe('DatePicker ', () => {
     render(<App ref={instanceRef} />);
 
     const picker = instanceRef.current.picker.root;
-    assert.equal(picker.querySelector('.rs-picker-toggle-value').innerText, '2021-06-10');
+    assert.equal(picker.querySelector('.rs-picker-toggle-value').textContent, '2021-06-10');
     instanceRef.current.setDate(null);
-    assert.equal(picker.querySelector('.rs-picker-toggle-placeholder').innerText, 'yyyy-MM-dd');
+    assert.equal(picker.querySelector('.rs-picker-toggle-placeholder').textContent, 'yyyy-MM-dd');
   });
 
   it('Should keep AM PM unchanged', () => {
@@ -502,12 +502,12 @@ describe('DatePicker ', () => {
 
     const picker = instance.overlay;
 
-    assert.equal(picker.querySelector('.rs-calendar-header-title-time').innerText, '01:00:00');
+    assert.equal(picker.querySelector('.rs-calendar-header-title-time').textContent, '01:00:00');
 
     ReactTestUtils.Simulate.click(picker.querySelector('.rs-calendar-time-dropdown-cell'));
 
-    assert.equal(picker.querySelector('.rs-calendar-header-meridian').innerText, 'PM');
-    assert.equal(picker.querySelector('.rs-calendar-header-title-time').innerText, '12:00:00');
+    assert.equal(picker.querySelector('.rs-calendar-header-meridian').textContent, 'PM');
+    assert.equal(picker.querySelector('.rs-calendar-header-title-time').textContent, '12:00:00');
   });
 
   it('Should change AM/PM ', () => {
@@ -521,8 +521,8 @@ describe('DatePicker ', () => {
     );
 
     const meridian = instance.overlay.querySelector('.rs-calendar-header-meridian');
-    assert.equal(meridian.innerText, 'PM');
+    assert.equal(meridian.textContent, 'PM');
     ReactTestUtils.Simulate.click(meridian);
-    assert.equal(meridian.innerText, 'AM');
+    assert.equal(meridian.textContent, 'AM');
   });
 });

--- a/src/DatePicker/test/ToolbarSpec.js
+++ b/src/DatePicker/test/ToolbarSpec.js
@@ -24,7 +24,7 @@ describe('Toolbar', () => {
         ]}
       />
     );
-    assert.equal(instance.querySelector('.btn-today').innerText, 'today');
+    assert.equal(instance.querySelector('.btn-today').textContent, 'today');
   });
 
   it('Should call `onOk` callback', () => {

--- a/src/Drawer/test/DrawerHeaderSpec.js
+++ b/src/Drawer/test/DrawerHeaderSpec.js
@@ -3,14 +3,13 @@ import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 
 import Drawer from '../Drawer';
-import { innerText } from '@test/testUtils';
 
 describe('Drawer.Header', () => {
   it('Should render a drawer header', () => {
     const title = 'Test';
     const instance = getDOMNode(<Drawer.Header>{title}</Drawer.Header>);
     assert.equal(instance.className, 'rs-drawer-header');
-    assert.equal(innerText(instance), 'Test');
+    assert.equal(instance.textContent, 'Test');
   });
 
   it('Should hide close button', () => {

--- a/src/Dropdown/test/DropdownMenuItemSpec.js
+++ b/src/Dropdown/test/DropdownMenuItemSpec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactTestUtils, { act, Simulate } from 'react-dom/test-utils';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 
 import DropdownItem from '../DropdownItem';
 import User from '@rsuite/icons/legacy/User';
@@ -11,14 +11,14 @@ describe('<Dropdown.Item>', () => {
     const instance = getDOMNode(<DropdownItem>{title}</DropdownItem>);
 
     assert.equal(instance.getAttribute('role'), 'menuitem', 'role');
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should render an <a> element given as="a"', () => {
     const title = 'Test';
     const instance = getDOMNode(<DropdownItem as="a">{title}</DropdownItem>);
     assert.equal(instance.tagName, 'A');
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should render a divider', () => {

--- a/src/Dropdown/test/DropdownSpec.js
+++ b/src/Dropdown/test/DropdownSpec.js
@@ -3,7 +3,6 @@ import ReactTestUtils, { act, Simulate } from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import Dropdown from '../Dropdown';
 import Button from '../../Button';
-import { innerText } from '@test/testUtils';
 import { KEY_VALUES } from '../../utils';
 import * as utils from '../../utils';
 
@@ -143,7 +142,7 @@ describe('<Dropdown>', () => {
       </Dropdown>
     );
 
-    assert.equal(innerText(instance.querySelector('.rs-dropdown-toggle')), 'abc');
+    assert.equal(instance.querySelector('.rs-dropdown-toggle').textContent, 'abc');
   });
 
   it('Should render custom component', () => {
@@ -842,8 +841,7 @@ describe('<Dropdown>', () => {
       </Dropdown>
     );
 
-    assert.equal(instance.innerText, 'new');
-    ReactTestUtils.Simulate.click(instance.querySelector('[role="button"]'));
-    assert.equal(instance.innerText, 'new\nitem-1\nitem-2');
+    const button = instance.querySelector('[role="button"]');
+    assert.equal(button.textContent, 'new');
   });
 });

--- a/src/Dropdown/test/DropdownToggleSpec.js
+++ b/src/Dropdown/test/DropdownToggleSpec.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
 import DropdownToggle from '../DropdownToggle';
-import { innerText } from '@test/testUtils';
 import User from '@rsuite/icons/legacy/User';
 
 describe('DropdownToggle', () => {
@@ -11,13 +10,13 @@ describe('DropdownToggle', () => {
 
     assert.include(instance.className, 'dropdown-toggle');
     assert.ok(instance.querySelector('.rs-dropdown-toggle-caret'));
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should have a title', () => {
     const title = 'Test';
     const instance = getDOMNode(<DropdownToggle>{title}</DropdownToggle>);
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should have an icon', () => {
@@ -44,7 +43,7 @@ describe('DropdownToggle', () => {
       );
     };
     const instance = getDOMNode(<DropdownToggle renderToggle={renderToggle}>abc</DropdownToggle>);
-    assert.equal(instance.innerText, 'new');
+    assert.equal(instance.textContent, 'new');
   });
 
   it('Should have a custom className', () => {

--- a/src/Footer/test/FooterSpec.js
+++ b/src/Footer/test/FooterSpec.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import Footer from '../Footer';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 
 describe('Footer', () => {
   it('Should render a Footer', () => {
     const title = 'Test';
     const instance = getDOMNode(<Footer>{title}</Footer>);
     assert.include(instance.className, 'rs-footer');
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should have a custom className', () => {

--- a/src/FormControl/test/FormControlSpec.js
+++ b/src/FormControl/test/FormControlSpec.js
@@ -154,7 +154,7 @@ describe('FormControl', () => {
       </Form>
     );
 
-    assert.equal(instance.querySelector('.rs-form-control-message-wrapper').innerText, 'error2');
+    assert.equal(instance.querySelector('.rs-form-control-message-wrapper').textContent, 'error2');
   });
 
   it('Should be associated with ErrorMessage via aria-errormessage', () => {

--- a/src/FormErrorMessage/test/FormErrorMessageSpec.js
+++ b/src/FormErrorMessage/test/FormErrorMessageSpec.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import FormErrorMessage from '../FormErrorMessage';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 
 describe('FormErrorMessage', () => {
   it('Should render a FormErrorMessage', () => {
     const title = 'Test';
     const instance = getDOMNode(<FormErrorMessage show>{title}</FormErrorMessage>);
     assert.include(instance.className, 'rs-form-error-message-wrapper');
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should be show', () => {

--- a/src/Header/test/HeaderSpec.js
+++ b/src/Header/test/HeaderSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 import Header from '../Header';
 
 describe('Header', () => {
@@ -7,7 +7,7 @@ describe('Header', () => {
     const title = 'Test';
     const instance = getDOMNode(<Header>{title}</Header>);
     assert.include(instance.className, 'rs-header');
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should have a custom className', () => {

--- a/src/InputPicker/test/InputPickerSpec.js
+++ b/src/InputPicker/test/InputPickerSpec.js
@@ -29,7 +29,7 @@ describe('InputPicker', () => {
     const instance = getDOMNode(<InputPicker defaultOpen data={data} defaultValue={'Eugenia'} />);
 
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-picker-toggle-clean'));
-    expect(instance.querySelector('.rs-picker-toggle-placeholder').innerText).to.equal('Select');
+    expect(instance.querySelector('.rs-picker-toggle-placeholder').textContent).to.equal('Select');
   });
 
   it('Should have "default" appearance by default', () => {
@@ -42,7 +42,7 @@ describe('InputPicker', () => {
     const instance = getDOMNode(<InputPicker defaultOpen data={data} value={'Eugenia'} />);
 
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-picker-toggle-clean'));
-    expect(instance.querySelector('.rs-picker-toggle-value').innerText).to.equal('Eugenia');
+    expect(instance.querySelector('.rs-picker-toggle-value').textContent).to.equal('Eugenia');
   });
 
   it('Should output a dropdown', () => {
@@ -65,10 +65,10 @@ describe('InputPicker', () => {
       <InputPicker plaintext data={data} placeholder="-" value={'Eugenia'} />
     );
 
-    assert.equal(instance1.target.innerText, 'Eugenia');
-    assert.equal(instance2.target.innerText, 'Not selected');
-    assert.equal(instance3.target.innerText, '-');
-    assert.equal(instance4.target.innerText, 'Eugenia');
+    assert.equal(instance1.target.textContent, 'Eugenia');
+    assert.equal(instance2.target.textContent, 'Not selected');
+    assert.equal(instance3.target.textContent, '-');
+    assert.equal(instance4.target.textContent, 'Eugenia');
   });
 
   it('Should be readOnly', () => {
@@ -110,9 +110,9 @@ describe('InputPicker', () => {
     const value = 'Louisa';
     const instance = getInstance(<InputPicker defaultOpen data={data} value={value} />);
 
-    assert.equal(instance.root.querySelector('.rs-picker-toggle-value').innerText, value);
+    assert.equal(instance.root.querySelector('.rs-picker-toggle-value').textContent, value);
     assert.equal(
-      instance.overlay.querySelector('.rs-picker-select-menu-item-active').innerText,
+      instance.overlay.querySelector('.rs-picker-select-menu-item-active').textContent,
       value
     );
   });
@@ -120,9 +120,9 @@ describe('InputPicker', () => {
   it('Should active item by `defaultValue`', () => {
     const value = 'Louisa';
     const instance = getInstance(<InputPicker defaultOpen data={data} defaultValue={value} />);
-    assert.equal(instance.root.querySelector('.rs-picker-toggle-value').innerText, value);
+    assert.equal(instance.root.querySelector('.rs-picker-toggle-value').textContent, value);
     assert.equal(
-      instance.overlay.querySelector('.rs-picker-select-menu-item-active').innerText,
+      instance.overlay.querySelector('.rs-picker-select-menu-item-active').textContent,
       value
     );
   });
@@ -136,7 +136,7 @@ describe('InputPicker', () => {
   it('Should have a placeholder', () => {
     const instance = getDOMNode(<InputPicker className="custom" placeholder="test" />);
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'test');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'test');
   });
 
   it('Allow `label` to be an empty string', () => {
@@ -144,7 +144,7 @@ describe('InputPicker', () => {
       <InputPicker placeholder="test" data={[{ label: '', value: '1' }]} value={'1'} defaultOpen />
     );
     const menuContainer = instance.overlay.querySelector('.rs-picker-select-menu-item-active');
-    assert.equal(menuContainer.innerText, '');
+    assert.equal(menuContainer.textContent, '');
   });
 
   it('Should render value by `renderValue`', () => {
@@ -157,7 +157,7 @@ describe('InputPicker', () => {
         renderValue={(value, item) => `${item.label}-${value}`}
       />
     );
-    assert.equal(instance.querySelector('.rs-picker-toggle-value').innerText, 'foo-bar');
+    assert.equal(instance.querySelector('.rs-picker-toggle-value').textContent, 'foo-bar');
   });
 
   it('Should output a value by renderValue()', () => {
@@ -177,18 +177,18 @@ describe('InputPicker', () => {
       <InputPicker renderValue={v => [v, placeholder]} data={[]} value={2} />
     );
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-value').innerText, `1${placeholder}`);
-    assert.equal(instance2.querySelector('.rs-picker-toggle-value').innerText, `2${placeholder}`);
+    assert.equal(instance.querySelector('.rs-picker-toggle-value').textContent, `1${placeholder}`);
+    assert.equal(instance2.querySelector('.rs-picker-toggle-value').textContent, `2${placeholder}`);
   });
 
   it('Should not be call renderValue()', () => {
     const instance = getDOMNode(<InputPicker renderValue={() => 'value'} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
   });
 
   it('Should render a placeholder when value error', () => {
     const instance = getDOMNode(<InputPicker value={2} placeholder={'test'} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'test');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'test');
   });
 
   it('Should call `onChange` callback with correct value', done => {
@@ -286,7 +286,7 @@ describe('InputPicker', () => {
     ReactTestUtils.Simulate.keyDown(instance.target, { key: 'ArrowDown' });
 
     assert.equal(
-      instance.overlay.querySelector('.rs-picker-select-menu-item-focus').innerText,
+      instance.overlay.querySelector('.rs-picker-select-menu-item-focus').textContent,
       'Kariane'
     );
   });
@@ -296,7 +296,7 @@ describe('InputPicker', () => {
     ReactTestUtils.Simulate.keyDown(instance.target, { key: 'ArrowUp' });
 
     assert.equal(
-      instance.overlay.querySelector('.rs-picker-select-menu-item-focus').innerText,
+      instance.overlay.querySelector('.rs-picker-select-menu-item-focus').textContent,
       'Eugenia'
     );
   });
@@ -356,7 +356,7 @@ describe('InputPicker', () => {
     );
     const list = instance.overlay.querySelectorAll('.rs-picker-select-menu-item');
     assert.equal(list.length, 1);
-    assert.ok(list[0].innerText, 'Louisa');
+    assert.ok(list[0].textContent, 'Louisa');
   });
 
   it('Should call renderValue', () => {
@@ -364,9 +364,9 @@ describe('InputPicker', () => {
     const instance2 = getDOMNode(<InputPicker value="Test" renderValue={() => null} />);
     const instance3 = getDOMNode(<InputPicker value="Test" renderValue={() => undefined} />);
 
-    assert.equal(instance1.querySelector('.rs-picker-toggle-value').innerText, '1');
-    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
-    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance1.querySelector('.rs-picker-toggle-value').textContent, '1');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
 
     assert.include(instance1.className, 'rs-picker-has-value');
     assert.notInclude(instance2.className, 'rs-picker-has-value');
@@ -376,7 +376,7 @@ describe('InputPicker', () => {
   it('Children should not be selected', () => {
     const data = [{ value: 1, label: 'A', children: [{ value: 2, label: 'B' }] }];
     const instance = getDOMNode(<InputPicker data={data} value={2} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
     assert.notInclude(instance.className, 'rs-picker-has-value');
   });
 

--- a/src/Loader/test/LoaderSpec.js
+++ b/src/Loader/test/LoaderSpec.js
@@ -25,7 +25,7 @@ describe('Loader', () => {
 
   it('Should have content', () => {
     let instance = getDOMNode(<Loader content="content" />);
-    assert.equal(instance.innerText, 'content');
+    assert.equal(instance.textContent, 'content');
   });
 
   it('Should have a speed', () => {

--- a/src/Message/test/MessageSpec.js
+++ b/src/Message/test/MessageSpec.js
@@ -12,12 +12,12 @@ describe('Message', () => {
   it('Should render a title', () => {
     const instance = getDOMNode(<Message header="title" />);
     assert.include(instance.className, 'rs-message-has-title');
-    assert.equal(instance.innerText, 'title');
+    assert.equal(instance.textContent, 'title');
   });
 
   it('Should render a description', () => {
     const instance = getDOMNode(<Message>description</Message>);
-    assert.equal(instance.innerText, 'description');
+    assert.equal(instance.textContent, 'description');
   });
 
   it('Should have a type', () => {

--- a/src/Modal/test/ModalDialogSpec.js
+++ b/src/Modal/test/ModalDialogSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import ModalDialog from '../ModalDialog';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 
 describe('ModalDialog', () => {
   it('Should render a dialog', () => {
@@ -10,7 +10,7 @@ describe('ModalDialog', () => {
 
     assert.equal(instance.className, 'rs-modal');
     assert.ok(instance.querySelector('.rs-modal-dialog'));
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should have a custom className in dialog', () => {

--- a/src/Modal/test/ModalHeaderSpec.js
+++ b/src/Modal/test/ModalHeaderSpec.js
@@ -3,14 +3,13 @@ import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 
 import ModalHeader from '../ModalHeader';
-import { innerText } from '@test/testUtils';
 
 describe('ModalHeader', () => {
   it('Should render a modal header', () => {
     const title = 'Test';
     const instance = getDOMNode(<ModalHeader>{title}</ModalHeader>);
     assert.equal(instance.className, 'rs-modal-header');
-    assert.equal(innerText(instance), 'Test');
+    assert.equal(instance.textContent, 'Test');
   });
 
   it('Should hide close button', () => {

--- a/src/MultiCascader/test/MultiCascaderSpec.js
+++ b/src/MultiCascader/test/MultiCascaderSpec.js
@@ -46,7 +46,7 @@ describe('MultiCascader', () => {
   it('Should render number', () => {
     const instance = getDOMNode(<MultiCascader data={items} value={['abcde-1', 'abcde-2']} />);
 
-    assert.equal(instance.querySelector('.rs-picker-value-count').innerText, '1');
+    assert.equal(instance.querySelector('.rs-picker-value-count').textContent, '1');
   });
 
   it('Should not render number', () => {
@@ -60,7 +60,7 @@ describe('MultiCascader', () => {
   it('Should render the parent node by children value', () => {
     const instance = getDOMNode(<MultiCascader data={items} value={['abcde-1', 'abcde-2']} />);
 
-    assert.equal(instance.querySelector('.rs-picker-value-list').innerText, 'abcde (All)');
+    assert.equal(instance.querySelector('.rs-picker-value-list').textContent, 'abcde (All)');
   });
 
   it('Should render the parent node by children defaultValue', () => {
@@ -68,7 +68,7 @@ describe('MultiCascader', () => {
       <MultiCascader data={items} defaultValue={['abcde-1', 'abcde-2']} />
     );
 
-    assert.equal(instance.querySelector('.rs-picker-value-list').innerText, 'abcde (All)');
+    assert.equal(instance.querySelector('.rs-picker-value-list').textContent, 'abcde (All)');
   });
 
   it('Should render the parent node by children value', () => {
@@ -76,7 +76,7 @@ describe('MultiCascader', () => {
       <MultiCascader data={items} value={['abcde-1']} uncheckableItemValues={['abcde-2']} />
     );
 
-    assert.equal(instance.querySelector('.rs-picker-value-list').innerText, 'abcde (All)');
+    assert.equal(instance.querySelector('.rs-picker-value-list').textContent, 'abcde (All)');
   });
 
   it('Should render the children nodes', () => {
@@ -88,7 +88,7 @@ describe('MultiCascader', () => {
       />
     );
 
-    assert.equal(instance.querySelector('.rs-picker-value-list').innerText, 'abcde-1,abcde-2');
+    assert.equal(instance.querySelector('.rs-picker-value-list').textContent, 'abcde-1,abcde-2');
   });
 
   it('Should be disabled', () => {
@@ -108,7 +108,7 @@ describe('MultiCascader', () => {
     const placeholder = 'foobar';
     const instance = getDOMNode(<MultiCascader placeholder={placeholder} />);
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, placeholder);
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, placeholder);
   });
 
   it('Should output a button', () => {
@@ -128,10 +128,10 @@ describe('MultiCascader', () => {
       <MultiCascader renderValue={() => placeholder} data={items} value={['abc']} />
     );
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-value').innerText, placeholder);
+    assert.equal(instance.querySelector('.rs-picker-toggle-value').textContent, placeholder);
 
     const instance2 = getDOMNode(<MultiCascader renderValue={() => placeholder} />);
-    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
   });
 
   it('Should output a value by renderValue()', () => {
@@ -151,13 +151,13 @@ describe('MultiCascader', () => {
       <MultiCascader renderValue={v => [v, placeholder]} data={[]} value={[2]} />
     );
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-value').innerText, `1${placeholder}`);
-    assert.equal(instance2.querySelector('.rs-picker-toggle-value').innerText, `2${placeholder}`);
+    assert.equal(instance.querySelector('.rs-picker-toggle-value').textContent, `1${placeholder}`);
+    assert.equal(instance2.querySelector('.rs-picker-toggle-value').textContent, `2${placeholder}`);
   });
 
   it('Should not be call renderValue()', () => {
     const instance = getDOMNode(<MultiCascader renderValue={() => 'value'} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
   });
 
   it('Should render a placeholder when value error', () => {
@@ -172,19 +172,19 @@ describe('MultiCascader', () => {
       />
     );
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'test');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'test');
   });
 
   it('Should be active by value', () => {
     const value = ['abcd'];
     const instance = getInstance(<MultiCascader defaultOpen data={items} value={value} />);
-    assert.equal(instance.overlay.querySelector('.rs-checkbox-checked').innerText, value);
+    assert.equal(instance.overlay.querySelector('.rs-checkbox-checked').textContent, value);
   });
 
   it('Should be active by defaultValue', () => {
     const value = ['abcd'];
     const instance = getInstance(<MultiCascader defaultOpen data={items} defaultValue={value} />);
-    assert.equal(instance.overlay.querySelector('.rs-checkbox-checked').innerText, value);
+    assert.equal(instance.overlay.querySelector('.rs-checkbox-checked').textContent, value);
   });
 
   it('Should call `onSelect` callback ', () => {
@@ -242,7 +242,7 @@ describe('MultiCascader', () => {
       ReactTestUtils.Simulate.click(target.querySelector('.rs-picker-toggle-clean'));
     });
 
-    assert.equal(target.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(target.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
   });
 
   it('Should have a custom className', () => {
@@ -271,9 +271,9 @@ describe('MultiCascader', () => {
     const instance2 = getDOMNode(<MultiCascader value={['Test']} renderValue={() => null} />);
     const instance3 = getDOMNode(<MultiCascader value={['Test']} renderValue={() => undefined} />);
 
-    assert.equal(instance1.querySelector('.rs-picker-toggle-value').innerText, '1');
-    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
-    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance1.querySelector('.rs-picker-toggle-value').textContent, '1');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
 
     assert.include(instance1.className, 'rs-picker-has-value');
     assert.notInclude(instance2.className, 'rs-picker-has-value');
@@ -302,13 +302,13 @@ describe('MultiCascader', () => {
     });
     const target = ref.current.picker.root;
 
-    assert.equal(target.querySelector('.rs-picker-value-list').innerText, 'abc');
+    assert.equal(target.querySelector('.rs-picker-value-list').textContent, 'abc');
 
     act(() => {
       ref.current.setValue([]);
     });
 
-    assert.equal(target.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(target.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
   });
 
   it('Should call onSelect callback with 3 params', () => {
@@ -361,7 +361,7 @@ describe('MultiCascader', () => {
     });
 
     assert.equal(overlay.querySelectorAll('.rs-check-item').length, 1);
-    assert.equal(overlay.querySelector('.rs-check-item').innerText, 'test');
+    assert.equal(overlay.querySelector('.rs-check-item').textContent, 'test');
   });
 
   it('Should children be loaded lazily', () => {
@@ -379,7 +379,7 @@ describe('MultiCascader', () => {
       instance.overlay.querySelector('.rs-picker-cascader-menu-has-children .rs-check-item')
     );
 
-    assert.equal(instance.overlay.querySelectorAll('.rs-check-item')[1].innerText, '2');
+    assert.equal(instance.overlay.querySelectorAll('.rs-check-item')[1].textContent, '2');
   });
 
   it('Should present an asyn loading state', () => {

--- a/src/Nav/test/NavItemSpec.js
+++ b/src/Nav/test/NavItemSpec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getByTestId, screen } from '@testing-library/react';
-import { getDOMNode, innerText } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 
 import NavItem from '../NavItem';
 import Sidenav from '../../Sidenav';
@@ -13,7 +13,7 @@ describe('<Nav.Item>', () => {
     let title = 'Test';
     let instance = getDOMNode(<NavItem>{title}</NavItem>);
     assert.equal(instance.tagName, 'A');
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should call onSelect callback with correct eventKey', done => {

--- a/src/Nav/test/NavSpec.js
+++ b/src/Nav/test/NavSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Nav from '../Nav';
@@ -11,7 +11,7 @@ describe('<Nav>', () => {
     const instance = getDOMNode(<Nav>{title}</Nav>);
     const node = instance;
     assert.ok(node.className.match(/\bnav\b/));
-    assert.equal(innerText(node), title);
+    assert.equal(node.textContent, title);
   });
 
   it('Should have a `nav-tabs` className', () => {

--- a/src/Navbar/test/NavbarBrandSpec.js
+++ b/src/Navbar/test/NavbarBrandSpec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import NavbarBrand from '../NavbarBrand';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 
 describe('NavbarBrand', () => {
   it('Should render a link', () => {
@@ -8,6 +8,6 @@ describe('NavbarBrand', () => {
     let instance = getDOMNode(<NavbarBrand href="/">{title}</NavbarBrand>);
     assert.equal(instance.tagName, 'A');
     assert.equal(instance.getAttribute('href'), '/');
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 });

--- a/src/Navbar/test/NavbarHeaderSpec.js
+++ b/src/Navbar/test/NavbarHeaderSpec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import NavbarHeader from '../NavbarHeader';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 
 describe('NavbarHeader (deprecated)', () => {
   beforeEach(() => {
@@ -16,7 +16,7 @@ describe('NavbarHeader (deprecated)', () => {
     let instance = getDOMNode(<NavbarHeader>{title}</NavbarHeader>);
     assert.equal(instance.tagName, 'DIV');
     assert.ok(instance.className.match(/\bnavbar-header\b/));
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should have a custom className', () => {

--- a/src/Notification/test/NotificationSpec.js
+++ b/src/Notification/test/NotificationSpec.js
@@ -11,7 +11,7 @@ describe('Notification', () => {
 
   it('Should render content', () => {
     const instance = getDOMNode(<Notification>text</Notification>);
-    assert.equal(instance.innerText, 'text');
+    assert.equal(instance.textContent, 'text');
   });
 
   it('Should be closable', () => {
@@ -28,7 +28,7 @@ describe('Notification', () => {
 
   it('Should have a header', () => {
     const instance = getDOMNode(<Notification header="header" />);
-    assert.equal(instance.querySelector('.rs-notification-title').innerText, 'header');
+    assert.equal(instance.querySelector('.rs-notification-title').textContent, 'header');
   });
 
   it('Should have a custom className', () => {

--- a/src/Pagination/test/PaginationButtonSpec.js
+++ b/src/Pagination/test/PaginationButtonSpec.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 import PaginationButton from '../PaginationButton';
 
 describe('PaginationButton', () => {
@@ -9,7 +9,7 @@ describe('PaginationButton', () => {
     const title = 'Test';
     const instance = getDOMNode(<PaginationButton>{title}</PaginationButton>);
     assert.equal(instance.tagName, 'BUTTON');
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should be disabled', () => {
@@ -50,8 +50,8 @@ describe('PaginationButton', () => {
     Button.displayName = 'Button';
     const activeInstance = getDOMNode(<PaginationButton active as={Button} />);
     const inactiveInstance = getDOMNode(<PaginationButton active={false} as={Button} />);
-    assert.equal(activeInstance.innerText, 'active');
-    assert.equal(inactiveInstance.innerText, 'inactive');
+    assert.equal(activeInstance.textContent, 'active');
+    assert.equal(inactiveInstance.textContent, 'inactive');
   });
 
   it('Custom elements can get the eventKey prop', () => {
@@ -63,7 +63,7 @@ describe('PaginationButton', () => {
       );
     });
     const instance = getDOMNode(<PaginationButton eventKey={1} as={Button} />);
-    assert.equal(instance.innerText, '1');
+    assert.equal(instance.textContent, '1');
   });
 
   it('Should have a custom className', () => {

--- a/src/Pagination/test/PaginationGroupSpec.js
+++ b/src/Pagination/test/PaginationGroupSpec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 
 import PaginationGroup from '../PaginationGroup';
-import { getDOMNode, getInstance, innerText } from '@test/testUtils';
+import { getDOMNode, getInstance } from '@test/testUtils';
 
 describe('Pagination Group', () => {
   it('Should output a PaginationGroup', () => {
@@ -74,12 +74,15 @@ describe('Pagination Group', () => {
         first={false}
       />
     );
-    assert.equal(instance.querySelector('.rs-pagination-btn-active').innerText, '2');
+    assert.equal(instance.querySelector('.rs-pagination-btn-active').textContent, '2');
   });
 
   it('Should show total', () => {
     const instance = getDOMNode(<PaginationGroup layout={['total']} total={100} />);
-    assert.equal(instance.querySelector('.rs-pagination-group-total').innerText, 'Total Rows: 100');
+    assert.equal(
+      instance.querySelector('.rs-pagination-group-total').textContent,
+      'Total Rows: 100'
+    );
   });
 
   it('Should call onChangePage callback', done => {
@@ -157,7 +160,7 @@ describe('Pagination Group', () => {
     const disabledDOMs = instance.querySelectorAll('.rs-pagination-btn-disabled');
     assert.ok(instance.querySelector('.rs-picker-disabled'));
     assert.equal(disabledDOMs.length, 1);
-    assert.equal(innerText(disabledDOMs[0]), '2');
+    assert.equal(disabledDOMs[0].textContent, '2');
   });
 
   it('Should have a custom className prefix', () => {
@@ -180,7 +183,7 @@ describe('Pagination Group', () => {
         boundaryLinks={true}
       />
     );
-    assert.equal(instance.querySelector('button:last-child').innerText, '10');
+    assert.equal(instance.querySelector('button:last-child').textContent, '10');
   });
 
   it('Should render a `more` icon', () => {

--- a/src/Pagination/test/PaginationSpec.js
+++ b/src/Pagination/test/PaginationSpec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-import { getDOMNode, innerText } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 import Pagination from '../Pagination';
 
 describe('Pagination', () => {
@@ -33,7 +33,7 @@ describe('Pagination', () => {
   it('Should be ellipsis', () => {
     const instance = getDOMNode(<Pagination pages={20} maxButtons={2} ellipsis={'abc'} />);
     assert.equal(instance.querySelectorAll('button').length, 3);
-    assert.equal(innerText(instance.querySelector('button.rs-pagination-btn-disabled')), 'abc');
+    assert.equal(instance.querySelector('button.rs-pagination-btn-disabled').textContent, 'abc');
   });
 
   it('Should be disabled', () => {
@@ -55,7 +55,7 @@ describe('Pagination', () => {
     );
     const disabledDOMs = instance.querySelectorAll('button.rs-pagination-btn-disabled');
     assert.equal(disabledDOMs.length, 1);
-    assert.equal(innerText(disabledDOMs[0]), '2');
+    assert.equal(disabledDOMs[0].textContent, '2');
   });
 
   it('Should render `first` button', () => {
@@ -80,12 +80,12 @@ describe('Pagination', () => {
 
   it('Should render boundary links', () => {
     const instance = getDOMNode(<Pagination pages={20} maxButtons={2} ellipsis boundaryLinks />);
-    assert.equal(innerText(instance.querySelector('button:last-child')), '20');
+    assert.equal(instance.querySelector('button:last-child').textContent, '20');
   });
 
   it('Should active page 5', () => {
     const instance = getDOMNode(<Pagination pages={20} activePage={5} />);
-    assert.equal(innerText(instance.querySelector('button.rs-pagination-btn-active')), '5');
+    assert.equal(instance.querySelector('button.rs-pagination-btn-active').textContent, '5');
   });
 
   it('Should call onSelect callback with correct eventKey', done => {

--- a/src/Panel/test/PanelSpec.js
+++ b/src/Panel/test/PanelSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import Panel from '../Panel';
-import { getDOMNode, innerText, render } from '@test/testUtils';
+import { getDOMNode, render } from '@test/testUtils';
 
 describe('Panel', () => {
   it('Should render a panel', () => {
@@ -9,7 +9,7 @@ describe('Panel', () => {
     const instance = getDOMNode(<Panel>{title}</Panel>);
     assert.equal(instance.tagName, 'DIV');
     assert.ok(instance.className.match(/\bpanel\b/));
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should default expanded', () => {
@@ -34,7 +34,7 @@ describe('Panel', () => {
 
   it('Should render the custom header', () => {
     const instance = getDOMNode(<Panel header={<a>abc</a>} />);
-    assert.equal(innerText(instance.querySelector('a.rs-panel-title')), 'abc');
+    assert.equal(instance.querySelector('a.rs-panel-title').textContent, 'abc');
   });
 
   it('Should have a role in header', () => {

--- a/src/PanelGroup/test/PanelGroupSpec.js
+++ b/src/PanelGroup/test/PanelGroupSpec.js
@@ -3,7 +3,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 
 import PanelGroup from '../PanelGroup';
 import Panel from '../../Panel';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 
 describe('PanelGroup', () => {
   it('Should render a PanelGroup', () => {
@@ -13,7 +13,7 @@ describe('PanelGroup', () => {
 
     assert.equal(instanceDom.tagName, 'DIV');
     assert.ok(instanceDom.className.match(/\bpanel-group\b/));
-    assert.equal(innerText(instanceDom), title);
+    assert.equal(instanceDom.textContent, title);
   });
 
   it('Should render 2 Panels', () => {

--- a/src/Picker/test/DropdownMenuCheckItemSpec.js
+++ b/src/Picker/test/DropdownMenuCheckItemSpec.js
@@ -10,7 +10,7 @@ describe('picker - DropdownMenuCheckItem', () => {
     const instance = getDOMNode(<DropdownMenuItem title="title">{Title}</DropdownMenuItem>);
 
     assert.equal(instance.tagName, 'DIV');
-    assert.equal(instance.innerText, Title);
+    assert.equal(instance.textContent, Title);
   });
 
   it('Should be active', () => {

--- a/src/Picker/test/DropdownMenuGroupSpec.js
+++ b/src/Picker/test/DropdownMenuGroupSpec.js
@@ -8,7 +8,7 @@ describe('picker - DropdownMenuGroup', () => {
     const instance = getDOMNode(<DropdownMenuGroup>{Title}</DropdownMenuGroup>);
 
     assert.equal(instance.className, 'rs-dropdown-menu-group');
-    assert.equal(instance.innerText, Title);
+    assert.equal(instance.textContent, Title);
   });
 
   it('Should have a title', () => {
@@ -18,7 +18,7 @@ describe('picker - DropdownMenuGroup', () => {
       </DropdownMenuGroup>
     );
 
-    assert.equal(instance.querySelector('.rs-dropdown-menu-group-title').innerText, 'title');
+    assert.equal(instance.querySelector('.rs-dropdown-menu-group-title').textContent, 'title');
   });
 
   it('Should have a role', () => {

--- a/src/Picker/test/DropdownMenuItemSpec.js
+++ b/src/Picker/test/DropdownMenuItemSpec.js
@@ -10,7 +10,7 @@ describe('picker - DropdownMenuItem', () => {
     const instance = getDOMNode(<DropdownMenuItem title="title">{Title}</DropdownMenuItem>);
 
     assert.equal(instance.tagName, 'DIV');
-    assert.equal(instance.innerText, Title);
+    assert.equal(instance.textContent, Title);
   });
 
   it('Should be active', () => {

--- a/src/Picker/test/DropdownMenuSpec.js
+++ b/src/Picker/test/DropdownMenuSpec.js
@@ -65,7 +65,7 @@ describe('picker -  DropdownMenu', () => {
       />
     );
 
-    assert.equal(instance.querySelector('.rs-dropdown-menu-item-active').innerText, 'c');
+    assert.equal(instance.querySelector('.rs-dropdown-menu-item-active').textContent, 'c');
   });
 
   it('Should have a maxHeight', () => {

--- a/src/Picker/test/PickerToggleSpec.js
+++ b/src/Picker/test/PickerToggleSpec.js
@@ -13,7 +13,7 @@ describe('<PickerToggle>', () => {
 
     assert.equal(instance.tagName, 'DIV');
     assert.include(instance.className, 'toggle');
-    assert.equal(instance.innerText, Title);
+    assert.equal(instance.textContent, Title);
   });
 
   it('Should output a button', () => {
@@ -26,7 +26,7 @@ describe('<PickerToggle>', () => {
 
     assert.equal(instance.tagName, 'BUTTON');
     assert.include(instance.className, 'toggle');
-    assert.equal(instance.innerText, Title);
+    assert.equal(instance.textContent, Title);
   });
 
   describe('Cleanable (`cleanable`=true)', () => {

--- a/src/Plaintext/test/PlaintextSpec.js
+++ b/src/Plaintext/test/PlaintextSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 import Plaintext from '../Plaintext';
 
 describe('Plaintext', () => {
@@ -7,7 +7,7 @@ describe('Plaintext', () => {
     const title = 'Test';
     const instance = getDOMNode(<Plaintext>{title}</Plaintext>);
     assert.include(instance.className, 'rs-plaintext');
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should have a custom className', () => {

--- a/src/Popover/test/PopoverSpec.js
+++ b/src/Popover/test/PopoverSpec.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
 import Popover from '../Popover';
-import { innerText } from '@test/testUtils';
 
 describe('Popover', () => {
   it('Should render a Popover', () => {
@@ -9,7 +8,7 @@ describe('Popover', () => {
     const instance = getDOMNode(<Popover>{title}</Popover>);
     assert.equal(instance.tagName, 'DIV');
     assert.equal(instance.className, 'rs-popover');
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should be full', () => {

--- a/src/Progress/test/ProgressCircleSpec.js
+++ b/src/Progress/test/ProgressCircleSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 import ProgressCircle from '../ProgressCircle';
 
 describe('Progress - Circle', () => {
@@ -10,7 +10,7 @@ describe('Progress - Circle', () => {
 
   it('Should have a percentage', () => {
     const instance = getDOMNode(<ProgressCircle percent={10} />);
-    assert.equal(innerText(instance), '10%');
+    assert.equal(instance.textContent, '10%');
   });
 
   it('Should have a width', () => {

--- a/src/Progress/test/ProgressLineSpec.js
+++ b/src/Progress/test/ProgressLineSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 import ProgressLine from '../ProgressLine';
 
 describe('Progress - Line', () => {
@@ -12,7 +12,7 @@ describe('Progress - Line', () => {
     const instance = getDOMNode(<ProgressLine percent={10} />);
 
     assert.equal(instance.querySelector('.rs-progress-line-bg').style.width, '10%');
-    assert.equal(innerText(instance), '10%');
+    assert.equal(instance.textContent, '10%');
   });
 
   it('Should have a height', () => {

--- a/src/RadioGroup/test/RadioGroupSpec.js
+++ b/src/RadioGroup/test/RadioGroupSpec.js
@@ -154,7 +154,7 @@ describe('RadioGroup', () => {
         <Radio value={false}>false</Radio>
       </RadioGroup>
     );
-    assert.equal(instance.querySelector('.rs-radio-checked').innerText, 'false');
+    assert.equal(instance.querySelector('.rs-radio-checked').textContent, 'false');
   });
 
   it('Should have a custom className', () => {

--- a/src/RangeSlider/test/RangeSliderSpec.js
+++ b/src/RangeSlider/test/RangeSliderSpec.js
@@ -49,7 +49,7 @@ describe('RangeSlider', () => {
 
   it('Should render custom title', () => {
     const instance = getDOMNode(<RangeSlider tooltip={false} handleTitle={'test'} />);
-    assert.equal(instance.querySelector('.rs-slider-handle').innerText, 'test');
+    assert.equal(instance.querySelector('.rs-slider-handle').textContent, 'test');
   });
 
   it('Should have a custom className', () => {

--- a/src/Rate/test/RateSpec.js
+++ b/src/Rate/test/RateSpec.js
@@ -57,7 +57,7 @@ describe('Rate', () => {
 
   it('Should render A character', () => {
     const instance = getDOMNode(<Rate defaultValue={1} character="A" />);
-    assert.equal(instance.querySelector('.rs-rate-character-before').innerText, 'A');
+    assert.equal(instance.querySelector('.rs-rate-character-before').textContent, 'A');
   });
 
   it('Should render a custom character', () => {

--- a/src/SelectPicker/test/SelectPickerSpec.js
+++ b/src/SelectPicker/test/SelectPickerSpec.js
@@ -30,7 +30,7 @@ describe('SelectPicker', () => {
     const instance = getDOMNode(<Dropdown defaultOpen data={data} defaultValue={'Eugenia'} />);
 
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-picker-toggle-clean'));
-    expect(instance.querySelector('.rs-picker-toggle-placeholder').innerText).to.equal('Select');
+    expect(instance.querySelector('.rs-picker-toggle-placeholder').textContent).to.equal('Select');
   });
 
   it('Should have "default" appearance by default', () => {
@@ -43,7 +43,7 @@ describe('SelectPicker', () => {
     const instance = getDOMNode(<Dropdown defaultOpen data={data} value={'Eugenia'} />);
 
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-picker-toggle-clean'));
-    expect(instance.querySelector('.rs-picker-toggle-value').innerText).to.equal('Eugenia');
+    expect(instance.querySelector('.rs-picker-toggle-value').textContent).to.equal('Eugenia');
   });
 
   it('Should output a dropdown', () => {
@@ -71,9 +71,9 @@ describe('SelectPicker', () => {
     const value = 'Louisa';
     const instance = getInstance(<Dropdown defaultOpen data={data} value={value} />);
 
-    assert.equal(instance.root.querySelector('.rs-picker-toggle-value').innerText, value);
+    assert.equal(instance.root.querySelector('.rs-picker-toggle-value').textContent, value);
     assert.equal(
-      instance.overlay.querySelector('.rs-picker-select-menu-item-active').innerText,
+      instance.overlay.querySelector('.rs-picker-select-menu-item-active').textContent,
       value
     );
   });
@@ -81,9 +81,9 @@ describe('SelectPicker', () => {
   it('Should active item by `defaultValue`', () => {
     const value = 'Louisa';
     const instance = getInstance(<Dropdown defaultOpen data={data} defaultValue={value} />);
-    assert.equal(instance.root.querySelector('.rs-picker-toggle-value').innerText, value);
+    assert.equal(instance.root.querySelector('.rs-picker-toggle-value').textContent, value);
     assert.equal(
-      instance.overlay.querySelector('.rs-picker-select-menu-item-active').innerText,
+      instance.overlay.querySelector('.rs-picker-select-menu-item-active').textContent,
       value
     );
   });
@@ -96,7 +96,7 @@ describe('SelectPicker', () => {
   it('Should have a placeholder', () => {
     const instance = getDOMNode(<Dropdown className="custom" placeholder="test" />);
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'test');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'test');
   });
 
   it('Allow `label` to be an empty string', () => {
@@ -104,7 +104,7 @@ describe('SelectPicker', () => {
       <Dropdown placeholder="test" data={[{ label: '', value: '1' }]} value={'1'} defaultOpen />
     );
     const menu = instance.overlay.querySelector('.rs-picker-select-menu-item-active');
-    assert.equal(menu.innerText, '');
+    assert.equal(menu.textContent, '');
   });
 
   it('Should render value by `renderValue`', () => {
@@ -118,7 +118,7 @@ describe('SelectPicker', () => {
       />
     );
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-value').innerText, 'foo-bar');
+    assert.equal(instance.querySelector('.rs-picker-toggle-value').textContent, 'foo-bar');
   });
 
   it('Should output a value by renderValue()', () => {
@@ -137,19 +137,19 @@ describe('SelectPicker', () => {
     // Invalid value
     const instance3 = getDOMNode(<Dropdown renderValue={v => [v, placeholder]} value={''} />);
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-value').innerText, `1${placeholder}`);
-    assert.equal(instance2.querySelector('.rs-picker-toggle-value').innerText, `2${placeholder}`);
-    assert.equal(instance3.querySelector('.rs-picker-toggle-value').innerText, placeholder);
+    assert.equal(instance.querySelector('.rs-picker-toggle-value').textContent, `1${placeholder}`);
+    assert.equal(instance2.querySelector('.rs-picker-toggle-value').textContent, `2${placeholder}`);
+    assert.equal(instance3.querySelector('.rs-picker-toggle-value').textContent, placeholder);
   });
 
   it('Should not be call renderValue()', () => {
     const instance = getDOMNode(<Dropdown renderValue={() => 'value'} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
   });
 
   it('Should render a placeholder when value error', () => {
     const instance = getDOMNode(<Dropdown value={2} placeholder={'test'} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'test');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'test');
   });
 
   it('Should call `onChange` callback with correct value', done => {
@@ -242,7 +242,7 @@ describe('SelectPicker', () => {
     ReactTestUtils.Simulate.keyDown(instance.target, { key: 'ArrowDown' });
 
     assert.equal(
-      instance.overlay.querySelector('.rs-picker-select-menu-item-focus').innerText,
+      instance.overlay.querySelector('.rs-picker-select-menu-item-focus').textContent,
       'Kariane'
     );
   });
@@ -251,7 +251,7 @@ describe('SelectPicker', () => {
     const instance = getInstance(<Dropdown defaultOpen data={data} defaultValue={'Kariane'} />);
     ReactTestUtils.Simulate.keyDown(instance.target, { key: 'ArrowUp' });
     assert.equal(
-      instance.overlay.querySelector('.rs-picker-select-menu-item-focus').innerText,
+      instance.overlay.querySelector('.rs-picker-select-menu-item-focus').textContent,
       'Eugenia'
     );
   });
@@ -312,7 +312,7 @@ describe('SelectPicker', () => {
     const list = instance.overlay.querySelectorAll('.rs-picker-select-menu-item');
 
     assert.equal(list.length, 1);
-    assert.ok(list[0].innerText, 'Louisa');
+    assert.ok(list[0].textContent, 'Louisa');
   });
 
   it('Should call renderValue', () => {
@@ -320,9 +320,9 @@ describe('SelectPicker', () => {
     const instance2 = getDOMNode(<Dropdown value="Test" renderValue={() => null} />);
     const instance3 = getDOMNode(<Dropdown value="Test" renderValue={() => undefined} />);
 
-    assert.equal(instance1.querySelector('.rs-picker-toggle-value').innerText, '1');
-    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
-    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance1.querySelector('.rs-picker-toggle-value').textContent, '1');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
 
     assert.include(instance1.className, 'rs-picker-has-value');
     assert.notInclude(instance2.className, 'rs-picker-has-value');
@@ -332,7 +332,7 @@ describe('SelectPicker', () => {
   it('Children should not be selected', () => {
     const data = [{ value: 1, label: 'A', children: [{ value: 2, label: 'B' }] }];
     const instance = getDOMNode(<Dropdown data={data} value={2} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
     assert.notInclude(instance.className, 'rs-picker-has-value');
   });
 

--- a/src/Sidebar/test/SidebarSpec.js
+++ b/src/Sidebar/test/SidebarSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 import Sidebar from '../Sidebar';
 
 describe('Sidebar', () => {
@@ -7,7 +7,7 @@ describe('Sidebar', () => {
     const title = 'Test';
     const instance = getDOMNode(<Sidebar>{title}</Sidebar>);
     assert.equal(instance.className, 'rs-sidebar');
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should have a custom className', () => {

--- a/src/Slider/test/SliderSpec.js
+++ b/src/Slider/test/SliderSpec.js
@@ -46,14 +46,14 @@ describe('Slider', () => {
     );
 
     const marks = instance.querySelectorAll('.rs-slider-mark-content');
-    assert.equal(marks[0].innerText, 'Single');
-    assert.equal(marks[1].innerText, 1);
-    assert.equal(marks[2].innerText, 2);
+    assert.equal(marks[0].textContent, 'Single');
+    assert.equal(marks[1].textContent, 1);
+    assert.equal(marks[2].textContent, 2);
   });
 
   it('Should render custom title', () => {
     const instance = getDOMNode(<Slider tooltip={false} handleTitle={'test'} />);
-    assert.equal(instance.innerText, 'test');
+    assert.equal(instance.textContent, 'test');
   });
 
   it('Should have a custom className', () => {
@@ -114,7 +114,7 @@ describe('Slider', () => {
     const instance = getDOMNode(<Slider plaintext />);
 
     assert.include(instance.className, 'rs-plaintext');
-    assert.equal(instance.innerText, 'Not selected');
+    assert.equal(instance.textContent, 'Not selected');
     assert.notInclude(instance.className, 'rs-slider');
   });
 

--- a/src/Steps/test/StepItemSpec.js
+++ b/src/Steps/test/StepItemSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 import StepItem from '../StepItem';
 import User from '@rsuite/icons/legacy/User';
 
@@ -27,17 +27,17 @@ describe('StepItem', () => {
 
   it('Should output a number ', () => {
     const instance = getDOMNode(<StepItem stepNumber={10} />);
-    assert.equal(innerText(instance), '10');
+    assert.equal(instance.textContent, '10');
   });
 
   it('Should render description ', () => {
     const instance = getDOMNode(<StepItem description={'test'} />);
-    assert.equal(innerText(instance), 'test');
+    assert.equal(instance.textContent, 'test');
   });
 
   it('Should render title ', () => {
     const instance = getDOMNode(<StepItem title={'test'} />);
-    assert.equal(innerText(instance), 'test');
+    assert.equal(instance.textContent, 'test');
   });
 
   it('Should have a custom className', () => {

--- a/src/Steps/test/StepsSpec.js
+++ b/src/Steps/test/StepsSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 import Steps from '../Steps';
 
 describe('Steps', () => {
@@ -24,7 +24,7 @@ describe('Steps', () => {
     );
 
     assert.equal(
-      innerText(instance.querySelector('.rs-steps-item-status-process .rs-steps-item-content')),
+      instance.querySelector('.rs-steps-item-status-process .rs-steps-item-content').textContent,
       'C'
     );
   });
@@ -40,7 +40,7 @@ describe('Steps', () => {
     );
 
     assert.equal(
-      innerText(instance.querySelector('.rs-steps-item-status-error .rs-steps-item-content')),
+      instance.querySelector('.rs-steps-item-status-error .rs-steps-item-content').textContent,
       'B'
     );
   });

--- a/src/TagInput/test/TagInputSpec.js
+++ b/src/TagInput/test/TagInputSpec.js
@@ -70,8 +70,8 @@ describe('TagInput', () => {
     ReactTestUtils.Simulate.keyDown(input, { key: 'Enter' });
 
     assert.equal(picker.querySelectorAll('.rs-tag').length, 2);
-    assert.equal(picker.querySelectorAll('.rs-tag')[0].innerText, 'abc');
-    assert.equal(picker.querySelectorAll('.rs-tag')[1].innerText, 'a');
+    assert.equal(picker.querySelectorAll('.rs-tag')[0].textContent, 'abc');
+    assert.equal(picker.querySelectorAll('.rs-tag')[1].textContent, 'a');
   });
 
   it('Should render 2 tags by value', () => {
@@ -81,8 +81,8 @@ describe('TagInput', () => {
     const picker = inputRef.current.root;
 
     assert.equal(picker.querySelectorAll('.rs-tag').length, 2);
-    assert.equal(picker.querySelectorAll('.rs-tag')[0].innerText, 'abc');
-    assert.equal(picker.querySelectorAll('.rs-tag')[1].innerText, '123');
+    assert.equal(picker.querySelectorAll('.rs-tag')[0].textContent, 'abc');
+    assert.equal(picker.querySelectorAll('.rs-tag')[1].textContent, '123');
   });
 
   it('Should render 2 tags by defaultValue', () => {
@@ -92,8 +92,8 @@ describe('TagInput', () => {
     const picker = inputRef.current.root;
 
     assert.equal(picker.querySelectorAll('.rs-tag').length, 2);
-    assert.equal(picker.querySelectorAll('.rs-tag')[0].innerText, 'abc');
-    assert.equal(picker.querySelectorAll('.rs-tag')[1].innerText, '123');
+    assert.equal(picker.querySelectorAll('.rs-tag')[0].textContent, 'abc');
+    assert.equal(picker.querySelectorAll('.rs-tag')[1].textContent, '123');
   });
 
   it('Should create a label only through `Enter`', () => {

--- a/src/TagPicker/test/TagPickerSpec.js
+++ b/src/TagPicker/test/TagPickerSpec.js
@@ -29,7 +29,7 @@ describe('TagPicker', () => {
 
     ReactTestUtils.Simulate.click(instance.root.querySelector('.rs-picker-toggle-clean'));
 
-    expect(instance.root.querySelector('.rs-picker-toggle-placeholder').innerText).to.equal(
+    expect(instance.root.querySelector('.rs-picker-toggle-placeholder').textContent).to.equal(
       'Select'
     );
   });
@@ -38,7 +38,7 @@ describe('TagPicker', () => {
     const instance = getDOMNode(<TagPicker defaultOpen data={data} value={['Eugenia']} />);
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-picker-toggle-clean'));
     expect(instance.querySelectorAll('.rs-tag').length).to.equal(1);
-    expect(instance.querySelector('.rs-tag-text').innerText).to.equal('Eugenia');
+    expect(instance.querySelector('.rs-tag-text').textContent).to.equal('Eugenia');
   });
 
   it('Should output a TagPicker', () => {
@@ -67,16 +67,16 @@ describe('TagPicker', () => {
   it('Should active item by `value`', () => {
     const value = 'Louisa';
     const instance = getInstance(<TagPicker defaultOpen data={data} value={[value]} />);
-    assert.equal(instance.root.querySelector('.rs-tag-text').innerText, value);
-    assert.equal(instance.overlay.querySelector('.rs-checkbox-checked').innerText, value);
+    assert.equal(instance.root.querySelector('.rs-tag-text').textContent, value);
+    assert.equal(instance.overlay.querySelector('.rs-checkbox-checked').textContent, value);
   });
 
   it('Should active item by `defaultValue`', () => {
     const value = 'Louisa';
     const instance = getInstance(<TagPicker defaultOpen data={data} defaultValue={[value]} />);
 
-    assert.equal(instance.root.querySelector('.rs-tag-text').innerText, value);
-    assert.equal(instance.overlay.querySelector('.rs-checkbox-checked').innerText, value);
+    assert.equal(instance.root.querySelector('.rs-tag-text').textContent, value);
+    assert.equal(instance.overlay.querySelector('.rs-checkbox-checked').textContent, value);
     assert.ok(instance.root.querySelector('.rs-tag-icon-close'));
   });
 
@@ -88,7 +88,7 @@ describe('TagPicker', () => {
   it('Should have a placeholder', () => {
     const instance = getDOMNode(<TagPicker className="custom" placeholder="test" />);
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'test');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'test');
   });
 
   it('Should render a placeholder when value error', () => {
@@ -102,7 +102,7 @@ describe('TagPicker', () => {
         value={['4']}
       />
     );
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'test');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'test');
   });
 
   it('Allow `label` to be an empty string', () => {
@@ -111,7 +111,7 @@ describe('TagPicker', () => {
     );
     const checkbox = instance.overlay.querySelector('.rs-checkbox-checked');
 
-    assert.equal(checkbox.innerText, '');
+    assert.equal(checkbox.textContent, '');
   });
 
   it('Should render value by `renderValue`', () => {
@@ -125,7 +125,7 @@ describe('TagPicker', () => {
       />
     );
 
-    assert.equal(instance.querySelector('.rs-picker-tag-wrapper').innerText, 'foo-bar');
+    assert.equal(instance.querySelector('.rs-picker-tag-wrapper').textContent, 'foo-bar');
   });
 
   it('Should output a value by renderValue()', () => {
@@ -145,13 +145,13 @@ describe('TagPicker', () => {
       <TagPicker renderValue={v => [v, placeholder]} data={[]} value={[2]} />
     );
 
-    assert.equal(instance.querySelector('.rs-picker-tag-wrapper').innerText, `1${placeholder}`);
-    assert.equal(instance2.querySelector('.rs-picker-tag-wrapper').innerText, `2${placeholder}`);
+    assert.equal(instance.querySelector('.rs-picker-tag-wrapper').textContent, `1${placeholder}`);
+    assert.equal(instance2.querySelector('.rs-picker-tag-wrapper').textContent, `2${placeholder}`);
   });
 
   it('Should render a placeholder when value error', () => {
     const instance = getDOMNode(<TagPicker value={[2]} placeholder={'test'} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'test');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'test');
   });
 
   it('Should call `onChange` callback', done => {
@@ -217,13 +217,13 @@ describe('TagPicker', () => {
   it('Should focus item by key=ArrowDown ', () => {
     const instance = getInstance(<TagPicker defaultOpen data={data} defaultValue={['Eugenia']} />);
     ReactTestUtils.Simulate.keyDown(instance.overlay, { key: 'ArrowDown' });
-    assert.equal(instance.overlay.querySelector('.rs-check-item-focus').innerText, 'Kariane');
+    assert.equal(instance.overlay.querySelector('.rs-check-item-focus').textContent, 'Kariane');
   });
 
   it('Should focus item by key=ArrowUp ', () => {
     const instance = getInstance(<TagPicker defaultOpen data={data} defaultValue={['Kariane']} />);
     ReactTestUtils.Simulate.keyDown(instance.overlay, { key: 'ArrowUp' });
-    assert.equal(instance.overlay.querySelector('.rs-check-item-focus').innerText, 'Eugenia');
+    assert.equal(instance.overlay.querySelector('.rs-check-item-focus').textContent, 'Eugenia');
   });
 
   it('Should call `onChange` by key=Enter ', done => {
@@ -337,7 +337,7 @@ describe('TagPicker', () => {
 
   it('Should not be call renderValue()', () => {
     const instance = getDOMNode(<TagPicker renderValue={() => 'value'} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
   });
 
   it('Should call renderValue', () => {
@@ -345,9 +345,9 @@ describe('TagPicker', () => {
     const instance2 = getDOMNode(<TagPicker value={['Test']} renderValue={() => null} />);
     const instance3 = getDOMNode(<TagPicker value={['Test']} renderValue={() => undefined} />);
 
-    assert.equal(instance1.querySelector('.rs-picker-tag-wrapper').innerText, '1');
-    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
-    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance1.querySelector('.rs-picker-tag-wrapper').textContent, '1');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
 
     assert.include(instance1.className, 'rs-picker-has-value');
     assert.notInclude(instance2.className, 'rs-picker-has-value');
@@ -357,7 +357,7 @@ describe('TagPicker', () => {
   it('Children should not be selected', () => {
     const data = [{ value: 1, label: 'A', children: [{ value: 2, label: 'B' }] }];
     const instance = getDOMNode(<TagPicker data={data} value={[2]} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
     assert.notInclude(instance.className, 'rs-picker-has-value');
   });
 
@@ -449,9 +449,9 @@ describe('TagPicker', () => {
       <TagPicker plaintext data={data} placeholder="-" value={['Eugenia']} />
     );
 
-    assert.equal(instance1.target.innerText, 'Eugenia');
-    assert.equal(instance2.target.innerText, 'Not selected');
-    assert.equal(instance3.target.innerText, '-');
-    assert.equal(instance4.target.innerText, 'Eugenia');
+    assert.equal(instance1.target.textContent, 'Eugenia');
+    assert.equal(instance2.target.textContent, 'Not selected');
+    assert.equal(instance3.target.textContent, '-');
+    assert.equal(instance4.target.textContent, 'Eugenia');
   });
 });

--- a/src/Timeline/test/TimelineItemSpec.js
+++ b/src/Timeline/test/TimelineItemSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getDOMNode, innerText } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 
 import TimelineItem from '../TimelineItem';
 
@@ -13,13 +13,13 @@ describe('TimelineItem', () => {
 
   it('Should render a dot', () => {
     const instance = getDOMNode(<TimelineItem dot={<i>test</i>} />);
-    assert.equal(innerText(instance.querySelector('.rs-timeline-item-custom-dot')), 'test');
+    assert.equal(instance.querySelector('.rs-timeline-item-custom-dot').textContent, 'test');
   });
 
   it('Should render a time', () => {
     const time = '2019-10-21';
     const instance = getDOMNode(<TimelineItem time={time} />);
-    assert.equal(innerText(instance.querySelector('.rs-timeline-item-time')), time);
+    assert.equal(instance.querySelector('.rs-timeline-item-time').textContent, time);
   });
 
   it('Should output the last item', () => {

--- a/src/Toggle/test/ToggleSpec.js
+++ b/src/Toggle/test/ToggleSpec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 
 import Toggle from '../Toggle';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 
 describe('Toggle', () => {
   it('Should output a toggle', () => {
@@ -27,12 +27,12 @@ describe('Toggle', () => {
 
   it('Should output a `off` in inner ', () => {
     const instance = getDOMNode(<Toggle unCheckedChildren="off" />);
-    assert.equal(innerText(instance), 'off');
+    assert.equal(instance.textContent, 'off');
   });
 
   it('Should output a `on` in inner ', () => {
     const instance = getDOMNode(<Toggle checkedChildren="on" checked />);
-    assert.equal(innerText(instance), 'on');
+    assert.equal(instance.textContent, 'on');
   });
 
   it('Should call onChange callback with correct checked state', done => {

--- a/src/Tooltip/test/TooltipSpec.js
+++ b/src/Tooltip/test/TooltipSpec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Tooltip from '../Tooltip';
-import { innerText, getDOMNode } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 
 describe('Tooltip', () => {
   it('Should render a Tooltip', () => {
@@ -8,7 +8,7 @@ describe('Tooltip', () => {
     const instance = getDOMNode(<Tooltip>{title}</Tooltip>);
     assert.equal(instance.tagName, 'DIV');
     assert.equal(instance.className, 'rs-tooltip');
-    assert.equal(innerText(instance), title);
+    assert.equal(instance.textContent, title);
   });
 
   it('Should have a id', () => {

--- a/src/TreePicker/test/TreePickerSpec.js
+++ b/src/TreePicker/test/TreePickerSpec.js
@@ -35,7 +35,7 @@ describe('TreePicker', () => {
   it('Should render default value', () => {
     const instance = getDOMNode(<TreePicker defaultOpen data={data} defaultValue={'Master'} />);
 
-    expect(instance.querySelector('.rs-picker-toggle-value').innerText).to.equal('Master');
+    expect(instance.querySelector('.rs-picker-toggle-value').textContent).to.equal('Master');
   });
 
   it('Should have "default" appearance by default', () => {
@@ -48,7 +48,7 @@ describe('TreePicker', () => {
     const instance = getDOMNode(<TreePicker defaultOpen data={data} defaultValue={'Master'} />);
 
     Simulate.click(instance.querySelector('.rs-picker-toggle-clean'));
-    expect(instance.querySelector('.rs-picker-toggle').innerText).to.equal('Select');
+    expect(instance.querySelector('.rs-picker-toggle').textContent).to.equal('Select');
   });
 
   it('Should output a clean button', () => {
@@ -98,7 +98,7 @@ describe('TreePicker', () => {
   it('Should have a placeholder', () => {
     const instance = getDOMNode(<TreePicker data={data} placeholder="test" />);
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'test');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'test');
   });
 
   it('Should render value by `renderValue()`', () => {
@@ -138,9 +138,9 @@ describe('TreePicker', () => {
       />
     );
 
-    assert.equal(instance1.querySelector('.rs-picker-toggle-value').innerText, 'Selected: 2');
-    assert.equal(instance2.querySelector('.rs-picker-toggle-value').innerText, `5${placeholder}`);
-    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, placeholder);
+    assert.equal(instance1.querySelector('.rs-picker-toggle-value').textContent, 'Selected: 2');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-value').textContent, `5${placeholder}`);
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').textContent, placeholder);
   });
 
   it('Should call renderValue', () => {
@@ -148,20 +148,20 @@ describe('TreePicker', () => {
     const instance2 = getDOMNode(<TreePicker value="Test" renderValue={() => null} />);
     const instance3 = getDOMNode(<TreePicker value="Test" renderValue={() => undefined} />);
 
-    assert.equal(instance1.querySelector('.rs-picker-toggle-value').innerText, '1');
-    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
-    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance1.querySelector('.rs-picker-toggle-value').textContent, '1');
+    assert.equal(instance2.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
+    assert.equal(instance3.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
   });
 
   it('Should not be call renderValue()', () => {
     const instance = getDOMNode(<TreePicker data={[]} renderValue={() => 'value'} />);
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'Select');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'Select');
   });
 
   it('Should render a placeholder when value error', () => {
     const instance = getDOMNode(<TreePicker placeholder="test" data={data} value={['4']} />);
 
-    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').innerText, 'test');
+    assert.equal(instance.querySelector('.rs-picker-toggle-placeholder').textContent, 'test');
   });
 
   it('Should call `onChange` callback', () => {
@@ -203,7 +203,7 @@ describe('TreePicker', () => {
     const instance = getInstance(<TreePicker open data={data} defaultExpandAll value="tester1" />);
     Simulate.keyDown(instance.target, { key: KEY_VALUES.DOWN });
 
-    assert.equal(instance.overlay.querySelector('.rs-tree-node-focus').innerText, 'Master');
+    assert.equal(instance.overlay.querySelector('.rs-tree-node-focus').textContent, 'Master');
   });
 
   it('Should focus item by keyCode=38 ', () => {
@@ -211,7 +211,7 @@ describe('TreePicker', () => {
 
     Simulate.click(instance.overlay.querySelector('span[data-key="0-0-1"]'));
     Simulate.keyDown(instance.target, { key: KEY_VALUES.UP });
-    assert.equal(instance.overlay.querySelector('.rs-tree-node-focus').innerText, 'tester0');
+    assert.equal(instance.overlay.querySelector('.rs-tree-node-focus').textContent, 'tester0');
   });
 
   it('Should focus item by keyCode=13 ', done => {
@@ -246,7 +246,7 @@ describe('TreePicker', () => {
 
     Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
     Simulate.keyDown(tree.overlay, { key: KEY_VALUES.LEFT });
-    assert.equal(tree.overlay.querySelector('.rs-tree-node-focus').innerText, 'Master');
+    assert.equal(tree.overlay.querySelector('.rs-tree-node-focus').textContent, 'Master');
 
     assert.equal(
       tree.overlay.querySelectorAll('div[data-ref="0-0"] > .rs-tree-node-expanded').length,
@@ -262,7 +262,7 @@ describe('TreePicker', () => {
 
     Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
     Simulate.keyDown(tree.overlay, { key: KEY_VALUES.LEFT });
-    assert.equal(tree.overlay.querySelector('.rs-tree-node-focus').innerText, 'Master');
+    assert.equal(tree.overlay.querySelector('.rs-tree-node-focus').textContent, 'Master');
   });
 
   /**
@@ -287,7 +287,7 @@ describe('TreePicker', () => {
 
     Simulate.click(tree.overlay.querySelector('span[data-key="0-0-0"]'));
     Simulate.keyDown(tree.overlay, { key: KEY_VALUES.RIGHT });
-    assert.equal(tree.overlay.querySelector('.rs-tree-node-focus').innerText, 'tester0');
+    assert.equal(tree.overlay.querySelector('.rs-tree-node-focus').textContent, 'tester0');
   });
 
   /**
@@ -298,7 +298,7 @@ describe('TreePicker', () => {
 
     Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
     Simulate.keyDown(tree.overlay, { key: KEY_VALUES.RIGHT });
-    assert.equal(tree.overlay.querySelector('.rs-tree-node-focus').innerText, 'tester0');
+    assert.equal(tree.overlay.querySelector('.rs-tree-node-focus').textContent, 'tester0');
   });
 
   it('Should have a custom className', () => {
@@ -461,7 +461,7 @@ describe('TreePicker', () => {
     );
     const list = getDOMNode(instance.overlay).querySelectorAll('.rs-tree-node');
     assert.equal(list.length, 1);
-    assert.ok(list[0].innerText, 'Louisa');
+    assert.ok(list[0].textContent, 'Louisa');
   });
 
   it('Should only clean the searchKeyword', () => {
@@ -478,7 +478,7 @@ describe('TreePicker', () => {
     Simulate.keyDown(searchBar, {
       key: KEY_VALUES.BACKSPACE
     });
-    assert.equal(instance.root.querySelector('.rs-picker-toggle-value').innerText, 'Master');
+    assert.equal(instance.root.querySelector('.rs-picker-toggle-value').textContent, 'Master');
 
     Simulate.keyDown(instance.overlay, {
       key: KEY_VALUES.BACKSPACE

--- a/src/Uploader/test/UploadFileItemSpec.js
+++ b/src/Uploader/test/UploadFileItemSpec.js
@@ -108,7 +108,7 @@ describe('UploadFileItem', () => {
         }}
       />
     );
-    assert.include(instance.querySelector('.file-info').innerText, 'a');
+    assert.include(instance.querySelector('.file-info').textContent, 'a');
   });
 
   it('Should have a custom style', () => {
@@ -133,7 +133,7 @@ describe('UploadFileItem', () => {
   it('Should render an <i> tag, when the file status is uploading', () => {
     const file = { blobFile: new File(['foo'], 'foo.txt'), status: 'finished' };
     const instance = getDOMNode(<UploadFileItem file={file} />);
-    assert.equal(instance.querySelector('.rs-uploader-file-item-size').innerText, '3B');
+    assert.equal(instance.querySelector('.rs-uploader-file-item-size').textContent, '3B');
   });
 
   it('Should not render a default thumbnail', () => {

--- a/src/toaster/test/toasterSpec.js
+++ b/src/toaster/test/toasterSpec.js
@@ -12,7 +12,7 @@ describe('toaster', () => {
 
     const message = element.querySelector('#msg-1');
     assert.include(message.className, 'rs-toast-fade-entered');
-    assert.equal(message.innerText, 'abc');
+    assert.equal(message.textContent, 'abc');
   });
 
   it('Should render 2 containers', () => {

--- a/src/utils/test/tplTransformSpec.js
+++ b/src/utils/test/tplTransformSpec.js
@@ -8,13 +8,13 @@ describe('[utils] tplTransform', () => {
     const str = '{1}Show {0} data {1}, {0}';
     const nodes = tplTransform(str, 30, 10);
     const instance = ReactTestUtils.renderIntoDocument(<div>{nodes}</div>);
-    assert.equal(instance.innerText, '10Show 30 data 10, 30');
+    assert.equal(instance.textContent, '10Show 30 data 10, 30');
   });
 
   it('Should return match value when parameter is 0', () => {
     const str = '共 {0} 条数据';
     const nodes = tplTransform(str, 0);
     const instance = ReactTestUtils.renderIntoDocument(<div>{nodes}</div>);
-    assert.equal(instance.innerText, '共 0 条数据');
+    assert.equal(instance.textContent, '共 0 条数据');
   });
 });

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -126,17 +126,6 @@ export function getDOMNode(children, waitForDidMount = true) {
 }
 
 /**
- * @param {HTMLElement} node
- * @return {String}
- */
-export function innerText(node) {
-  if (window.navigator.userAgent.toLowerCase().indexOf('firefox') !== -1) {
-    return node.textContent;
-  }
-  return node.innerText;
-}
-
-/**
  * @return {HTMLDivElement}
  */
 export function createTestContainer() {


### PR DESCRIPTION
Replace all `.innerText` usage in test scripts with `.textContent`.