### PR TITLE
build(deps): bump rsuite-table from 5.1.0 to 5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7698,11 +7698,6 @@
       "integrity": "sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ==",
       "dev": true
     },
-    "element-resize-event": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/element-resize-event/-/element-resize-event-3.0.6.tgz",
-      "integrity": "sha512-sSeXY9rNDp86bJODW68pxLcy3A5FrPZfIgOrJHzqgYzX513Zq6/ytdBigp7KeJEpZZopBBSiO1cVuiRkZpNxLw=="
-    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -17416,15 +17411,15 @@
       }
     },
     "rsuite-table": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.1.0.tgz",
-      "integrity": "sha512-HsG20TWiRC6gwBnfrNy0068nOV3CO4ipTEhevHrj5PaSjyOofTzTR4pgg6pQgV3t4cg70XaWgitf7BBRCSjFeA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.2.0.tgz",
+      "integrity": "sha512-MiJtfZYSMXqaUdEFQ0Q5A5mNjiB0upZumoqMyd0WGsJDC6Ff8tbnMEDBbcMcQ6GcL2MSJoxi1vz3kIo/mZ1Wew==",
       "requires": {
         "@babel/runtime": "^7.12.5",
+        "@juggle/resize-observer": "^3.3.1",
         "@rsuite/icons": "^1.0.0",
         "classnames": "^2.2.5",
         "dom-lib": "^3.0.0",
-        "element-resize-event": "^3.0.6",
         "lodash": "^4.17.21"
       }
     },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "react-virtualized": "^9.22.3",
-    "rsuite-table": "^5.1.0",
+    "rsuite-table": "^5.2.0",
     "schema-typed": "^2.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION

### Bug Fixes

* **Table:** fix scroll bar not re-rendering after table resize ([#267](https://github.com/rsuite/rsuite-table/issues/267)) ([185f759](https://github.com/rsuite/rsuite-table/commit/185f759536b2686472995acb72e838827716ec21))


### Features

* **Column:** added support for nested values of dataKey on Column ([#268](https://github.com/rsuite/rsuite-table/issues/268)) ([50ec875](https://github.com/rsuite/rsuite-table/commit/50ec875891fa33fc677a7c9e2e07a4af060773a5))


### Performance Improvements

* **TreeTable:** improve the performance of tree table ([#266](https://github.com/rsuite/rsuite-table/issues/266)) ([25eeee6](https://github.com/rsuite/rsuite-table/commit/25eeee62c2c5539e956d4bcf3643b951002ae36f))
