### PR TITLE
build(deps): bump rsuite-table from 5.3.0 to 5.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17411,9 +17411,9 @@
       }
     },
     "rsuite-table": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.3.0.tgz",
-      "integrity": "sha512-UjzZ2+X5Ww1IqQhf5+lkYmU9D6//cyqD3hkl052uS/3uvieieWN0B8Hh3kgqh3RkvjFgRGfKxW2KlFrCr6HDMw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.3.1.tgz",
+      "integrity": "sha512-5p5bN5bzqyPVVL8QNjDwRvMr4iffXpOx5trJZZjm/TyrD0lSDMzd8lLAs/F6C7/6hmpWFKYjTLRt/8UIrIriXQ==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "react-virtualized": "^9.22.3",
-    "rsuite-table": "^5.3.0",
+    "rsuite-table": "^5.3.1",
     "schema-typed": "^2.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
## [5.3.1](https://github.com/rsuite/rsuite-table/compare/5.3.0...5.3.1) (2022-01-06)

### Bug Fixes

- **Table:** fix rowSpan is invalid in ie brower ([#293](https://github.com/rsuite/rsuite-table/issues/293)) ([ea49e51](https://github.com/rsuite/rsuite-table/commit/ea49e513746fb4b44077d3baafbd27886e744aab))