### PR TITLE
Fix: link to custom theme page. Fixed #2333

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ React Suite is [MIT licensed][license]. Copyright (c) 2016-present, HYPERS.
 [rsuite-design]: https://rsuitejs.com/design/default
 [live-preview-on-codesandbox]: https://codesandbox.io/s/rsuite-template-5vq6zo2z5l
 [rsuite-doc-guide]: https://rsuitejs.com/en/guide/introduction
-[rsuite-doc-guide-themes]: https://rsuitejs.com/en/guide/themes
+[rsuite-doc-guide-themes]: https://rsuitejs.com/en/guide/customization
 [rsuite-doc-guide-intl]: https://rsuitejs.com/en/guide/intl
 [rsuite-doc-guide-rtl]: https://rsuitejs.com/en/guide/rtl
 [rsuite-components-overview]: https://rsuitejs.com/en/components/overview

--- a/README_zh.md
+++ b/README_zh.md
@@ -140,7 +140,7 @@ React Suite 基于 [MIT licensed][license] 发布。
 [rsuite-design]: https://rsuitejs.com/design/default
 [live-preview-on-codesandbox]: https://codesandbox.io/s/rsuite-template-5vq6zo2z5l
 [rsuite-doc-guide]: https://rsuitejs.com/guide/introduction
-[rsuite-doc-guide-themes]: https://rsuitejs.com/guide/themes
+[rsuite-doc-guide-themes]: https://rsuitejs.com/guide/customization
 [rsuite-doc-guide-intl]: https://rsuitejs.com/guide/intl
 [rsuite-doc-guide-intl]: https://rsuitejs.com/en/guide/intl
 [rsuite-components-overview]: https://rsuitejs.com/components/overview

--- a/docs/pages/guide/introduction/en-US/index.md
+++ b/docs/pages/guide/introduction/en-US/index.md
@@ -113,7 +113,7 @@ RSUITE is [MIT licensed][license]. Copyright (c) 2016-present, HYPERS.
 [rsuite-design]: https://rsuitejs.com/design/default
 [live-preview-on-codesandbox]: https://codesandbox.io/s/mo7jxvr9x9?from-embed
 [rsuite-doc-guide]: https://rsuitejs.com/guide/introduction
-[rsuite-doc-guide-themes]: https://rsuitejs.com/guide/themes
+[rsuite-doc-guide-themes]: https://rsuitejs.com/guide/customization
 [rsuite-doc-guide-intl]: https://rsuitejs.com/guide/intl
 [rsuite-components-overview]: https://rsuitejs.com/components/overview
 [release-notes]: https://github.com/rsuite/rsuite/releases

--- a/docs/pages/guide/introduction/zh-CN/index.md
+++ b/docs/pages/guide/introduction/zh-CN/index.md
@@ -115,7 +115,7 @@ RSUITE 基于 [MIT licensed][license] 发布。
 [rsuite-design]: https://rsuitejs.com/design/default
 [live-preview-on-codesandbox]: https://codesandbox.io/s/mo7jxvr9x9?from-embed
 [rsuite-doc-guide]: https://rsuitejs.com/guide/introduction
-[rsuite-doc-guide-themes]: https://rsuitejs.com/guide/themes
+[rsuite-doc-guide-themes]: https://rsuitejs.com/guide/customization
 [rsuite-doc-guide-intl]: https://rsuitejs.com/guide/intl
 [rsuite-components-overview]: https://rsuitejs.com/components/overview
 [release-notes]: https://github.com/rsuite/rsuite/releases

--- a/docs/pages/guide/use-with-create-react-app/en-US/index.md
+++ b/docs/pages/guide/use-with-create-react-app/en-US/index.md
@@ -111,7 +111,7 @@ module.exports = override(
 
 Re-executing `yarn start`, the red button is the configuration was successful
 
-We uses [react-app-rewired][react-app-rewired] and [customize-cra][customize-cra] to implement custom themes with [less-loader][less-loader] using `modifyVars` configuration. For more details, see [Customize Theme](/guide/themes).
+We uses [react-app-rewired][react-app-rewired] and [customize-cra][customize-cra] to implement custom themes with [less-loader][less-loader] using `modifyVars` configuration. For more details, see [Customize Theme](/guide/customization).
 
 ## Troubleshooting
 

--- a/docs/pages/guide/use-with-create-react-app/zh-CN/index.md
+++ b/docs/pages/guide/use-with-create-react-app/zh-CN/index.md
@@ -110,7 +110,7 @@ module.exports = override(
 
 重新执行 `yarn start`，看到红色按钮就是配置成功了。
 
-这里使用 [react-app-rewired][react-app-rewired] 和 [customize-cra][customize-cra],配合 [less-loader][less-loader] 利用 `modifyVars` 配置实现定制主题。更多方法，详见[定制主题](/guide/themes)。
+这里使用 [react-app-rewired][react-app-rewired] 和 [customize-cra][customize-cra],配合 [less-loader][less-loader] 利用 `modifyVars` 配置实现定制主题。更多方法，详见[定制主题](/guide/customization)。
 
 ## 常见问题
 

--- a/docs/pages/resources/palette/en-US/index.md
+++ b/docs/pages/resources/palette/en-US/index.md
@@ -1,6 +1,6 @@
 # Palette
 
-In rsuite, [custom themes](/guide/themes) are supported, and you can preview the effect of a component by using the color palette preset theme colors.
+In rsuite, [custom themes](/guide/customization) are supported, and you can preview the effect of a component by using the color palette preset theme colors.
 
 Use `@H500` as `@primary-color`.
 

--- a/docs/pages/resources/palette/zh-CN/index.md
+++ b/docs/pages/resources/palette/zh-CN/index.md
@@ -1,5 +1,5 @@
 # 调色板
 
-在 RSUITE 中，支持[自定义主题](/guide/themes)，可以通过调色板预设主题颜色，预览组件效果。使用 `@H500`做为`@primary-color`。
+在 RSUITE 中，支持[自定义主题](/guide/customization)，可以通过调色板预设主题颜色，预览组件效果。使用 `@H500`做为`@primary-color`。
 
 <br/>

--- a/examples/custom-multiple-themes/README.md
+++ b/examples/custom-multiple-themes/README.md
@@ -1,3 +1,3 @@
 # RSUITE multiple themes example
 
-This example used [webpack-multiple-themes-compile](https://github.com/rsuite/webpack-multiple-themes-compile) library to compile style files. About rsuite customize theme more info , you can visited to our [homepage](https://rsuitejs.com/en/guide/themes).
+This example used [webpack-multiple-themes-compile](https://github.com/rsuite/webpack-multiple-themes-compile) library to compile style files. About rsuite customize theme more info , you can visited to our [homepage](https://rsuitejs.com/en/guide/customization).


### PR DESCRIPTION
Link from the page `/resources/palette` to `/guide/customization` was broken