### PR TITLE
docs(table): remove `bodyRef` in props

### DIFF
--- a/docs/pages/components/table/en-US/index.md
+++ b/docs/pages/components/table/en-US/index.md
@@ -292,7 +292,6 @@ https://codesandbox.io/s/rsuite-table-with-react-dnd-m06cm
 | affixHeader              | boolean,number                                                                    | Affix the table header to the specified location on the page                                  |
 | affixHorizontalScrollbar | boolean,number                                                                    | Affix the table horizontal scrollbar to the specified position on the page                    |
 | autoHeight               | boolean                                                                           | Automatic height                                                                              |
-| bodyRef                  | Ref                                                                               | A ref attached to the table body element                                                      |
 | bordered                 | boolean                                                                           | Show border                                                                                   |
 | cellBordered             | boolean                                                                           | Show cell border                                                                              |
 | data \*                  | object[]                                                                          | Table data                                                                                    |

--- a/docs/pages/components/table/zh-CN/index.md
+++ b/docs/pages/components/table/zh-CN/index.md
@@ -288,7 +288,6 @@ https://codesandbox.io/s/rsuite-table-with-react-dnd-m06cm
 | affixHeader              | boolean,number                                                                    | 将表头固定到页面上的指定位置                                 |
 | affixHorizontalScrollbar | boolean,number                                                                    | 将横向滚动条固定在页面底部的指定位置                         |
 | autoHeight               | boolean                                                                           | 自动高度                                                     |
-| bodyRef                  | Ref                                                                               | 表格主体部分上的 ref                                         |
 | bordered                 | boolean                                                                           | 表格边框                                                     |
 | cellBordered             | boolean                                                                           | 单元格边框                                                   |
 | data \*                  | object[]                                                                          | 表格数据                                                     |


### PR DESCRIPTION
https://github.com/rsuite/rsuite/blob/main/docs/pages/guide/v5-features/en-US/index.md#improvements-to-table