### PR TITLE
fix(tree): remove dragNode Element when drag node (#2185)

### DIFF
--- a/docs/pages/components/tree/en-US/index.md
+++ b/docs/pages/components/tree/en-US/index.md
@@ -55,7 +55,6 @@
 | onDrop                  | (dropData:DropDataType, event) => void                                                         | Called when node drop                                                     |
 | onExpand                | (expandItemValues: any [], activeNode: DataItemType, concat:(data, children) => Array) => void | Callback When tree node is displayed                                      |
 | onSelect                | (activeNode:DataItemType, value, event) => void                                                | Callback function after selecting tree node                               |
-| renderDragNode          | (nodeData:DataItemType) => ReactNode                                                           | Custom Render drag node when draggable is true                            |
 | renderTreeIcon          | (nodeData:DataItemType) => ReactNode                                                           | Custom Render icon                                                        |
 | renderTreeNode          | (nodeData:DataItemType) => ReactNode                                                           | Custom Render tree Node                                                   |
 | searchKeyword           | string                                                                                         | searchKeyword (Controlled)                                                |

--- a/docs/pages/components/tree/zh-CN/index.md
+++ b/docs/pages/components/tree/zh-CN/index.md
@@ -55,11 +55,10 @@
 | onDrop                  | (dropData:DropDataType, event) => void                                                        | drop 回调                                                                       |
 | onExpand                | (expandItemValues: any [], activeNode:DataItemType, concat:(data, children) => Array) => void | 树节点展示时的回调                                                              |
 | onSelect                | (activeNode:DataItemType, value, event) => void                                               | 选择树节点后的回调函数                                                          |
-| renderDragNode          | (nodeData:DataItemType) => ReactNode                                                          | 当 draggable 为 true 时，自定义渲染拖拽节点                                     |
 | renderTreeIcon          | (nodeData:DataItemType) => ReactNode                                                          | 自定义渲染 图标                                                                 |
 | renderTreeNode          | (nodeData:DataItemType) => ReactNode                                                          | 自定义渲染 tree 节点                                                            |
 | searchKeyword           | string                                                                                        | (受控)搜索关键词                                                                |
-| showIndentLine 、       | boolean                                                                                       | 是否显示缩进线                                                                  |
+| showIndentLine          | boolean                                                                                       | 是否显示缩进线                                                                  |
 | value                   | string                                                                                        | 当前选中的值                                                                    |
 | valueKey                | string `('value')`                                                                            | tree 数据结构 value 属性名称                                                    |
 | virtualized             | boolean                                                                                       | 是否开启虚拟列表                                                                |

--- a/src/CheckTree/index.tsx
+++ b/src/CheckTree/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { FormControlPickerProps, RsRefForwardingComponent } from '../@types/common';
 import CheckTreePicker, { ValueType } from '../CheckTreePicker';
 
@@ -14,9 +14,8 @@ export interface CheckTreeProps
 
 const CheckTree: RsRefForwardingComponent<'div', CheckTreeProps> = React.forwardRef(
   (props: CheckTreeProps, ref: React.Ref<any>) => {
-    const dragNodeRef = useRef();
     return (
-      <TreeContext.Provider value={{ inline: true, dragNodeRef }}>
+      <TreeContext.Provider value={{ inline: true }}>
         <CheckTreePicker ref={ref} {...props} />
       </TreeContext.Provider>
     );

--- a/src/Tree/Tree.tsx
+++ b/src/Tree/Tree.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import TreePicker from '../TreePicker';
 import TreeContext from './TreeContext';
 import { StandardProps, ItemDataType, RsRefForwardingComponent } from '../@types/common';
@@ -51,8 +51,6 @@ export interface TreeDragProps<ItemDataType = Record<string, any>> {
 
   /** Called when node drop */
   onDrop?: (dropData: DropData<ItemDataType>, e: React.DragEvent) => void;
-
-  renderDragNode?: (dragNode: ItemDataType) => React.ReactNode;
 }
 
 export interface TreeBaseProps<ValueType = string | number, ItemDataType = Record<string, any>>
@@ -146,9 +144,8 @@ export interface TreeProps<ValueType = string | number>
 
 const Tree: RsRefForwardingComponent<'div', TreeProps> = React.forwardRef(
   (props: TreeProps, ref: React.Ref<any>) => {
-    const dragNodeRef = useRef();
     return (
-      <TreeContext.Provider value={{ inline: true, dragNodeRef }}>
+      <TreeContext.Provider value={{ inline: true }}>
         <TreePicker ref={ref} {...props} />
       </TreeContext.Provider>
     );

--- a/src/Tree/TreeContext.ts
+++ b/src/Tree/TreeContext.ts
@@ -2,7 +2,6 @@ import React from 'react';
 
 export interface TreeContextProps {
   inline?: boolean;
-  dragNodeRef?: React.MutableRefObject<any>;
 }
 
 const TreeContext = React.createContext<TreeContextProps>({});

--- a/src/TreePicker/TreeNode.tsx
+++ b/src/TreePicker/TreeNode.tsx
@@ -1,9 +1,8 @@
-import React, { forwardRef, useCallback, useContext } from 'react';
+import React, { forwardRef, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import hasClass from 'dom-lib/hasClass';
 import ArrowDown from '@rsuite/icons/legacy/ArrowDown';
 import Spinner from '@rsuite/icons/legacy/Spinner';
-import TreeContext from '../Tree/TreeContext';
 import reactToString from '../utils/reactToString';
 import { useClassNames } from '../utils';
 import { getTreeNodeIndent } from '../utils/treeUtils';
@@ -83,7 +82,6 @@ const TreeNode: RsRefForwardingComponent<'div', TreeNodeProps> = forwardRef<
     ref
   ) => {
     const { prefix, merge, withClassPrefix } = useClassNames(classPrefix);
-    const { dragNodeRef } = useContext(TreeContext);
 
     const getTitle = useCallback(() => {
       if (typeof label === 'string') {
@@ -122,14 +120,9 @@ const TreeNode: RsRefForwardingComponent<'div', TreeNodeProps> = forwardRef<
 
     const handleDragStart = useCallback(
       (event: React.DragEvent) => {
-        const dragNode = dragNodeRef?.current;
-
-        if (dragNode) {
-          event.dataTransfer?.setDragImage(dragNode, 0, 0);
-        }
         onDragStart?.(nodeData, event);
       },
-      [dragNodeRef, nodeData, onDragStart]
+      [nodeData, onDragStart]
     );
 
     const handleDragEnter = useCallback(

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -162,7 +162,6 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
     renderExtraFooter,
     renderMenu,
     renderValue,
-    renderDragNode,
     ...rest
   } = props;
   const triggerRef = useRef<OverlayTriggerInstance>(null);
@@ -172,7 +171,7 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
   const searchInputRef = useRef<HTMLInputElement>(null);
   const treeViewRef = useRef<HTMLDivElement>(null);
   const { rtl, locale } = useCustom<PickerLocale>('Picker', overrideLocale);
-  const { inline, dragNodeRef } = useContext(TreeContext);
+  const { inline } = useContext(TreeContext);
 
   const [value, setValue, isControlled] = useControlled(controlledValue, defaultValue);
   const {
@@ -287,13 +286,6 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
   useEffect(() => {
     setSearchKeyword(searchKeyword ?? '');
   }, [searchKeyword, setSearchKeyword]);
-
-  useEffect(() => {
-    if (dragNodeRef) {
-      dragNodeRef.current = treeViewRef.current?.querySelector(`.${treePrefix('drag-node-mover')}`);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const getDropData = useCallback(
     (nodeData: any) => {
@@ -765,17 +757,6 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
       );
     };
 
-  const renderDefaultDragNode = () => {
-    if (draggable && !isNil(dragNode)) {
-      let dragNodeContent = dragNode?.[labelKey];
-      if (isFunction(renderDragNode)) {
-        dragNodeContent = renderDragNode(dragNode);
-      }
-      return <span className={treePrefix('drag-node-mover')}>{dragNodeContent}</span>;
-    }
-    return null;
-  };
-
   const renderTree = () => {
     const classes = withTreeClassPrefix({
       [className ?? '']: inline,
@@ -816,7 +797,6 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
             formattedNodes
           )}
         </div>
-        {renderDefaultDragNode()}
       </div>
     );
   };

--- a/src/TreePicker/styles/index.less
+++ b/src/TreePicker/styles/index.less
@@ -13,20 +13,6 @@
   overflow-y: auto;
   flex: 1 1 auto;
 
-  &-drag-node-mover {
-    position: absolute;
-    top: -1000px;
-    color: var(--rs-text-primary);
-    background-color: var(--rs-bg-overlay);
-    display: inline-block;
-    margin: 0;
-    padding: @picker-tree-node-padding-vertical @picker-tree-node-padding-horizontal;
-    border-radius: 6px;
-    box-shadow: 0 1px 8px rgba(0, 0, 0, 0.12);
-    z-index: 1060;
-    cursor: move;
-  }
-
   &.rs-tree-virtualized {
     overflow: hidden;
 


### PR DESCRIPTION
1. Remove custom dragNode element when drag node
2. Remove `renderDragNode` props
3. Update `Tree` docs