### PR TITLE
fix(Sidenav): remove underline on hovered SidenavItem

### DIFF
--- a/src/Sidenav/styles/index.less
+++ b/src/Sidenav/styles/index.less
@@ -139,6 +139,10 @@
   outline: 0;
   overflow: hidden;
 
+  &:hover {
+    text-decoration: none;
+  }
+
   &:focus-visible,
   &&-focus {
     .focus-ring(slim-inset);


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/8225666/140727998-f56a2d2f-3c97-4703-a61d-8fb6adf4bc9c.png)

After
![image](https://user-images.githubusercontent.com/8225666/140728025-146ebdb4-071b-4474-a2dd-671939945fa6.png)
