### PR TITLE
chore: remove build:docs script

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -177,11 +177,12 @@ module.exports = {
     };
 
     // If we are building docs with local rsuite from src (local development and review builds),
-    // we should target `react` and `react-dom` imports to root node_modules
+    // we should stick `react` and `react-dom` imports to docs/node_modules
+    // preventing "more than one copy of React" error
     if (__USE_SRC__) {
       Object.assign(config.resolve.alias, {
-        react: path.resolve(__dirname, '../node_modules/react'),
-        'react-dom': path.resolve(__dirname, '../node_modules/react-dom')
+        react: path.resolve(__dirname, './node_modules/react'),
+        'react-dom': path.resolve(__dirname, './node_modules/react-dom')
       });
     }
 

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -42,6 +42,10 @@ module.exports = {
     DEV: __DEV__ ? 1 : 0,
     VERSION: pkg.version
   },
+  eslint: {
+    // ESLint is ignored because it's already run in CI workflow
+    ignoreDuringBuilds: true
+  },
   /**
    *
    * @param {import('webpack').Configuration} config

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "build": "npm run build:gulp && npm run dist && npm run build:types",
     "build:gulp": "gulp build --gulpfile scripts/gulpfile.js",
     "build:types": "npx tsc --emitDeclarationOnly --outDir lib/cjs && npx tsc --emitDeclarationOnly --outDir lib/esm",
-    "build:docs": "npm run build --prefix docs",
     "postbuild": "mocha test/validateBuilds.js",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "dist:analyze": "ANALYZE=true webpack --mode production --progress",


### PR DESCRIPTION
Configure Vercel project to use its Next.js preset. An experimental is created here https://vercel.com/rsuite/rsuite-nextjs .

## ✅ Checklist

- [x] Make sure `rsuite-nextjs` project is deployed successfully in this PR.
- [x] Make sure `rsuite-nextjs` project is also deployed successfully in other PRs.
- [ ] Merge this PR and make sure `rsuite-nextjs` project is also deployed successfully on `main` branch.
- [ ] Replace `rsuite` with `rsuite-nextjs` as the default production project.