### PR TITLE
docs(Tag): add missing tag size props

### DIFF
--- a/docs/pages/components/tag/en-US/index.md
+++ b/docs/pages/components/tag/en-US/index.md
@@ -28,10 +28,11 @@ Tag for categorizing or markup.
 
 ### `<Tag>`
 
-| Property    | Type `(Default)`      | Description                                          |
-| ----------- | --------------------- | ---------------------------------------------------- |
-| as          | ElementType `('div')` | You can use a custom element type for this component |
-| children \* | ReactNode             | The content of the component.                        |
-| classPrefix | string `('tag')`      | The prefix of the component CSS class                |
-| closable    | boolean               |
-| onClose     | (event) => void       | Click the callback function for the Close button     |
+| Property    | Type `(Default)`                        | Description                                          |
+| ----------- | --------------------------------------- | ---------------------------------------------------- |
+| as          | ElementType `('div')`                   | You can use a custom element type for this component |
+| children \* | ReactNode                               | The content of the component.                        |
+| classPrefix | string `('tag')`                        | The prefix of the component CSS class                |
+| closable    | boolean                                 |                                                      |
+| onClose     | (event) => void                         | Click the callback function for the Close button     |
+| size        | enum: 'sm'&#124;'md'&#124;'lg' `('md')` | Set the tag size                                     |

--- a/docs/pages/components/tag/zh-CN/index.md
+++ b/docs/pages/components/tag/zh-CN/index.md
@@ -28,10 +28,11 @@
 
 ### `<Tag>`
 
-| 属性名称    | 类型`(默认值)`        | 描述                   |
-| ----------- | --------------------- | ---------------------- |
-| children \* | ReactNode             | 组件的内容             |
-| classPrefix | string `('tag')`      | 组件 CSS 类的前缀      |
-| closable    | boolean               |
-| as          | ElementType `('div')` | 为组件自定义元素类型   |
-| onClose     | (event) => void       | 点击关闭按钮的回调函数 |
+| 属性名称    | 类型`(默认值)`                          | 描述                   |
+| ----------- | --------------------------------------- | ---------------------- |
+| children \* | ReactNode                               | 组件的内容             |
+| classPrefix | string `('tag')`                        | 组件 CSS 类的前缀      |
+| closable    | boolean                                 |                        |
+| as          | ElementType `('div')`                   | 为组件自定义元素类型   |
+| onClose     | (event) => void                         | 点击关闭按钮的回调函数 |
+| size        | enum: 'sm'&#124;'md'&#124;'lg' `('md')` | 标签尺寸               |


### PR DESCRIPTION
Hi, 
the props `size` is missing from the docs. 
Let me know what text you want to see in the zh-CN version and I'll update the PR!