### PR TITLE
docs(brand): fix brand misplacement on mobile

### DIFF
--- a/docs/components/TopLevelNav/TopLevelNav.tsx
+++ b/docs/components/TopLevelNav/TopLevelNav.tsx
@@ -22,35 +22,31 @@ interface ButtonWithTooltipProps {
   [key: string]: any;
 }
 
-function ButtonWithTooltip({
-  children,
-  as = 'a',
-  tip,
-  className,
-  ...props
-}: ButtonWithTooltipProps) {
-  const btn = (
-    <Button {...props} size="lg" className={classNames('icon-btn-circle', className)} as={as}>
-      {children}
-    </Button>
-  );
-  if (isMobile) {
-    return btn;
+const ButtonWithTooltip = React.forwardRef(
+  ({ children, as = 'a', tip, className, ...props }: ButtonWithTooltipProps, ref) => {
+    const btn = (
+      <Button {...props} size="lg" className={classNames('icon-btn-circle', className)} as={as}>
+        {children}
+      </Button>
+    );
+    if (isMobile) {
+      return btn;
+    }
+    return (
+      <Whisper ref={ref} speaker={<Tooltip>{tip}</Tooltip>} placement="right" trigger="hover">
+        {btn}
+      </Whisper>
+    );
   }
-  return (
-    <Whisper speaker={<Tooltip>{tip}</Tooltip>} placement="right" trigger="hover">
-      {btn}
-    </Whisper>
-  );
-}
+);
 
-function SearchButton({ tip, ...rest }: any) {
+const SearchButton = React.forwardRef(({ tip, ...rest }: any, ref) => {
   return (
-    <ButtonWithTooltip tip={tip} {...rest}>
+    <ButtonWithTooltip tip={tip} {...rest} ref={ref}>
       <Icon as={() => <SvgIcons.Search />} style={{ fontSize: 20 }} />
     </ButtonWithTooltip>
   );
-}
+});
 
 interface TopLevelNavProps {
   onToggleMenu?: (show: boolean) => void;
@@ -83,7 +79,7 @@ function getNavItems(messages) {
   ];
 }
 
-export default function TopLevelNav(props: TopLevelNavProps) {
+const TopLevelNav = React.forwardRef((props: TopLevelNavProps, ref: React.Ref<HTMLDivElement>) => {
   const { children, showSubmenu, hideToggle, onToggleMenu: onToggleMenuProp } = props;
   const router = useRouter();
 
@@ -136,7 +132,7 @@ export default function TopLevelNav(props: TopLevelNavProps) {
   };
 
   return (
-    <div className="top-level-nav">
+    <div className="top-level-nav" ref={ref}>
       {!hideToggle && (
         <IconButton
           circle
@@ -214,4 +210,6 @@ export default function TopLevelNav(props: TopLevelNavProps) {
         )}
     </div>
   );
-}
+});
+
+export default TopLevelNav;

--- a/docs/components/TopLevelNav/styles.less
+++ b/docs/components/TopLevelNav/styles.less
@@ -12,6 +12,11 @@
     }
   }
 
+  @media (max-width: @media-xs) {
+    text-align: left;
+    padding-left: 10px;
+  }
+
   @media (min-width: @media-xs) {
     position: fixed;
     padding: 10px 0;


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/1203827/148190049-69fa03c5-cc51-4442-90b4-d87aec7ccfe7.png)
after
![image](https://user-images.githubusercontent.com/1203827/148190093-6ccda7bb-9b22-4086-83d1-84e9f496f5dc.png)

## Fix warning

```
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

Check the render method of `TopLevelNav`.
```

