### PR TITLE
fix(TagPicker): fix placeholder misalignment in plaintext mode

### DIFF
--- a/src/InputPicker/InputPicker.tsx
+++ b/src/InputPicker/InputPicker.tsx
@@ -738,7 +738,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
 
       // TagPicker has -6px margin-left on the plaintext wrapper
       // for fixing margin-left on tags from 2nd line on
-      if (multi) {
+      if (multi && hasValue) {
         plaintextProps.style = {
           marginLeft: -6
         };

--- a/src/TagPicker/test/TagPickerSpec.js
+++ b/src/TagPicker/test/TagPickerSpec.js
@@ -453,5 +453,10 @@ describe('TagPicker', () => {
     assert.equal(instance2.target.textContent, 'Not selected');
     assert.equal(instance3.target.textContent, '-');
     assert.equal(instance4.target.textContent, 'Eugenia');
+
+    assert.equal(instance1.target.style.marginLeft, '-6px');
+    assert.isEmpty(instance2.target.style.marginLeft);
+    assert.isEmpty(instance3.target.style.marginLeft);
+    assert.equal(instance4.target.style.marginLeft, '-6px');
   });
 });


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/1203827/142960943-62c95f27-56b5-4924-9ad2-5798a69a47dd.png)
after:
![image](https://user-images.githubusercontent.com/1203827/142961026-11856742-4805-4b34-b660-6c81e9f4f802.png)

