### PR TITLE
fix(SelectPicker): fix onChange argument type

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10393,12 +10393,6 @@
         "mime-types": "~2.1.24"
       }
     },
-    "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
-      "dev": true
-    },
     "ua-parser-js": {
       "version": "0.7.28",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",

--- a/docs/package.json
+++ b/docs/package.json
@@ -92,7 +92,6 @@
     "rimraf": "^3.0.2",
     "rtlcss": "^2.4.1",
     "rtlcss-webpack-plugin": "^4.0.6",
-    "typescript": "^4.3.5",
     "webpack": "^5.11.0",
     "webpack-cli": "^4.2.0",
     "webpack-dev-server": "^3.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19801,6 +19801,12 @@
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
       "dev": true
     },
+    "ts-expect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ts-expect/-/ts-expect-1.3.0.tgz",
+      "integrity": "sha512-e4g0EJtAjk64xgnFPD6kTBUtpnMVzDrMb12N1YZV0VvSlhnVT3SGxiYTLdGy8Q5cYHOIC/FAHmZ10eGrAguicQ==",
+      "dev": true
+    },
     "ts-node": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-config-standard": "^21.0.0",
     "tinycolor2": "^1.4.1",
+    "ts-expect": "^1.3.0",
     "typescript": "^4.4.4",
     "webpack": "^5.11.0",
     "webpack-bundle-analyzer": "^4.3.0",

--- a/src/@types/common.ts
+++ b/src/@types/common.ts
@@ -215,12 +215,12 @@ export interface SVGIcon {
   id: string;
 }
 
-export interface ItemDataType extends Record<string, any> {
+export interface ItemDataType<T = number | string> extends Record<string, any> {
   label?: string | React.ReactNode;
-  value?: string | number;
+  value?: T;
   groupBy?: string;
-  parent?: ItemDataType;
-  children?: ItemDataType[];
+  parent?: ItemDataType<T>;
+  children?: ItemDataType<T>[];
   loading?: boolean;
 }
 

--- a/src/Picker/propTypes.ts
+++ b/src/Picker/propTypes.ts
@@ -13,7 +13,8 @@ export const pickerPropTypes = {
   containerPadding: PropTypes.number,
   container: PropTypes.oneOfType([PropTypes.any, PropTypes.func]),
   disabled: PropTypes.bool,
-  toggleAs: PropTypes.elementType,
+  // PropTypes.elementType conflictin with React.ElementType
+  // toggleAs: PropTypes.elementType,
   menuClassName: PropTypes.string,
   menuStyle: PropTypes.object,
   placeholder: PropTypes.node,
@@ -30,12 +31,12 @@ export const pickerPropTypes = {
   onOpen: PropTypes.func,
   onClose: PropTypes.func,
   onClean: PropTypes.func,
-  listProps: PropTypes.object
+  listProps: PropTypes.any
 };
 
 export const listPickerPropTypes = {
   ...pickerPropTypes,
-  data: PropTypes.array,
+  data: PropTypes.array.isRequired,
   valueKey: PropTypes.string,
   labelKey: PropTypes.string,
   childrenKey: PropTypes.string,

--- a/src/Picker/utils.ts
+++ b/src/Picker/utils.ts
@@ -183,7 +183,7 @@ interface FocusItemValueProps {
  * @param defaultFocusItemValue
  * @param props
  */
-export const useFocusItemValue = <T extends number | string>(
+export const useFocusItemValue = <T>(
   defaultFocusItemValue: T | null | undefined,
   props: FocusItemValueProps
 ) => {
@@ -198,7 +198,7 @@ export const useFocusItemValue = <T extends number | string>(
   } = props;
   const [focusItemValue, setFocusItemValue] = useState<T | null | undefined>(defaultFocusItemValue);
   const [layer, setLayer] = useState(defaultLayer);
-  const [keys, setKeys] = useState<Array<string | undefined>>([]);
+  const [keys, setKeys] = useState<any[]>([]);
 
   /**
    * Get the elements visible in all options.
@@ -279,9 +279,9 @@ export const useFocusItemValue = <T extends number | string>(
       const subMenu = menu?.querySelector(`[data-layer="${nextLayer}"]`);
 
       if (subMenu) {
-        return Array.from(subMenu.querySelectorAll<HTMLElement>(focusableQueryKey))?.map(
-          item => item.dataset?.key
-        );
+        return Array.from(subMenu.querySelectorAll<HTMLElement>(focusableQueryKey))?.map<
+          T | undefined
+        >(item => item.dataset?.key as any);
       }
 
       return null;
@@ -297,7 +297,7 @@ export const useFocusItemValue = <T extends number | string>(
       if (nextKeys) {
         setKeys(nextKeys);
         setLayer(nextLayer);
-        setFocusItemValue(nextKeys[0] as T);
+        setFocusItemValue(nextKeys[0]);
         callback?.(nextKeys[0], event);
       }
     },

--- a/src/SelectPicker/SelectPicker.tsx
+++ b/src/SelectPicker/SelectPicker.tsx
@@ -32,14 +32,13 @@ import {
   OverlayTriggerInstance,
   PositionChildProps,
   listPickerPropTypes,
-  PickerComponent
+  PickerInstance
 } from '../Picker';
 
 import { FormControlPickerProps, ItemDataType } from '../@types/common';
 import { ListProps } from 'react-virtualized/dist/commonjs/List';
 
-export type ValueType = number | string;
-export interface SelectProps<T = ValueType> {
+export interface SelectProps<T> {
   /** Set group condition key in data */
   groupBy?: string;
 
@@ -90,14 +89,20 @@ export interface SelectProps<T = ValueType> {
   onClean?: (event: React.SyntheticEvent) => void;
 }
 
-export interface SelectPickerProps<T = ValueType>
-  extends FormControlPickerProps<T, PickerLocale, ItemDataType>,
+export interface SelectPickerProps<T>
+  extends FormControlPickerProps<T, PickerLocale, ItemDataType<T>>,
     SelectProps<T> {}
 
 const emptyArray = [];
 
-const SelectPicker: PickerComponent<SelectPickerProps> = React.forwardRef(
-  (props: SelectPickerProps, ref) => {
+export interface SelectPickerComponent {
+  <T>(props: SelectPickerProps<T>): JSX.Element | null;
+  displayName?: string;
+  propTypes?: React.WeakValidationMap<SelectPickerProps<any>>;
+}
+
+const SelectPicker = React.forwardRef(
+  <T extends number | string>(props: SelectPickerProps<T>, ref: React.Ref<PickerInstance>) => {
     const {
       as: Component = 'div',
       appearance = 'default',
@@ -148,7 +153,11 @@ const SelectPicker: PickerComponent<SelectPickerProps> = React.forwardRef(
     const overlayRef = useRef<HTMLDivElement>(null);
     const searchInputRef = useRef<HTMLInputElement>(null);
     const { locale } = useCustom<PickerLocale>('Picker', overrideLocale);
-    const [value, setValue] = useControlled(valueProp, defaultValue);
+    const [value, setValue] = useControlled(valueProp, defaultValue) as [
+      T | null | undefined,
+      (value: React.SetStateAction<T | null>) => void,
+      boolean
+    ];
 
     // Used to hover the focus item  when trigger `onKeydown`
     const {
@@ -392,7 +401,7 @@ const SelectPicker: PickerComponent<SelectPickerProps> = React.forwardRef(
             disabled={disabled}
             cleanable={cleanable && !disabled}
             hasValue={hasValue}
-            inputValue={value}
+            inputValue={value ?? ''}
             active={active}
             placement={placement}
           >
@@ -402,7 +411,7 @@ const SelectPicker: PickerComponent<SelectPickerProps> = React.forwardRef(
       </PickerToggleTrigger>
     );
   }
-);
+) as SelectPickerComponent;
 
 SelectPicker.displayName = 'SelectPicker';
 SelectPicker.propTypes = {

--- a/src/SelectPicker/test/SelectPicker.test.tsx
+++ b/src/SelectPicker/test/SelectPicker.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { expectType } from 'ts-expect';
+import SelectPicker from '../SelectPicker';
+
+// Infer value and onChange types from data
+const numberValuedData = [{ label: 'One', value: 1 }];
+
+<SelectPicker data={numberValuedData} value={1} />;
+// @ts-expect-error should not accept string value
+<SelectPicker data={numberValuedData} value="1" />;
+<SelectPicker
+  data={numberValuedData}
+  onChange={newValue => {
+    expectType<number>(newValue);
+  }}
+/>;
+
+const stringValuedData = [{ label: 'One', value: 'One' }];
+
+<SelectPicker data={stringValuedData} value="1" />;
+// @ts-expect-error should not accept number value
+<SelectPicker data={stringValuedData} value={1} />;
+<SelectPicker
+  data={stringValuedData}
+  onChange={newValue => {
+    expectType<string>(newValue);
+  }}
+/>;


### PR DESCRIPTION
The value type used to be fixed as `number | string` on `<SelectPicker>`.

![wecom-temp-4c36685ca532bc943b5dbeedb56602c4](https://user-images.githubusercontent.com/8225666/145378304-86ec92f2-0403-4036-b3e2-5661f286b95d.png)

Now `value` and `onChange(value)` types are inferred from `data` prop.
