### PR TITLE
docs(Picker): maxHeight renamed as menuMaxHeight

### DIFF
--- a/docs/pages/components/check-picker/en-US/index.md
+++ b/docs/pages/components/check-picker/en-US/index.md
@@ -94,13 +94,13 @@ type ValueType = (string | number)[];
 | container          | HTMLElement &#124; (() => HTMLElement)                                            | Sets the rendering container                                |
 | data \*            | DataItemType[]                                                                    | The data of component                                       |
 | defaultValue       | ValueType                                                                         | Default values of the selected items                        |
-| disabled           | boolean                                                                           | Whether disabled component                                   |
+| disabled           | boolean                                                                           | Whether disabled component                                  |
 | disabledItemValues | ValueType[]                                                                       | Disable item by value                                       |
 | groupBy            | string                                                                            | Set group condition key in data                             |
 | labelKey           | string `('label')`                                                                | Set label key in data                                       |
 | listProps          | [ListProps][listprops]                                                            | List-related properties in `react-virtualized`              |
 | locale             | [PickerLocaleType](/guide/i18n/#pickers)                                          | Locale text                                                 |
-| maxHeight          | number `(320)`                                                                    | The max height of Dropdown                                  |
+| menuMaxHeight      | number `(320)`                                                                    | The max height of Dropdown                                  |
 | menuClassName      | string                                                                            | A css class to apply to the Menu DOM node.                  |
 | menuStyle          | CSSProperties                                                                     | A style to apply to the Menu DOM node.                      |
 | onChange           | (value:ValueType, event) => void                                                  | Callback fired when value change                            |

--- a/docs/pages/components/check-picker/zh-CN/index.md
+++ b/docs/pages/components/check-picker/zh-CN/index.md
@@ -100,7 +100,7 @@ type ValueType = (string | number)[];
 | labelKey           | string `('label')`                                                      | 设置选项显示内容在 `data` 中的 `key`   |
 | listProps          | [ListProps][listprops]                                                  | `react-virtualized` 中 List 的相关属性 |
 | locale             | [PickerLocaleType](/zh/guide/i18n/#pickers)                             | 本地化的文本                           |
-| maxHeight          | number `(320)`                                                          | 设置 Dropdown 的最大高度               |
+| menuMaxHeight      | number `(320)`                                                          | 设置 Dropdown 的最大高度               |
 | menuClassName      | string                                                                  | 应用于菜单 DOM 节点的 css class        |
 | menuStyle          | CSSProperties                                                           | 应用于菜单 DOM 节点的 style            |
 | onChange           | (value:ValueType, event) => void                                        | `value` 发生改变时的回调函数           |

--- a/docs/pages/components/input-picker/en-US/index.md
+++ b/docs/pages/components/input-picker/en-US/index.md
@@ -70,7 +70,7 @@ Learn more in [Accessibility](/guide/accessibility).
 | labelKey           | string `('label')`                                                        | Set options to display the 'key' in 'data'                  |
 | listProps          | [ListProps][listprops]                                                    | List-related properties in `react-virtualized`              |
 | locale             | [PickerLocaleType](/guide/i18n/#pickers)                                  | Locale text                                                 |
-| maxHeight          | number `(320)`                                                            | Set the max height of the Dropdown                          |
+| menuMaxHeight      | number `(320)`                                                            | Set the max height of the Dropdown                          |
 | menuClassName      | string                                                                    | A css class to apply to the Menu DOM node.                  |
 | menuStyle          | CSSProperties                                                             | A style to apply to the Menu DOM node.                      |
 | onChange           | (value:string, event) => void                                             | callback function when value changes                        |

--- a/docs/pages/components/input-picker/zh-CN/index.md
+++ b/docs/pages/components/input-picker/zh-CN/index.md
@@ -70,7 +70,7 @@
 | labelKey           | string `('label')`                                                        | 设置选项显示内容在 `data` 中的 `key`       |
 | listProps          | [ListProps][listprops]                                                    | `react-virtualized` 中 List 的相关属性     |
 | locale             | [PickerLocaleType](/zh/guide/i18n/#pickers)                               | 本地化的文本                               |
-| maxHeight          | number `(320)`                                                            | 设置 Dropdown 的最大高度                   |
+| menuMaxHeight      | number `(320)`                                                            | 设置 Dropdown 的最大高度                   |
 | menuClassName      | string                                                                    | 应用于菜单 DOM 节点的 css class            |
 | menuStyle          | CSSProperties                                                             | 应用于菜单 DOM 节点的 style                |
 | onChange           | (value:string, event) => void                                             | `value` 发生改变时的回调函数               |

--- a/docs/pages/components/select-picker/en-US/index.md
+++ b/docs/pages/components/select-picker/en-US/index.md
@@ -88,7 +88,7 @@ type ValueType = string | number;
 | labelKey           | string `('label')`                                                           | Set options to display the 'key' in 'data'                  |
 | listProps          | [ListProps][listprops]                                                       | List-related properties in `react-virtualized`              |
 | locale             | [PickerLocaleType](/guide/i18n/#pickers)                                     | Locale text                                                 |
-| maxHeight          | number `(320)`                                                               | Set the max height of the Dropdown                          |
+| menuMaxHeight      | number `(320)`                                                               | Set the max height of the Dropdown                          |
 | menuClassName      | string                                                                       | A css class to apply to the Menu DOM node.                  |
 | menuStyle          | CSSProperties                                                                | A style to apply to the Menu DOM node.                      |
 | onChange           | (value:ValueType, event) => void                                             | callback function when value changes                        |

--- a/docs/pages/components/select-picker/zh-CN/index.md
+++ b/docs/pages/components/select-picker/zh-CN/index.md
@@ -84,7 +84,7 @@
 | labelKey           | string `('label')`                                                        | 设置选项显示内容在 `data` 中的 `key`   |
 | listProps          | [ListProps][listprops]                                                    | `react-virtualized` 中 List 的相关属性 |
 | locale             | [PickerLocaleType](/zh/guide/i18n/#pickers)                               | 本地化的文本                           |
-| maxHeight          | number `(320)`                                                            | 设置 Dropdown 的最大高度               |
+| menuMaxHeight      | number `(320)`                                                            | 设置 Dropdown 的最大高度               |
 | menuClassName      | string                                                                    | 应用于菜单 DOM 节点的 css class        |
 | menuStyle          | CSSProperties                                                             | 应用于菜单 DOM 节点的 style            |
 | onChange           | (value:string, event) => void                                             | `value` 发生改变时的回调函数           |

--- a/docs/pages/components/tag-picker/en-US/index.md
+++ b/docs/pages/components/tag-picker/en-US/index.md
@@ -60,13 +60,13 @@ Learn more in [Accessibility](/guide/accessibility).
 | creatable          | boolean                                                                | Settings can create new options                             |
 | data \*            | DataItemType[]                                                         | The data of component                                       |
 | defaultValue       | string[]                                                               | Default values of the selected items                        |
-| disabled           | boolean                                                                | Whether disabled component                                   |
+| disabled           | boolean                                                                | Whether disabled component                                  |
 | disabledItemValues | string[]                                                               | Disable item by value                                       |
 | groupBy            | string                                                                 | Set group condition key in data                             |
 | labelKey           | string `('label')`                                                     | Set label key in data                                       |
 | listProps          | [ListProps][listprops]                                                 | List-related properties in `react-virtualized`              |
 | locale             | [PickerLocaleType](/guide/i18n/#pickers)                               | Locale text                                                 |
-| maxHeight          | number `(320)`                                                         | The max height of Dropdown                                  |
+| menuMaxHeight      | number `(320)`                                                         | The max height of Dropdown                                  |
 | menuClassName      | string                                                                 | A css class to apply to the Menu DOM node.                  |
 | menuStyle          | CSSProperties                                                          | A style to apply to the Menu DOM node.                      |
 | onChange           | (value:string[], event) => void                                        | Callback fired when value change                            |

--- a/docs/pages/components/tag-picker/zh-CN/index.md
+++ b/docs/pages/components/tag-picker/zh-CN/index.md
@@ -67,7 +67,7 @@
 | groupBy            | string                                                                  | 设置分组条件在 `data` 中的 `key`           |
 | labelKey           | string `('label')`                                                      | 设置选项显示内容在 `data` 中的 `key`       |
 | listProps          | [ListProps][listprops]                                                  | `react-virtualized` 中 List 的相关属性     |
-| maxHeight          | number `(320)`                                                          | 设置 Dropdown 的最大高度                   |
+| menuMaxHeight      | number `(320)`                                                          | 设置 Dropdown 的最大高度                   |
 | menuClassName      | string                                                                  | 应用于菜单 DOM 节点的 css class            |
 | menuStyle          | CSSProperties                                                           | 应用于菜单 DOM 节点的 style                |
 | onChange           | (value:string, event) => void                                           | `value` 发生改变时的回调函数               |


### PR DESCRIPTION
`maxHeight` prop that controls menu's max height in a picker has been renamed to `menuMaxHeight` in v5, but the docs was not updated for that.

See discussion here https://github.com/rsuite/rsuite/issues/2088#issuecomment-958845003