### PR TITLE
build(deps): bump rsuite-table from 5.2.0 to 5.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17411,16 +17411,24 @@
       }
     },
     "rsuite-table": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.2.0.tgz",
-      "integrity": "sha512-MiJtfZYSMXqaUdEFQ0Q5A5mNjiB0upZumoqMyd0WGsJDC6Ff8tbnMEDBbcMcQ6GcL2MSJoxi1vz3kIo/mZ1Wew==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.2.1.tgz",
+      "integrity": "sha512-enBpwlmy0ClD4D6O22Ix3ct+ulq6q5z6+XTuU16+WGVvfZRDJxG8d61uDib436M1yTWaoNLeUQVU0DBHf6FsjA==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",
         "@rsuite/icons": "^1.0.0",
         "classnames": "^2.2.5",
         "dom-lib": "^3.0.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "react-is": "^17.0.2"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        }
       }
     },
     "rtlcss": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "react-virtualized": "^9.22.3",
-    "rsuite-table": "^5.2.0",
+    "rsuite-table": "^5.2.1",
     "schema-typed": "^2.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Bug Fixes

* **scrollbar:** enhanced verification of the number of columns ([#275](https://github.com/rsuite/rsuite-table/issues/275)) ([a666996](https://github.com/rsuite/rsuite-table/commit/a666996dbf68b1a12ad565911345af8b55a9398c))
* **scrollbar:** fix scroll left reset ([#273](https://github.com/rsuite/rsuite-table/issues/273)) ([dab0f27](https://github.com/rsuite/rsuite-table/commit/dab0f2796c3168dc8fc0bc480b15f63cd04fe5af))
* **tree:** fix unrecalculated row height after tree node is expanded ([#277](https://github.com/rsuite/rsuite-table/issues/277)) ([3788875](https://github.com/rsuite/rsuite-table/commit/378887509981db5cfc3a98e47c2751cc0559f3f8))
* **wordWrap:** fix can't word wrap in tree table ([#274](https://github.com/rsuite/rsuite-table/issues/274)) ([58436e4](https://github.com/rsuite/rsuite-table/commit/58436e47e85d03dad274bc30f0052432a544b79d))

