### PR TITLE
fix(Sidenav): prevent text wrapping when collapsing

### DIFF
--- a/src/Sidenav/styles/index.less
+++ b/src/Sidenav/styles/index.less
@@ -378,6 +378,7 @@
     .rs-dropdown .rs-dropdown-toggle,
     .rs-dropdown-item,
     .rs-dropdown-item-submenu > .rs-dropdown-menu-toggle {
+      white-space: nowrap;
       text-overflow: clip;
     }
   }


### PR DESCRIPTION
Fix #2183

Before

https://user-images.githubusercontent.com/8225666/146748198-dd62732d-3baa-4ed1-a638-a509c843269a.mov

After

https://user-images.githubusercontent.com/8225666/146748245-12359d12-1ca7-44b3-9bbb-dd1fcb7c72b8.mov
