### PR TITLE
fix(tree): expose methods for tree that can scroll the list

### DIFF
--- a/docs/pages/components/tree/fragments/basic.md
+++ b/docs/pages/components/tree/fragments/basic.md
@@ -3,11 +3,33 @@
 ```js
 /**
  * import data from
- * https://github.com/rsuite/rsuite/blob/master/docs/public/data/city-simplified.json
+ * https://github.com/rsuite/rsuite/blob/main/docs/public/data/en/city-simplified.json
  */
 
-const instance = <Tree data={data} defaultExpandAll />;
-ReactDOM.render(instance);
+const App = () => {
+  const treeRef = React.useRef();
+  const [index, setIndex] = React.useState(1);
+  return (
+    <div bordered>
+      <Panel bordered>
+        <Tree data={data} ref={treeRef} defaultExpandAll virtualized />
+      </Panel>
+      <hr />
+      <div style={{ justifyContent: 'flex-start', display: 'flex' }}>
+        <InputNumber value={index} onChange={setIndex} style={{ width: 100, marginRight: 10 }} />
+        <Button
+          onClick={() => {
+            // https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#scrolltorow-index-number
+            treeRef.current.list.scrollToRow(index);
+          }}
+        >
+          scrollToRow
+        </Button>
+      </div>
+    </div>
+  );
+};
+ReactDOM.render(<App />);
 ```
 
 <!--end-code-->

--- a/docs/pages/components/tree/index.tsx
+++ b/docs/pages/components/tree/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Tree } from 'rsuite';
+import { Tree, Button, InputNumber, Panel } from 'rsuite';
 
 const { useState } = React;
 
@@ -8,5 +8,5 @@ import useFetchData from '@/utils/useFetchData';
 
 export default function Page() {
   const { response: data } = useFetchData('city-simplified');
-  return <DefaultPage dependencies={{ useState, Tree, data }} />;
+  return <DefaultPage dependencies={{ useState, Button, InputNumber, Tree, data, Panel }} />;
 }

--- a/src/CheckTree/test/CheckTreeSpec.js
+++ b/src/CheckTree/test/CheckTreeSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getInstance } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
 import CheckTree from '../index';
 
 const data = [
@@ -29,9 +29,9 @@ const data = [
   }
 ];
 
-describe('Tree', () => {
+describe('CheckTree', () => {
   it('Should render a multi-selectable tree', () => {
-    const instance = getInstance(<CheckTree data={data} />);
+    const instance = getDOMNode(<CheckTree data={data} />);
 
     assert.include(instance.className, 'rs-check-tree');
     assert.equal(instance.getAttribute('role'), 'tree');

--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -491,7 +491,14 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
     ]
   );
 
-  usePublicMethods(ref, { triggerRef, overlayRef, targetRef }, inline);
+  usePublicMethods(ref, {
+    rootRef: inline ? treeViewRef : null,
+    triggerRef,
+    overlayRef,
+    targetRef,
+    listRef,
+    inline
+  });
 
   const handleClean = useCallback(
     (event: React.SyntheticEvent) => {
@@ -762,7 +769,7 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
     return (
       <div
         id={id ? `${id}-listbox` : undefined}
-        ref={inline ? mergeRefs(treeViewRef, ref as any) : treeViewRef}
+        ref={treeViewRef}
         role="tree"
         aria-multiselectable
         className={classes}

--- a/src/Picker/VirtualizedList.tsx
+++ b/src/Picker/VirtualizedList.tsx
@@ -1,10 +1,40 @@
 import React from 'react';
 import VirtualizedList, { ListProps, ListRowProps } from 'react-virtualized/dist/commonjs/List';
 import VirtualizedAutoSizer, { AutoSizerProps } from 'react-virtualized/dist/commonjs/AutoSizer';
+import type { Alignment } from 'react-virtualized';
 
+// https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#public-methods
 export interface ListInstance {
-  child: Element;
-  scrollToRow?: (index: number) => void;
+  /**
+   * Forcefully re-render the inner Grid component.
+   */
+  forceUpdateGrid(): void;
+
+  /**
+   * Gets offset for a given row and alignment.
+   */
+  getOffsetForRow(params: { alignment?: Alignment; index?: number }): number;
+
+  /**
+   * Pre-measure all rows in a List.
+   */
+  measureAllRows(): void;
+
+  /**
+   * Recompute row heights and offsets after the specified index (defaults to 0).
+   */
+  recomputeRowHeights(index?: number): void;
+
+  /**
+   * Scroll to the specified offset. Useful for animating position changes.
+   */
+  scrollToPosition(scrollTop?: number): void;
+
+  /**
+   * Ensure row is visible. This method can be used to safely scroll back to a cell
+   * that a user has scrolled away from even if it was previously scrolled to.
+   */
+  scrollToRow(index?: number): void;
 }
 
 export type { ListProps, AutoSizerProps, ListRowProps };

--- a/src/Picker/utils.ts
+++ b/src/Picker/utils.ts
@@ -591,7 +591,11 @@ export function usePublicMethods(ref, parmas: PickerDependentParameters) {
       },
       get list() {
         if (!listRef?.current) {
-          throw new Error('The list is not found, please set `virtualized` for the component.');
+          throw new Error(`
+            The list is not found.
+            1.Please set virtualized for the component.
+            2.Please confirm whether the picker is open.
+          `);
         }
         return listRef?.current;
       },

--- a/src/Tree/test/TreeSpec.js
+++ b/src/Tree/test/TreeSpec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Simulate } from 'react-dom/test-utils';
-import { getInstance } from '@test/testUtils';
+import { getDOMNode } from '@test/testUtils';
+import { render } from '@testing-library/react';
 import Tree from '../Tree';
 
 const data = [
@@ -32,7 +33,7 @@ const data = [
 
 describe('Tree', () => {
   it('Should render a tree', () => {
-    const instance = getInstance(<Tree data={data} />);
+    const instance = getDOMNode(<Tree data={data} />);
 
     assert.include(instance.className, 'rs-tree');
     assert.equal(instance.getAttribute('role'), 'tree');
@@ -40,7 +41,7 @@ describe('Tree', () => {
 
   it('Should call `onDragStart` callback', () => {
     const onDragStartSpy = sinon.spy();
-    const instance = getInstance(<Tree data={data} onDragStart={onDragStartSpy} draggable />);
+    const instance = getDOMNode(<Tree data={data} onDragStart={onDragStartSpy} draggable />);
     const treeNode = instance.querySelector('.rs-tree-node');
 
     Simulate.dragStart(treeNode);
@@ -52,7 +53,7 @@ describe('Tree', () => {
 
   it('Should call `onDragEnter` callback', () => {
     const onDragEnterSpy = sinon.spy();
-    const instance = getInstance(<Tree data={data} onDragEnter={onDragEnterSpy} draggable />);
+    const instance = getDOMNode(<Tree data={data} onDragEnter={onDragEnterSpy} draggable />);
     const treeNode = instance.querySelector('.rs-tree-node');
 
     Simulate.dragEnter(treeNode);
@@ -62,7 +63,7 @@ describe('Tree', () => {
 
   it('Should call `onDragOver` callback', () => {
     const onDragOverSpy = sinon.spy();
-    const instance = getInstance(<Tree data={data} onDragOver={onDragOverSpy} draggable />);
+    const instance = getDOMNode(<Tree data={data} onDragOver={onDragOverSpy} draggable />);
     const treeNode = instance.querySelector('.rs-tree-node');
 
     Simulate.dragOver(treeNode);
@@ -72,7 +73,7 @@ describe('Tree', () => {
 
   it('Should call `onDragLeave` callback', () => {
     const onDragLeaveSpy = sinon.spy();
-    const instance = getInstance(<Tree data={data} onDragLeave={onDragLeaveSpy} draggable />);
+    const instance = getDOMNode(<Tree data={data} onDragLeave={onDragLeaveSpy} draggable />);
     const treeNode = instance.querySelector('.rs-tree-node');
 
     Simulate.dragLeave(treeNode);
@@ -82,11 +83,37 @@ describe('Tree', () => {
 
   it('Should call `onDragEnd` callback', () => {
     const onDragEndSpy = sinon.spy();
-    const instance = getInstance(<Tree data={data} onDragEnd={onDragEndSpy} draggable />);
+    const instance = getDOMNode(<Tree data={data} onDragEnd={onDragEndSpy} draggable />);
     const treeNode = instance.querySelector('.rs-tree-node');
 
     Simulate.dragEnd(treeNode);
     assert.isTrue(onDragEndSpy.calledOnce);
     assert.equal(onDragEndSpy.firstCall.firstArg.value, 'Master');
+  });
+
+  it('Should catch the not set virtualized exception', () => {
+    expect(() => {
+      const ref = React.createRef();
+      render(<Tree data={data} ref={ref} />);
+      ref.current.list;
+    }).to.throw('The list is not found, please set `virtualized` for the component.');
+  });
+
+  it('Should scroll the list by `scrollToRow`', () => {
+    const onScrollSpy = sinon.spy();
+    const ref = React.createRef();
+    render(
+      <Tree
+        data={data}
+        ref={ref}
+        virtualized
+        style={{ height: 30 }}
+        listProps={{
+          onScroll: onScrollSpy
+        }}
+      />
+    );
+    ref.current.list.scrollToRow(2);
+    assert.isTrue(onScrollSpy.calledOnce);
   });
 });

--- a/src/Tree/test/TreeStylesSpec.js
+++ b/src/Tree/test/TreeStylesSpec.js
@@ -34,7 +34,7 @@ describe('CheckTree styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
     render(<Tree virtualized={false} data={data} ref={instanceRef} />);
-    const itemLabel = document.body.querySelector('.rs-tree .rs-tree-node-label');
+    const itemLabel = instanceRef.current.root.querySelector('.rs-tree .rs-tree-node-label');
     inChrome && assert.equal(getStyle(itemLabel, 'padding'), '0px 0px 0px 16px');
   });
 });

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -526,7 +526,14 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
     targetRef.current?.focus();
   }, [activeNode, setSearchKeyword, valueKey]);
 
-  usePublicMethods(ref, { triggerRef, overlayRef, targetRef }, inline);
+  usePublicMethods(ref, {
+    rootRef: inline ? treeViewRef : null,
+    triggerRef,
+    overlayRef,
+    targetRef,
+    listRef,
+    inline
+  });
 
   const handleFocusItem = useCallback(
     (key: string) => {
@@ -771,7 +778,7 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
       <div
         role="tree"
         id={id ? `${id}-listbox` : undefined}
-        ref={inline ? mergeRefs(treeViewRef, ref as any) : treeViewRef}
+        ref={treeViewRef}
         className={classes}
         style={styles}
         onKeyDown={inline ? handleTreeKeyDown : undefined}

--- a/src/TreePicker/test/TreePickerSpec.js
+++ b/src/TreePicker/test/TreePickerSpec.js
@@ -508,4 +508,31 @@ describe('TreePicker', () => {
     const node = instance.overlay.querySelector('.rs-tree-node');
     assert.equal(node.style.height, '28px');
   });
+
+  it('Should catch the not set virtualized exception', () => {
+    expect(() => {
+      const ref = React.createRef();
+      render(<TreePicker data={data} ref={ref} />);
+      ref.current.list;
+    }).to.throw(Error);
+  });
+
+  it('Should scroll the list by `scrollToRow`', () => {
+    const onScrollSpy = sinon.spy();
+    const ref = React.createRef();
+    render(
+      <TreePicker
+        data={data}
+        ref={ref}
+        virtualized
+        style={{ height: 30 }}
+        open
+        listProps={{
+          onScroll: onScrollSpy
+        }}
+      />
+    );
+    ref.current.list.scrollToRow(2);
+    assert.isTrue(onScrollSpy.calledOnce);
+  });
 });


### PR DESCRIPTION
fix: https://github.com/rsuite/rsuite/issues/1994
fix: https://github.com/rsuite/rsuite/issues/2173

## Usage

```tsx
const treeRef = React.useRef();
return (
  <Tree data={data} ref={treeRef}  virtualized />
);

// https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#scrolltorow-index-number
treeRef.current.list.scrollToRow(index);

```

### Tree and CheckTree Instance

```ts
interface Instance {
  root?: Element;
  // https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#public-methods
  list?: ListInstance;
}
```

### Picker Instance
```ts
interface Instance {
  root?: Element;
  // https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#public-methods
  list?: ListInstance;
  overlay?: Element;
  target?: Element;
  updatePosition?: () => void;
  open?: () => void;
  close?: () => void;
}
```


