### PR TITLE
fix(DateRangePicker): fix DateRangePicker cannot switch am/pm

### DIFF
--- a/docs/pages/components/date-range-picker/en-US/index.md
+++ b/docs/pages/components/date-range-picker/en-US/index.md
@@ -14,7 +14,7 @@ If `<DateRangePicker>` does not satisfy the business scenario in which you selec
 
 <!--{include:`basic.md`}-->
 
-### Date time or time
+### Date Time or Time
 
 <!--{include:`format-date-time.md`}-->
 
@@ -50,7 +50,7 @@ If `<DateRangePicker>` does not satisfy the business scenario in which you selec
 
 <!--{include:`show-only-calendar.md`}-->
 
-### Disabled and read only
+### Disabled and Readonly
 
 <!--{include:`disabled.md`}-->
 
@@ -180,6 +180,7 @@ type DisabledDateFunction = (
 | -------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | appearance           | enum: 'default' &#124; 'subtle' `('default')`           | Set picker appearence                                                                |
 | block                | boolean                                                 | Blocking an entire row                                                               |
+| caretAs              | ElementType                                             | Custom component for the caret icon                                                  |
 | character            | string `(' ~ ')`                                        | The character that separates two dates                                               |
 | cleanable            | boolean `(true)`                                        | Whether the selected value can be cleared                                            |
 | container            | HTMLElement &#124; (() => HTMLElement)                  | Sets the rendering container                                                         |
@@ -212,12 +213,12 @@ type DisabledDateFunction = (
 | preventOverflow      | boolean                                                 | Prevent floating element overflow                                                    |
 | ranges               | Range[] `(Ranges)`                                      | Whortcut config，defeult: `Today`,`Yesterday`，`Last 7 days`                         |
 | renderValue          | (value: ValueType, format: string) => ReactNode         | Custom render selected date range                                                    |
+| showMeridian         | boolean                                                 | Display hours in 12 format                                                           |
 | showOneCalendar      | boolen                                                  | Whether to show only one calendar                                                    |
 | showWeekNumbers      | boolean                                                 | Whether to show week numbers                                                         |
 | size                 | enum: 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')` | A picker can have different sizes                                                    |
 | toggleAs             | ElementType `('a')`                                     | You can use a custom element for this component                                      |
 | value                | ValueType                                               | Value (Controlled)                                                                   |
-| caretAs              | ElementType                                             | Custom component for the caret icon                                                  |
 
 ## Default
 

--- a/docs/pages/components/date-range-picker/fragments/format-date-time.md
+++ b/docs/pages/components/date-range-picker/fragments/format-date-time.md
@@ -2,10 +2,15 @@
 
 ```js
 const instance = (
-  <div>
+  <div className="field">
+    <p>Date Time Range</p>
     <DateRangePicker format="yyyy-MM-dd HH:mm:ss" />
-    <hr />
+
+    <p>Time Range</p>
     <DateRangePicker format="HH:mm:ss" ranges={[]} />
+
+    <p>Meridian format</p>
+    <DateRangePicker format="yyyy-MM-dd hh:mm aa" showMeridian />
   </div>
 );
 ReactDOM.render(instance);

--- a/docs/pages/components/date-range-picker/zh-CN/index.md
+++ b/docs/pages/components/date-range-picker/zh-CN/index.md
@@ -182,6 +182,7 @@ type DisabledDateFunction = (
 | -------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------- |
 | appearance           | enum: 'default' &#124; 'subtle' `('default')`           | 设置外观                                                                        |
 | block                | boolean                                                 | 堵塞整行                                                                        |
+| caretAs              | ElementType                                             | 自定义右侧箭头图标的组件                                                        |
 | character            | string `(' ~ ')`                                        | 两个日期之间的分隔符                                                            |
 | cleanable            | boolean `(true)`                                        | 可以清除选择值                                                                  |
 | container            | HTMLElement &#124; (() => HTMLElement)                  | 设置渲染的容器                                                                  |
@@ -215,12 +216,12 @@ type DisabledDateFunction = (
 | preventOverflow      | boolean                                                 | 防止浮动元素溢出                                                                |
 | ranges               | Range `(Ranges)`                                        | 快捷项配置，默认 `今天`,`昨天`，`最近 7 天`                                     |
 | renderValue          | (value: ValueType, format: string) => ReactNode         | 自定义被选中的选项                                                              |
+| showMeridian         | boolean                                                 | 显示 12 小时制的时间格式                                                        |
 | showOneCalendar      | boolen                                                  | 显示一个日历                                                                    |
 | showWeekNumbers      | boolean                                                 | 显示周数量                                                                      |
 | size                 | enum: 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')` | 设置组件尺寸                                                                    |
 | toggleAs             | ElementType `('a')`                                     | 为组件自定义元素类型                                                            |
 | value                | ValueType                                               | 值 `受控`                                                                       |
-| caretAs              | ElementType                                             | 自定义右侧箭头图标的组件                                                        |
 
 ## Default
 

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -71,6 +71,9 @@ export interface DateRangePickerProps extends PickerBaseProps, FormControlBasePr
   /** Show only one calendar select */
   showOneCalendar?: boolean;
 
+  /** Meridian format */
+  showMeridian?: boolean;
+
   /** Set default date for calendar */
   defaultCalendarValue?: ValueType;
 
@@ -145,8 +148,8 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
     renderValue,
     showOneCalendar = false,
     showWeekNumbers,
+    showMeridian,
     style,
-
     toggleAs,
     value: valueProp,
     onChange,
@@ -460,6 +463,29 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
   );
 
   /**
+   * The callback triggered when PM/AM is switched.
+   */
+  const handleToggleMeridian = useCallback(
+    (index: number) => {
+      const next = Array.from(calendarDate) as ValueType;
+
+      const clonedDate = new Date(next[index].valueOf());
+      const hours = DateUtils.getHours(clonedDate);
+      const nextHours = hours >= 12 ? hours - 12 : hours + 12;
+
+      next[index] = DateUtils.setHours(clonedDate, nextHours);
+
+      setCalendarDate(next);
+
+      // If the value already exists, update the value again.
+      if (selectValue.length === 2) {
+        setSelectValue(next);
+      }
+    },
+    [calendarDate, selectValue]
+  );
+
+  /**
    * Toolbar operation callback function
    */
   const handleShortcutPageDate = useCallback(
@@ -657,10 +683,12 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
       showOneCalendar,
       showWeekNumbers,
       value: selectValue,
+      showMeridian,
       onChangeCalendarDate: handleChangeCalendarDate,
       onChangeCalendarTime: handleChangeCalendarTime,
       onMouseMove: handleMouseMove,
-      onSelect: handleSelectValueChange
+      onSelect: handleSelectValueChange,
+      onToggleMeridian: handleToggleMeridian
     };
 
     return (
@@ -775,11 +803,12 @@ DateRangePicker.propTypes = {
   isoWeek: PropTypes.bool,
   oneTap: PropTypes.bool,
   limitEndYear: PropTypes.number,
-  showWeekNumbers: PropTypes.bool,
   onChange: PropTypes.func,
   onOk: PropTypes.func,
   disabledDate: PropTypes.func,
   onSelect: PropTypes.func,
+  showWeekNumbers: PropTypes.bool,
+  showMeridian: PropTypes.bool,
   showOneCalendar: PropTypes.bool
 };
 

--- a/src/DateRangePicker/test/DateRangePickerSpec.js
+++ b/src/DateRangePicker/test/DateRangePickerSpec.js
@@ -502,6 +502,62 @@ describe('DateRangePicker', () => {
     assert.equal(format(onChangeSpy.firstCall.firstArg[1], 'dd/MM/yyyy'), '09/11/2021');
   });
 
+  it('Should be show meridian', () => {
+    const instance = getInstance(
+      <DateRangePicker
+        value={[parseISO('2017-08-14 13:00:00'), parseISO('2017-09-14 13:00:00')]}
+        format="dd MMM yyyy hh:mm:ss a"
+        defaultOpen
+        showMeridian
+      />
+    );
+    const picker = instance.overlay;
+
+    assert.equal(picker.querySelector('.rs-calendar-header-meridian').textContent, 'PM');
+    assert.equal(picker.querySelector('.rs-calendar-header-title-time').textContent, '01:00:00');
+    assert.equal(
+      picker.querySelector('.rs-calendar-time-dropdown-column').querySelectorAll('li').length,
+      12
+    );
+    assert.equal(picker.querySelector('.rs-calendar-time-dropdown-column li').textContent, '12');
+  });
+
+  it('Should keep AM PM unchanged', () => {
+    const instance = getInstance(
+      <DateRangePicker
+        value={[parseISO('2017-08-14 13:00:00'), parseISO('2017-09-14 13:00:00')]}
+        format="hh:mm:ss a"
+        defaultOpen
+        showMeridian
+      />
+    );
+
+    const picker = instance.overlay;
+
+    assert.equal(picker.querySelector('.rs-calendar-header-title-time').textContent, '01:00:00');
+
+    ReactTestUtils.Simulate.click(picker.querySelector('.rs-calendar-time-dropdown-cell'));
+
+    assert.equal(picker.querySelector('.rs-calendar-header-meridian').textContent, 'PM');
+    assert.equal(picker.querySelector('.rs-calendar-header-title-time').textContent, '12:00:00');
+  });
+
+  it('Should change AM/PM ', () => {
+    const instance = getInstance(
+      <DateRangePicker
+        value={[parseISO('2017-08-14 13:00:00'), parseISO('2017-09-14 13:00:00')]}
+        format="hh:mm:ss a"
+        defaultOpen
+        showMeridian
+      />
+    );
+
+    const meridian = instance.overlay.querySelector('.rs-calendar-header-meridian');
+    assert.equal(meridian.textContent, 'PM');
+    ReactTestUtils.Simulate.click(meridian);
+    assert.equal(meridian.textContent, 'AM');
+  });
+
   describe('Plain text', () => {
     it('Should render formatted date range', () => {
       const { getByTestId } = render(


### PR DESCRIPTION
Fix #2166, support `showMeridian` on `<DateRangePicker>`
```tsx
<DateRangePicker format="yyyy-MM-dd hh:mm aa" showMeridian />
```

![image](https://user-images.githubusercontent.com/1203827/144024993-2e39e4f2-182c-4dc1-9f4d-00ee94413a77.png)
