### PR TITLE
build(deps): bump rsuite-table from 5.0.1 to 5.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17689,9 +17689,9 @@
       }
     },
     "rsuite-table": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.0.1.tgz",
-      "integrity": "sha512-jtAa5o/UU62DG1SOyrR6LaPYX6WPK4s5U3UkQnrFWNfSrpy8umb00Rn2orU3eK+IvL8e7R2a1RM8QGcXIIZThg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.0.2.tgz",
+      "integrity": "sha512-Kp1tFyht66Z8jVGdONCKI1ViBkU3CUV1Gn9nubvLXbDSYkUzTBa88OQoCz5vSXc9In9dlTZ9K0flIV/e+cWXAw==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@rsuite/icons": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "prop-types": "^15.7.2",
     "react-text-mask": "^5.4.3",
     "react-virtualized": "^9.22.3",
-    "rsuite-table": "^5.0.1",
+    "rsuite-table": "^5.0.2",
     "schema-typed": "^2.0.1"
   },
   "peerDependencies": {


### PR DESCRIPTION

### Bug Fixes

* **scroll:** fix `resizable` will affect the scroll bar reset ([#258](https://github.com/rsuite/rsuite-table/issues/258)) ([8bf2ae6](https://github.com/rsuite/rsuite-table/commit/8bf2ae65c13b2b43336e2b0805e119af216aa9c5))
* **Table:** fix scroll event not working ([#257](https://github.com/rsuite/rsuite-table/issues/257)) ([7212e66](https://github.com/rsuite/rsuite-table/commit/7212e66cd6c6f48fd1b114fb9b823b9b31045af6))
* **Table:** remove default value of rowKey ([#259](https://github.com/rsuite/rsuite-table/issues/259)) ([191ffda](https://github.com/rsuite/rsuite-table/commit/191ffda3cba90a06c062d70737a46bfd4df537f9))

