### PR TITLE
test(toaster): fix unstable coverage for setTimeout cases

### DIFF
--- a/src/toaster/test/toasterSpec.js
+++ b/src/toaster/test/toasterSpec.js
@@ -1,8 +1,13 @@
 import React from 'react';
+import { screen } from '@testing-library/react';
 import toaster from '../toaster';
 
 const element = document.createElement('div');
 document.body.appendChild(element);
+
+afterEach(() => {
+  sinon.restore();
+});
 
 describe('toaster', () => {
   it('Should push a message', () => {
@@ -29,29 +34,53 @@ describe('toaster', () => {
     assert.ok(element.querySelector('.rs-toast-container.rs-toast-container-bottom-end'));
   });
 
-  it('Should reomve a message', () => {
-    const key = toaster.push(<div id="msg-2">abc</div>, {
-      container: element
-    });
+  it('Should remove a message', () => {
+    const clock = sinon.useFakeTimers();
+
+    const key = toaster.push(
+      <div id="msg-2" data-testid="message">
+        abc
+      </div>,
+      {
+        container: element
+      }
+    );
 
     const message = element.querySelector('#msg-2');
     assert.include(message.className, 'rs-toast-fade-entered');
 
     toaster.remove(key);
     assert.include(element.querySelector('#msg-2').className, 'rs-toast-fade-exiting');
+
+    clock.tick(400);
+    expect(screen.queryByTestId('message')).not.to.exist;
   });
 
   it('Should clear all message', () => {
-    toaster.push(<div className="message">123</div>, {
-      container: element
-    });
+    const clock = sinon.useFakeTimers();
+    toaster.push(
+      <div className="message" data-testid="message">
+        123
+      </div>,
+      {
+        container: element
+      }
+    );
 
-    toaster.push(<div className="message">456</div>, {
-      container: element
-    });
+    toaster.push(
+      <div className="message" data-testid="message">
+        456
+      </div>,
+      {
+        container: element
+      }
+    );
 
     assert.equal(element.querySelectorAll('.message').length, 2);
     toaster.clear();
     assert.equal(element.querySelectorAll('.message.rs-toast-fade-exiting').length, 2);
+
+    clock.tick(400);
+    expect(screen.queryByTestId('message')).not.to.exist;
   });
 });


### PR DESCRIPTION
Flaky coverage on setTimeout callbacks as shown here https://app.codecov.io/gh/rsuite/rsuite/compare/2165/changes#D1L77
![image](https://user-images.githubusercontent.com/8225666/145784700-f8590b6c-c92a-4278-86dc-2e021bf27f65.png)
