### PR TITLE
fix(Input): correct value argument type for onChange callback

### DIFF
--- a/src/@types/common.ts
+++ b/src/@types/common.ts
@@ -120,14 +120,23 @@ export interface PickerBaseProps<LocaleType = any> extends WithAsProps, Animatio
   renderExtraFooter?: () => React.ReactNode;
 }
 
-export interface FormControlBaseProps<ValueType = any> {
+export interface FormControlBaseProps<
+  ValueType = React.InputHTMLAttributes<HTMLInputElement>['value']
+> {
+  /** Name of the form field */
+  name?: string;
+
   /** Initial value */
   defaultValue?: ValueType;
 
   /** Current value of the component. Creates a controlled component */
   value?: ValueType;
 
-  /** Called after the value has been changed */
+  /**
+   * Called after the value has been changed
+   * todo Override event as React.ChangeEvent in components where onChange is delegated
+   *      to an underlying <input> element
+   */
   onChange?: (value: ValueType, event: React.SyntheticEvent) => void;
 
   /** Set the component to be disabled and cannot be entered */

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -18,7 +18,7 @@ export interface LocaleType {
 export interface InputProps
   extends WithAsProps,
     Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'size'>,
-    FormControlBaseProps<string | number | ReadonlyArray<string>> {
+    FormControlBaseProps {
   /** The HTML input type */
   type?: string;
 
@@ -30,6 +30,8 @@ export interface InputProps
 
   /** Ref of input element */
   inputRef?: React.Ref<any>;
+
+  onChange?: (value: string, event: React.ChangeEvent<HTMLInputElement>) => void;
 
   /** Called on press enter */
   onPressEnter?: React.KeyboardEventHandler<HTMLInputElement>;


### PR DESCRIPTION
`<Input onChange>` only emits `value` as `string`.