### PR TITLE
fix(useUniqueId): fix issue #2153

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,7 +3,7 @@
  * Run all tests: `npm run tdd`
  * Run all styles tests: `M=styles npm run tdd`
  * Run a component test: `M=Button npm run tdd`
- * Run a test of a file: `src/Picker/test/PickerToggleSpec.js npm run tdd`
+ * Run a test of a file: `F=src/Picker/test/PickerToggleSpec.js npm run tdd`
  */
 
 /**

--- a/src/utils/test/useUniqueIdSpec.js
+++ b/src/utils/test/useUniqueIdSpec.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks/dom';
+import useUniqueId from '../useUniqueId';
+
+describe('[utils] useUniqueId', () => {
+  it('should be defined', () => {
+    expect(useUniqueId).to.be.exist;
+  });
+
+  it('should return a empty string at first than a unique id when mounted', () => {
+    const callbackSpy = sinon.spy();
+
+    const useEffect = React.useEffect;
+    React.useEffect = callbackSpy;
+
+    const hook1 = renderHook(() => useUniqueId());
+    expect(hook1.result.current).to.be.empty;
+    assert.equal(callbackSpy.callCount, 1);
+
+    React.useEffect = useEffect;
+
+    const hook2 = renderHook(() => useUniqueId());
+    expect(hook2.result.current).to.not.be.empty;
+  });
+
+  it('should return different unique ids', () => {
+    const hook1 = renderHook(() => useUniqueId());
+    const hook2 = renderHook(() => useUniqueId());
+    expect(hook1.result.current).to.not.be.equal(hook2.result.current);
+  });
+});

--- a/src/utils/useUniqueId.ts
+++ b/src/utils/useUniqueId.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useState } from 'react';
 import uniqueId from 'lodash/uniqueId';
 
 /**
@@ -7,11 +7,14 @@ import uniqueId from 'lodash/uniqueId';
  * @param idProp If id is provided, it will be used instead of generating a new one
  */
 export default function useUniqueId(prefix: string, idProp?: string) {
-  const idRef = useRef<string>();
+  const [idState, setIDState] = useState<string>('');
 
-  if (!idRef.current) {
-    idRef.current = uniqueId(prefix);
-  }
+  useEffect(() => {
+    if (!idState) {
+      setIDState(uniqueId(prefix));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  return idProp ?? idRef.current;
+  return idProp ?? idState;
 }


### PR DESCRIPTION
Hello, I think this PR fixes the #2153 issue.

I have changed the `useUniqueId` to return a empty string and (with a `useEffect`) change it to a real unique id.

This way both the server and client will have the same output when using SSR.

I'm not sure if this is the best approach, but it works, I have tested with a local project and now the error is gone.