### PR TITLE
perf(CheckPicker): infer value and onChange types from data prop

### DIFF
--- a/src/CheckPicker/CheckPicker.tsx
+++ b/src/CheckPicker/CheckPicker.tsx
@@ -37,17 +37,17 @@ import {
   OverlayTriggerInstance,
   PositionChildProps,
   listPickerPropTypes,
-  PickerComponent
+  PickerInstance
 } from '../Picker';
 
 import { ItemDataType, FormControlPickerProps } from '../@types/common';
-import { SelectProps } from '../SelectPicker';
+import type { MultipleSelectProps } from '../SelectPicker';
 import { TreeNodeType } from '../CheckTreePicker/utils';
 
 export type ValueType = (number | string)[];
-export interface CheckPickerProps<T = ValueType>
-  extends FormControlPickerProps<T, PickerLocale, ItemDataType>,
-    SelectProps<T> {
+export interface CheckPickerProps<T>
+  extends FormControlPickerProps<T[], PickerLocale, ItemDataType<T>>,
+    MultipleSelectProps<T> {
   /** Top the selected option in the options */
   sticky?: boolean;
 
@@ -57,8 +57,14 @@ export interface CheckPickerProps<T = ValueType>
 
 const emptyArray = [];
 
-const CheckPicker: PickerComponent<CheckPickerProps> = React.forwardRef(
-  (props: CheckPickerProps, ref) => {
+export interface CheckPickerComponent {
+  <T>(props: CheckPickerProps<T>): JSX.Element | null;
+  displayName?: string;
+  propTypes?: React.WeakValidationMap<CheckPickerProps<any>>;
+}
+
+const CheckPicker: CheckPickerComponent = React.forwardRef(
+  <T extends number | string>(props: CheckPickerProps<T>, ref: React.Ref<PickerInstance>) => {
     const {
       as: Component = 'div',
       appearance = 'default',
@@ -166,7 +172,7 @@ const CheckPicker: PickerComponent<CheckPickerProps> = React.forwardRef(
     };
 
     const handleChangeValue = useCallback(
-      (value: ValueType, event: React.SyntheticEvent) => {
+      (value: T[], event: React.SyntheticEvent) => {
         onChange?.(value, event);
       },
       [onChange]
@@ -405,7 +411,7 @@ const CheckPicker: PickerComponent<CheckPickerProps> = React.forwardRef(
       </PickerToggleTrigger>
     );
   }
-);
+) as CheckPickerComponent;
 
 CheckPicker.displayName = 'CheckPicker';
 CheckPicker.propTypes = {

--- a/src/CheckPicker/test/CheckPicker.test.tsx
+++ b/src/CheckPicker/test/CheckPicker.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { expectType } from 'ts-expect';
+import CheckPicker from '../CheckPicker';
+
+// Infer value and onChange types from data
+const numberValuedData = [{ label: 'One', value: 1 }];
+
+<CheckPicker data={numberValuedData} value={[1]} />;
+// @ts-expect-error should not accept single value
+<CheckPicker data={numberValuedData} value={1} />;
+// @ts-expect-error should not accept string value
+<CheckPicker data={numberValuedData} value={['1']} />;
+<CheckPicker
+  data={numberValuedData}
+  onChange={newValue => {
+    expectType<number[]>(newValue);
+  }}
+/>;
+
+const stringValuedData = [{ label: 'One', value: 'One' }];
+
+<CheckPicker data={stringValuedData} value={['1']} />;
+// @ts-expect-error should not accept single value
+<CheckPicker data={numberValuedData} value="1" />;
+// @ts-expect-error should not accept number value
+<CheckPicker data={stringValuedData} value={[1]} />;
+<CheckPicker
+  data={stringValuedData}
+  onChange={newValue => {
+    expectType<string[]>(newValue);
+  }}
+/>;

--- a/src/SelectPicker/SelectPicker.tsx
+++ b/src/SelectPicker/SelectPicker.tsx
@@ -89,6 +89,15 @@ export interface SelectProps<T> {
   onClean?: (event: React.SyntheticEvent) => void;
 }
 
+export interface MultipleSelectProps<T> extends Omit<SelectProps<T>, 'renderValue'> {
+  /** Custom render selected items */
+  renderValue?: (
+    value: T[],
+    item: ItemDataType<T>[],
+    selectedElement: React.ReactNode
+  ) => React.ReactNode;
+}
+
 export interface SelectPickerProps<T>
   extends FormControlPickerProps<T, PickerLocale, ItemDataType<T>>,
     SelectProps<T> {}

--- a/src/SelectPicker/index.tsx
+++ b/src/SelectPicker/index.tsx
@@ -1,3 +1,3 @@
 import SelectPicker from './SelectPicker';
-export type { SelectProps, SelectPickerProps } from './SelectPicker';
+export type { SelectProps, MultipleSelectProps, SelectPickerProps } from './SelectPicker';
 export default SelectPicker;


### PR DESCRIPTION
`value` and `onChange(value)` type are now inferred from `data` item's `value` property.