### PR TITLE
fix(Table): fix the column of grouping cannot be centered

### DIFF
--- a/src/Table/styles/index.less
+++ b/src/Table/styles/index.less
@@ -342,10 +342,6 @@
     &-cell {
       position: absolute;
       border-right: 1px solid var(--rs-border-secondary);
-
-      &-content {
-        display: table-cell;
-      }
     }
   }
 }


### PR DESCRIPTION
fix: https://github.com/rsuite/rsuite-table/issues/276
ref: https://github.com/rsuite/rsuite-table/commit/d0c7f34f16a6433cd089921fbd4cc522db29cea8#diff-901047440991f732080fa2e54e7166ff0fdb5cb1860ca1c2fb46c8b7403e4f15L20-L23