### PR TITLE
feat(Carousel): Expose active index

### DIFF
--- a/docs/pages/components/carousel/en-US/index.md
+++ b/docs/pages/components/carousel/en-US/index.md
@@ -12,6 +12,10 @@ Display a set of elements in a carousel
 
 <!--{include:`basic.md`}-->
 
+### Initial index
+
+<!--{include:`position.md`}-->
+
 ### Appearance
 
 <!--{include:`appearance.md`}-->
@@ -27,6 +31,7 @@ Display a set of elements in a carousel
 | Property         | Type `(Default)`                                       | Description                                    |
 | ---------------- | ------------------------------------------------------ | ---------------------------------------------- |
 | as               | ElementType `('div')`                                  | Custom element type                            |
+| index            | number (`0`)                                           | Initial active element index                   |
 | autoplay         | boolean                                                | Automatic carousel element.                    |
 | autoplayInterval | number (`4000`)                                        | Delay in ms until navigating to the next item. |
 | children         | ReactNode                                              | Carousel elements                              |

--- a/docs/pages/components/carousel/en-US/index.md
+++ b/docs/pages/components/carousel/en-US/index.md
@@ -31,7 +31,7 @@ Display a set of elements in a carousel
 | Property         | Type `(Default)`                                       | Description                                    |
 | ---------------- | ------------------------------------------------------ | ---------------------------------------------- |
 | as               | ElementType `('div')`                                  | Custom element type                            |
-| activeIndex      | number (`0`)                                           | Active element index                           |
+| activeIndex      | number (`0`)                                           | Controls the current visible slide                           |
 | autoplay         | boolean                                                | Automatic carousel element.                    |
 | autoplayInterval | number (`4000`)                                        | Delay in ms until navigating to the next item. |
 | children         | ReactNode                                              | Carousel elements                              |

--- a/docs/pages/components/carousel/en-US/index.md
+++ b/docs/pages/components/carousel/en-US/index.md
@@ -12,7 +12,7 @@ Display a set of elements in a carousel
 
 <!--{include:`basic.md`}-->
 
-### Initial index
+### Controlled index
 
 <!--{include:`position.md`}-->
 
@@ -31,7 +31,7 @@ Display a set of elements in a carousel
 | Property         | Type `(Default)`                                       | Description                                    |
 | ---------------- | ------------------------------------------------------ | ---------------------------------------------- |
 | as               | ElementType `('div')`                                  | Custom element type                            |
-| index            | number (`0`)                                           | Initial active element index                   |
+| activeIndex      | number (`0`)                                           | Active element index                           |
 | autoplay         | boolean                                                | Automatic carousel element.                    |
 | autoplayInterval | number (`4000`)                                        | Delay in ms until navigating to the next item. |
 | children         | ReactNode                                              | Carousel elements                              |

--- a/docs/pages/components/carousel/en-US/index.md
+++ b/docs/pages/components/carousel/en-US/index.md
@@ -28,16 +28,17 @@ Display a set of elements in a carousel
 
 ### `<Carousel>`
 
-| Property         | Type `(Default)`                                       | Description                                    |
-| ---------------- | ------------------------------------------------------ | ---------------------------------------------- |
-| as               | ElementType `('div')`                                  | Custom element type                            |
-| activeIndex      | number (`0`)                                           | Controls the current visible slide                           |
-| autoplay         | boolean                                                | Automatic carousel element.                    |
-| autoplayInterval | number (`4000`)                                        | Delay in ms until navigating to the next item. |
-| children         | ReactNode                                              | Carousel elements                              |
-| classPrefix      | string `('carousel')`                                  | Component CSS class prefix                     |
-| onSelect         | (index: number, event?: React.ChangeEvent) => void     | Callback fired when the active item changes    |
-| onSlideEnd       | (index: number, event?: React.TransitionEvent) => void | Callback fired when a slide transition ends    |
-| onSlideStart     | (index: number, event?: React.ChangeEvent) => void     | Callback fired when a slide transition starts  |
-| placement        | enum:'top','bottom','left','right' `('bottom')`        | Button placement                               |
-| shape            | enum:'dot','bar' `('dot')`                             | Button shape                                   |
+| Property           | Type `(Default)`                                       | Description                                    |
+| ------------------ | ------------------------------------------------------ | ---------------------------------------------- |
+| activeIndex        | number                                                 | Controls the current visible slide             |
+| as                 | ElementType `('div')`                                  | Custom element type                            |
+| autoplay           | boolean                                                | Automatic carousel element.                    |
+| autoplayInterval   | number (`4000`)                                        | Delay in ms until navigating to the next item. |
+| children           | ReactNode                                              | Carousel elements                              |
+| classPrefix        | string `('carousel')`                                  | Component CSS class prefix                     |
+| defaultActiveIndex | number (`0`)                                           | The default initial slide                      |
+| onSelect           | (index: number, event?: React.ChangeEvent) => void     | Callback fired when the active item changes    |
+| onSlideEnd         | (index: number, event?: React.TransitionEvent) => void | Callback fired when a slide transition ends    |
+| onSlideStart       | (index: number, event?: React.ChangeEvent) => void     | Callback fired when a slide transition starts  |
+| placement          | enum:'top','bottom','left','right' `('bottom')`        | Button placement                               |
+| shape              | enum:'dot','bar' `('dot')`                             | Button shape                                   |

--- a/docs/pages/components/carousel/fragments/position.md
+++ b/docs/pages/components/carousel/fragments/position.md
@@ -1,0 +1,17 @@
+<!--start-code-->
+
+```js
+const instance = (
+  <Carousel index={2} className="custom-slider">
+    <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=1" height="250" />
+    <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=2" height="250" />
+    <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=3" height="250" />
+    <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=4" height="250" />
+    <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=5" height="250" />
+  </Carousel>
+);
+
+ReactDOM.render(instance);
+```
+
+<!--end-code-->

--- a/docs/pages/components/carousel/fragments/position.md
+++ b/docs/pages/components/carousel/fragments/position.md
@@ -2,7 +2,7 @@
 
 ```js
 const instance = (
-  <Carousel index={2} className="custom-slider">
+  <Carousel activeIndex={2} className="custom-slider">
     <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=1" height="250" />
     <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=2" height="250" />
     <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=3" height="250" />

--- a/docs/pages/components/carousel/fragments/position.md
+++ b/docs/pages/components/carousel/fragments/position.md
@@ -1,17 +1,26 @@
 <!--start-code-->
 
 ```js
-const instance = (
-  <Carousel activeIndex={2} className="custom-slider">
-    <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=1" height="250" />
-    <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=2" height="250" />
-    <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=3" height="250" />
-    <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=4" height="250" />
-    <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=5" height="250" />
-  </Carousel>
-);
+const App = () => {
+  const [activeIndex, setActiveIndex] = React.useState(2);
+  return (
+    <Carousel
+      className="custom-slider"
+      activeIndex={activeIndex}
+      onSelect={index => {
+        setActiveIndex(index);
+      }}
+    >
+      <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=1" height="250" />
+      <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=2" height="250" />
+      <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=3" height="250" />
+      <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=4" height="250" />
+      <img src="https://via.placeholder.com/600x250/8f8e94/FFFFFF?text=5" height="250" />
+    </Carousel>
+  );
+};
 
-ReactDOM.render(instance);
+ReactDOM.render(<App />);
 ```
 
 <!--end-code-->

--- a/docs/pages/components/carousel/zh-CN/index.md
+++ b/docs/pages/components/carousel/zh-CN/index.md
@@ -12,7 +12,7 @@
 
 <!--{include:`basic.md`}-->
 
-### 受控指数
+### 受控的幻灯片
 
 <!--{include:`position.md`}-->
 
@@ -31,7 +31,7 @@
 | 属性名称     | 类型`(默认值)`                                         | 描述                       |
 | ------------ | ------------------------------------------------------ | -------------------------- |
 | as           | ElementType `('div')`                                  | 自定义元素类型             |
-| activeIndex  | number (`0`)                                           | 活性元素指数               |
+| activeIndex  | number (`0`)                                           | 控制当前可见幻灯片               |
 | autoplay     | boolean                                                | 自动轮播                   |
 | children     | ReactNode                                              | 轮播的元素                 |
 | classPrefix  | string `('carousel')`                                  | 组件 CSS 类的前缀          |

--- a/docs/pages/components/carousel/zh-CN/index.md
+++ b/docs/pages/components/carousel/zh-CN/index.md
@@ -12,6 +12,10 @@
 
 <!--{include:`basic.md`}-->
 
+### 初始指数
+
+<!--{include:`position.md`}-->
+
 ### 外观
 
 <!--{include:`appearance.md`}-->
@@ -27,6 +31,7 @@
 | 属性名称     | 类型`(默认值)`                                         | 描述                       |
 | ------------ | ------------------------------------------------------ | -------------------------- |
 | as           | ElementType `('div')`                                  | 自定义元素类型             |
+| index        | number (`0`)                                           | 初始活动元素索引           |
 | autoplay     | boolean                                                | 自动轮播                   |
 | children     | ReactNode                                              | 轮播的元素                 |
 | classPrefix  | string `('carousel')`                                  | 组件 CSS 类的前缀          |

--- a/docs/pages/components/carousel/zh-CN/index.md
+++ b/docs/pages/components/carousel/zh-CN/index.md
@@ -28,15 +28,16 @@
 
 ### `<Carousel>`
 
-| 属性名称     | 类型`(默认值)`                                         | 描述                       |
-| ------------ | ------------------------------------------------------ | -------------------------- |
-| as           | ElementType `('div')`                                  | 自定义元素类型             |
-| activeIndex  | number (`0`)                                           | 控制当前可见幻灯片               |
-| autoplay     | boolean                                                | 自动轮播                   |
-| children     | ReactNode                                              | 轮播的元素                 |
-| classPrefix  | string `('carousel')`                                  | 组件 CSS 类的前缀          |
-| onSelect     | (index: number, event?: React.ChangeEvent) => void     | 活动项更改时触发的回调     |
-| onSlideEnd   | (index: number, event?: React.TransitionEvent) => void | 幻灯片过渡结束时触发的回调 |
-| onSlideStart | (index: number, event?: React.ChangeEvent) => void     | 幻灯片过渡开始时触发的回调 |
-| placement    | enum:'top','bottom','left','right' `('bottom')`        | 按钮的位置                 |
-| shape        | enum:'dot','bar' `('dot')`                             | 按钮的形状                 |
+| 属性名称           | 类型`(默认值)`                                         | 描述                       |
+| ------------------ | ------------------------------------------------------ | -------------------------- |
+| activeIndex        | number                                                 | 控制当前可见幻灯片         |
+| as                 | ElementType `('div')`                                  | 自定义元素类型             |
+| autoplay           | boolean                                                | 自动轮播                   |
+| children           | ReactNode                                              | 轮播的元素                 |
+| classPrefix        | string `('carousel')`                                  | 组件 CSS 类的前缀          |
+| defaultActiveIndex | number (`0`)                                           | 默认的初始幻灯片           |
+| onSelect           | (index: number, event?: React.ChangeEvent) => void     | 活动项更改时触发的回调     |
+| onSlideEnd         | (index: number, event?: React.TransitionEvent) => void | 幻灯片过渡结束时触发的回调 |
+| onSlideStart       | (index: number, event?: React.ChangeEvent) => void     | 幻灯片过渡开始时触发的回调 |
+| placement          | enum:'top','bottom','left','right' `('bottom')`        | 按钮的位置                 |
+| shape              | enum:'dot','bar' `('dot')`                             | 按钮的形状                 |

--- a/docs/pages/components/carousel/zh-CN/index.md
+++ b/docs/pages/components/carousel/zh-CN/index.md
@@ -12,7 +12,7 @@
 
 <!--{include:`basic.md`}-->
 
-### 初始指数
+### 受控指数
 
 <!--{include:`position.md`}-->
 
@@ -31,7 +31,7 @@
 | 属性名称     | 类型`(默认值)`                                         | 描述                       |
 | ------------ | ------------------------------------------------------ | -------------------------- |
 | as           | ElementType `('div')`                                  | 自定义元素类型             |
-| index        | number (`0`)                                           | 初始活动元素索引           |
+| activeIndex  | number (`0`)                                           | 活性元素指数               |
 | autoplay     | boolean                                                | 自动轮播                   |
 | children     | ReactNode                                              | 轮播的元素                 |
 | classPrefix  | string `('carousel')`                                  | 组件 CSS 类的前缀          |

--- a/src/Carousel/Carousel.tsx
+++ b/src/Carousel/Carousel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useRef } from 'react';
+import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useClassNames, useCustom, guid, ReactChildren, useTimeout, mergeRefs } from '../utils';
@@ -17,7 +17,10 @@ export interface CarouselProps extends WithAsProps {
   /** Button shape */
   shape?: 'dot' | 'bar';
 
-  /** Callback fired when the active item changes */
+  /** Active element index */
+  index?: number;
+
+  /** Callback fired when the active item manually changes */
   onSelect?: (index: number, event: React.ChangeEvent<HTMLInputElement>) => void;
 
   /** Callback fired when a slide transition starts */
@@ -38,6 +41,7 @@ const Carousel: RsRefForwardingComponent<'div', CarouselProps> = React.forwardRe
       shape = 'dot',
       autoplay,
       autoplayInterval = 4000,
+      index = 0,
       onSelect,
       onSlideStart,
       onSlideEnd,
@@ -51,26 +55,38 @@ const Carousel: RsRefForwardingComponent<'div', CarouselProps> = React.forwardRe
     const vertical = placement === 'left' || placement === 'right';
     const lengthKey = vertical ? 'height' : 'width';
 
-    const [activeIndex, setActiveIndex] = useState(0);
+    const [activeIndex, setActiveIndex] = useState(index);
     const [lastIndex, setLastIndex] = useState(0);
+    const [inputActiveIndex, setInputActiveIndex] = useState(index);
     const rootRef = useRef<HTMLDivElement>(null);
 
-    const handleSlide = (nextActiveIndex?: number, event?: React.ChangeEvent<HTMLInputElement>) => {
-      if (!rootRef.current) {
-        return;
-      }
+    // Set a timer for automatic playback.
+    // `autoplay` needs to be cast to boolean type to avoid undefined parameters.
+    const { clear, reset } = useTimeout(
+      () => handleSlide(),
+      autoplayInterval,
+      !!autoplay && count > 1
+    );
 
-      clear();
-      const index = nextActiveIndex ?? activeIndex + 1;
+    const handleSlide = useCallback(
+      (nextActiveIndex?: number, event?: React.ChangeEvent<HTMLInputElement>) => {
+        if (!rootRef.current) {
+          return;
+        }
 
-      // When index is greater than count, start from 1 again.
-      const nextIndex = index % count;
+        clear();
+        const index = nextActiveIndex ?? activeIndex + 1;
 
-      setActiveIndex(nextIndex);
-      onSlideStart?.(nextIndex, event);
-      setLastIndex(nextActiveIndex == null ? activeIndex : nextIndex);
-      reset();
-    };
+        // When index is greater than count, start from 1 again.
+        const nextIndex = index % count;
+
+        setActiveIndex(nextIndex);
+        onSlideStart?.(nextIndex, event);
+        setLastIndex(nextActiveIndex == null ? activeIndex : nextIndex);
+        reset();
+      },
+      [activeIndex, count, clear, onSlideStart, reset]
+    );
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const activeIndex = +event.target.value;
@@ -85,9 +101,14 @@ const Carousel: RsRefForwardingComponent<'div', CarouselProps> = React.forwardRe
       [activeIndex, onSlideEnd]
     );
 
-    // Set a timer for automatic playback.
-    // `autoplay` needs to be cast to boolean type to avoid undefined parameters.
-    const { clear, reset } = useTimeout(handleSlide, autoplayInterval, !!autoplay && count > 1);
+    useEffect(() => {
+      if (inputActiveIndex !== index) {
+        setInputActiveIndex(index);
+        if (index >= 0 && index !== activeIndex) {
+          handleSlide(index);
+        }
+      }
+    }, [index, inputActiveIndex, activeIndex, handleSlide, setInputActiveIndex]);
 
     const uniqueId = useMemo(() => guid(), []);
     const items = React.Children.map(
@@ -174,6 +195,7 @@ Carousel.propTypes = {
   autoplayInterval: PropTypes.number,
   placement: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
   shape: PropTypes.oneOf(['dot', 'bar']),
+  index: PropTypes.number,
   onSelect: PropTypes.func,
   onSlideStart: PropTypes.func,
   onSlideEnd: PropTypes.func

--- a/src/Carousel/Carousel.tsx
+++ b/src/Carousel/Carousel.tsx
@@ -18,7 +18,7 @@ export interface CarouselProps extends WithAsProps {
   shape?: 'dot' | 'bar';
 
   /** Active element index */
-  index?: number;
+  activeIndex?: number;
 
   /** Callback fired when the active item manually changes */
   onSelect?: (index: number, event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -41,7 +41,7 @@ const Carousel: RsRefForwardingComponent<'div', CarouselProps> = React.forwardRe
       shape = 'dot',
       autoplay,
       autoplayInterval = 4000,
-      index = 0,
+      activeIndex = 0,
       onSelect,
       onSlideStart,
       onSlideEnd,
@@ -55,9 +55,9 @@ const Carousel: RsRefForwardingComponent<'div', CarouselProps> = React.forwardRe
     const vertical = placement === 'left' || placement === 'right';
     const lengthKey = vertical ? 'height' : 'width';
 
-    const [activeIndex, setActiveIndex] = useState(index);
+    const [currentIndex, setCurrentIndex] = useState(activeIndex);
     const [lastIndex, setLastIndex] = useState(0);
-    const [inputActiveIndex, setInputActiveIndex] = useState(index);
+    const [inputActiveIndex, setInputActiveIndex] = useState(activeIndex);
     const rootRef = useRef<HTMLDivElement>(null);
 
     // Set a timer for automatic playback.
@@ -75,17 +75,17 @@ const Carousel: RsRefForwardingComponent<'div', CarouselProps> = React.forwardRe
         }
 
         clear();
-        const index = nextActiveIndex ?? activeIndex + 1;
+        const index = nextActiveIndex ?? currentIndex + 1;
 
         // When index is greater than count, start from 1 again.
         const nextIndex = index % count;
 
-        setActiveIndex(nextIndex);
+        setCurrentIndex(nextIndex);
         onSlideStart?.(nextIndex, event);
-        setLastIndex(nextActiveIndex == null ? activeIndex : nextIndex);
+        setLastIndex(nextActiveIndex == null ? currentIndex : nextIndex);
         reset();
       },
-      [activeIndex, count, clear, onSlideStart, reset]
+      [currentIndex, count, clear, onSlideStart, reset]
     );
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -96,19 +96,19 @@ const Carousel: RsRefForwardingComponent<'div', CarouselProps> = React.forwardRe
 
     const handleTransitionEnd = useCallback(
       (event: React.TransitionEvent<HTMLDivElement>) => {
-        onSlideEnd?.(activeIndex, event);
+        onSlideEnd?.(currentIndex, event);
       },
-      [activeIndex, onSlideEnd]
+      [currentIndex, onSlideEnd]
     );
 
     useEffect(() => {
-      if (inputActiveIndex !== index) {
-        setInputActiveIndex(index);
-        if (index >= 0 && index !== activeIndex) {
-          handleSlide(index);
+      if (inputActiveIndex !== activeIndex) {
+        setInputActiveIndex(activeIndex);
+        if (activeIndex >= 0 && activeIndex !== currentIndex) {
+          handleSlide(activeIndex);
         }
       }
-    }, [index, inputActiveIndex, activeIndex, handleSlide, setInputActiveIndex]);
+    }, [activeIndex, inputActiveIndex, currentIndex, handleSlide, setInputActiveIndex]);
 
     const uniqueId = useMemo(() => guid(), []);
     const items = React.Children.map(
@@ -126,7 +126,7 @@ const Carousel: RsRefForwardingComponent<'div', CarouselProps> = React.forwardRe
               type="radio"
               onChange={handleChange}
               value={index}
-              checked={activeIndex === index}
+              checked={currentIndex === index}
             />
             <label htmlFor={inputKey} className={prefix('label')} />
           </li>
@@ -134,7 +134,7 @@ const Carousel: RsRefForwardingComponent<'div', CarouselProps> = React.forwardRe
 
         return React.cloneElement(child, {
           key: `slider-item${index}`,
-          'aria-hidden': activeIndex !== index,
+          'aria-hidden': currentIndex !== index,
           style: { ...child.props.style, [lengthKey]: `${100 / count}%` },
           className: classNames(prefix('slider-item'), child.props.className)
         });
@@ -145,14 +145,14 @@ const Carousel: RsRefForwardingComponent<'div', CarouselProps> = React.forwardRe
 
     const positiveOrder = vertical || !rtl;
     const sign = positiveOrder ? '-' : '';
-    const activeRatio = `${sign}${(100 / count) * activeIndex}%`;
+    const activeRatio = `${sign}${(100 / count) * currentIndex}%`;
     const sliderStyles = {
       [lengthKey]: `${count * 100}%`,
       transform: vertical
         ? `translate3d(0, ${activeRatio} ,0)`
         : `translate3d(${activeRatio}, 0 ,0)`
     };
-    const showMask = count > 1 && activeIndex === 0 && activeIndex !== lastIndex;
+    const showMask = count > 1 && currentIndex === 0 && currentIndex !== lastIndex;
 
     return (
       <Component {...rest} ref={mergeRefs(ref, rootRef)} className={classes}>
@@ -195,7 +195,7 @@ Carousel.propTypes = {
   autoplayInterval: PropTypes.number,
   placement: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
   shape: PropTypes.oneOf(['dot', 'bar']),
-  index: PropTypes.number,
+  activeIndex: PropTypes.number,
   onSelect: PropTypes.func,
   onSlideStart: PropTypes.func,
   onSlideEnd: PropTypes.func

--- a/src/Carousel/test/CarouselSpec.js
+++ b/src/Carousel/test/CarouselSpec.js
@@ -94,7 +94,7 @@ describe('Carousel', () => {
 
   it('Should initialize with the passed index position', () => {
     const instance = getDOMNode(
-      <Carousel index={2}>
+      <Carousel activeIndex={2}>
         <div>1</div>
         <div>2</div>
         <div>3</div>

--- a/src/Carousel/test/CarouselSpec.js
+++ b/src/Carousel/test/CarouselSpec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
+import { render, screen } from '@testing-library/react';
 import Carousel from '../Carousel';
 
 describe('Carousel', () => {
@@ -103,5 +104,34 @@ describe('Carousel', () => {
     );
 
     assert.equal(instance.querySelector('[aria-hidden=false]').textContent, '3');
+  });
+
+  it('Should handle active index dynamically', () => {
+    const ref = React.createRef();
+    const App = React.forwardRef((props, ref) => {
+      const [index, setIndex] = React.useState(1);
+      React.useImperativeHandle(ref, () => ({
+        setIndex: newIndex => {
+          setIndex(newIndex);
+        }
+      }));
+
+      return (
+        <Carousel activeIndex={index}>
+          <div>1</div>
+          <div>2</div>
+          <div>3</div>
+          <div>4</div>
+        </Carousel>
+      );
+    });
+
+    const { container } = render(<App ref={ref} />);
+
+    assert.equal(container.querySelector('[aria-hidden=false]').textContent, '2');
+
+    ref.current.setIndex(3);
+
+    assert.equal(container.querySelector('[aria-hidden=false]').textContent, '4');
   });
 });

--- a/src/Carousel/test/CarouselSpec.js
+++ b/src/Carousel/test/CarouselSpec.js
@@ -91,4 +91,17 @@ describe('Carousel', () => {
 
     ReactTestUtils.Simulate.transitionEnd(instance.querySelector('.rs-carousel-slider'));
   });
+
+  it('Should initialize with the passed index position', () => {
+    const instance = getDOMNode(
+      <Carousel index={2}>
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+        <div>4</div>
+      </Carousel>
+    );
+
+    assert.equal(instance.querySelector('[aria-hidden=false]').textContent, '3');
+  });
 });

--- a/src/Carousel/test/CarouselSpec.js
+++ b/src/Carousel/test/CarouselSpec.js
@@ -92,9 +92,9 @@ describe('Carousel', () => {
     ReactTestUtils.Simulate.transitionEnd(instance.querySelector('.rs-carousel-slider'));
   });
 
-  it('Should initialize with the passed index position', () => {
+  it('Should initialize with the default index position', () => {
     const instance = getDOMNode(
-      <Carousel activeIndex={2}>
+      <Carousel defaultActiveIndex={2}>
         <div>1</div>
         <div>2</div>
         <div>3</div>

--- a/src/Carousel/test/CarouselSpec.js
+++ b/src/Carousel/test/CarouselSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { testStandardProps } from '@test/commonCases';
 import Carousel from '../Carousel';
 


### PR DESCRIPTION
**Changes:**
This PR exposes the active index to the user so he can either initialize with a different index or to change it externally. It keeps all the behaviors already in place.

**Rationale:**
Sometimes the user want to initialize a different initial position, for example loading last status of his navigation, or change the active element externally, for example having an expanded view of a thumbnail that has navigation between elements and needs to keep the carousel in sync. 
