### PR TITLE
feat(Cascader): add parent node in serach result while parentSelectable

### DIFF
--- a/src/Cascader/Cascader.tsx
+++ b/src/Cascader/Cascader.tsx
@@ -197,7 +197,7 @@ const Cascader: PickerComponent<CascaderProps> = React.forwardRef((props: Cascad
     (keyword?: string): ItemDataType[] => {
       const items: ItemDataType[] = [];
       const result = flattenData.filter(item => {
-        if (item[childrenKey]) {
+        if (!parentSelectable && item[childrenKey]) {
           return false;
         }
         return someKeyword(item, keyword);
@@ -213,7 +213,7 @@ const Cascader: PickerComponent<CascaderProps> = React.forwardRef((props: Cascad
       }
       return items;
     },
-    [childrenKey, flattenData, someKeyword]
+    [childrenKey, flattenData, someKeyword, parentSelectable]
   );
 
   // Used to hover the focuse item  when trigger `onKeydown`

--- a/src/Cascader/test/CascaderSpec.js
+++ b/src/Cascader/test/CascaderSpec.js
@@ -412,6 +412,52 @@ describe('Cascader', () => {
     });
   });
 
+  it('Should show search items with parentSelectable', () => {
+    const items = [
+      {
+        value: 't',
+        label: 't'
+      },
+      {
+        value: 'h',
+        label: 'h'
+      },
+      {
+        value: 'g',
+        label: 'g',
+        children: [
+          {
+            value: 'g-m',
+            label: 'g-m'
+          },
+          {
+            value: 'g-b',
+            label: 'g-b'
+          }
+        ]
+      }
+    ];
+
+    const cascaderRef = React.createRef();
+
+    render(<Cascader ref={cascaderRef} defaultOpen data={items} parentSelectable />);
+
+    ReactTestUtils.act(() => {
+      const input = cascaderRef.current.overlay.querySelector('.rs-picker-search-bar-input');
+
+      ReactTestUtils.Simulate.focus(input);
+
+      input.value = 'g';
+      ReactTestUtils.Simulate.change(input);
+    });
+
+    ReactTestUtils.act(() => {
+      const searchResult = cascaderRef.current.overlay.querySelectorAll('.rs-picker-cascader-row');
+
+      assert.equal(searchResult.length, 3);
+    });
+  });
+
   describe('ref testing', () => {
     it('Should control the open and close of picker', async () => {
       const onOpenSpy = sinon.spy();

--- a/src/Cascader/test/CascaderSpec.js
+++ b/src/Cascader/test/CascaderSpec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
+import UserEvent from '@testing-library/user-event';
 import ReactTestUtils from 'react-dom/test-utils';
 import Cascader from '../Cascader';
 import Button from '../../Button';
@@ -442,20 +443,13 @@ describe('Cascader', () => {
 
     render(<Cascader ref={cascaderRef} defaultOpen data={items} parentSelectable />);
 
-    ReactTestUtils.act(() => {
-      const input = cascaderRef.current.overlay.querySelector('.rs-picker-search-bar-input');
+    const input = cascaderRef.current.overlay.querySelector('.rs-picker-search-bar-input');
 
-      ReactTestUtils.Simulate.focus(input);
+    UserEvent.type(input, 'g');
 
-      input.value = 'g';
-      ReactTestUtils.Simulate.change(input);
-    });
+    const searchResult = cascaderRef.current.overlay.querySelectorAll('.rs-picker-cascader-row');
 
-    ReactTestUtils.act(() => {
-      const searchResult = cascaderRef.current.overlay.querySelectorAll('.rs-picker-cascader-row');
-
-      assert.equal(searchResult.length, 3);
-    });
+    assert.equal(searchResult.length, 3);
   });
 
   describe('ref testing', () => {


### PR DESCRIPTION
## CHANGES
with `parentSelectable`, show match parent node in search result
### Example
```tsx
<Cascader
  data={[
    {
      label: 'a'
      value: 'a',
      children: [
        {
          label: 'a-1',
          value: 'a-1'
        },
        {
          label: 'a-2',
          value: 'a-2'
        }
      ]
    }
  ]}
  parentSelectable
/>
```
### result
- a
- a / a-1
- a / a-2
---------

### Screenshot
![截屏2022-01-20 上午10 28 23](https://user-images.githubusercontent.com/14308293/150261192-d28ee2f5-180e-40f8-b94c-fad2d2551a71.png)

