### PR TITLE
refactor(Toggle): add underlying input element

### DIFF
--- a/docs/less/code-view.less
+++ b/docs/less/code-view.less
@@ -44,7 +44,7 @@ a code {
   margin-top: 10px;
 }
 
-.code-view .rs-btn-toggle {
+.code-view .rs-toggle {
   margin-right: 8px;
   .rs-icon {
     width: 14px;

--- a/docs/public/less/palette.less
+++ b/docs/public/less/palette.less
@@ -84,7 +84,7 @@
     //#== Radio
     .repaint-input(radio);
     //#== Toggle
-    &-btn-toggle.rs-btn-toggle-checked {
+    &-toggle.rs-toggle-checked {
       background-color: @H500;
     }
     //#== Slider

--- a/src/Toggle/Toggle.tsx
+++ b/src/Toggle/Toggle.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { KEY_VALUES, useClassNames, useControlled, useCustom } from '../utils';
-import { WithAsProps, TypeAttributes } from '../@types/common';
+import { useClassNames, useControlled, useCustom } from '../utils';
+import { WithAsProps, TypeAttributes, RsRefForwardingComponent } from '../@types/common';
 import Plaintext from '../Plaintext';
 import { ToggleLocale } from '../locales';
 import Loader from '../Loader';
@@ -41,10 +41,10 @@ export interface ToggleProps extends WithAsProps {
   onChange?: (checked: boolean, event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-/**
- * fixme: Should contain an input[type=checkbox]
- */
-const Toggle = React.forwardRef((props: ToggleProps, ref) => {
+const Toggle: RsRefForwardingComponent<'label', ToggleProps> = React.forwardRef<
+  HTMLLabelElement,
+  ToggleProps
+>((props, ref) => {
   const {
     as: Component = 'span',
     disabled,
@@ -54,7 +54,7 @@ const Toggle = React.forwardRef((props: ToggleProps, ref) => {
     className,
     checkedChildren,
     unCheckedChildren,
-    classPrefix = 'btn-toggle',
+    classPrefix = 'toggle',
     checked: checkedProp,
     defaultChecked,
     size,
@@ -84,57 +84,39 @@ const Toggle = React.forwardRef((props: ToggleProps, ref) => {
     [disabled, readOnly, setChecked, onChange]
   );
 
-  const handleClick = useCallback(() => {
-    inputRef.current.click();
-  }, [inputRef]);
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<Element>) => {
-      if (e.key !== KEY_VALUES.SPACE) {
-        return;
-      }
-      e.preventDefault();
-      inputRef.current.click();
-    },
-    [inputRef]
-  );
-
   if (plaintext) {
     return <Plaintext>{inner || label}</Plaintext>;
   }
 
   return (
-    <Component
-      role="switch"
-      aria-checked={checked}
-      aria-disabled={disabled}
-      aria-label={typeof inner === 'string' ? inner : label}
-      aria-busy={loading || undefined}
-      tabIndex={0}
-      {...rest}
-      ref={ref}
-      className={classes}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-    >
+    <label ref={ref} className={classes} {...rest}>
       <input
         ref={inputRef}
         type="checkbox"
         checked={checked}
         disabled={disabled}
         readOnly={readOnly}
-        hidden
         onChange={handleInputChange}
+        className={prefix('input')}
+        role="switch"
+        aria-checked={checked}
+        aria-disabled={disabled}
+        aria-label={typeof inner === 'string' ? inner : label}
+        aria-busy={loading || undefined}
       />
-      <span className={prefix('inner')}>{inner}</span>
-      {loading && <Loader className={prefix('loader')} />}
-    </Component>
+      <Component className={prefix('presentation')}>
+        <span className={prefix('inner')}>{inner}</span>
+        {loading && <Loader className={prefix('loader')} />}
+      </Component>
+    </label>
   );
 });
 
 Toggle.displayName = 'Toggle';
 Toggle.propTypes = {
   disabled: PropTypes.bool,
+  readOnly: PropTypes.bool,
+  plaintext: PropTypes.bool,
   checked: PropTypes.bool,
   defaultChecked: PropTypes.bool,
   checkedChildren: PropTypes.node,
@@ -142,7 +124,13 @@ Toggle.propTypes = {
   loading: PropTypes.bool,
   classPrefix: PropTypes.string,
   className: PropTypes.string,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  as: PropTypes.elementType,
+  size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  locale: PropTypes.shape({
+    on: PropTypes.string,
+    off: PropTypes.string
+  })
 };
 
 export default Toggle;

--- a/src/Toggle/styles/index.less
+++ b/src/Toggle/styles/index.less
@@ -40,6 +40,14 @@
     box-shadow: inset 0 0 0 1px var(--rs-toggle-thumb);
   });
 
+  .rs-toggle-input:focus-visible + & {
+    .focus-ring();
+
+    .high-contrast-mode({
+      box-shadow: inset 0 0 0 1px var(--rs-toggle-thumb), var(--rs-state-focus-shadow);;
+    });
+  }
+
   &:hover {
     background-color: var(--rs-toggle-hover-bg);
   }

--- a/src/Toggle/styles/index.less
+++ b/src/Toggle/styles/index.less
@@ -8,10 +8,23 @@
 
 // The switch trail
 // todo: Consider renaming as .rs-toggle
-.rs-btn-toggle {
-  // Default size is middle.
-  .btn-toggle(md);
+.rs-toggle {
+  position: relative;
 
+  // Default size is middle.
+  .toggle(md);
+}
+
+.rs-toggle-input {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  opacity: 0;
+}
+
+.rs-toggle-presentation {
   position: relative;
   display: inline-block;
   box-sizing: border-box;
@@ -32,20 +45,6 @@
   }
 
   // The switch thumb
-  &-loader {
-    position: absolute;
-    transition: left @toggle-transition, margin-left @toggle-transition, width @toggle-transition;
-
-    .rs-loader-spin {
-      &::before {
-        border-color: var(--rs-toggle-loader-ring);
-      }
-      &::after {
-        border-top-color: var(--rs-toggle-loader-rotor);
-      }
-    }
-  }
-
   &::after {
     content: '';
     cursor: pointer;
@@ -59,7 +58,7 @@
   }
 
   // disabled state
-  &&-disabled {
+  .rs-toggle-disabled & {
     background-color: var(--rs-toggle-disabled-bg);
     color: var(--rs-toggle-disabled-thumb);
     box-shadow: inset 0 0 0 1px var(--rs-toggle-disabled-thumb);
@@ -67,7 +66,7 @@
   }
 
   // checked state
-  &&-checked {
+  .rs-toggle-checked & {
     background-color: var(--rs-toggle-checked-bg);
     color: var(--rs-toggle-checked-thumb);
     box-shadow: none;
@@ -77,12 +76,12 @@
     }
   }
 
-  &&-disabled&-checked {
+  .rs-toggle-disabled.rs-toggle-checked & {
     background-color: var(--rs-toggle-checked-disabled-bg);
     color: var(--rs-toggle-checked-disabled-thumb);
   }
 
-  &&-loading {
+  .rs-toggle-loading & {
     &::after {
       display: none;
     }
@@ -90,7 +89,7 @@
 }
 
 // Label text inside the switch
-.rs-btn-toggle-inner {
+.rs-toggle-inner {
   display: block;
   transition: margin @toggle-transition;
 
@@ -99,17 +98,31 @@
   });
 }
 
+.rs-toggle-loader {
+  position: absolute;
+  transition: left @toggle-transition, margin-left @toggle-transition, width @toggle-transition;
+
+  .rs-loader-spin {
+    &::before {
+      border-color: var(--rs-toggle-loader-ring);
+    }
+    &::after {
+      border-top-color: var(--rs-toggle-loader-rotor);
+    }
+  }
+}
+
 // small
-.rs-btn-toggle-sm {
-  .btn-toggle(sm);
+.rs-toggle-sm {
+  .toggle(sm);
 }
 
 // middle
-.rs-btn-toggle-md {
-  .btn-toggle(md);
+.rs-toggle-md {
+  .toggle(md);
 }
 
 // large
-.rs-btn-toggle-lg {
-  .btn-toggle(lg);
+.rs-toggle-lg {
+  .toggle(lg);
 }

--- a/src/Toggle/styles/mixin.less
+++ b/src/Toggle/styles/mixin.less
@@ -1,18 +1,20 @@
 .toggle-size-variant(@toogle-height,@min-width,@toggle-handle-gap,@toggle-inner-margin,@toggle-inner-font-size) {
   @handle-diameter: (@toogle-height - @toggle-handle-gap*2);
 
-  height: @toogle-height;
-  min-width: @min-width;
-  border-radius: (@toogle-height / 2);
-
-  &-loader {
+  .rs-toggle-loader {
     width: @handle-diameter;
     height: @handle-diameter;
     left: @toggle-handle-gap;
     top: @toggle-handle-gap;
   }
 
-  &::after {
+  .rs-toggle-presentation {
+    height: @toogle-height;
+    min-width: @min-width;
+    border-radius: (@toogle-height / 2);
+  }
+
+  .rs-toggle-presentation::after {
     width: @handle-diameter;
     height: @handle-diameter;
     left: @toggle-handle-gap;
@@ -20,11 +22,11 @@
     border-radius: (@handle-diameter / 2);
   }
 
-  &:active::after {
+  .rs-toggle-presentation:active::after {
     width: (@handle-diameter * @toggle-active-scale);
   }
 
-  .rs-btn-toggle-inner {
+  .rs-toggle-inner {
     margin-left: @toogle-height;
     margin-right: @toggle-inner-margin;
     height: @toogle-height;
@@ -36,7 +38,7 @@
     }
   }
 
-  &.rs-btn-toggle-checked {
+  &.rs-toggle-checked .rs-toggle-presentation {
     &::after {
       left: 100%;
       margin-left: -(@handle-diameter + @toggle-handle-gap);
@@ -46,20 +48,20 @@
       margin-left: -(@handle-diameter * @toggle-active-scale + @toggle-handle-gap);
     }
 
-    .rs-btn-toggle-inner {
+    .rs-toggle-inner {
       margin-right: @toogle-height;
       margin-left: @toggle-inner-margin;
     }
   }
 
-  &.rs-btn-toggle-checked &-loader {
+  &.rs-toggle-checked .rs-toggle-loader {
     left: 100%;
     margin-left: -(@handle-diameter + @toggle-handle-gap);
   }
 }
 
 // Small
-.btn-toggle(sm) {
+.toggle(sm) {
   .toggle-size-variant(
     @toggle-sm-height,
     @toggle-sm-min-width,
@@ -70,7 +72,7 @@
 }
 
 // Middle
-.btn-toggle(md) {
+.toggle(md) {
   .toggle-size-variant(
     @toggle-md-height,
     @toggle-md-min-width,
@@ -81,7 +83,7 @@
 }
 
 // Large
-.btn-toggle(lg) {
+.toggle(lg) {
   .toggle-size-variant(
     @toggle-lg-height,
     @toggle-lg-min-width,

--- a/src/Toggle/test/ToggleSpec.js
+++ b/src/Toggle/test/ToggleSpec.js
@@ -8,7 +8,7 @@ import { getDOMNode } from '@test/testUtils';
 describe('Toggle', () => {
   it('Should output a toggle', () => {
     const instance = getDOMNode(<Toggle />);
-    assert.equal(instance.className, 'rs-btn-toggle');
+    assert.equal(instance.className, 'rs-toggle');
   });
 
   it('Should be disabled', () => {
@@ -18,12 +18,12 @@ describe('Toggle', () => {
 
   it('Should be checked', () => {
     const instance = getDOMNode(<Toggle checked />);
-    assert.ok(instance.className.match(/\bbtn-toggle-checked\b/));
+    assert.ok(instance.className.match(/\btoggle-checked\b/));
   });
 
   it('Should apply size class', () => {
     const instance = getDOMNode(<Toggle size="lg" />);
-    assert.ok(instance.className.match(/\bbtn-toggle-lg\b/));
+    assert.ok(instance.className.match(/\btoggle-lg\b/));
   });
 
   it('Should output a `off` in inner ', () => {
@@ -54,15 +54,15 @@ describe('Toggle', () => {
     it('Should toggle with the Space key', () => {
       const onChangeSpy = sinon.spy();
 
-      const { getByTestId, rerender } = render(
+      const { getByRole, rerender } = render(
         <Toggle onChange={onChangeSpy} data-testid="toggle" />
       );
-      getByTestId('toggle').focus();
+      getByRole('switch').focus();
       userEvent.keyboard('{space}');
       expect(onChangeSpy).to.have.been.calledWith(true);
 
       rerender(<Toggle checked onChange={onChangeSpy} data-testid="toggle" />);
-      getByTestId('toggle').focus();
+      getByRole('switch').focus();
       userEvent.keyboard('{space}');
       expect(onChangeSpy).to.have.been.calledWith(false);
     });
@@ -107,13 +107,13 @@ describe('Toggle', () => {
   });
 
   describe('Loading', () => {
-    it('Should have "rs-btn-toggle-loading" className', () => {
+    it('Should have "rs-toggle-loading" className', () => {
       const { getByTestId } = render(<Toggle loading data-testid="toggle" />);
-      expect(getByTestId('toggle')).to.have.class('rs-btn-toggle-loading');
+      expect(getByTestId('toggle')).to.have.class('rs-toggle-loading');
     });
     it('Should have `aria-busy` attribute set to `true`', () => {
-      const { getByTestId } = render(<Toggle loading data-testid="toggle" />);
-      expect(getByTestId('toggle')).to.have.attr('aria-busy', 'true');
+      const { getByRole } = render(<Toggle loading />);
+      expect(getByRole('switch')).to.have.attr('aria-busy', 'true');
     });
   });
 });

--- a/src/Toggle/test/ToggleSpec.js
+++ b/src/Toggle/test/ToggleSpec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import ReactTestUtils from 'react-dom/test-utils';
+import userEvent from '@testing-library/user-event';
 
 import Toggle from '../Toggle';
 import { getDOMNode } from '@test/testUtils';
@@ -36,31 +36,58 @@ describe('Toggle', () => {
     assert.equal(instance.textContent, 'on');
   });
 
-  it('Should call onChange callback with correct checked state', done => {
-    const doneOp = checked => {
-      try {
-        assert.isTrue(checked);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
-    const instance = getDOMNode(<Toggle onChange={doneOp} />);
-    ReactTestUtils.Simulate.click(instance);
-  });
+  describe('onChange', () => {
+    it('Should call onChange callback with checked state', () => {
+      const onChangeSpy = sinon.spy();
 
-  it('Should call onChange callback and the correct arguments returned', done => {
-    const doneOp = checked => {
-      try {
-        assert.isFalse(checked);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+      const { getByTestId, rerender } = render(
+        <Toggle onChange={onChangeSpy} data-testid="toggle" />
+      );
+      userEvent.click(getByTestId('toggle'));
+      expect(onChangeSpy).to.have.been.calledWith(true);
 
-    const instance = getDOMNode(<Toggle defaultChecked={true} onChange={doneOp} />);
-    ReactTestUtils.Simulate.click(instance);
+      rerender(<Toggle checked onChange={onChangeSpy} data-testid="toggle" />);
+      userEvent.click(getByTestId('toggle'));
+      expect(onChangeSpy).to.have.been.calledWith(false);
+    });
+
+    it('Should toggle with the Space key', () => {
+      const onChangeSpy = sinon.spy();
+
+      const { getByTestId, rerender } = render(
+        <Toggle onChange={onChangeSpy} data-testid="toggle" />
+      );
+      getByTestId('toggle').focus();
+      userEvent.keyboard('{space}');
+      expect(onChangeSpy).to.have.been.calledWith(true);
+
+      rerender(<Toggle checked onChange={onChangeSpy} data-testid="toggle" />);
+      getByTestId('toggle').focus();
+      userEvent.keyboard('{space}');
+      expect(onChangeSpy).to.have.been.calledWith(false);
+    });
+
+    it('Should not call `onChange` callback when disabled', () => {
+      const onChangeSpy = sinon.spy();
+
+      const { getByTestId } = render(
+        <Toggle disabled onChange={onChangeSpy} data-testid="toggle" />
+      );
+      userEvent.click(getByTestId('toggle'));
+
+      expect(onChangeSpy).not.to.have.been.called;
+    });
+
+    it('Should not call `onChange` callback when readOnly', () => {
+      const onChangeSpy = sinon.spy();
+
+      const { getByTestId } = render(
+        <Toggle readOnly onChange={onChangeSpy} data-testid="toggle" />
+      );
+      userEvent.click(getByTestId('toggle'));
+
+      expect(onChangeSpy).not.to.have.been.called;
+    });
   });
 
   it('Should have a custom className', () => {
@@ -77,20 +104,6 @@ describe('Toggle', () => {
   it('Should have a custom className prefix', () => {
     const instance = getDOMNode(<Toggle classPrefix="custom-prefix" />);
     assert.ok(instance.className.match(/\bcustom-prefix\b/));
-  });
-
-  it('Should toggle with the space key', done => {
-    const doneOp = checked => {
-      try {
-        assert.isTrue(checked);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
-
-    const instance = getDOMNode(<Toggle onChange={doneOp} />);
-    ReactTestUtils.Simulate.keyDown(instance, { key: ' ' });
   });
 
   describe('Loading', () => {

--- a/src/Toggle/test/ToggleStylesSpec.js
+++ b/src/Toggle/test/ToggleStylesSpec.js
@@ -7,6 +7,10 @@ import '../styles/index.less';
 describe('Toggle styles', () => {
   it('Should render the correct styles', () => {
     const dom = getDOMNode(<Toggle />);
-    assert.equal(getStyle(dom, 'backgroundColor'), toRGB('#d9d9d9'), 'Toggle background-color');
+    assert.equal(
+      getStyle(dom.querySelector('.rs-toggle-presentation'), 'backgroundColor'),
+      toRGB('#d9d9d9'),
+      'Toggle background-color'
+    );
   });
 });


### PR DESCRIPTION
- Add an underlying `<input type="checkbox">` in `<Toggle>` component.
- Passes `ChangeEvent` from the input to `onChange` callback on `<Toggle>`