### PR TITLE
ci(codecov): use codecov-action v2

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -52,6 +52,6 @@ jobs:
           CI: true
           BROWSER: ${{ matrix.browser }}
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           flags: ${{ matrix.browser }}


### PR DESCRIPTION
Respecting https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1