### PR TITLE
build(deps): bump rsuite-table from 5.3.1 to 5.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17411,9 +17411,9 @@
       }
     },
     "rsuite-table": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.3.1.tgz",
-      "integrity": "sha512-5p5bN5bzqyPVVL8QNjDwRvMr4iffXpOx5trJZZjm/TyrD0lSDMzd8lLAs/F6C7/6hmpWFKYjTLRt/8UIrIriXQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.3.2.tgz",
+      "integrity": "sha512-4ZAxHLdKt9UojE7UqDzUxbzPBwYNMRsrwwJSmrwq18Afqk83HX/7UFCXPhxLX3wu49SVX6pnkAE9I5K1EB2/ug==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "react-virtualized": "^9.22.3",
-    "rsuite-table": "^5.3.1",
+    "rsuite-table": "^5.3.2",
     "schema-typed": "^2.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
## [5.3.2](https://github.com/rsuite/rsuite-table/compare/5.3.1...5.3.2) (2022-01-13)


### Bug Fixes

* **ssr:** fix `window` is not defined for Table Columns ([#294](https://github.com/rsuite/rsuite-table/issues/294)) ([42e1189](https://github.com/rsuite/rsuite-table/commit/42e1189671bfe1687c7894df7ba5e67aa8a0bc24))

