### PR TITLE
feat(RangeSlider): add `constraint` prop

### DIFF
--- a/docs/pages/components/slider/en-US/index.md
+++ b/docs/pages/components/slider/en-US/index.md
@@ -35,6 +35,12 @@ A Slider component for displaying current value
 
 <!--{include:`value.md`}-->
 
+### Constraint
+
+Limit starting value to be no greater than 25 and ending value to be no smaller than 35.
+
+<!--{include:`constraint.md`}-->
+
 ### Custom
 
 <!--{include:`custom.md`}-->
@@ -105,23 +111,24 @@ WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#slider
 
 ### `<RangeSlider>`
 
-| Property          | Type `(Default)`                                       | Description                                                      |
-| ----------------- | ------------------------------------------------------ | ---------------------------------------------------------------- |
-| barClassName      | string                                                 | A css class to apply to the Bar DOM node                         |
-| defaultValue      | [number,number]                                        | Default value                                                    |
-| disabled          | boolean                                                | The disabled of component                                        |
-| getAriaValueText  | (value: number,eventKey:'start'&#124;'end') => string; | Provide a user-friendly name for the current value of the slider |
-| graduated         | boolean                                                | Show Ticks                                                       |
-| handleClassName   | string                                                 | A css class to apply to the Handle node                          |
-| handleStyle       | CSSProperties                                          | A css style to apply to the Handle node                          |
-| handleTitle       | ReactNode                                              | Customizing what is displayed inside a handle                    |
-| max               | number`(100)`                                          | Maximum sliding range                                            |
-| min               | number`(0)`                                            | Minimum value of sliding range                                   |
-| onChange          | (value: [number,number]) => void                       | Callback function that changes data                              |
-| onChangeCommitted | (value: [number,number], event) => void;               | Callback function that is fired when the mouseup is triggered    |
-| progress          | boolean                                                | Show sliding progress bar                                        |
-| renderMark        | (mark: number) => ReactNode                            | Customize labels on the render ruler                             |
-| step              | number`(1)`                                            | Slide the value of one step                                      |
-| tooltip           | boolean`(true)`                                        | Whether to show `Tooltip` when sliding                           |
-| value             | [number,number]                                        | Value (Controlled)                                               |
-| vertical          | boolean                                                | Vertical Slide                                                   |
+| Property          | Type `(Default)`                                       | Description                                                                                                          |
+| ----------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| barClassName      | string                                                 | A css class to apply to the Bar DOM node                                                                             |
+| constraint        | `(value: [number, number]) => boolean`                 | Validate next value before `onChange` is triggered. Prevent `onChange` being triggered if constraint returns `false` |
+| defaultValue      | [number,number]                                        | Default value                                                                                                        |
+| disabled          | boolean                                                | The disabled of component                                                                                            |
+| getAriaValueText  | (value: number,eventKey:'start'&#124;'end') => string; | Provide a user-friendly name for the current value of the slider                                                     |
+| graduated         | boolean                                                | Show Ticks                                                                                                           |
+| handleClassName   | string                                                 | A css class to apply to the Handle node                                                                              |
+| handleStyle       | CSSProperties                                          | A css style to apply to the Handle node                                                                              |
+| handleTitle       | ReactNode                                              | Customizing what is displayed inside a handle                                                                        |
+| max               | number`(100)`                                          | Maximum sliding range                                                                                                |
+| min               | number`(0)`                                            | Minimum value of sliding range                                                                                       |
+| onChange          | (value: [number,number]) => void                       | Callback function that changes data                                                                                  |
+| onChangeCommitted | (value: [number,number], event) => void;               | Callback function that is fired when the mouseup is triggered                                                        |
+| progress          | boolean                                                | Show sliding progress bar                                                                                            |
+| renderMark        | (mark: number) => ReactNode                            | Customize labels on the render ruler                                                                                 |
+| step              | number`(1)`                                            | Slide the value of one step                                                                                          |
+| tooltip           | boolean`(true)`                                        | Whether to show `Tooltip` when sliding                                                                               |
+| value             | [number,number]                                        | Value (Controlled)                                                                                                   |
+| vertical          | boolean                                                | Vertical Slide                                                                                                       |

--- a/docs/pages/components/slider/fragments/constraint.md
+++ b/docs/pages/components/slider/fragments/constraint.md
@@ -1,0 +1,16 @@
+<!--start-code-->
+
+```js
+const instance = (
+  <div>
+    <RangeSlider
+      max={50}
+      defaultValue={[10, 40]}
+      constraint={([start, end]) => start <= 25 && end >= 35}
+    />
+  </div>
+);
+ReactDOM.render(instance);
+```
+
+<!--end-code-->

--- a/docs/pages/components/slider/zh-CN/index.md
+++ b/docs/pages/components/slider/zh-CN/index.md
@@ -35,6 +35,12 @@
 
 <!--{include:`value.md`}-->
 
+### 约束
+
+限制起始值不得大于 25, 结束值不得小于 35。
+
+<!--{include:`constraint.md`}-->
+
 ### 自定义
 
 <!--{include:`custom.md`}-->
@@ -103,23 +109,24 @@ WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#slider
 
 ### `<RangeSlider>`
 
-| 属性名称          | 类型`(默认值)`                                         | 描述                                          |
-| ----------------- | ------------------------------------------------------ | --------------------------------------------- |
-| barClassName      | string                                                 | 应用于滑动条 DOM 节点的 css class             |
-| defaultValue      | [number,number]                                        | 默认值                                        |
-| disabled          | boolean                                                | 是否禁用                                      |
-| getAriaValueText  | (value: number,eventKey:'start'&#124;'end') => string; | 提供 Slider 的当前值的用户友好名称            |
-| graduated         | boolean                                                | 显示刻度                                      |
-| handleClassName   | string                                                 | 应用于手柄 DOM 节点的 css class               |
-| handleStyle       | CSSProperties                                          | 附加手柄样式                                  |
-| handleTitle       | ReactNode                                              | 自定义手柄内显示内容                          |
-| max               | number`(100)`                                          | 滑动范围的最大值                              |
-| min               | number`(0)`                                            | 滑动范围的最小值                              |
-| onChange          | (value: [number,number], event) => void                | 数据发生改变的回调函数                        |
-| onChangeCommitted | (value: [number,number], event) => void;               | 在 mouseup 事件触发后，同时数据发生改变的回调 |
-| progress          | boolean                                                | 显示滑动的进度条                              |
-| renderMark        | (mark: number) => ReactNode                            | 自定义渲染标尺上的标签                        |
-| step              | number`(1)`                                            | 滑动一步的值                                  |
-| tooltip           | boolean`(true)`                                        | 滑动时候，是否显示 tooltip                    |
-| value             | [number,number]                                        | 值（受控）                                    |
-| vertical          | boolean                                                | 垂直滑动                                      |
+| 属性名称          | 类型`(默认值)`                                         | 描述                                                                       |
+| ----------------- | ------------------------------------------------------ | -------------------------------------------------------------------------- |
+| barClassName      | string                                                 | 应用于滑动条 DOM 节点的 css class                                          |
+| constraint        | `(value: [number, number]) => boolean`                 | 在 `onChange` 触发之前对下一个值进行检查, 返回 `false` 则不触发 `onChange` |
+| defaultValue      | [number,number]                                        | 默认值                                                                     |
+| disabled          | boolean                                                | 是否禁用                                                                   |
+| getAriaValueText  | (value: number,eventKey:'start'&#124;'end') => string; | 提供 Slider 的当前值的用户友好名称                                         |
+| graduated         | boolean                                                | 显示刻度                                                                   |
+| handleClassName   | string                                                 | 应用于手柄 DOM 节点的 css class                                            |
+| handleStyle       | CSSProperties                                          | 附加手柄样式                                                               |
+| handleTitle       | ReactNode                                              | 自定义手柄内显示内容                                                       |
+| max               | number`(100)`                                          | 滑动范围的最大值                                                           |
+| min               | number`(0)`                                            | 滑动范围的最小值                                                           |
+| onChange          | (value: [number,number], event) => void                | 数据发生改变的回调函数                                                     |
+| onChangeCommitted | (value: [number,number], event) => void;               | 在 mouseup 事件触发后，同时数据发生改变的回调                              |
+| progress          | boolean                                                | 显示滑动的进度条                                                           |
+| renderMark        | (mark: number) => ReactNode                            | 自定义渲染标尺上的标签                                                     |
+| step              | number`(1)`                                            | 滑动一步的值                                                               |
+| tooltip           | boolean`(true)`                                        | 滑动时候，是否显示 tooltip                                                 |
+| value             | [number,number]                                        | 值（受控）                                                                 |
+| vertical          | boolean                                                | 垂直滑动                                                                   |

--- a/src/RangeSlider/RangeSlider.tsx
+++ b/src/RangeSlider/RangeSlider.tsx
@@ -207,7 +207,7 @@ const RangeSlider = React.forwardRef((props: RangeSliderProps, ref) => {
    */
   const handleChangeCommitted = useCallback(
     (event: React.MouseEvent, dataset?: DOMStringMap) => {
-      const nextValue = getNextValue(event, dataset! as HandleDataset);
+      const nextValue = getNextValue(event, dataset as HandleDataset);
 
       if (isRangeMatchingConstraint(nextValue)) {
         setValue(nextValue);

--- a/src/RangeSlider/test/RangeSliderSpec.js
+++ b/src/RangeSlider/test/RangeSliderSpec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import RangeSlider from '../RangeSlider';
@@ -45,6 +46,16 @@ describe('RangeSlider', () => {
 
     assert.equal(onChangeSpy.firstCall.firstArg[0], 0);
     assert.equal(onChangeSpy.firstCall.firstArg[1], 50);
+  });
+
+  it('Should not call onChange when next value does not match given constraint', async () => {
+    const onChange = sinon.spy();
+    const { container } = render(
+      <RangeSlider defaultValue={[10, 50]} onChange={onChange} constraint={() => false} />
+    );
+
+    fireEvent.click(container.querySelector('.rs-slider-progress-bar'));
+    expect(onChange).not.to.have.been.called;
   });
 
   it('Should render custom title', () => {

--- a/src/RangeSlider/test/RangeSliderSpec.js
+++ b/src/RangeSlider/test/RangeSliderSpec.js
@@ -48,13 +48,29 @@ describe('RangeSlider', () => {
     assert.equal(onChangeSpy.firstCall.firstArg[1], 50);
   });
 
+  it('Should respond to keyboard event', async () => {
+    const onChange = sinon.spy();
+    const { getAllByRole } = render(<RangeSlider value={[10, 50]} onChange={onChange} />);
+
+    // FIXME Should dispatch event on [role=slider] directly
+    fireEvent.keyDown(getAllByRole('slider')[0].closest('.rs-slider-handle'), {
+      key: 'ArrowRight'
+    });
+    expect(onChange).to.have.been.calledWith([11, 50]);
+  });
+
   it('Should not call onChange when next value does not match given constraint', async () => {
     const onChange = sinon.spy();
-    const { container } = render(
-      <RangeSlider defaultValue={[10, 50]} onChange={onChange} constraint={() => false} />
+    const { getAllByRole, container } = render(
+      <RangeSlider value={[10, 50]} onChange={onChange} constraint={() => false} />
     );
 
     fireEvent.click(container.querySelector('.rs-slider-progress-bar'));
+    expect(onChange).not.to.have.been.called;
+
+    fireEvent.keyDown(getAllByRole('slider')[0].closest('.rs-slider-handle'), {
+      key: 'ArrowRight'
+    });
     expect(onChange).not.to.have.been.called;
   });
 


### PR DESCRIPTION
When `constraint` prop is specified, RangeSlider checks if next value matches the constraint before calling `onChange`. If the value does not match the given constraint, RangeSlider remains current value and does not call `onChange`.

### API Signature

```ts
interface RangeSliderProps {
  constraint?: (value: [number, number]) => boolean;
}
```

Return a boolean to indicate whether next value (passed as the `value` argument) matches the constraint.

### Example

The RangeSlider below cannot set a starting value greater than 10 nor an ending value smaller than 90.

```jsx
<RangeSlider 
  defaultValue={[0, 100]}
  constraint={([start, end]) => start <= 10 && end >= 90}
/>
```