### PR TITLE
fix(Carousel): make onSelect prop optional

### DIFF
--- a/src/Carousel/Carousel.tsx
+++ b/src/Carousel/Carousel.tsx
@@ -18,7 +18,7 @@ export interface CarouselProps extends WithAsProps {
   shape?: 'dot' | 'bar';
 
   /** Callback fired when the active item changes */
-  onSelect: (index: number, event: React.ChangeEvent<HTMLInputElement>) => void;
+  onSelect?: (index: number, event: React.ChangeEvent<HTMLInputElement>) => void;
 
   /** Callback fired when a slide transition starts */
   onSlideStart?: (index: number, event: React.ChangeEvent<HTMLInputElement>) => void;


### PR DESCRIPTION
Hey, I'm trying to use the Carousel component (https://rsuitejs.com/components/carousel/) in our project but, it requires an `onSelect` props. I don't think this property needs to be required. Right?