### PR TITLE
Typo: Changed onFoucs to onFocus

### DIFF
--- a/docs/pages/guide/composition/en-US/index.md
+++ b/docs/pages/guide/composition/en-US/index.md
@@ -26,7 +26,7 @@ Our component only processes the `prop` defined in its `propTypes`, all unproces
 ```jsx
 return (
   <>
-    <Input tabIndex={1} onFoucs={e => console.log(e)} />
+    <Input tabIndex={1} onFocus={e => console.log(e)} />
   </>
 );
 ```


### PR DESCRIPTION
Small typo that could cause issues when people copy and paste from the guide.