### PR TITLE
fix(component): uploader fileMap is not updated when status is error

### DIFF
--- a/src/Uploader/Uploader.tsx
+++ b/src/Uploader/Uploader.tsx
@@ -215,7 +215,7 @@ class Uploader extends React.Component<UploaderProps, UploaderState> {
 
   handleAjaxUploadError = (
     file: FileType,
-    response: object,
+    status: object,
     event: React.SyntheticEvent<any>,
     xhr: XMLHttpRequest
   ) => {
@@ -224,7 +224,7 @@ class Uploader extends React.Component<UploaderProps, UploaderState> {
       status: 'error'
     };
     this.updateFileList(nextFile, () => {
-      this.props.onError?.(response, nextFile, event, xhr);
+      this.props.onError?.(status, nextFile, event, xhr);
     });
   };
 

--- a/src/Uploader/Uploader.tsx
+++ b/src/Uploader/Uploader.tsx
@@ -215,7 +215,7 @@ class Uploader extends React.Component<UploaderProps, UploaderState> {
 
   handleAjaxUploadError = (
     file: FileType,
-    status: object,
+    response: object,
     event: React.SyntheticEvent<any>,
     xhr: XMLHttpRequest
   ) => {
@@ -224,7 +224,7 @@ class Uploader extends React.Component<UploaderProps, UploaderState> {
       status: 'error'
     };
     this.updateFileList(nextFile, () => {
-      this.props.onError?.(status, nextFile, event, xhr);
+      this.props.onError?.(response, nextFile, event, xhr);
     });
   };
 
@@ -284,7 +284,7 @@ class Uploader extends React.Component<UploaderProps, UploaderState> {
       fileList: nextFileList
     };
 
-    if (nextFile.progress) {
+    if (nextFile.progress || nextFile.status === 'error') {
       const { fileMap } = this.state;
 
       fileMap[nextFile.fileKey] = {


### PR DESCRIPTION
- ~Fix wrong parameter name in function `handleAjaxUploadError`~
- When we control the component `Uploader` state via props `fileList`, fileMap won't be updated if uploaded failed since nextFile.progress is always undefined. It cause the function `getFileList` always return incorrect info across in many caller functions.