### PR TITLE
docs: revert adding fa_IR

### DIFF
--- a/docs/pages/guide/i18n/index.tsx
+++ b/docs/pages/guide/i18n/index.tsx
@@ -17,7 +17,6 @@ import ru_RU from 'rsuite/locales/ru_RU';
 import sv_SE from 'rsuite/locales/sv_SE';
 import zh_CN from 'rsuite/locales/zh_CN';
 import zh_TW from 'rsuite/locales/zh_TW';
-import fa_IR from 'rsuite/locales/fa_IR';
 
 const locales = [
   { key: 'ar_EG', value: ar_EG },
@@ -27,7 +26,6 @@ const locales = [
   { key: 'en_US', value: en_US },
   { key: 'es_AR', value: es_AR },
   { key: 'es_ES', value: es_ES },
-  { key: 'fa_IR', value: fa_IR },
   { key: 'fi_FI', value: fi_FI },
   { key: 'it_IT', value: it_IT },
   { key: 'ko_KR', value: ko_KR },


### PR DESCRIPTION
Importing `fa_IR` locales is causing production deployment to fail as the feature is not yet released.

- [ ] Revert this PR after `fa_IR` locale is released.