### PR TITLE
refactor: focus rings

### DIFF
--- a/src/Button/styles/index.less
+++ b/src/Button/styles/index.less
@@ -14,7 +14,6 @@
   text-align: center;
   vertical-align: middle;
   cursor: pointer;
-  outline: 0 !important;
   white-space: nowrap;
   transition: @btn-transition;
   // Reset border style in all browser
@@ -31,10 +30,7 @@
 
   .rs-btn-md();
 
-  &:focus {
-    outline: 0;
-    box-shadow: var(--rs-state-focus-shadow);
-  }
+  .with-focus-ring();
 
   .button-activated({
     color: var(--rs-btn-default-hover-text);

--- a/src/Dropdown/styles/index.less
+++ b/src/Dropdown/styles/index.less
@@ -108,6 +108,7 @@
     z-index: @zindex-dropdown + 1;
     float: left;
     box-shadow: var(--rs-dropdown-shadow);
+    outline: none;
 
     .high-contrast-mode({
       border: 1px solid var(--rs-border-primary);

--- a/src/Dropdown/styles/mixin.less
+++ b/src/Dropdown/styles/mixin.less
@@ -39,8 +39,6 @@
   padding-right: @dropdown-toggle-padding-right;
   // Fixed: Content is not centered when customizing renderTitle.
   display: inline-block;
-  // Rest `:focus` blue border.
-  outline: none;
   cursor: pointer;
 }
 

--- a/src/Navbar/styles/index.less
+++ b/src/Navbar/styles/index.less
@@ -73,8 +73,6 @@
 .rs-navbar-brand,
 .rs-navbar-item,
 .rs-navbar-nav > .rs-dropdown-item {
-  outline: 0;
-
   &,
   &:hover,
   &:focus,
@@ -109,6 +107,11 @@
 // Dropdown
 .rs-navbar-nav > .rs-dropdown .rs-dropdown-toggle {
   &:extend(.rs-navbar-item);
+
+  &:focus,
+  &:focus-visible {
+    &:extend(.rs-navbar-item:focus-visible);
+  }
 
   padding-right: @navbar-item-padding-x+ @dropdown-caret-width+ @dropdown-caret-padding;
 

--- a/src/Navbar/styles/index.less
+++ b/src/Navbar/styles/index.less
@@ -83,7 +83,9 @@
   }
 
   &:focus-visible {
-    .focus-ring();
+    // Navbar is usually placed by the top edge of the page
+    // thus use an inset focus ring to prevent overflow clipping
+    .focus-ring(inset);
 
     .high-contrast-mode({
       .focus-ring(slim-inset);

--- a/src/Sidenav/styles/index.less
+++ b/src/Sidenav/styles/index.less
@@ -110,6 +110,12 @@
     width: 100%;
     white-space: normal;
 
+    // Sidenav is usually placed by the left/right edge of the page
+    // thus use an inset focus ring to prevent overflow clipping
+    &:focus {
+      .focus-ring(inset);
+    }
+
     > .rs-icon:not(.rs-dropdown-toggle-caret) {
       font-size: @sidenav-level1-item-font-size;
       margin-right: @sidenav-icon-spacing;

--- a/src/styles/color-modes/dark.less
+++ b/src/styles/color-modes/dark.less
@@ -27,6 +27,7 @@
   --rs-bg-active: @H700;
   --rs-bg-backdrop: fade(@B900, 80%);
   --rs-state-hover-bg: @B600;
+  --rs-color-focus-ring: 0 0 0 3px fade(@H500, 25%);
   --rs-state-focus-shadow: 0 0 0 3px fade(@H500, 25%);
   --rs-state-focus-outline: 3px solid fade(@H500, 25%);
   --rs-shadow-overlay: 0 4px 4px rgba(0, 0, 0, 0.12), 0 0 10px rgba(0, 0, 0, 0.06);

--- a/src/styles/color-modes/high-contrast.less
+++ b/src/styles/color-modes/high-contrast.less
@@ -27,6 +27,7 @@
   --rs-bg-active: @H500;
   --rs-bg-backdrop: fade(@B900, 80%);
   --rs-state-hover-bg: @B600;
+  --rs-color-focus-ring: @B000;
   --rs-state-focus-shadow: 0 0 0 3px @B900, 0 0 0 5px @B000;
   --rs-state-focus-shadow-slim: 0 0 0 2px @B000;
   --rs-state-focus-outline: 3px solid fade(@H500, 25%);

--- a/src/styles/color-modes/light.less
+++ b/src/styles/color-modes/light.less
@@ -34,6 +34,7 @@
   --rs-bg-active: @H500;
   --rs-bg-backdrop: fade(@B900, 30%);
   --rs-state-hover-bg: @H050;
+  --rs-color-focus-ring: fade(@H500, 25%);
   --rs-state-focus-shadow: 0 0 0 3px fade(@H500, 25%);
   --rs-state-focus-outline: 3px solid fade(@H500, 25%);
   --rs-shadow-overlay: 0 4px 4px rgba(0, 0, 0, 0.12), 0 0 10px rgba(0, 0, 0, 0.06);

--- a/src/styles/mixins/utilities.less
+++ b/src/styles/mixins/utilities.less
@@ -140,6 +140,7 @@
 .focus-ring(slim) {
   .focus-ring();
 
+  outline-width: 2px;
   outline-offset: 0;
 }
 
@@ -150,7 +151,9 @@
 }
 
 .focus-ring(slim-inset) {
-  box-shadow: inset var(--rs-state-focus-shadow-slim);
+  .focus-ring(inset);
+
+  outline-width: 2px;
 }
 
 .focus-ring(outline) {

--- a/src/styles/mixins/utilities.less
+++ b/src/styles/mixins/utilities.less
@@ -122,7 +122,7 @@
 
 // Useful when adding focus ring to an element
 .with-focus-ring() {
-  &:focus {
+  &:focus-visible {
     .focus-ring();
   }
 }
@@ -146,8 +146,8 @@
 
 .focus-ring(inset) {
   .focus-ring();
+
   outline-offset: -3px;
-  // box-shadow: inset var(--rs-state-focus-shadow);
 }
 
 .focus-ring(slim-inset) {

--- a/src/styles/mixins/utilities.less
+++ b/src/styles/mixins/utilities.less
@@ -129,15 +129,24 @@
 
 // Useful when appending the ring into an existing :focus rule
 .focus-ring() {
-  box-shadow: var(--rs-state-focus-shadow);
+  outline: 3px solid var(--rs-color-focus-ring);
+  // box-shadow: var(--rs-state-focus-shadow);
+
+  .high-contrast-mode({
+    outline-offset: 2px;
+  });
 }
 
 .focus-ring(slim) {
-  box-shadow: var(--rs-state-focus-shadow-slim);
+  .focus-ring();
+
+  outline-offset: 0;
 }
 
 .focus-ring(inset) {
-  box-shadow: inset var(--rs-state-focus-shadow);
+  .focus-ring();
+  outline-offset: -3px;
+  // box-shadow: inset var(--rs-state-focus-shadow);
 }
 
 .focus-ring(slim-inset) {


### PR DESCRIPTION
### Use `outline` instead of `box-shadow` for focus rings

Outline does not occupy space.

### Use inset focus rings on Sidenav and Navbar items

Sidenav and Navbar are usually placed by the edge of the page, causing an outset focus ring to be clipped.

Sidenav currently
![image](https://user-images.githubusercontent.com/8225666/147541019-92c521c7-0c2a-4a71-997b-3fdc478dc3fb.png)

Sidenav in this edit
![image](https://user-images.githubusercontent.com/8225666/147541040-abe85599-6a76-46d8-a941-c3df8fb100b5.png)

Navbar currently
![image](https://user-images.githubusercontent.com/8225666/147540930-d6a8409f-7d39-4746-8733-4b5d4ee9b47f.png)

Navbar in this edit
![image](https://user-images.githubusercontent.com/8225666/147540956-0afb6fcb-9d8c-408d-a049-6c0afa118893.png)

### `<Button>` only shows focus ring when focused by keyboard

No longer display focus ring when activated by mouse click.
