### PR TITLE
fix(Dropdown): reduce padding in noCaret variant

### DIFF
--- a/src/Dropdown/styles/index.less
+++ b/src/Dropdown/styles/index.less
@@ -81,10 +81,10 @@
     // Force set style even if has `.btn`.
     .dropdown-toggle();
   }
-}
 
-.rs-dropdown-toggle.rs-dropdown-no-caret {
-  padding-right: @padding-x;
+  &.rs-dropdown-toggle-no-caret {
+    padding-right: @padding-x;
+  }
 }
 
 // The dropdown menu (ul)

--- a/src/Dropdown/test/DropdownStylesSpec.js
+++ b/src/Dropdown/test/DropdownStylesSpec.js
@@ -34,4 +34,10 @@ describe('Dropdown styles', () => {
 
     expect(getByRole('button')).to.have.style('backgroundColor', getGrayScale('B050'));
   });
+
+  it('Should have 12px right padding given `noCaret=true`', () => {
+    const { getByRole } = render(<Dropdown title="Dropdown" noCaret />);
+
+    expect(getByRole('button')).to.have.style('paddingRight', '12px');
+  });
 });


### PR DESCRIPTION
Close #2213

Before
![image](https://user-images.githubusercontent.com/8225666/146510639-654a6a68-bc2e-4fd5-b67c-9d82cdcb9a22.png)


After
![image](https://user-images.githubusercontent.com/8225666/146510611-b8e5d355-a86b-4d3b-8151-de8d9e1e79ad.png)
