### PR TITLE
feat(AvatarGroup): add support for AvatarGroup

### DIFF
--- a/docs/less/pages/components/avatar.less
+++ b/docs/less/pages/components/avatar.less
@@ -1,8 +1,0 @@
-.avatar-group {
-  display: flex;
-  align-items: flex-end;
-
-  .rs-avatar {
-    margin-left: 10px;
-  }
-}

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -181,10 +181,14 @@ module.exports = {
     // preventing "more than one copy of React" error
     if (__USE_SRC__) {
       Object.assign(config.resolve.alias, {
+        rsuite: path.resolve(__dirname, '../src'),
         react: path.resolve(__dirname, './node_modules/react'),
         'react-dom': path.resolve(__dirname, './node_modules/react-dom')
       });
     }
+
+    console.log(VERCEL_ENV);
+    console.dir(config.resolve.alias);
 
     return config;
   },

--- a/docs/pages/components/avatar/en-US/index.md
+++ b/docs/pages/components/avatar/en-US/index.md
@@ -12,27 +12,31 @@ Used to display an avatar or brand.
 
 <!--{include:`basic.md`}-->
 
-### Text
+### Character avatar
 
 You can change the `<Avatar>` background color and font color by `style`;
 
 <!--{include:`text.md`}-->
 
-### With Icon
+### Icon avatars
 
 <!--{include:`icon.md`}-->
 
-### Image avatar
+### Image avatars
 
 You can set `alt` for `<Avatar>` , it make sure avatar show pure text avatar when image load failed.
 
 <!--{include:`image.md`}-->
 
-### Size
+### Sizes
 
 <!--{include:`size.md`}-->
 
-### Badge
+### Stacked avatars
+
+<!--{include:`stack.md`}-->
+
+### With badge
 
 <!--{include:`badge.md`}-->
 
@@ -51,3 +55,11 @@ You can set `alt` for `<Avatar>` , it make sure avatar show pure text avatar whe
 | sizes       | string                                            | The `sizes` attribute for the `img` element.                                                   |
 | src         | string                                            | The `src` attribute for the `img` element.                                                     |
 | srcSet      | string                                            | The `srcSet` attribute for the `img` element. Use this attribute for responsive image display. |
+
+### `<AvatarGroup>`
+
+| Property | Type`(Default)`                          | Description                    |
+| -------- | ---------------------------------------- | ------------------------------ |
+| size     | enum: 'lg'&#124;'md'&#124;'sm'&#124;'xs' | Set the size of all avatars    |
+| spacing  | number                                   | Set the spacing of the avatars |
+| stack    | boolean                                  | Render all avatars as stacks   |

--- a/docs/pages/components/avatar/fragments/badge.md
+++ b/docs/pages/components/avatar/fragments/badge.md
@@ -2,19 +2,15 @@
 
 ```js
 const instance = (
-  <div className="avatar-group">
+  <AvatarGroup>
     <Badge>
-      <Avatar>
-        <Icon as={AvatarIcon} />
-      </Avatar>
+      <Avatar src="https://avatars.githubusercontent.com/u/12592949" alt="@superman66" />
     </Badge>
 
     <Badge content="20">
-      <Avatar>
-        <Icon as={AvatarIcon} />
-      </Avatar>
+      <Avatar src="https://avatars.githubusercontent.com/u/8225666" alt="@SevenOutman" />
     </Badge>
-  </div>
+  </AvatarGroup>
 );
 
 ReactDOM.render(instance);

--- a/docs/pages/components/avatar/fragments/basic.md
+++ b/docs/pages/components/avatar/fragments/basic.md
@@ -2,7 +2,7 @@
 
 ```js
 const instance = (
-  <AvatarGroup gap={6}>
+  <AvatarGroup spacing={6}>
     <Avatar src="https://avatars.githubusercontent.com/u/12592949" alt="@superman66" />
     <Avatar src="https://avatars.githubusercontent.com/u/8225666" alt="@SevenOutman" />
   </AvatarGroup>

--- a/docs/pages/components/avatar/fragments/basic.md
+++ b/docs/pages/components/avatar/fragments/basic.md
@@ -1,21 +1,11 @@
 <!--start-code-->
 
 ```js
-/**
- * .avatar-group{
- *   display: flex;
- *   align-items: flex-end;
- * }
- *
- * .avatar-group .rs-avatar {
- *   margin-left: 10px;
- * }
- */
 const instance = (
-  <div className="avatar-group">
-    <Avatar>RS</Avatar>
-    <Avatar circle>RS</Avatar>
-  </div>
+  <AvatarGroup gap={6}>
+    <Avatar src="https://avatars.githubusercontent.com/u/12592949" alt="@superman66" />
+    <Avatar src="https://avatars.githubusercontent.com/u/8225666" alt="@SevenOutman" />
+  </AvatarGroup>
 );
 
 ReactDOM.render(instance);

--- a/docs/pages/components/avatar/fragments/icon.md
+++ b/docs/pages/components/avatar/fragments/icon.md
@@ -2,14 +2,16 @@
 
 ```js
 const instance = (
-  <div className="avatar-group">
+  <AvatarGroup gap={6}>
     <Avatar>
       <User />
     </Avatar>
     <Avatar>
       <Icon as={AvatarIcon} />
     </Avatar>
-  </div>
+    <Avatar>🙂</Avatar>
+    <Avatar>👍</Avatar>
+  </AvatarGroup>
 );
 
 ReactDOM.render(instance);

--- a/docs/pages/components/avatar/fragments/icon.md
+++ b/docs/pages/components/avatar/fragments/icon.md
@@ -2,7 +2,7 @@
 
 ```js
 const instance = (
-  <AvatarGroup gap={6}>
+  <AvatarGroup spacing={6}>
     <Avatar>
       <User />
     </Avatar>

--- a/docs/pages/components/avatar/fragments/image.md
+++ b/docs/pages/components/avatar/fragments/image.md
@@ -2,11 +2,18 @@
 
 ```js
 const instance = (
-  <div className="avatar-group">
-    <Avatar src="https://404.error" alt="RS" />
-    <Avatar src="https://avatars2.githubusercontent.com/u/12592949?s=460&v=4" />
-    <Avatar circle src="https://avatars2.githubusercontent.com/u/12592949?s=460&v=4" />
-  </div>
+  <AvatarGroup gap={6}>
+    <Avatar circle src="https://avatars.githubusercontent.com/u/12592949" alt="@superman66" />
+    <Avatar circle src="https://avatars.githubusercontent.com/u/8225666" alt="@SevenOutman" />
+    <Avatar circle src="https://avatars.githubusercontent.com/u/15609339" alt="@hiyangguo" />
+    <Avatar circle src="https://avatars.githubusercontent.com/u/14308293" alt="@MarvelSQ" />
+    <Avatar circle src="https://avatars.githubusercontent.com/u/1203827" alt="@simonguo" />
+    <Avatar circle src="https://avatars.githubusercontent.com/u/9625224" alt="@theJian" />
+    <Avatar circle src="https://avatars.githubusercontent.com/u/15884443" alt="@LeightonYao" />
+    <Avatar circle src="https://avatars.githubusercontent.com/u/10924138" alt="@zmhawk" />
+    <Avatar circle src="https://avatars.githubusercontent.com/u/2797600" alt="@posebear1990" />
+    <Avatar circle src="https://avatars.githubusercontent.com/u/23637144" alt="@Sleaf" />
+  </AvatarGroup>
 );
 
 ReactDOM.render(instance);

--- a/docs/pages/components/avatar/fragments/image.md
+++ b/docs/pages/components/avatar/fragments/image.md
@@ -2,7 +2,7 @@
 
 ```js
 const instance = (
-  <AvatarGroup gap={6}>
+  <AvatarGroup spacing={6}>
     <Avatar circle src="https://avatars.githubusercontent.com/u/12592949" alt="@superman66" />
     <Avatar circle src="https://avatars.githubusercontent.com/u/8225666" alt="@SevenOutman" />
     <Avatar circle src="https://avatars.githubusercontent.com/u/15609339" alt="@hiyangguo" />

--- a/docs/pages/components/avatar/fragments/import.md
+++ b/docs/pages/components/avatar/fragments/import.md
@@ -1,6 +1,7 @@
 ```js
-import { Avatar } from 'rsuite';
+import { Avatar, AvatarGroup } from 'rsuite';
 
 // or
 import Avatar from 'rsuite/Avatar';
+import AvatarGroup from 'rsuite/AvatarGroup';
 ```

--- a/docs/pages/components/avatar/fragments/size.md
+++ b/docs/pages/components/avatar/fragments/size.md
@@ -3,7 +3,7 @@
 ```js
 const instance = (
   <div>
-    <AvatarGroup gap={6}>
+    <AvatarGroup spacing={6}>
       <Avatar
         size="lg"
         circle

--- a/docs/pages/components/avatar/fragments/stack.md
+++ b/docs/pages/components/avatar/fragments/stack.md
@@ -3,36 +3,7 @@
 ```js
 const instance = (
   <div>
-    <AvatarGroup gap={6}>
-      <Avatar
-        size="lg"
-        circle
-        src="https://avatars.githubusercontent.com/u/12592949"
-        alt="@SevenOutman"
-      />
-      <Avatar
-        size="md"
-        circle
-        src="https://avatars.githubusercontent.com/u/12592949"
-        alt="@SevenOutman"
-      />
-      <Avatar
-        size="sm"
-        circle
-        src="https://avatars.githubusercontent.com/u/12592949"
-        alt="@SevenOutman"
-      />
-      <Avatar
-        size="xs"
-        circle
-        src="https://avatars.githubusercontent.com/u/12592949"
-        alt="@SevenOutman"
-      />
-    </AvatarGroup>
-
-    <hr />
-
-    <AvatarGroup size="xs">
+    <AvatarGroup stack>
       <Avatar circle src="https://avatars.githubusercontent.com/u/12592949" alt="@superman66" />
       <Avatar circle src="https://avatars.githubusercontent.com/u/8225666" alt="@SevenOutman" />
       <Avatar circle src="https://avatars.githubusercontent.com/u/15609339" alt="@hiyangguo" />
@@ -43,6 +14,18 @@ const instance = (
       <Avatar circle src="https://avatars.githubusercontent.com/u/10924138" alt="@zmhawk" />
       <Avatar circle src="https://avatars.githubusercontent.com/u/2797600" alt="@posebear1990" />
       <Avatar circle src="https://avatars.githubusercontent.com/u/23637144" alt="@Sleaf" />
+    </AvatarGroup>
+
+    <hr />
+    <AvatarGroup stack>
+      <Avatar circle src="https://avatars.githubusercontent.com/u/12592949" alt="@superman66" />
+      <Avatar circle src="https://avatars.githubusercontent.com/u/8225666" alt="@SevenOutman" />
+      <Avatar circle src="https://avatars.githubusercontent.com/u/15609339" alt="@hiyangguo" />
+      <Avatar circle src="https://avatars.githubusercontent.com/u/14308293" alt="@MarvelSQ" />
+      <Avatar circle src="https://avatars.githubusercontent.com/u/1203827" alt="@simonguo" />
+      <Avatar circle style={{ background: '#111' }}>
+        +4
+      </Avatar>
     </AvatarGroup>
   </div>
 );

--- a/docs/pages/components/avatar/fragments/stack.md
+++ b/docs/pages/components/avatar/fragments/stack.md
@@ -1,30 +1,39 @@
 <!--start-code-->
 
 ```js
+const users = [
+  { avatar: 'https://avatars.githubusercontent.com/u/12592949', name: 'superman66' },
+  { avatar: 'https://avatars.githubusercontent.com/u/8225666', name: 'SevenOutman' },
+  { avatar: 'https://avatars.githubusercontent.com/u/15609339', name: 'hiyangguo' },
+  { avatar: 'https://avatars.githubusercontent.com/u/14308293', name: 'MarvelSQ' },
+  { avatar: 'https://avatars.githubusercontent.com/u/1203827', name: 'simonguo' },
+  { avatar: 'https://avatars.githubusercontent.com/u/9625224', name: 'theJian' },
+  { avatar: 'https://avatars.githubusercontent.com/u/15884443', name: 'LeightonYao' },
+  { avatar: 'https://avatars.githubusercontent.com/u/10924138', name: 'zmhawk' },
+  { avatar: 'https://avatars.githubusercontent.com/u/2797600', name: 'posebear1990' },
+  { avatar: 'https://avatars.githubusercontent.com/u/23637144', name: 'Sleaf' }
+];
+
+const max = 4;
+
 const instance = (
   <div>
     <AvatarGroup stack>
-      <Avatar circle src="https://avatars.githubusercontent.com/u/12592949" alt="@superman66" />
-      <Avatar circle src="https://avatars.githubusercontent.com/u/8225666" alt="@SevenOutman" />
-      <Avatar circle src="https://avatars.githubusercontent.com/u/15609339" alt="@hiyangguo" />
-      <Avatar circle src="https://avatars.githubusercontent.com/u/14308293" alt="@MarvelSQ" />
-      <Avatar circle src="https://avatars.githubusercontent.com/u/1203827" alt="@simonguo" />
-      <Avatar circle src="https://avatars.githubusercontent.com/u/9625224" alt="@theJian" />
-      <Avatar circle src="https://avatars.githubusercontent.com/u/15884443" alt="@LeightonYao" />
-      <Avatar circle src="https://avatars.githubusercontent.com/u/10924138" alt="@zmhawk" />
-      <Avatar circle src="https://avatars.githubusercontent.com/u/2797600" alt="@posebear1990" />
-      <Avatar circle src="https://avatars.githubusercontent.com/u/23637144" alt="@Sleaf" />
+      {users.map(user => (
+        <Avatar circle key={user.name} src={user.avatar} alt={user.name} />
+      ))}
     </AvatarGroup>
 
     <hr />
+
     <AvatarGroup stack>
-      <Avatar circle src="https://avatars.githubusercontent.com/u/12592949" alt="@superman66" />
-      <Avatar circle src="https://avatars.githubusercontent.com/u/8225666" alt="@SevenOutman" />
-      <Avatar circle src="https://avatars.githubusercontent.com/u/15609339" alt="@hiyangguo" />
-      <Avatar circle src="https://avatars.githubusercontent.com/u/14308293" alt="@MarvelSQ" />
-      <Avatar circle src="https://avatars.githubusercontent.com/u/1203827" alt="@simonguo" />
+      {users
+        .filter((user, i) => i < max)
+        .map(user => (
+          <Avatar circle key={user.name} src={user.avatar} alt={user.name} />
+        ))}
       <Avatar circle style={{ background: '#111' }}>
-        +4
+        +{users.length - max}
       </Avatar>
     </AvatarGroup>
   </div>

--- a/docs/pages/components/avatar/fragments/text.md
+++ b/docs/pages/components/avatar/fragments/text.md
@@ -2,11 +2,21 @@
 
 ```js
 const instance = (
-  <div className="avatar-group">
-    <Avatar>RS</Avatar>
-    <Avatar style={{ background: '#7B1FA2' }}>RS</Avatar>
-    <Avatar style={{ background: '#edfae1', color: '#4caf50' }}>RS</Avatar>
-  </div>
+  <AvatarGroup gap={6}>
+    <Avatar style={{ background: '#000' }}>R</Avatar>
+    <Avatar style={{ background: '#7B1FA2' }}>Suite</Avatar>
+    <Avatar style={{ background: '#004299' }}>👍</Avatar>
+
+    <Avatar circle style={{ background: '#000' }}>
+      R
+    </Avatar>
+    <Avatar circle style={{ background: '#7B1FA2' }}>
+      Suite
+    </Avatar>
+    <Avatar circle style={{ background: '#004299' }}>
+      👍
+    </Avatar>
+  </AvatarGroup>
 );
 
 ReactDOM.render(instance);

--- a/docs/pages/components/avatar/fragments/text.md
+++ b/docs/pages/components/avatar/fragments/text.md
@@ -2,7 +2,7 @@
 
 ```js
 const instance = (
-  <AvatarGroup gap={6}>
+  <AvatarGroup spacing={6}>
     <Avatar style={{ background: '#000' }}>R</Avatar>
     <Avatar style={{ background: '#7B1FA2' }}>Suite</Avatar>
     <Avatar style={{ background: '#004299' }}>👍</Avatar>

--- a/docs/pages/components/avatar/index.tsx
+++ b/docs/pages/components/avatar/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Avatar, Badge } from 'rsuite';
+import { Avatar, AvatarGroup, Badge } from 'rsuite';
 import DefaultPage from '@/components/Page';
 import { Avatar as AvatarIcon } from '@/components/SvgIcons';
 import User from '@rsuite/icons/legacy/User';
 import { Icon } from '@rsuite/icons';
 
 export default function Page() {
-  return <DefaultPage dependencies={{ Avatar, Badge, AvatarIcon, User, Icon }} />;
+  return <DefaultPage dependencies={{ Avatar, AvatarGroup, Badge, AvatarIcon, User, Icon }} />;
 }

--- a/docs/pages/components/avatar/zh-CN/index.md
+++ b/docs/pages/components/avatar/zh-CN/index.md
@@ -12,17 +12,17 @@
 
 <!--{include:`basic.md`}-->
 
-### 文字
+### 字符头像
 
-您可以使用 `style` 来改变 `<Avatar>` 的背景色和文字颜色。
+You can create an avatar component containing simple characters, and change the background color and text color of `<Avatar>` by using `style`.
 
 <!--{include:`text.md`}-->
 
-### 图标
+### 图标头像
 
 <!--{include:`icon.md`}-->
 
-### 图片
+### 图片头像
 
 您可以为 `<Avatar>` 设置 `alt` 以确保当图片加载失败时，依然可以显示文字版本的头像
 
@@ -32,7 +32,11 @@
 
 <!--{include:`size.md`}-->
 
-### 徽标
+### 堆积的头像组
+
+<!--{include:`stack.md`}-->
+
+### 带有徽标的头像
 
 <!--{include:`badge.md`}-->
 
@@ -51,3 +55,11 @@
 | sizes       | string                                            | img 元素的 sizes 属性。                                 |
 | src         | string                                            | img 元素的 src 属性, 设置头像图片地址。                 |
 | srcSet      | string                                            | img 元素的 srcSet 属性。 使用此属性进行响应式图像显示。 |
+
+### `<AvatarGroup>`
+
+| 属性名称 | 类型`(默认值)`                           | 描述                       |
+| -------- | ---------------------------------------- | -------------------------- |
+| size     | enum: 'lg'&#124;'md'&#124;'sm'&#124;'xs' | 为一组的头像设置尺寸       |
+| spacing  | number                                   | 为一组的头像设置间距       |
+| stack    | boolean                                  | 把一组头像以堆栈的方式显示 |

--- a/docs/tsconfig.local.json
+++ b/docs/tsconfig.local.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "paths": {
       "@/*": ["./*"],
-      "rsuite/*": ["../src/*"]
+      "rsuite": ["../src"],
+      "rsuite/*": ["../src/*"],
+      "react": ["./node_modules/@types/react"]
     },
     "incremental": true
   }

--- a/docs/utils/component.config.json
+++ b/docs/utils/component.config.json
@@ -14,11 +14,7 @@
     "id": "button",
     "name": "Button",
     "title": "按钮",
-    "components": [
-      "Button",
-      "ButtonGroup",
-      "IconButton"
-    ],
+    "components": ["Button", "ButtonGroup", "IconButton"],
     "designHash": {
       "default": "1",
       "dark": "1"
@@ -28,12 +24,7 @@
     "id": "drawer",
     "name": "Drawer",
     "title": "抽屉",
-    "components": [
-      "Drawer",
-      "Drawer.Header",
-      "Drawer.Body",
-      "Drawer.Footer"
-    ],
+    "components": ["Drawer", "Drawer.Header", "Drawer.Body", "Drawer.Footer"],
     "designHash": {
       "default": "16",
       "dark": "16"
@@ -43,9 +34,7 @@
     "id": "divider",
     "name": "Divider",
     "title": "分割线",
-    "components": [
-      "Divider"
-    ],
+    "components": ["Divider"],
     "designHash": {
       "default": "22",
       "dark": "22"
@@ -60,9 +49,7 @@
     "id": "loader",
     "name": "Loader",
     "title": "加载器",
-    "components": [
-      "Loader"
-    ],
+    "components": ["Loader"],
     "designHash": {
       "default": "12",
       "dark": "12"
@@ -72,9 +59,7 @@
     "id": "message",
     "name": "Message",
     "title": "消息框",
-    "components": [
-      "Message"
-    ],
+    "components": ["Message"],
     "designHash": {
       "default": "13",
       "dark": null
@@ -84,12 +69,7 @@
     "id": "modal",
     "name": "Modal",
     "title": "模态框",
-    "components": [
-      "Modal",
-      "Modal.Header",
-      "Modal.Body",
-      "Modal.Footer"
-    ],
+    "components": ["Modal", "Modal.Header", "Modal.Body", "Modal.Footer"],
     "designHash": {
       "default": "14",
       "dark": "14"
@@ -99,9 +79,7 @@
     "id": "notification",
     "name": "Notification",
     "title": "通知框",
-    "components": [
-      "Notification"
-    ],
+    "components": ["Notification"],
     "designHash": {
       "default": "11",
       "dark": "11"
@@ -111,10 +89,7 @@
     "id": "tooltip",
     "name": "Tooltip",
     "title": "文字提示",
-    "components": [
-      "Tooltip",
-      "Whisper"
-    ],
+    "components": ["Tooltip", "Whisper"],
     "designHash": {
       "default": "9",
       "dark": "9"
@@ -124,10 +99,7 @@
     "id": "popover",
     "name": "Popover",
     "title": "弹出框",
-    "components": [
-      "Popover",
-      "Whisper"
-    ],
+    "components": ["Popover", "Whisper"],
     "designHash": {
       "default": "10",
       "dark": "10"
@@ -137,10 +109,7 @@
     "id": "progress",
     "name": "Progress",
     "title": "进度条",
-    "components": [
-      "Progress.Line",
-      "Progress.Circle"
-    ],
+    "components": ["Progress.Line", "Progress.Circle"],
     "designHash": {
       "default": "23",
       "dark": "23"
@@ -150,11 +119,7 @@
     "id": "placeholder",
     "name": "Placeholder",
     "title": "占位符",
-    "components": [
-      "Placeholder.Graph",
-      "Placeholder.Grid",
-      "Placeholder.Paragraph"
-    ],
+    "components": ["Placeholder.Graph", "Placeholder.Grid", "Placeholder.Paragraph"],
     "designHash": {
       "default": "24",
       "dark": "24"
@@ -170,18 +135,13 @@
     "id": "affix",
     "name": "Affix",
     "title": "固定位置",
-    "components": [
-      "Affix"
-    ]
+    "components": ["Affix"]
   },
   {
     "id": "breadcrumb",
     "name": "Breadcrumb",
     "title": "面包屑",
-    "components": [
-      "Breadcrumb",
-      "Breadcrumb.Item"
-    ],
+    "components": ["Breadcrumb", "Breadcrumb.Item"],
     "designHash": {
       "default": "37",
       "dark": "37"
@@ -191,11 +151,7 @@
     "id": "dropdown",
     "name": "Dropdown",
     "title": "下拉菜单",
-    "components": [
-      "Dropdown",
-      "Dropdown.Item",
-      "Dropdown.Menu"
-    ],
+    "components": ["Dropdown", "Dropdown.Item", "Dropdown.Menu"],
     "designHash": {
       "default": "27",
       "dark": "27"
@@ -205,11 +161,7 @@
     "id": "nav",
     "name": "Nav",
     "title": "导航",
-    "components": [
-      "Nav",
-      "Nav.Item",
-      "Nav.Dropdown"
-    ],
+    "components": ["Nav", "Nav.Item", "Nav.Dropdown"],
     "designHash": {
       "default": "28",
       "dark": "28"
@@ -219,12 +171,7 @@
     "id": "navbar",
     "name": "Navbar",
     "title": "导航栏",
-    "components": [
-      "Navbar",
-      "Navbar.Header",
-      "Navbar.Brand",
-      "Navbar.Body"
-    ],
+    "components": ["Navbar", "Navbar.Header", "Navbar.Brand", "Navbar.Body"],
     "designHash": {
       "default": "30",
       "dark": "30"
@@ -234,11 +181,7 @@
     "id": "sidenav",
     "name": "Sidenav",
     "title": "侧导航",
-    "components": [
-      "Sidenav",
-      "Sidenav.Header",
-      "Sidenav.Body"
-    ],
+    "components": ["Sidenav", "Sidenav.Header", "Sidenav.Body"],
     "designHash": {
       "default": "31",
       "dark": "31"
@@ -248,10 +191,7 @@
     "id": "steps",
     "name": "Steps",
     "title": "步骤条",
-    "components": [
-      "Steps",
-      "Steps.Item"
-    ],
+    "components": ["Steps", "Steps.Item"],
     "designHash": {
       "default": "35",
       "dark": "35"
@@ -261,9 +201,7 @@
     "id": "pagination",
     "name": "Pagination",
     "title": "分页",
-    "components": [
-      "Pagination"
-    ],
+    "components": ["Pagination"],
     "designHash": {
       "default": "36",
       "dark": "36"
@@ -279,32 +217,19 @@
     "id": "container",
     "name": "Container",
     "title": "容器布局",
-    "components": [
-      "Container",
-      "Header",
-      "Footer",
-      "Content",
-      "Sidebar"
-    ]
+    "components": ["Container", "Header", "Footer", "Content", "Sidebar"]
   },
   {
     "id": "flexbox-grid",
     "name": "FlexboxGrid",
     "title": "弹性栅格",
-    "components": [
-      "FlexboxGrid",
-      "FlexboxGrid.Item"
-    ]
+    "components": ["FlexboxGrid", "FlexboxGrid.Item"]
   },
   {
     "id": "grid",
     "name": "Grid",
     "title": "栅格",
-    "components": [
-      "Grid",
-      "Row",
-      "Col"
-    ]
+    "components": ["Grid", "Row", "Col"]
   },
   {
     "group": true,
@@ -316,9 +241,7 @@
     "id": "auto-complete",
     "name": "AutoComplete",
     "title": "自动完成控件",
-    "components": [
-      "AutoComplete"
-    ],
+    "components": ["AutoComplete"],
     "designHash": {
       "default": "50",
       "dark": "50"
@@ -328,9 +251,7 @@
     "id": "cascader",
     "name": "Cascader",
     "title": "级联选择器",
-    "components": [
-      "Cascader"
-    ],
+    "components": ["Cascader"],
     "designHash": {
       "default": "60",
       "dark": "60"
@@ -340,9 +261,7 @@
     "id": "check-picker",
     "name": "CheckPicker",
     "title": "多项选择器",
-    "components": [
-      "CheckPicker"
-    ],
+    "components": ["CheckPicker"],
     "designHash": {
       "default": "55",
       "dark": "55"
@@ -352,9 +271,7 @@
     "id": "check-tree-picker",
     "name": "CheckTreePicker",
     "title": "树形多项选择器",
-    "components": [
-      "CheckTreePicker"
-    ],
+    "components": ["CheckTreePicker"],
     "designHash": {
       "default": "58",
       "dark": "58"
@@ -364,10 +281,7 @@
     "id": "checkbox",
     "name": "Checkbox",
     "title": "复选框",
-    "components": [
-      "Checkbox",
-      "CheckboxGroup"
-    ],
+    "components": ["Checkbox", "CheckboxGroup"],
     "designHash": {
       "default": "43",
       "dark": "43"
@@ -377,9 +291,7 @@
     "id": "date-picker",
     "name": "DatePicker",
     "title": "日期选择器",
-    "components": [
-      "DatePicker"
-    ],
+    "components": ["DatePicker"],
     "designHash": {
       "default": "63",
       "dark": "63"
@@ -389,9 +301,7 @@
     "id": "date-range-picker",
     "name": "DateRangePicker",
     "title": "日期范围选择器",
-    "components": [
-      "DateRangePicker"
-    ],
+    "components": ["DateRangePicker"],
     "designHash": {
       "default": "68",
       "dark": "68"
@@ -401,13 +311,7 @@
     "id": "form",
     "name": "Form",
     "title": "表单",
-    "components": [
-      "Form",
-      "FormControl",
-      "FormGroup",
-      "ControlLabel",
-      "HelpBlock"
-    ],
+    "components": ["Form", "FormControl", "FormGroup", "ControlLabel", "HelpBlock"],
     "designHash": {
       "default": "38",
       "dark": "38"
@@ -417,22 +321,13 @@
     "id": "form-validation",
     "name": "Form Validation",
     "title": "表单校验",
-    "components": [
-      "Form",
-      "FormControl",
-      "Schema"
-    ]
+    "components": ["Form", "FormControl", "Schema"]
   },
   {
     "id": "input",
     "name": "Input",
     "title": "输入框",
-    "components": [
-      "Input",
-      "InputGroup",
-      "InputGroup.Button",
-      "InputGroup.Addon"
-    ],
+    "components": ["Input", "InputGroup", "InputGroup.Button", "InputGroup.Addon"],
     "designHash": {
       "default": "46",
       "dark": "46"
@@ -442,9 +337,7 @@
     "id": "input-number",
     "name": "InputNumber",
     "title": "数字输入框",
-    "components": [
-      "InputNumber"
-    ],
+    "components": ["InputNumber"],
     "designHash": {
       "default": "49",
       "dark": "49"
@@ -454,9 +347,7 @@
     "id": "input-picker",
     "name": "InputPicker",
     "title": "输入选择器",
-    "components": [
-      "InputPicker"
-    ],
+    "components": ["InputPicker"],
     "designHash": {
       "default": "52",
       "dark": "52"
@@ -466,9 +357,7 @@
     "id": "multi-cascader",
     "name": "MultiCascader",
     "title": "级联多项选择器",
-    "components": [
-      "MultiCascader"
-    ],
+    "components": ["MultiCascader"],
     "designHash": {
       "default": "61",
       "dark": "61"
@@ -478,10 +367,7 @@
     "id": "radio",
     "name": "Radio",
     "title": "单选框",
-    "components": [
-      "Radio",
-      "RadioGroup"
-    ],
+    "components": ["Radio", "RadioGroup"],
     "designHash": {
       "default": "44",
       "dark": "44"
@@ -491,9 +377,7 @@
     "id": "rate",
     "name": "Rate",
     "title": "评分",
-    "components": [
-      "Rate"
-    ],
+    "components": ["Rate"],
     "designHash": {
       "default": "73",
       "dark": "72"
@@ -503,9 +387,7 @@
     "id": "select-picker",
     "name": "SelectPicker",
     "title": "单项选择器",
-    "components": [
-      "SelectPicker"
-    ],
+    "components": ["SelectPicker"],
     "designHash": {
       "default": "54",
       "dark": "54"
@@ -515,10 +397,7 @@
     "id": "slider",
     "name": "Slider",
     "title": "滑动输入控件",
-    "components": [
-      "Slider",
-      "RangeSlider"
-    ],
+    "components": ["Slider", "RangeSlider"],
     "designHash": {
       "default": "71",
       "dark": "70"
@@ -528,9 +407,7 @@
     "id": "tag-picker",
     "name": "TagPicker",
     "title": "标签选择器",
-    "components": [
-      "TagPicker"
-    ],
+    "components": ["TagPicker"],
     "designHash": {
       "default": "53",
       "dark": "53"
@@ -540,17 +417,13 @@
     "id": "tag-input",
     "name": "TagInput",
     "title": "标签输入",
-    "components": [
-      "TagInput"
-    ]
+    "components": ["TagInput"]
   },
   {
     "id": "toggle",
     "name": "Toggle",
     "title": "开关",
-    "components": [
-      "Toggle"
-    ],
+    "components": ["Toggle"],
     "designHash": {
       "default": "51",
       "dark": "51"
@@ -560,9 +433,7 @@
     "id": "tree-picker",
     "name": "TreePicker",
     "title": "树形单项选择器",
-    "components": [
-      "TreePicker"
-    ],
+    "components": ["TreePicker"],
     "designHash": {
       "default": "57",
       "dark": "57"
@@ -572,9 +443,7 @@
     "id": "uploader",
     "name": "Uploader",
     "title": "上传控件",
-    "components": [
-      "Uploader"
-    ],
+    "components": ["Uploader"],
     "designHash": {
       "default": "72",
       "dark": "71"
@@ -590,9 +459,7 @@
     "id": "avatar",
     "name": "Avatar",
     "title": "头像",
-    "components": [
-      "Avatar"
-    ],
+    "components": ["Avatar", "AvatarGroup"],
     "designHash": {
       "default": "76",
       "dark": "74"
@@ -602,9 +469,7 @@
     "id": "badge",
     "name": "Badge",
     "title": "徽标",
-    "components": [
-      "Badge"
-    ],
+    "components": ["Badge"],
     "designHash": {
       "default": "75",
       "dark": "75"
@@ -614,9 +479,7 @@
     "id": "calendar",
     "name": "Calendar",
     "title": "日历",
-    "components": [
-      "Calendar"
-    ],
+    "components": ["Calendar"],
     "designHash": {
       "default": "93",
       "dark": "91"
@@ -626,9 +489,7 @@
     "id": "carousel",
     "name": "Carousel",
     "title": "轮播",
-    "components": [
-      "Carousel"
-    ],
+    "components": ["Carousel"],
     "designHash": {
       "default": "92",
       "dark": "90"
@@ -638,18 +499,13 @@
     "id": "check-tree",
     "name": "CheckTree",
     "title": "树形多选控件",
-    "components": [
-      "CheckTree"
-    ]
+    "components": ["CheckTree"]
   },
   {
     "id": "list",
     "name": "List",
     "title": "列表",
-    "components": [
-      "List",
-      "List.Item"
-    ],
+    "components": ["List", "List.Item"],
     "designHash": {
       "default": "90",
       "dark": "88"
@@ -659,12 +515,7 @@
     "id": "table",
     "name": "Table",
     "title": "表格",
-    "components": [
-      "Table",
-      "Table.Column",
-      "Table.HeaderCell",
-      "Table.Cell"
-    ],
+    "components": ["Table", "Table.Column", "Table.HeaderCell", "Table.Cell"],
     "designHash": {
       "default": "77",
       "dark": "76"
@@ -674,9 +525,7 @@
     "id": "tag",
     "name": "Tag",
     "title": "标签",
-    "components": [
-      "Tag"
-    ],
+    "components": ["Tag"],
     "designHash": {
       "default": "89",
       "dark": "87"
@@ -686,18 +535,13 @@
     "id": "tree",
     "name": "Tree",
     "title": "树形控件",
-    "components": [
-      "Tree"
-    ]
+    "components": ["Tree"]
   },
   {
     "id": "timeline",
     "name": "Timeline",
     "title": "时间轴",
-    "components": [
-      "Timeline",
-      "Timeline.Item"
-    ],
+    "components": ["Timeline", "Timeline.Item"],
     "designHash": {
       "default": "87",
       "dark": "85"
@@ -707,10 +551,7 @@
     "id": "panel",
     "name": "Panel",
     "title": "面板",
-    "components": [
-      "Panel",
-      "PanelGroup"
-    ],
+    "components": ["Panel", "PanelGroup"],
     "designHash": {
       "default": "86",
       "dark": "84"
@@ -738,24 +579,19 @@
     "id": "custom-provider",
     "name": "CustomProvider",
     "title": "个性化配置",
-    "apis": [
-      "CustomProvider"
-    ]
-  },{
+    "apis": ["CustomProvider"]
+  },
+  {
     "id": "dom-helper",
     "name": "DOMHelper",
     "title": "DOM 助手",
-    "apis": [
-      "DOMHelper"
-    ]
+    "apis": ["DOMHelper"]
   },
   {
     "id": "whisper",
     "name": "Whisper",
     "title": "弹窗触发器",
-    "components": [
-      "Whisper"
-    ]
+    "components": ["Whisper"]
   },
   {
     "id": "schema",

--- a/src/Avatar/Avatar.tsx
+++ b/src/Avatar/Avatar.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useClassNames } from '../utils';
 import { TypeAttributes, WithAsProps, RsRefForwardingComponent } from '../@types/common';
+import { AvatarGroupContext } from '../AvatarGroup/AvatarGroup';
 
 export interface AvatarProps extends WithAsProps {
   /** A avatar can have different sizes */
@@ -41,7 +42,7 @@ const Avatar: RsRefForwardingComponent<'div', AvatarProps> = React.forwardRef(
     const {
       classPrefix = 'avatar',
       as: Component = 'div',
-      size,
+      size: sizeProp,
       className,
       children,
       src,
@@ -53,13 +54,9 @@ const Avatar: RsRefForwardingComponent<'div', AvatarProps> = React.forwardRef(
       ...rest
     } = props;
 
+    const { size } = useContext(AvatarGroupContext);
     const { withClassPrefix, prefix, merge } = useClassNames(classPrefix);
-    const classes = merge(
-      className,
-      withClassPrefix(size, {
-        circle
-      })
-    );
+    const classes = merge(className, withClassPrefix(sizeProp || size, { circle }));
 
     return (
       <Component {...rest} ref={ref} className={classes}>

--- a/src/Avatar/styles/index.less
+++ b/src/Avatar/styles/index.less
@@ -9,6 +9,8 @@
   align-items: center;
   border-radius: 4px;
   overflow: hidden;
+  position: relative;
+
   .avatar-md();
 
   & > .rs-icon {
@@ -16,8 +18,6 @@
   }
 
   &-image {
-    position: relative;
-
     &::before {
       content: attr(alt);
       position: absolute;

--- a/src/AvatarGroup/AvatarGroup.tsx
+++ b/src/AvatarGroup/AvatarGroup.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useClassNames, useCustom } from '../utils';
+import { TypeAttributes, WithAsProps, RsRefForwardingComponent } from '../@types/common';
+
+export interface AvatarGroupProps extends WithAsProps {
+  /** Render all avatars as stacks */
+  stack?: boolean;
+
+  /** Set the spacing of the avatar */
+  spacing?: number;
+
+  /** Set the size of all avatars. */
+  size?: TypeAttributes.Size;
+}
+
+export const AvatarGroupContext = React.createContext<{ size?: TypeAttributes.Size }>({});
+
+const AvatarGroup: RsRefForwardingComponent<'div', AvatarGroupProps> = React.forwardRef(
+  (props: AvatarGroupProps, ref) => {
+    const {
+      as: Component = 'div',
+      classPrefix = 'avatar-group',
+      spacing,
+      className,
+      children,
+      stack,
+      size,
+      ...rest
+    } = props;
+
+    const { rtl } = useCustom('AvatarGroup');
+    const { withClassPrefix, merge } = useClassNames(classPrefix);
+    const classes = merge(className, withClassPrefix({ stack }));
+
+    return (
+      <Component {...rest} ref={ref} className={classes}>
+        <AvatarGroupContext.Provider value={{ size }}>
+          {spacing
+            ? React.Children.map(children as React.ReactElement[], child => {
+                return React.cloneElement(child, {
+                  style: { [rtl ? 'marginLeft' : 'marginRight']: spacing, ...child.props.style }
+                });
+              })
+            : children}
+        </AvatarGroupContext.Provider>
+      </Component>
+    );
+  }
+);
+
+AvatarGroup.displayName = 'AvatarGroup';
+AvatarGroup.propTypes = {
+  as: PropTypes.elementType,
+  classPrefix: PropTypes.string,
+  className: PropTypes.string,
+  children: PropTypes.node,
+  stack: PropTypes.bool,
+  spacing: PropTypes.number,
+  size: PropTypes.oneOf(['lg', 'md', 'sm', 'xs'])
+};
+
+export default AvatarGroup;

--- a/src/AvatarGroup/index.tsx
+++ b/src/AvatarGroup/index.tsx
@@ -1,0 +1,3 @@
+import AvatarGroup from './AvatarGroup';
+export type { AvatarGroupProps } from './AvatarGroup';
+export default AvatarGroup;

--- a/src/AvatarGroup/styles/index.less
+++ b/src/AvatarGroup/styles/index.less
@@ -1,0 +1,19 @@
+@import '../../styles/common';
+
+.rs-avatar-group {
+  display: flex;
+  align-items: flex-end;
+  &-stack {
+    .rs-avatar {
+      box-sizing: content-box;
+      margin-right: -10px;
+      transition: margin 0.15s;
+      &:last-child {
+        margin-right: 0;
+      }
+      &:hover {
+        margin-right: 0;
+      }
+    }
+  }
+}

--- a/src/AvatarGroup/test/AvatarGroupSpec.js
+++ b/src/AvatarGroup/test/AvatarGroupSpec.js
@@ -19,6 +19,7 @@ describe('AvatarGroup', () => {
       <AvatarGroup spacing={10}>
         <Avatar>A</Avatar>
         <Avatar>B</Avatar>
+        {[<Avatar key={1}>C</Avatar>, <Avatar key={2}>D</Avatar>]}
       </AvatarGroup>
     );
 
@@ -26,6 +27,8 @@ describe('AvatarGroup', () => {
 
     assert.equal(avatars[0].style.marginRight, '10px');
     assert.equal(avatars[1].style.marginRight, '10px');
+    assert.equal(avatars[2].style.marginRight, '10px');
+    assert.equal(avatars[3].style.marginRight, '10px');
   });
 
   it('Should be stack', () => {

--- a/src/AvatarGroup/test/AvatarGroupSpec.js
+++ b/src/AvatarGroup/test/AvatarGroupSpec.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import AvatarGroup from '../AvatarGroup';
+import Avatar from '../../Avatar';
+import { getDOMNode } from '@test/testUtils';
+
+describe('AvatarGroup', () => {
+  it('Should change the size of all avatars', () => {
+    const instance = getDOMNode(
+      <AvatarGroup size="xs">
+        <Avatar>A</Avatar>
+        <Avatar>B</Avatar>
+      </AvatarGroup>
+    );
+    assert.equal(instance.querySelectorAll('.rs-avatar-xs').length, 2);
+  });
+
+  it('Should set the spacing between the avatars', () => {
+    const instance = getDOMNode(
+      <AvatarGroup spacing={10}>
+        <Avatar>A</Avatar>
+        <Avatar>B</Avatar>
+      </AvatarGroup>
+    );
+
+    const avatars = instance.querySelectorAll('.rs-avatar');
+
+    assert.equal(avatars[0].style.marginRight, '10px');
+    assert.equal(avatars[1].style.marginRight, '10px');
+  });
+
+  it('Should be stack', () => {
+    const instance = getDOMNode(<AvatarGroup stack />);
+    assert.include(instance.className, 'rs-avatar-group-stack');
+  });
+
+  it('Should have a custom style', () => {
+    const fontSize = '12px';
+    const instance = getDOMNode(<AvatarGroup style={{ fontSize }} />);
+    assert.equal(instance.style.fontSize, fontSize);
+  });
+
+  it('Should have a custom className prefix', () => {
+    const instance = getDOMNode(<AvatarGroup classPrefix="custom-prefix" />);
+    assert.include(instance.className, 'custom-prefix');
+  });
+});

--- a/src/AvatarGroup/test/AvatarGroupSpec.js
+++ b/src/AvatarGroup/test/AvatarGroupSpec.js
@@ -1,29 +1,31 @@
 import React from 'react';
 import AvatarGroup from '../AvatarGroup';
 import Avatar from '../../Avatar';
-import { getDOMNode } from '@test/testUtils';
+import { render } from '@testing-library/react';
 
 describe('AvatarGroup', () => {
   it('Should change the size of all avatars', () => {
-    const instance = getDOMNode(
-      <AvatarGroup size="xs">
+    const { getByTestId } = render(
+      <AvatarGroup size="xs" data-testid="group">
         <Avatar>A</Avatar>
         <Avatar>B</Avatar>
       </AvatarGroup>
     );
-    assert.equal(instance.querySelectorAll('.rs-avatar-xs').length, 2);
+
+    assert.equal(getByTestId('group').querySelectorAll('.rs-avatar-xs').length, 2);
   });
 
   it('Should set the spacing between the avatars', () => {
-    const instance = getDOMNode(
-      <AvatarGroup spacing={10}>
+    const { getByTestId } = render(
+      <AvatarGroup spacing={10} data-testid="group">
+        <Avatar>A</Avatar>
         <Avatar>A</Avatar>
         <Avatar>B</Avatar>
         {[<Avatar key={1}>C</Avatar>, <Avatar key={2}>D</Avatar>]}
       </AvatarGroup>
     );
 
-    const avatars = instance.querySelectorAll('.rs-avatar');
+    const avatars = getByTestId('group').querySelectorAll('.rs-avatar');
 
     assert.equal(avatars[0].style.marginRight, '10px');
     assert.equal(avatars[1].style.marginRight, '10px');
@@ -32,18 +34,18 @@ describe('AvatarGroup', () => {
   });
 
   it('Should be stack', () => {
-    const instance = getDOMNode(<AvatarGroup stack />);
-    assert.include(instance.className, 'rs-avatar-group-stack');
+    const { getByTestId } = render(<AvatarGroup stack data-testid="group" />);
+    assert.include(getByTestId('group').className, 'rs-avatar-group-stack');
   });
 
   it('Should have a custom style', () => {
     const fontSize = '12px';
-    const instance = getDOMNode(<AvatarGroup style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
+    const { getByTestId } = render(<AvatarGroup style={{ fontSize }} data-testid="group" />);
+    assert.equal(getByTestId('group').style.fontSize, fontSize);
   });
 
   it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<AvatarGroup classPrefix="custom-prefix" />);
-    assert.include(instance.className, 'custom-prefix');
+    const { getByTestId } = render(<AvatarGroup classPrefix="custom-prefix" data-testid="group" />);
+    assert.include(getByTestId('group').className, 'custom-prefix');
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,6 +61,9 @@ export type { BadgeProps } from './Badge';
 export { default as Avatar } from './Avatar';
 export type { AvatarProps } from './Avatar';
 
+export { default as AvatarGroup } from './AvatarGroup';
+export type { AvatarGroupProps } from './AvatarGroup';
+
 export { default as toaster } from './toaster';
 export type { Toaster } from './toaster';
 

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -4,6 +4,7 @@
 @import '../Animation/styles/index';
 @import '../AutoComplete/styles/index';
 @import '../Avatar/styles/index';
+@import '../AvatarGroup/styles/index';
 @import '../Badge/styles/index';
 @import '../Breadcrumb/styles/index';
 @import '../Button/styles/index';


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1203827/145388179-78b421d7-96ce-4c64-8bb2-12fff1ce3d2b.png)


https://rsuite-nextjs-git-feat-avatargroup-rsuite.vercel.app/components/avatar/

## Usage
```jsx
<AvatarGroup stack>
  <Avatar circle src="https://avatars.githubusercontent.com/u/12592949" alt="@superman66" />
  <Avatar circle src="https://avatars.githubusercontent.com/u/8225666" alt="@SevenOutman" />
  <Avatar circle src="https://avatars.githubusercontent.com/u/15609339" alt="@hiyangguo" />
  <Avatar circle src="https://avatars.githubusercontent.com/u/14308293" alt="@MarvelSQ" />
  <Avatar circle src="https://avatars.githubusercontent.com/u/1203827" alt="@simonguo" />
</AvatarGroup>
```
