### PR TITLE
build(deps): bump rsuite-table from 5.2.2 to 5.3.0

### DIFF
--- a/docs/pages/components/table/en-US/index.md
+++ b/docs/pages/components/table/en-US/index.md
@@ -263,7 +263,7 @@ If you want the cell to wrap, you just need to set `wordWrap`
 
 ### Draggable(with react-dnd)
 
-https://codesandbox.io/s/rsuite-table-with-react-dnd-m06cm
+https://codesandbox.io/s/rsuite5-table-with-react-dnd-16o4n
 
 ## Accessibility
 
@@ -313,8 +313,9 @@ https://codesandbox.io/s/rsuite-table-with-react-dnd-m06cm
 | onSortColumn             | (dataKey:string, sortType:string) => void                                         | Click the callback function of the sort sequence to return the value `sortColumn`, `sortType`                          |
 | renderEmpty              | (info: ReactNode) => ReactNode                                                    | Customized data is empty display content                                                                               |
 | renderLoading            | (loading: ReactNode) => ReactNode                                                 | Customize the display content in the data load                                                                         |
+| renderRow                | (children?: ReactNode, rowData?: RowDataType) => ReactNode                        | Custom row element                                                                                                     |
 | renderRowExpanded        | (rowDate?: Object) => ReactNode                                                   | Customize what you can do to expand a zone                                                                             |
-| renderTreeToggle         | (icon:node, rowData:object, expanded:boolean) => node                             | Tree table, the callback function in the expanded node                                                                 |
+| renderTreeToggle         | (icon:node, rowData:object, expanded:boolean) => ReactNode                        | Tree table, the callback function in the expanded node                                                                 |
 | rowClassName             | string , (rowData:object) => string                                               | Add an optional extra class name to row                                                                                |
 | rowExpandedHeight        | number `(100)`                                                                    | Set the height of an expandable area                                                                                   |
 | rowHeight                | (rowData:object) => number, number`(46)`                                          | Row height                                                                                                             |

--- a/docs/pages/components/table/zh-CN/index.md
+++ b/docs/pages/components/table/zh-CN/index.md
@@ -260,7 +260,7 @@ export const EditCell = ({ rowData, dataKey, onChange, ...props }) => {
 
 ### 可拖拽(与 react-dnd 组合)
 
-https://codesandbox.io/s/rsuite-table-with-react-dnd-m06cm
+https://codesandbox.io/s/rsuite5-table-with-react-dnd-16o4n
 
 ## 无障碍设计
 
@@ -309,8 +309,9 @@ https://codesandbox.io/s/rsuite-table-with-react-dnd-m06cm
 | onSortColumn             | (dataKey:string, sortType:string) => void                                         | 点击排序列的回调函数，返回 `sortColumn`, `sortType` 这两个值 |
 | renderEmpty              | (info: ReactNode) => ReactNode                                                    | 自定义渲染数据为空的状态                                     |
 | renderLoading            | (loading: ReactNode) => ReactNode                                                 | 自定义渲染数据加载中的状态                                   |
+| renderRow                | (children?: ReactNode, rowData?: RowDataType) => ReactNode                        | 自定义渲染行                                                 |
 | renderRowExpanded        | (rowDate?: Object) => ReactNode                                                   | 自定义可以展开区域的内容                                     |
-| renderTreeToggle         | (icon:node, rowData:object, expanded:boolean) => node                             | 树形表格，在展开节点的回调函数                               |
+| renderTreeToggle         | (icon:node, rowData:object, expanded:boolean) => ReactNode                        | 树形表格，在展开节点的回调函数                               |
 | rowClassName             | string , (rowData:object) => string                                               | 为行自定义 className                                         |
 | rowExpandedHeight        | number `(100)`                                                                    | 设置可展开区域的高度                                         |
 | rowHeight                | (rowData:object) => number, number`(46)`                                          | 行高                                                         |

--- a/package-lock.json
+++ b/package-lock.json
@@ -17411,9 +17411,9 @@
       }
     },
     "rsuite-table": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.2.2.tgz",
-      "integrity": "sha512-KnzzUm4ZoyR/RJeFkSHaBskXvWwSSG+Fxp3q7QNh9taEUgD2NHLswz1y37Os45Kf8iOHHKZA9Gc3KSSkhys+5w==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.3.0.tgz",
+      "integrity": "sha512-UjzZ2+X5Ww1IqQhf5+lkYmU9D6//cyqD3hkl052uS/3uvieieWN0B8Hh3kgqh3RkvjFgRGfKxW2KlFrCr6HDMw==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "react-virtualized": "^9.22.3",
-    "rsuite-table": "^5.2.2",
+    "rsuite-table": "^5.3.0",
     "schema-typed": "^2.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
# [5.3.0](https://github.com/rsuite/rsuite-table/compare/5.2.2...5.3.0) (2021-12-23)


### Features

* **Table:** support renderRow on <Table> ([#287](https://github.com/rsuite/rsuite-table/issues/287)) ([732a35e](https://github.com/rsuite/rsuite-table/commit/732a35e5567048bdf6cc1a21d6887f0481913b46))


