### PR TITLE
test(Sidenav): silent depreated prop warnings

### DIFF
--- a/src/Sidenav/test/SidenavSpec.js
+++ b/src/Sidenav/test/SidenavSpec.js
@@ -29,7 +29,7 @@ describe('<Sidenav>', () => {
   });
 
   it('Should call onSelect callback', () => {
-    const consoleWarnSpy = sinon.spy(console, 'warn');
+    const consoleWarnStub = sinon.stub(console, 'warn').callsFake(() => null);
 
     const onSelectSpy = sinon.spy();
 
@@ -44,7 +44,7 @@ describe('<Sidenav>', () => {
 
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-sidenav-item'));
 
-    expect(consoleWarnSpy, 'Deprecation warning').to.have.been.calledWith(
+    expect(consoleWarnStub, 'Deprecation warning').to.have.been.calledWith(
       sinon.match(/onselect.+deprecated/i)
     );
     expect(onSelectSpy, 'onSelect').to.have.been.calledWith('1');
@@ -189,7 +189,7 @@ describe('<Sidenav>', () => {
   });
 
   it('Should set `aria-selected=true` on the item indicated by `activeKey`', () => {
-    const consoleWarnSpy = sinon.spy(console, 'warn');
+    const consoleWarnStub = sinon.stub(console, 'warn').callsFake(() => null);
 
     const instance = getDOMNode(
       <Sidenav activeKey="1">
@@ -201,7 +201,7 @@ describe('<Sidenav>', () => {
         </Nav>
       </Sidenav>
     );
-    expect(consoleWarnSpy, 'Deprecation warning').to.have.been.calledWith(
+    expect(consoleWarnStub, 'Deprecation warning').to.have.been.calledWith(
       sinon.match(/activekey.+deprecated/i)
     );
     expect(instance.querySelector('#selected-item').getAttribute('aria-selected')).to.equal('true');


### PR DESCRIPTION
Suppress warnings when testing deprecated APIs.

![image](https://user-images.githubusercontent.com/8225666/146881123-de9cef07-17ef-43f4-bb80-9b1c35dd6663.png)
