### PR TITLE
fix(CheckTreePicker): fix root node style incorrect

### DIFF
--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -757,7 +757,7 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
   const renderCheckTree = () => {
     const classes = withCheckTreeClassPrefix({
       [className ?? '']: inline,
-      'without-children': !isSomeNodeHasChildren,
+      'without-children': !isSomeNodeHasChildren(data, childrenKey),
       virtualized
     });
 

--- a/src/CheckTreePicker/styles/index.less
+++ b/src/CheckTreePicker/styles/index.less
@@ -73,7 +73,7 @@
       }
 
       // Only has the first level
-      .without-children & {
+      .rs-check-tree-without-children & {
         padding-left: 34px; //text gap + checkbox space
 
         &::before {

--- a/src/CheckTreePicker/test/CheckTreePickerStylesSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerStylesSpec.js
@@ -39,4 +39,11 @@ describe('CheckTreePicker styles', () => {
     const itemLabel = document.body.querySelector('.rs-check-tree .rs-checkbox-checker label');
     assert.equal(getStyle(itemLabel, 'padding'), '8px 12px 8px 58px');
   });
+
+  itChrome('Should render the correct styles when data has only one level structure', () => {
+    const instanceRef = React.createRef();
+    render(<CheckTreePicker data={[{ value: 1, label: 1 }]} ref={instanceRef} open />);
+    const itemLabel = document.body.querySelector('.rs-check-tree .rs-checkbox-checker label');
+    assert.equal(getStyle(itemLabel, 'padding'), '8px 12px 8px 34px');
+  });
 });

--- a/src/CheckTreePicker/utils.ts
+++ b/src/CheckTreePicker/utils.ts
@@ -53,7 +53,7 @@ export function isSomeChildChecked(
 }
 
 export function isSomeNodeHasChildren(data: any[], childrenKey: string): boolean {
-  return data.some((node: TreeNodeType) => node[childrenKey]);
+  return data.some((node: TreeNodeType) => Array.isArray(node[childrenKey]));
 }
 
 /**


### PR DESCRIPTION
Fix CheckTreePicker style incorrect when data has only one level structure.

![image](https://user-images.githubusercontent.com/12592949/148340901-547e767e-b54f-40d8-a260-12a81bd50923.png)

