### PR TITLE
feat(FormControl): allow explicit default value

### DIFF
--- a/src/FormControl/FormControl.tsx
+++ b/src/FormControl/FormControl.tsx
@@ -87,6 +87,7 @@ const FormControl: FormControlComponent = React.forwardRef((props: FormControlPr
     disabled = disabledContext,
     onChange,
     onBlur,
+    defaultValue,
     ...rest
   } = props;
 
@@ -176,7 +177,7 @@ const FormControl: FormControlComponent = React.forwardRef((props: FormControlPr
         name={name}
         onChange={handleFieldChange}
         onBlur={handleFieldBlur}
-        defaultValue={formDefaultValue[name]}
+        defaultValue={defaultValue ?? formDefaultValue[name]}
         value={val}
       />
 

--- a/src/FormControl/test/FormControlSpec.js
+++ b/src/FormControl/test/FormControlSpec.js
@@ -118,6 +118,36 @@ describe('FormControl', () => {
     assert.equal(instance.querySelector('input').value, '');
   });
 
+  it('Should render correctly form default value when set', () => {
+    const mockValue = 'value';
+    const instance = getDOMNode(
+      <Form formDefaultValue={{ name: mockValue }}>
+        <FormControl name="name" />
+      </Form>
+    );
+    assert.equal(instance.querySelector('input').value, mockValue);
+  });
+
+  it('Should render correctly default value when explicitly set and form default is not set', () => {
+    const mockValue = 'value';
+    const instance = getDOMNode(
+      <Form formDefaultValue={null}>
+        <FormControl name="name" defaultValue={mockValue} />
+      </Form>
+    );
+    assert.equal(instance.querySelector('input').value, mockValue);
+  });
+
+  it('Should render correctly default value when explicitly set over form default', () => {
+    const mockValue = 'value';
+    const instance = getDOMNode(
+      <Form formDefaultValue={{ name: 'another value' }}>
+        <FormControl name="name" defaultValue={mockValue} />
+      </Form>
+    );
+    assert.equal(instance.querySelector('input').value, mockValue);
+  });
+
   it('Should render correctly when form error was null', () => {
     const instance = getDOMNode(
       <Form formError={null}>


### PR DESCRIPTION
### Rationale:
In the current implementation, if a user explicitly sets a default value to a `FormControl`, it never gets applied as it is overwritten by the `Form` context `defaultValues`. In some scenarios, either for convention of the project, structure/reusable components and other situations, it is desirable that the component can be set with default value regardless of the `Form` configuration.

### Solution:
We're allowing to set the `defaultValue` prop in the component and it gets used preferentially over the Form configuration if set.