### PR TITLE
build(docs): use node 16 docker image

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,5 +1,5 @@
 # Install dependencies
-FROM node:alpine AS deps
+FROM node:16-alpine AS deps
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
@@ -8,14 +8,14 @@ COPY package.json package-lock.json ./
 RUN npm ci
 
 # Rebuild the source code
-FROM node:alpine AS builder
+FROM node:16-alpine AS builder
 WORKDIR /app
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
 RUN VERCEL_ENV=production npm run build:docker
 
 # Production image, copy all the files and run next
-FROM node:alpine AS runner
+FROM node:16-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV production


### PR DESCRIPTION
Next.js is failing on Node.js 17. See discussion here https://github.com/vercel/next.js/issues/30078#issuecomment-954048931