### PR TITLE
test: re-use common test cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4727,9 +4727,9 @@
       }
     },
     "chai-dom": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/chai-dom/-/chai-dom-1.9.0.tgz",
-      "integrity": "sha512-UXSbhcGVBWv/5qVqbJY/giTDRyo3wKapUsWluEuVvxcJLFXkyf8l4D2PTd6trzrmca6WWnGdpaFkYdl1P0WjtA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/chai-dom/-/chai-dom-1.11.0.tgz",
+      "integrity": "sha512-ZzGlEfk1UhHH5+N0t9bDqstOxPEXmn3EyXvtsok5rfXVDOFDJbHVy12rED6ZwkJAUDs2w7/Da4Hlq2LB63kltg==",
       "dev": true
     },
     "chalk": {

--- a/src/Avatar/test/AvatarSpec.js
+++ b/src/Avatar/test/AvatarSpec.js
@@ -1,8 +1,11 @@
 import React from 'react';
-import Avatar from '../Avatar';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
+import Avatar from '../Avatar';
 
 describe('Avatar', () => {
+  testStandardProps(<Avatar />);
+
   it('Should render avatar', () => {
     const content = 'RS';
     const instance = getDOMNode(<Avatar>{content}</Avatar>);
@@ -56,16 +59,5 @@ describe('Avatar', () => {
   it('Should apply size class', () => {
     const instance = getDOMNode(<Avatar size="lg">RS</Avatar>);
     assert.include(instance.className, 'rs-avatar-lg');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Avatar style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Avatar classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/AvatarGroup/test/AvatarGroupSpec.js
+++ b/src/AvatarGroup/test/AvatarGroupSpec.js
@@ -1,9 +1,12 @@
 import React from 'react';
+import { render } from '@testing-library/react';
+import { testStandardProps } from '@test/commonCases';
 import AvatarGroup from '../AvatarGroup';
 import Avatar from '../../Avatar';
-import { render } from '@testing-library/react';
 
 describe('AvatarGroup', () => {
+  testStandardProps(<AvatarGroup />);
+
   it('Should change the size of all avatars', () => {
     const { getByTestId } = render(
       <AvatarGroup size="xs" data-testid="group">
@@ -36,16 +39,5 @@ describe('AvatarGroup', () => {
   it('Should be stack', () => {
     const { getByTestId } = render(<AvatarGroup stack data-testid="group" />);
     assert.include(getByTestId('group').className, 'rs-avatar-group-stack');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const { getByTestId } = render(<AvatarGroup style={{ fontSize }} data-testid="group" />);
-    assert.equal(getByTestId('group').style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const { getByTestId } = render(<AvatarGroup classPrefix="custom-prefix" data-testid="group" />);
-    assert.include(getByTestId('group').className, 'custom-prefix');
   });
 });

--- a/src/Badge/test/BadgeSpec.js
+++ b/src/Badge/test/BadgeSpec.js
@@ -1,8 +1,11 @@
 import React from 'react';
-import Badge from '../Badge';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
+import Badge from '../Badge';
 
 describe('Badge', () => {
+  testStandardProps(<Badge />);
+
   it('Should render independent', () => {
     const instance = getDOMNode(<Badge />);
     assert.include(instance.className, 'rs-badge-independent');

--- a/src/Breadcrumb/test/BreadcrumbItemSpec.js
+++ b/src/Breadcrumb/test/BreadcrumbItemSpec.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode, getInstance } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Breadcrumb from '../Breadcrumb';
+import BreadcrumbItem from '../BreadcrumbItem';
 
 describe('Breadcrumb.Item', () => {
+  testStandardProps(<BreadcrumbItem />);
+
   it('Should render `a` as inner element when is not active', () => {
     const instance = getDOMNode(<Breadcrumb.Item href="#">Crumb</Breadcrumb.Item>);
 
@@ -27,16 +31,6 @@ describe('Breadcrumb.Item', () => {
 
     assert.ok(instance);
     assert.notOk(instance.hasAttribute('href'));
-  });
-
-  it('Should add custom classes onto `li` wrapper element', () => {
-    const instance = getDOMNode(
-      <Breadcrumb.Item className="custom-one custom-two">Active Crumb</Breadcrumb.Item>
-    );
-
-    const classes = instance.className;
-    assert.include(classes, 'custom-one');
-    assert.include(classes, 'custom-two');
   });
 
   it('Should spread additional props onto inner element', done => {
@@ -87,21 +81,5 @@ describe('Breadcrumb.Item', () => {
       </Breadcrumb.Item>
     );
     assert.equal(instance.target, '_blank');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Breadcrumb.Item className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    let instance = getDOMNode(<Breadcrumb.Item style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Breadcrumb.Item classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Breadcrumb/test/BreadcrumbSpec.js
+++ b/src/Breadcrumb/test/BreadcrumbSpec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { render } from '@testing-library/react';
 import { getDOMNode, getInstance } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Breadcrumb from '../Breadcrumb';
 
 afterEach(() => {
@@ -9,6 +10,8 @@ afterEach(() => {
 });
 
 describe('Breadcrumb', () => {
+  testStandardProps(<Breadcrumb />);
+
   it('Should apply id to the wrapper nav element', () => {
     const instance = getDOMNode(<Breadcrumb id="custom-id" />);
 
@@ -19,15 +22,6 @@ describe('Breadcrumb', () => {
   it('Should have breadcrumb class', () => {
     const instance = getInstance(<Breadcrumb />);
     assert.include(instance.className, 'breadcrumb');
-  });
-
-  it('Should have custom classes', () => {
-    const instance = getDOMNode(<Breadcrumb className="custom-one custom-two" />);
-    const classes = instance.className;
-
-    assert.include(classes, 'breadcrumb');
-    assert.include(classes, 'custom-one');
-    assert.include(classes, 'custom-two');
   });
 
   it('Should automatically collapse if there are more than 5 items', () => {
@@ -88,22 +82,6 @@ describe('Breadcrumb', () => {
     assert.equal(instance.childNodes[1].className, 'rs-breadcrumb-separator');
     assert.equal(instance.childNodes[1].tagName, 'SPAN');
     assert.equal(instance.childNodes[1].textContent, '-');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Breadcrumb className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Breadcrumb style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Breadcrumb classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should not get "children with the same key" warning when generating items with array.map', () => {

--- a/src/Button/test/ButtonSpec.js
+++ b/src/Button/test/ButtonSpec.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-import Button from '../Button';
 import { getDOMNode, getInstance } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
+import Button from '../Button';
 
 describe('Button', () => {
+  testStandardProps(<Button />);
+
   it('Should output a button', () => {
     const instance = getDOMNode(<Button>Title</Button>);
     assert.equal(instance.textContent, 'Title');
@@ -89,22 +92,6 @@ describe('Button', () => {
   it('Should be active', () => {
     const instance = getDOMNode(<Button active>Title</Button>);
     assert.ok(instance.className.match(/\bactive\b/));
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Button className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Button style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Button classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should have a correct role', () => {

--- a/src/ButtonGroup/test/ButtonGroupSpec.js
+++ b/src/ButtonGroup/test/ButtonGroupSpec.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import ButtonGroup from '../ButtonGroup';
 import Button from '../../Button';
 
 describe('ButtonGroup', () => {
+  testStandardProps(<ButtonGroup />);
+
   it('Should output a button group', () => {
     const instance = getDOMNode(<ButtonGroup />);
     assert.equal(instance.nodeName, 'DIV');
@@ -49,11 +52,6 @@ describe('ButtonGroup', () => {
     assert.ok(instance.className.match(/\bbtn-group-justified\b/));
   });
 
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<ButtonGroup className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
   it('Should render 2 <button>', () => {
     const instance = getDOMNode(
       <ButtonGroup>
@@ -62,16 +60,5 @@ describe('ButtonGroup', () => {
       </ButtonGroup>
     );
     assert.equal(instance.querySelectorAll('button').length, 2);
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<ButtonGroup style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<ButtonGroup classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/ButtonToolbar/test/ButtonToolbarSpec.js
+++ b/src/ButtonToolbar/test/ButtonToolbarSpec.js
@@ -1,11 +1,14 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 
 import Button from '../../Button';
 import ButtonGroup from '../../ButtonGroup';
 import ButtonToolbar from '../ButtonToolbar';
 
 describe('ButtonToolbar', () => {
+  testStandardProps(<ButtonToolbar />);
+
   it('Should output a button toolbar', () => {
     const instance = getDOMNode(
       <ButtonToolbar>
@@ -17,21 +20,5 @@ describe('ButtonToolbar', () => {
     assert.equal(instance.nodeName, 'DIV');
     assert.ok(instance.className.match(/\bbtn-toolbar\b/));
     assert.equal(instance.getAttribute('role'), 'toolbar');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<ButtonToolbar className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<ButtonToolbar style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<ButtonToolbar classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Calendar/test/CalendarPanelSpec.js
+++ b/src/Calendar/test/CalendarPanelSpec.js
@@ -3,9 +3,12 @@ import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { parseISO } from '../../utils/dateUtils';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import CalendarPanel from '../CalendarPanel';
 
 describe('Calendar - Panel', () => {
+  testStandardProps(<CalendarPanel />);
+
   it('Should render a div with `calendar` class', () => {
     const instance = getDOMNode(<CalendarPanel />);
 
@@ -57,22 +60,6 @@ describe('Calendar - Panel', () => {
     ReactTestUtils.Simulate.click(
       instance.querySelector('.rs-calendar-table-cell-is-today .rs-calendar-table-cell-content')
     );
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<CalendarPanel className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<CalendarPanel style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<CalendarPanel classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should be a controlled value', done => {

--- a/src/Calendar/test/CalendarSpec.js
+++ b/src/Calendar/test/CalendarSpec.js
@@ -2,9 +2,12 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { parseISO } from '../../utils/dateUtils';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Calendar from '../Calendar';
 
 describe('Calendar', () => {
+  testStandardProps(<Calendar />);
+
   it('Should render a div with `calendar` class', () => {
     const instance = getDOMNode(<Calendar calendarDate={new Date(2021, 11, 24)} />);
 
@@ -33,27 +36,5 @@ describe('Calendar', () => {
 
     fireEvent.click(getByRole('button', { name: '24 Dec 2021' }));
     expect(onSelect).to.have.been.calledWith(new Date(2021, 11, 24));
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(
-      <Calendar className="custom" calendarDate={new Date(2021, 11, 24)} />
-    );
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(
-      <Calendar style={{ fontSize }} calendarDate={new Date(2021, 11, 24)} />
-    );
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(
-      <Calendar classPrefix="custom-prefix" calendarDate={new Date(2021, 11, 24)} />
-    );
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Carousel/test/CarouselSpec.js
+++ b/src/Carousel/test/CarouselSpec.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Carousel from '../Carousel';
 
 describe('Carousel', () => {
+  testStandardProps(<Carousel />);
+
   it('Should button be displayed on the right', () => {
     const instance = getDOMNode(<Carousel placement="right" />);
     assert.ok(instance.className.match(/\bcarousel-placement-right\b/));
@@ -24,22 +27,6 @@ describe('Carousel', () => {
   it('Should button be displayed as a bar', () => {
     const instance = getDOMNode(<Carousel shape="bar" />);
     assert.ok(instance.className.match(/\bcarousel-shape-bar\b/));
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Carousel className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Carousel style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Carousel classPrefix="custom-prefix" md={1} />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should be autoplay', done => {

--- a/src/Checkbox/test/CheckboxSpec.js
+++ b/src/Checkbox/test/CheckboxSpec.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { render } from '@testing-library/react';
-import Checkbox from '../Checkbox';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
+import Checkbox from '../Checkbox';
 
 describe('Checkbox', () => {
+  testStandardProps(<Checkbox />);
+
   it('Should render a checkbox', () => {
     const instance = getDOMNode(<Checkbox>Test</Checkbox>);
     assert.equal(instance.querySelectorAll('input[type="checkbox"]').length, 1);
@@ -125,22 +128,6 @@ describe('Checkbox', () => {
     );
 
     ReactTestUtils.Simulate.change(instance.querySelector('input'));
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Checkbox className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Checkbox style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Checkbox classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   describe('Plain text', () => {

--- a/src/CheckboxGroup/test/CheckboxGroupSpec.js
+++ b/src/CheckboxGroup/test/CheckboxGroupSpec.js
@@ -2,12 +2,15 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 
 import CheckboxGroup from '../CheckboxGroup';
 import Checkbox from '../../Checkbox';
 import { globalKey } from '../../utils/prefix';
 
 describe('CheckboxGroup', () => {
+  testStandardProps(<CheckboxGroup />);
+
   it('Should render a checkbox group', () => {
     const instance = getDOMNode(
       <CheckboxGroup>
@@ -131,22 +134,6 @@ describe('CheckboxGroup', () => {
 
     const checkboxs = instance.querySelectorAll(`.${globalKey}checkbox`);
     ReactTestUtils.Simulate.change(checkboxs[2].querySelector('input'));
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<CheckboxGroup className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<CheckboxGroup style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<CheckboxGroup classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   describe('Plain text', () => {

--- a/src/Col/test/ColSpec.js
+++ b/src/Col/test/ColSpec.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Col from '../Col';
 
 describe('Col', () => {
+  testStandardProps(<Col />);
+
   it('Should render a Col', () => {
     const title = 'Test';
     const instance = getDOMNode(<Col md={1}>{title}</Col>);
@@ -60,21 +63,5 @@ describe('Col', () => {
     assert.include(classes, 'rs-hidden-sm');
     assert.include(classes, 'rs-hidden-md');
     assert.include(classes, 'rs-hidden-lg');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Col className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Col style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Col classPrefix="custom-prefix" md={1} />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Container/test/ContainerSpec.js
+++ b/src/Container/test/ContainerSpec.js
@@ -1,10 +1,12 @@
 import React from 'react';
-
+import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Container from '../Container';
 import Sidebar from '../../Sidebar';
-import { getDOMNode } from '@test/testUtils';
 
 describe('Container', () => {
+  testStandardProps(<Container />);
+
   it('Should render a Container', () => {
     const title = 'Test';
     const instance = getDOMNode(
@@ -31,29 +33,5 @@ describe('Container', () => {
     setTimeout(() => {
       assert.include(instance.className, 'rs-container-has-sidebar');
     }, 0);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(
-      <Container className="custom">
-        <span />
-      </Container>
-    );
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(
-      <Container style={{ fontSize }}>
-        <span />
-      </Container>
-    );
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Container classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Content/test/ContentSpec.js
+++ b/src/Content/test/ContentSpec.js
@@ -1,29 +1,16 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Content from '../Content';
 
 describe('Content', () => {
+  testStandardProps(<Content />);
+
   it('Should render a Content', () => {
     const title = 'Test';
     const instance = getDOMNode(<Content>{title}</Content>);
 
     assert.equal(instance.className, 'rs-content');
     assert.equal(instance.textContent, title);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Content className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Content style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Content classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Divider/test/DividerSpec.js
+++ b/src/Divider/test/DividerSpec.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Divider from '../Divider';
 
 describe('Divider', () => {
+  testStandardProps(<Divider />);
+
   it('Should render a Divider', () => {
     const instance = getDOMNode(<Divider />);
     const classes = instance.className;
@@ -22,21 +25,5 @@ describe('Divider', () => {
     const instance = getDOMNode(<Divider>abc</Divider>);
     const classes = instance.className;
     assert.include(classes, 'rs-divider-with-text');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Divider className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Divider style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Divider classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Dropdown/test/DropdownMenuItemSpec.js
+++ b/src/Dropdown/test/DropdownMenuItemSpec.js
@@ -136,7 +136,7 @@ describe('<Dropdown.Item>', () => {
       </Dropdown>
     );
 
-    expect(getByTestId('item')).to.have.style('fontSize', fontSize);
+    expect(getByTestId('item')).to.have.style('font-size', fontSize);
   });
 
   it('Should have a custom className prefix', () => {

--- a/src/Dropdown/test/DropdownStylesSpec.js
+++ b/src/Dropdown/test/DropdownStylesSpec.js
@@ -32,12 +32,12 @@ describe('Dropdown styles', () => {
   it('Should render a Button in default appearance', () => {
     const { getByRole } = render(<Dropdown title="Dropdown" />);
 
-    expect(getByRole('button')).to.have.style('backgroundColor', getGrayScale('B050'));
+    expect(getByRole('button')).to.have.style('background-color', getGrayScale('B050'));
   });
 
   it('Should have 12px right padding given `noCaret=true`', () => {
     const { getByRole } = render(<Dropdown title="Dropdown" noCaret />);
 
-    expect(getByRole('button')).to.have.style('paddingRight', '12px');
+    expect(getByRole('button')).to.have.style('padding-right', '12px');
   });
 });

--- a/src/FlexboxGrid/test/FlexboxGridItemSpec.js
+++ b/src/FlexboxGrid/test/FlexboxGridItemSpec.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import FlexboxGridItem from '../FlexboxGridItem';
 import Col from '../../Col';
 
 describe('FlexboxGridItem', () => {
+  testStandardProps(<FlexboxGridItem />);
+
   it('Should render a FlexboxGridItem', () => {
     const instance = getDOMNode(<FlexboxGridItem>Test</FlexboxGridItem>);
     assert.include(instance.className, 'rs-flex-box-grid-item');
@@ -23,21 +26,5 @@ describe('FlexboxGridItem', () => {
     const instance = getDOMNode(<FlexboxGridItem as={Col} md={1} />);
     assert.include(instance.className, 'rs-col');
     assert.include(instance.className, 'rs-col-md-1');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<FlexboxGridItem className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<FlexboxGridItem style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<FlexboxGridItem classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/FlexboxGrid/test/FlexboxGridSpec.js
+++ b/src/FlexboxGrid/test/FlexboxGridSpec.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import FlexboxGrid from '../FlexboxGrid';
 
 describe('FlexboxGrid', () => {
+  testStandardProps(<FlexboxGrid />);
+
   it('Should render a FlexboxGrid', () => {
     const instance = getDOMNode(<FlexboxGrid>Test</FlexboxGrid>);
     assert.include(instance.className, 'rs-flex-box-grid');
@@ -16,21 +19,5 @@ describe('FlexboxGrid', () => {
   it('Should be justify content on the center', () => {
     const instance = getDOMNode(<FlexboxGrid justify="center" />);
     assert.include(instance.className, 'rs-flex-box-grid-center');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<FlexboxGrid className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<FlexboxGrid style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<FlexboxGrid classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Footer/test/FooterSpec.js
+++ b/src/Footer/test/FooterSpec.js
@@ -1,28 +1,15 @@
 import React from 'react';
-import Footer from '../Footer';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
+import Footer from '../Footer';
 
 describe('Footer', () => {
+  testStandardProps(<Footer />);
+
   it('Should render a Footer', () => {
     const title = 'Test';
     const instance = getDOMNode(<Footer>{title}</Footer>);
     assert.include(instance.className, 'rs-footer');
     assert.equal(instance.textContent, title);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Footer className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Footer style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Footer classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Form/test/FormSpec.js
+++ b/src/Form/test/FormSpec.js
@@ -4,6 +4,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import _isNil from 'lodash/isNil';
 import _omit from 'lodash/omit';
 import { getDOMNode, getInstance } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 
 import Form from '../Form';
 import FormControl from '../../FormControl';
@@ -33,6 +34,8 @@ const modelAsync = Schema.Model({
 });
 
 describe('Form', () => {
+  testStandardProps(<Form />);
+
   it('Should render a Form', () => {
     let title = 'Test';
     let instance = getDOMNode(<Form>{title}</Form>);
@@ -475,22 +478,6 @@ describe('Form', () => {
       </Form>
     );
     ReactTestUtils.Simulate.change(instance.querySelector('input[name="name"]'));
-  });
-
-  it('Should have a custom className', () => {
-    let instance = getDOMNode(<Form className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    let instance = getDOMNode(<Form style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Form classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   /*** checkAsync */

--- a/src/FormControlLabel/test/FormControlLabelSpec.js
+++ b/src/FormControlLabel/test/FormControlLabelSpec.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import FormControlLabel from '../FormControlLabel';
 import FormGroup from '../../FormGroup';
 
 describe('FormControlLabel', () => {
+  testStandardProps(<FormControlLabel />);
+
   it('Should render a FormControlLabel', () => {
     let title = 'Test';
     let instance = getDOMNode(<FormControlLabel>{title}</FormControlLabel>);
@@ -19,21 +22,5 @@ describe('FormControlLabel', () => {
       </FormGroup>
     );
     assert.equal(instance.children[0].getAttribute('for'), 'test');
-  });
-
-  it('Should have a custom className', () => {
-    let instance = getDOMNode(<FormControlLabel className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    let instance = getDOMNode(<FormControlLabel style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<FormControlLabel classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/FormErrorMessage/test/FormErrorMessageSpec.js
+++ b/src/FormErrorMessage/test/FormErrorMessageSpec.js
@@ -1,8 +1,11 @@
 import React from 'react';
-import FormErrorMessage from '../FormErrorMessage';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
+import FormErrorMessage from '../FormErrorMessage';
 
 describe('FormErrorMessage', () => {
+  testStandardProps(<FormErrorMessage show />);
+
   it('Should render a FormErrorMessage', () => {
     const title = 'Test';
     const instance = getDOMNode(<FormErrorMessage show>{title}</FormErrorMessage>);
@@ -23,21 +26,5 @@ describe('FormErrorMessage', () => {
   it('Should hava a `bottomStart` for placement', () => {
     const instance = getDOMNode(<FormErrorMessage show placement="bottomStart" />);
     assert.include(instance.className, 'rs-form-error-message-placement-bottom-start');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<FormErrorMessage show className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<FormErrorMessage show style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<FormErrorMessage show classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/FormGroup/test/FormGroupSpec.js
+++ b/src/FormGroup/test/FormGroupSpec.js
@@ -1,32 +1,18 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
-
+import { testStandardProps } from '@test/commonCases';
 import FormGroup from '../FormGroup';
 import Input from '../../Input';
 import FormControlLabel from '../../FormControlLabel';
 
 describe('FormGroup', () => {
+  testStandardProps(<FormGroup />);
+
   it('Should render a FormGroup', () => {
     let title = 'Test';
     let instance = getDOMNode(<FormGroup>{title}</FormGroup>);
     assert.equal(instance.className, 'rs-form-group');
     assert.equal(instance.innerHTML, title);
-  });
-
-  it('Should have a custom className', () => {
-    let instance = getDOMNode(<FormGroup className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    let instance = getDOMNode(<FormGroup style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<FormGroup classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should be assigned a controlId', () => {

--- a/src/FormHelpText/test/FormHelpTextSpec.js
+++ b/src/FormHelpText/test/FormHelpTextSpec.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import FormHelpText from '../FormHelpText';
-import { assert } from 'chai';
 
 describe('FormHelpText', () => {
+  testStandardProps(<FormHelpText />);
+
   it('Should render a FormHelpText', () => {
     const title = 'Test';
     const instance = getDOMNode(<FormHelpText>{title}</FormHelpText>);
@@ -22,21 +24,5 @@ describe('FormHelpText', () => {
     const id = 'Test';
     const instance = getDOMNode(<FormHelpText htmlFor={id} />);
     assert.ok(instance.getAttribute('for'), id);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<FormHelpText className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<FormHelpText style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<FormHelpText classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Grid/test/GridSpec.js
+++ b/src/Grid/test/GridSpec.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Grid from '../Grid';
 
 describe('Grid', () => {
+  testStandardProps(<Grid />);
+
   it('Should render a container', () => {
     let title = 'Test';
     let instance = getDOMNode(<Grid>{title}</Grid>);
@@ -14,21 +17,5 @@ describe('Grid', () => {
     let title = 'Test';
     let instance = getDOMNode(<Grid fluid>{title}</Grid>);
     assert.equal(instance.className, 'rs-grid-container-fluid');
-  });
-
-  it('Should have a custom className', () => {
-    let instance = getDOMNode(<Grid className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    let instance = getDOMNode(<Grid style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Grid classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Header/test/HeaderSpec.js
+++ b/src/Header/test/HeaderSpec.js
@@ -1,28 +1,15 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Header from '../Header';
 
 describe('Header', () => {
+  testStandardProps(<Header />);
+
   it('Should render a Header', () => {
     const title = 'Test';
     const instance = getDOMNode(<Header>{title}</Header>);
     assert.include(instance.className, 'rs-header');
     assert.equal(instance.textContent, title);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Header className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Header style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Header classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/IconButton/test/IconButtonSpec.js
+++ b/src/IconButton/test/IconButtonSpec.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
-import IconButton from '../IconButton';
+import { testStandardProps } from '@test/commonCases';
 import User from '@rsuite/icons/legacy/User';
-import Star from '@rsuite/icons/legacy/Star';
+import IconButton from '../IconButton';
 
 describe('IconButton', () => {
+  testStandardProps(<IconButton />);
+
   it('Should output a button', () => {
     const instance = getDOMNode(<IconButton />);
     assert.include(instance.className, 'rs-btn-icon');
@@ -14,28 +16,5 @@ describe('IconButton', () => {
   it('Should output a icon', () => {
     const instance = getDOMNode(<IconButton icon={<User />} />);
     assert.ok(instance.querySelector('.rs-icon'));
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<IconButton icon={<Star />} className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<IconButton icon={<Star />} style={{ fontSize }} />);
-
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    let instance = getDOMNode(<IconButton style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<IconButton classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Input/test/InputSpec.js
+++ b/src/Input/test/InputSpec.js
@@ -2,10 +2,13 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 
 import Input from '../Input';
 
 describe('Input', () => {
+  testStandardProps(<Input />);
+
   it('Should render a input', () => {
     const domNode = getDOMNode(<Input />);
     assert.include(domNode.className, 'rs-input');
@@ -43,22 +46,6 @@ describe('Input', () => {
   it('Should set size', () => {
     const instance = getDOMNode(<Input size="lg" />);
     assert.include(instance.className, 'rs-input-lg');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Input className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Input style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Input classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   describe('Plain text', () => {

--- a/src/InputGroup/test/InputGroupSpec.js
+++ b/src/InputGroup/test/InputGroupSpec.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import InputGroup from '../InputGroup';
 import Input from '../../Input/Input';
 
 describe('InputGroup', () => {
+  testStandardProps(<InputGroup />);
+
   it('Should render a container', () => {
     const title = 'Test';
     const instance = getDOMNode(<InputGroup>{title}</InputGroup>);
@@ -56,27 +59,5 @@ describe('InputGroup', () => {
       </InputGroup>
     );
     assert.ok(instance.querySelector('.rs-input-group-btn'));
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<InputGroup className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<InputGroup style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    let instance = getDOMNode(<InputGroup style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<InputGroup classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/InputNumber/test/InputNumberSpec.js
+++ b/src/InputNumber/test/InputNumberSpec.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import ReactTestUtils, { act } from 'react-dom/test-utils';
-
-import InputNumber from '../InputNumber';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
+import InputNumber from '../InputNumber';
 
 describe('InputNumber', () => {
+  testStandardProps(<InputNumber />);
+
   it('Should render a input', () => {
     const domNode = getDOMNode(<InputNumber />);
     assert.include(domNode.className, 'rs-input-number');
@@ -157,22 +159,6 @@ describe('InputNumber', () => {
     };
     const instance = getDOMNode(<InputNumber onFocus={doneOp} />);
     ReactTestUtils.Simulate.focus(instance.querySelector('.rs-input'));
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<InputNumber className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<InputNumber style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<InputNumber classPrefix="custom-prefix" />);
-    assert.include(instance.className, 'custom-prefix');
   });
 
   describe('Plain text', () => {

--- a/src/List/test/ListItemSpec.js
+++ b/src/List/test/ListItemSpec.js
@@ -1,8 +1,12 @@
 import React from 'react';
-import List from '../List';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
+import List from '../List';
+import ListItem from '../ListItem';
 
 describe('ListItem', () => {
+  testStandardProps(<ListItem />);
+
   it('Should render a ListItem', () => {
     const domNode = getDOMNode(
       <List>
@@ -21,24 +25,5 @@ describe('ListItem', () => {
       </List>
     );
     assert.include(domNode.firstChild.className, 'rs-list-item-disabled');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const domNode = getDOMNode(
-      <List>
-        <List.Item index={1} style={{ fontSize }} />
-      </List>
-    );
-    assert.equal(domNode.firstChild.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const domNode = getDOMNode(
-      <List>
-        <List.Item index={1} classPrefix="custom-prefix" />
-      </List>
-    );
-    assert.include(domNode.firstChild.className, 'custom-prefix');
   });
 });

--- a/src/List/test/ListSpec.js
+++ b/src/List/test/ListSpec.js
@@ -1,24 +1,16 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
-import List from '../List';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
+import List from '../List';
 
 describe('List', () => {
+  testStandardProps(<List />);
+
   it('Should render a List', () => {
     const domNode = getDOMNode(<List />);
     assert.include(domNode.className, 'rs-list');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const domNode = getDOMNode(<List style={{ fontSize }} />);
-    assert.equal(domNode.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const domNode = getDOMNode(<List classPrefix="custom-prefix" />);
-    assert.ok(domNode.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should be bordered', () => {

--- a/src/Loader/test/LoaderSpec.js
+++ b/src/Loader/test/LoaderSpec.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Loader from '../Loader';
 
 describe('Loader', () => {
+  testStandardProps(<Loader />);
+
   it('Should render a Loader', () => {
     let instance = getDOMNode(<Loader />);
     assert.include(instance.className, 'rs-loader');
@@ -36,21 +39,5 @@ describe('Loader', () => {
   it('Should have a size', () => {
     let instance = getDOMNode(<Loader size="lg" />);
     assert.include(instance.className, 'rs-loader-lg');
-  });
-
-  it('Should have a custom className', () => {
-    let instance = getDOMNode(<Loader className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    let instance = getDOMNode(<Loader style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Loader classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Message/test/MessageSpec.js
+++ b/src/Message/test/MessageSpec.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Message from '../Message';
 
 describe('Message', () => {
+  testStandardProps(<Message />);
+
   it('Should render a Message', () => {
     const instance = getDOMNode(<Message />);
     assert.include(instance.className, 'rs-message');
@@ -48,21 +51,5 @@ describe('Message', () => {
     const instance = getDOMNode(<Message closable onClose={doneOp} />);
     const closeButton = instance.querySelector('.rs-btn-close');
     ReactTestUtils.Simulate.click(closeButton);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Message className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Message style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Message classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Nav/test/NavItemSpec.js
+++ b/src/Nav/test/NavItemSpec.js
@@ -3,12 +3,14 @@ import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getByTestId, screen } from '@testing-library/react';
 import { getDOMNode } from '@test/testUtils';
-
+import { testStandardProps } from '@test/commonCases';
 import NavItem from '../NavItem';
 import Sidenav from '../../Sidenav';
 import Nav from '../Nav';
 
 describe('<Nav.Item>', () => {
+  testStandardProps(<NavItem />);
+
   it('Should render a <a>', () => {
     let title = 'Test';
     let instance = getDOMNode(<NavItem>{title}</NavItem>);
@@ -85,22 +87,6 @@ describe('<Nav.Item>', () => {
     let instance = getDOMNode(<NavItem onClick={onHideSpy} disabled />);
     ReactTestUtils.Simulate.click(instance);
     assert.ok(!onHideSpy.calledOnce);
-  });
-
-  it('Should have a custom className', () => {
-    let instance = getDOMNode(<NavItem className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    let instance = getDOMNode(<NavItem style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<NavItem classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should render a tooltip when used inside a collapsed <Sidenav>', async () => {

--- a/src/Nav/test/NavSpec.js
+++ b/src/Nav/test/NavSpec.js
@@ -1,11 +1,14 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Nav from '../Nav';
 import Dropdown from '../../Dropdown';
 
 describe('<Nav>', () => {
+  testStandardProps(<Nav />);
+
   it('Should render a nav', () => {
     const title = 'Test';
     const instance = getDOMNode(<Nav>{title}</Nav>);
@@ -53,22 +56,6 @@ describe('<Nav>', () => {
       </Nav>
     );
     assert.ok(instance.querySelectorAll('a')[1].className.match(/\bnav-item-active\b/));
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Nav className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Nav style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Nav classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should call onSelect callback with correct arguments', () => {

--- a/src/Nav/test/NavStylesSpec.js
+++ b/src/Nav/test/NavStylesSpec.js
@@ -22,6 +22,6 @@ describe('Nav styles', () => {
       </Nav>
     );
 
-    expect(getByRole('button')).to.have.style('backgroundColor', 'rgba(0, 0, 0, 0)');
+    expect(getByRole('button')).to.have.style('background-color', 'rgba(0, 0, 0, 0)');
   });
 });

--- a/src/Navbar/test/NavbarBrandSpec.js
+++ b/src/Navbar/test/NavbarBrandSpec.js
@@ -1,8 +1,11 @@
 import React from 'react';
-import NavbarBrand from '../NavbarBrand';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
+import NavbarBrand from '../NavbarBrand';
 
 describe('NavbarBrand', () => {
+  testStandardProps(<NavbarBrand />);
+
   it('Should render a link', () => {
     let title = 'RSUITE';
     let instance = getDOMNode(<NavbarBrand href="/">{title}</NavbarBrand>);

--- a/src/Navbar/test/NavbarSpec.js
+++ b/src/Navbar/test/NavbarSpec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Navbar from '../Navbar';
 import Nav from '../../Nav';
 import Dropdown from '../../Dropdown';
@@ -13,6 +14,8 @@ afterEach(() => {
 });
 
 describe('Navbar', () => {
+  testStandardProps(<Navbar />);
+
   it('Should render a navbar', () => {
     const instance = getDOMNode(<Navbar />);
     assert.include(instance.className, 'rs-navbar');
@@ -25,22 +28,6 @@ describe('Navbar', () => {
       </Navbar>
     );
     assert.ok(instance.querySelector('.rs-nav.rs-navbar-nav'));
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Navbar className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Navbar style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Navbar classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   context('Use <Dropdown> within <Navbar>', () => {

--- a/src/Navbar/test/NavbarStylesSpec.js
+++ b/src/Navbar/test/NavbarStylesSpec.js
@@ -25,8 +25,8 @@ describe('Navbar styles', () => {
       );
 
       expect(getByTestId('icon'))
-        .to.have.style('fontSize', '16px')
-        .and.to.have.style('marginRight', '5px');
+        .to.have.style('font-size', '16px')
+        .and.to.have.style('margin-right', '5px');
     });
   });
 });

--- a/src/Notification/test/NotificationSpec.js
+++ b/src/Notification/test/NotificationSpec.js
@@ -1,9 +1,12 @@
 import React from 'react';
-import Notification from '../Notification';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import ReactTestUtils from 'react-dom/test-utils';
+import Notification from '../Notification';
 
 describe('Notification', () => {
+  testStandardProps(<Notification />);
+
   it('Should output a notification', () => {
     const instance = getDOMNode(<Notification />);
     assert.ok(instance.className.match(/\brs-notification\b/));
@@ -29,22 +32,6 @@ describe('Notification', () => {
   it('Should have a header', () => {
     const instance = getDOMNode(<Notification header="header" />);
     assert.equal(instance.querySelector('.rs-notification-title').textContent, 'header');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Notification className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Notification style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Notification classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should call onClose callback', done => {

--- a/src/Panel/test/PanelSpec.js
+++ b/src/Panel/test/PanelSpec.js
@@ -2,10 +2,13 @@ import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import Panel from '../Panel';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
+import Panel from '../Panel';
 
 describe('Panel', () => {
+  testStandardProps(<Panel />);
+
   it('Should render a panel', () => {
     const title = 'Test';
     const instance = getDOMNode(<Panel>{title}</Panel>);
@@ -103,21 +106,5 @@ describe('Panel', () => {
 
     title = ref.current.querySelector('.rs-panel-title');
     ReactTestUtils.Simulate.click(title.firstChild);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Panel className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Panel style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Panel classPrefix="custom-prefix" />);
-    assert.include(instance.className, 'custom-prefix');
   });
 });

--- a/src/PanelGroup/test/PanelGroupSpec.js
+++ b/src/PanelGroup/test/PanelGroupSpec.js
@@ -2,11 +2,14 @@ import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import PanelGroup from '../PanelGroup';
 import Panel from '../../Panel';
-import { getDOMNode } from '@test/testUtils';
 
 describe('PanelGroup', () => {
+  testStandardProps(<PanelGroup />);
+
   it('Should render a PanelGroup', () => {
     const title = 'Test';
     const instance = getDOMNode(<PanelGroup>{title}</PanelGroup>);
@@ -59,21 +62,5 @@ describe('PanelGroup', () => {
 
     userEvent.click(getByText('Click me'));
     expect(onSelectSpy).to.have.been.calledWith(undefined);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<PanelGroup className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<PanelGroup style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<PanelGroup classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Placeholder/test/PlaceholderGraphSpec.js
+++ b/src/Placeholder/test/PlaceholderGraphSpec.js
@@ -1,24 +1,16 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import PlaceholderGraph from '../PlaceholderGraph';
 
 describe('PlaceholderGraph', () => {
+  testStandardProps(<PlaceholderGraph />);
+
   it('Should render a PlaceholderGraph', () => {
     const instance = getDOMNode(<PlaceholderGraph />);
 
     assert.equal(instance.tagName, 'DIV');
     assert.equal(instance.className, 'rs-placeholder rs-placeholder-graph');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<PlaceholderGraph style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<PlaceholderGraph classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Height should be 100px', () => {

--- a/src/Placeholder/test/PlaceholderGridSpec.js
+++ b/src/Placeholder/test/PlaceholderGridSpec.js
@@ -1,24 +1,15 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
-
+import { testStandardProps } from '@test/commonCases';
 import PlaceholderGrid from '../PlaceholderGrid';
 
 describe('PlaceholderGrid', () => {
+  testStandardProps(<PlaceholderGrid />);
+
   it('Should render a PlaceholderGrid', () => {
     const instance = getDOMNode(<PlaceholderGrid />);
     assert.equal(instance.tagName, 'DIV');
     assert.equal(instance.className, 'rs-placeholder rs-placeholder-grid');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<PlaceholderGrid style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<PlaceholderGrid classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should render 10 columns', () => {

--- a/src/Placeholder/test/PlaceholderParagraphSpec.js
+++ b/src/Placeholder/test/PlaceholderParagraphSpec.js
@@ -1,24 +1,16 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import PlaceholderParagraph from '../PlaceholderParagraph';
 
 describe('PlaceholderParagraph', () => {
+  testStandardProps(<PlaceholderParagraph />);
+
   it('Should render a PlaceholderParagraph', () => {
     const instance = getDOMNode(<PlaceholderParagraph />);
 
     assert.equal(instance.tagName, 'DIV');
     assert.equal(instance.className, 'rs-placeholder rs-placeholder-paragraph');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<PlaceholderParagraph style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<PlaceholderParagraph classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should render 5 rows', () => {

--- a/src/Popover/test/PopoverSpec.js
+++ b/src/Popover/test/PopoverSpec.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Popover from '../Popover';
 
 describe('Popover', () => {
+  testStandardProps(<Popover />);
+
   it('Should render a Popover', () => {
     const title = 'Test';
     const instance = getDOMNode(<Popover>{title}</Popover>);
@@ -19,21 +22,5 @@ describe('Popover', () => {
   it('Should have a id', () => {
     const instance = getDOMNode(<Popover id="popover" />);
     assert.equal(instance.id, 'popover');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Popover className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Popover style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Popover classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Progress/test/ProgressCircleSpec.js
+++ b/src/Progress/test/ProgressCircleSpec.js
@@ -1,8 +1,13 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import ProgressCircle from '../ProgressCircle';
 
 describe('Progress - Circle', () => {
+  testStandardProps(<ProgressCircle />, {
+    customClassName: false
+  });
+
   it('Should render a Circle', () => {
     const instance = getDOMNode(<ProgressCircle />);
     assert.ok(instance.className.match(/\brs-progress-circle\b/));
@@ -46,22 +51,6 @@ describe('Progress - Circle', () => {
       instance.querySelector('.rs-progress-stroke').getAttribute('stroke-linecap'),
       'butt'
     );
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<ProgressCircle className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<ProgressCircle style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<ProgressCircle classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should render start position by `gapPosition`', () => {

--- a/src/Progress/test/ProgressLineSpec.js
+++ b/src/Progress/test/ProgressLineSpec.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import ProgressLine from '../ProgressLine';
 
 describe('Progress - Line', () => {
+  testStandardProps(<ProgressLine />);
+
   it('Should render a Line', () => {
     const instance = getDOMNode(<ProgressLine />);
     assert.ok(instance.className.match(/\brs-progress-line\b/));
@@ -39,22 +42,6 @@ describe('Progress - Line', () => {
   it('Should render a status', () => {
     const instance = getDOMNode(<ProgressLine status="success" />);
     assert.ok(instance.className.match(/\brs-progress-line-success\b/));
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<ProgressLine className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<ProgressLine style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<ProgressLine classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should be vertical', () => {

--- a/src/Radio/test/RadioSpec.js
+++ b/src/Radio/test/RadioSpec.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-
-import Radio from '../Radio';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
+import Radio from '../Radio';
 
 describe('Radio', () => {
+  testStandardProps(<Radio />);
+
   it('Should render a radio', () => {
     const instance = getDOMNode(<Radio>Test</Radio>);
     assert.equal(instance.querySelectorAll('input[type="radio"]').length, 1);
@@ -113,21 +115,5 @@ describe('Radio', () => {
     );
 
     ReactTestUtils.Simulate.change(instance.querySelector('input'));
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Radio className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Radio style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Radio classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/RadioGroup/test/RadioGroupSpec.js
+++ b/src/RadioGroup/test/RadioGroupSpec.js
@@ -2,11 +2,13 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
-
+import { testStandardProps } from '@test/commonCases';
 import RadioGroup from '../RadioGroup';
 import Radio from '../../Radio';
 
 describe('RadioGroup', () => {
+  testStandardProps(<RadioGroup />);
+
   it('Should render a radio group', () => {
     const instance = getDOMNode(
       <RadioGroup>
@@ -156,22 +158,6 @@ describe('RadioGroup', () => {
       </RadioGroup>
     );
     assert.equal(instance.querySelector('.rs-radio-checked').textContent, 'false');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<RadioGroup className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<RadioGroup style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<RadioGroup classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should apply appearance', () => {

--- a/src/RangeSlider/test/RangeSliderSpec.js
+++ b/src/RangeSlider/test/RangeSliderSpec.js
@@ -2,9 +2,12 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import RangeSlider from '../RangeSlider';
 
 describe('RangeSlider', () => {
+  testStandardProps(<RangeSlider />);
+
   it('Should render a RangeSlider', () => {
     const instance = getDOMNode(<RangeSlider />);
     assert.equal(instance.className, 'rs-slider');
@@ -77,22 +80,6 @@ describe('RangeSlider', () => {
   it('Should render custom title', () => {
     const instance = getDOMNode(<RangeSlider tooltip={false} handleTitle={'test'} />);
     assert.equal(instance.querySelector('.rs-slider-handle').textContent, 'test');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<RangeSlider className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<RangeSlider style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<RangeSlider classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should handle keyboard operations', () => {

--- a/src/Rate/test/RateSpec.js
+++ b/src/Rate/test/RateSpec.js
@@ -2,11 +2,14 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import CameraRetro from '@rsuite/icons/legacy/CameraRetro';
 import Star from '@rsuite/icons/legacy/Star';
 import Rate from '../Rate';
 
 describe('Rate', () => {
+  testStandardProps(<Rate />);
+
   it('Should render a default Rate', () => {
     const instance = getDOMNode(<Rate />);
     assert.equal(instance.querySelectorAll('li.rs-rate-character-empty').length, 5);
@@ -157,22 +160,6 @@ describe('Rate', () => {
   it('Should be vertical', () => {
     const instance = getDOMNode(<Rate defaultValue={1.5} vertical allowHalf />);
     assert.ok(instance.querySelectorAll('.rs-rate-character-vertical').length);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Rate className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Rate style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Rate classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should update characterMap when value is updated', () => {

--- a/src/Row/test/RowSpec.js
+++ b/src/Row/test/RowSpec.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
-
+import { testStandardProps } from '@test/commonCases';
 import Row from '../Row';
 
 describe('Row', () => {
+  testStandardProps(<Row />);
+
   it('Should render a row', () => {
     const instance = getDOMNode(
       <Row>
@@ -24,34 +26,5 @@ describe('Row', () => {
     assert.equal(instance.style.marginRight, '-5px');
     assert.equal(instance.childNodes[0].style.paddingLeft, '5px');
     assert.equal(instance.childNodes[0].style.paddingRight, '5px');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(
-      <Row className="custom">
-        <div />
-      </Row>
-    );
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(
-      <Row style={{ fontSize }}>
-        <div />
-      </Row>
-    );
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(
-      <Row classPrefix="custom-prefix">
-        <div />
-      </Row>
-    );
-
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Sidebar/test/SidebarSpec.js
+++ b/src/Sidebar/test/SidebarSpec.js
@@ -1,28 +1,15 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Sidebar from '../Sidebar';
 
 describe('Sidebar', () => {
+  testStandardProps(<Sidebar />);
+
   it('Should render a Sidebar', () => {
     const title = 'Test';
     const instance = getDOMNode(<Sidebar>{title}</Sidebar>);
     assert.equal(instance.className, 'rs-sidebar');
     assert.equal(instance.textContent, title);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Sidebar className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Sidebar style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Sidebar classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Sidenav/test/SidenavBodySpec.js
+++ b/src/Sidenav/test/SidenavBodySpec.js
@@ -1,29 +1,15 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
-
+import { testStandardProps } from '@test/commonCases';
 import SidenavBody from '../SidenavBody';
 
 describe('SidenavBody', () => {
+  testStandardProps(<SidenavBody />);
+
   it('Should render a body', () => {
     const title = 'Test';
     const instance = getDOMNode(<SidenavBody>{title}</SidenavBody>);
     assert.equal(instance.className, 'rs-sidenav-body');
     assert.equal(instance.innerHTML, title);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<SidenavBody className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<SidenavBody style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<SidenavBody classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Sidenav/test/SidenavHeaderSpec.js
+++ b/src/Sidenav/test/SidenavHeaderSpec.js
@@ -1,29 +1,15 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
-
+import { testStandardProps } from '@test/commonCases';
 import SidenavHeader from '../SidenavHeader';
 
 describe('SidenavHeader', () => {
+  testStandardProps(<SidenavHeader />);
+
   it('Should render a header', () => {
     const title = 'Test';
     const instance = getDOMNode(<SidenavHeader>{title}</SidenavHeader>);
     assert.equal(instance.className, 'rs-sidenav-header');
     assert.equal(instance.innerHTML, title);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<SidenavHeader className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<SidenavHeader style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<SidenavHeader classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Sidenav/test/SidenavSpec.js
+++ b/src/Sidenav/test/SidenavSpec.js
@@ -1,17 +1,19 @@
 import React from 'react';
 import ReactTestUtils, { act, Simulate } from 'react-dom/test-utils';
 import { getByTestId, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { getDOMNode } from '@test/testUtils';
-
+import { testStandardProps } from '@test/commonCases';
 import Sidenav from '../Sidenav';
 import Nav from '../../Nav';
 import Dropdown from '../../Dropdown';
-import userEvent from '@testing-library/user-event';
 
 describe('<Sidenav>', () => {
   afterEach(() => {
     sinon.restore();
   });
+
+  testStandardProps(<Sidenav />);
 
   it('Should render a navigation', () => {
     const instance = getDOMNode(<Sidenav />);
@@ -170,22 +172,6 @@ describe('<Sidenav>', () => {
     });
 
     expect(instance.querySelector('.rs-dropdown-header')).not.to.be.null;
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Sidenav className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Sidenav style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Sidenav classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should set `aria-selected=true` on the item indicated by `activeKey`', () => {

--- a/src/Sidenav/test/SidenavToggleSpec.js
+++ b/src/Sidenav/test/SidenavToggleSpec.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
-
+import { testStandardProps } from '@test/commonCases';
 import SidenavToggle from '../SidenavToggle';
 
 describe('SidenavToggle', () => {
+  testStandardProps(<SidenavToggle />);
+
   it('Should render a toggle', () => {
     const instance = getDOMNode(<SidenavToggle />);
     assert.include(instance.className, 'rs-sidenav-toggle');
@@ -16,21 +18,5 @@ describe('SidenavToggle', () => {
     };
     const instance = getDOMNode(<SidenavToggle onToggle={doneOp} />);
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-btn-icon'));
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<SidenavToggle className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<SidenavToggle style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<SidenavToggle classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Slider/test/SliderSpec.js
+++ b/src/Slider/test/SliderSpec.js
@@ -2,9 +2,12 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Slider from '../Slider';
 
 describe('Slider', () => {
+  testStandardProps(<Slider />);
+
   it('Should render a Slider', () => {
     const instance = getDOMNode(<Slider />);
     assert.equal(instance.className, 'rs-slider');
@@ -55,22 +58,6 @@ describe('Slider', () => {
   it('Should render custom title', () => {
     const instance = getDOMNode(<Slider tooltip={false} handleTitle={'test'} />);
     assert.equal(instance.textContent, 'test');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Slider className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Slider style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Slider classPrefix="custom-prefix" />);
-    assert.include(instance.className, 'custom-prefix');
   });
 
   it('Should handle keyboard operations', () => {

--- a/src/Stack/test/StackSpec.js
+++ b/src/Stack/test/StackSpec.js
@@ -1,8 +1,11 @@
 import React from 'react';
-import Stack from '../Stack';
 import { render } from '@testing-library/react';
+import { testStandardProps } from '@test/commonCases';
+import Stack from '../Stack';
 
 describe('Stack', () => {
+  testStandardProps(<Stack />);
+
   it('Should output a stack', () => {
     const { getByTestId } = render(<Stack data-testid="test"></Stack>);
 
@@ -54,16 +57,5 @@ describe('Stack', () => {
 
     assert.equal(getByTestId('test').children.length, 3);
     assert.equal(getByTestId('test').children[1].textContent, '|');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const { getByTestId } = render(<Stack style={{ fontSize }} data-testid="test" />);
-    assert.equal(getByTestId('test').style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const { getByTestId } = render(<Stack classPrefix="custom-prefix" data-testid="test" />);
-    assert.include(getByTestId('test').className, 'custom-prefix');
   });
 });

--- a/src/Steps/test/StepItemSpec.js
+++ b/src/Steps/test/StepItemSpec.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import StepItem from '../StepItem';
 import User from '@rsuite/icons/legacy/User';
 
 describe('StepItem', () => {
+  testStandardProps(<StepItem />);
+
   it('Should render a StepItem', () => {
     const instance = getDOMNode(<StepItem />);
     assert.equal(instance.className, 'rs-steps-item');
@@ -49,21 +52,5 @@ describe('StepItem', () => {
   it('Should render title ', () => {
     const instance = getDOMNode(<StepItem title={'test'} />);
     assert.equal(instance.textContent, 'test');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<StepItem className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<StepItem style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<StepItem classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Steps/test/StepsSpec.js
+++ b/src/Steps/test/StepsSpec.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 import Steps from '../Steps';
 
 describe('Steps', () => {
+  testStandardProps(<Steps />);
+
   it('Should render a Steps', () => {
     const instance = getDOMNode(<Steps />);
     assert.equal(instance.className, 'rs-steps rs-steps-horizontal');
@@ -48,21 +51,5 @@ describe('Steps', () => {
   it('Should be small', () => {
     const instance = getDOMNode(<Steps small />);
     assert.ok(instance.className.match(/\brs-steps-small\b/));
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Steps className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Steps style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Steps classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Tag/test/TagSpec.js
+++ b/src/Tag/test/TagSpec.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
-
+import { testStandardProps } from '@test/commonCases';
 import Tag from '../Tag';
 
 describe('Tag', () => {
+  testStandardProps(<Tag />);
   it('Should output a Tag', () => {
     const instance = getDOMNode(<Tag />);
     assert.equal(instance.className, 'rs-tag rs-tag-md rs-tag-default');
@@ -20,21 +21,5 @@ describe('Tag', () => {
       </Tag>
     );
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-tag-icon-close'));
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Tag className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Tag style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Tag classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/TagGroup/test/TagGroupSpec.js
+++ b/src/TagGroup/test/TagGroupSpec.js
@@ -1,27 +1,13 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
-
+import { testStandardProps } from '@test/commonCases';
 import TagGroup from '../TagGroup';
 
 describe('TagGroup', () => {
+  testStandardProps(<TagGroup />);
+
   it('Should output a TagGroup', () => {
     const instance = getDOMNode(<TagGroup />);
     assert.equal(instance.className, 'rs-tag-group');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<TagGroup className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<TagGroup style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<TagGroup classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/TagGroup/test/TagGroupStylesSpec.js
+++ b/src/TagGroup/test/TagGroupStylesSpec.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import TagGroup from '../index';
 import { getStyle, itChrome } from '@test/testUtils';
+import TagGroup from '../TagGroup';
+
+import '../../Tag/styles/index.less';
 
 describe('TagGroup styles', () => {
   itChrome('Should render the correct styles', () => {

--- a/src/Timeline/test/TimelineItemSpec.js
+++ b/src/Timeline/test/TimelineItemSpec.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
-
+import { testStandardProps } from '@test/commonCases';
 import TimelineItem from '../TimelineItem';
 
 describe('TimelineItem', () => {
+  testStandardProps(<TimelineItem />);
+
   it('Should output a TimelineItem', () => {
     const instance = getDOMNode(<TimelineItem />);
     assert.equal(instance.className, 'rs-timeline-item');
@@ -25,21 +27,5 @@ describe('TimelineItem', () => {
   it('Should output the last item', () => {
     const instance = getDOMNode(<TimelineItem last />);
     assert.ok(instance.className.match(/\brs-timeline-item-last\b/));
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<TimelineItem className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<TimelineItem style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<TimelineItem classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Timeline/test/TimelineSpec.js
+++ b/src/Timeline/test/TimelineSpec.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import { getDOMNode } from '@test/testUtils';
-
+import { testStandardProps } from '@test/commonCases';
 import Timeline from '../Timeline';
 
 describe('Timeline', () => {
+  testStandardProps(<Timeline />);
+
   it('Should output a Timeline', () => {
     const instance = getDOMNode(<Timeline />);
     assert.ok(instance.className.match(/\brs-timeline\b/));
@@ -14,20 +16,9 @@ describe('Timeline', () => {
     assert.equal(instance.tagName, 'DIV');
   });
 
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Timeline className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
   it('Should be endless', () => {
     const instance = getDOMNode(<Timeline endless />);
     assert.ok(instance.className.match(/\bendless\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Timeline style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
   });
 
   it('Should have a with-time className', () => {
@@ -42,10 +33,5 @@ describe('Timeline', () => {
   it('Should have a custom align', () => {
     const instance = getDOMNode(<Timeline align="left" />);
     assert.ok(instance.className.match(/\brs-timeline-align-left\b/));
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Timeline classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Toggle/test/ToggleSpec.js
+++ b/src/Toggle/test/ToggleSpec.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-
-import Toggle from '../Toggle';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
+import Toggle from '../Toggle';
 
 describe('Toggle', () => {
+  testStandardProps(<Toggle />);
+
   it('Should output a toggle', () => {
     const instance = getDOMNode(<Toggle />);
     assert.equal(instance.className, 'rs-toggle');
@@ -99,22 +101,6 @@ describe('Toggle', () => {
 
       expect(onChangeSpy).not.to.have.been.called;
     });
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Toggle className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Toggle style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Toggle classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   describe('Loading', () => {

--- a/src/Tooltip/test/TooltipSpec.js
+++ b/src/Tooltip/test/TooltipSpec.js
@@ -1,8 +1,11 @@
 import React from 'react';
-import Tooltip from '../Tooltip';
 import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
+import Tooltip from '../Tooltip';
 
 describe('Tooltip', () => {
+  testStandardProps(<Tooltip />);
+
   it('Should render a Tooltip', () => {
     const title = 'Test';
     const instance = getDOMNode(<Tooltip>{title}</Tooltip>);
@@ -14,21 +17,5 @@ describe('Tooltip', () => {
   it('Should have a id', () => {
     const instance = getDOMNode(<Tooltip id="tooltip" />);
     assert.equal(instance.id, 'tooltip');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Tooltip className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Tooltip style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Tooltip classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/test/commonCases.js
+++ b/test/commonCases.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+export function testTestIdProp(element) {
+  it('Should accept data-testid prop', () => {
+    const { getByTestId } = render(React.cloneElement(element, { 'data-testid': 'element' }));
+
+    expect(getByTestId('element')).to.exist;
+  });
+}
+
+export function testClassNameProp(element, customClassName = 'custom-class') {
+  it('Should accept custom className', () => {
+    const { getByTestId } = render(
+      React.cloneElement(element, { 'data-testid': 'element', className: customClassName })
+    );
+
+    expect(getByTestId('element')).to.have.class(customClassName);
+  });
+}
+
+export function testClassPrefixProp(element) {
+  it('Should accept custom className prefix', () => {
+    const customClassPrefix = 'custom-prefix';
+    const { getByTestId } = render(
+      React.cloneElement(element, { 'data-testid': 'element', classPrefix: customClassPrefix })
+    );
+    expect(getByTestId('element')).to.have.class(new RegExp('^rs-' + customClassPrefix));
+  });
+}
+
+export function testStyleProp(element) {
+  it('Should accept custom style', () => {
+    const fontSize = '12px';
+    const { getByTestId } = render(
+      React.cloneElement(element, { 'data-testid': 'element', style: { fontSize } })
+    );
+
+    expect(getByTestId('element')).to.have.style('font-size', fontSize);
+  });
+}
+
+export function testStandardProps(element, options) {
+  describe('Standard props', () => {
+    testTestIdProp(element);
+    if (options?.customClassName !== false) {
+      testClassNameProp(element, options?.customClassName);
+    }
+    testClassPrefixProp(element);
+    testStyleProp(element);
+  });
+}


### PR DESCRIPTION
Move test cases for common props:

- `data-testid` attribute
- `className` prop
- `classPrefix` prop
- `style` prop

 into `test/commonCases` for reusage