### PR TITLE
fix(caretAs): fix DatePicker and DateRangePicker cannot replace caret

### DIFF
--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -30,7 +30,8 @@ import {
   PositionChildProps,
   usePickerClassName,
   usePublicMethods,
-  useToggleKeyDownEvent
+  useToggleKeyDownEvent,
+  PickerToggleProps
 } from '../Picker';
 
 import { FormControlBaseProps, PickerBaseProps, RsRefForwardingComponent } from '../@types/common';
@@ -41,7 +42,8 @@ export type { RangeType } from './Toolbar';
 
 export interface DatePickerProps
   extends PickerBaseProps<DatePickerLocale>,
-    FormControlBaseProps<Date | null> {
+    FormControlBaseProps<Date | null>,
+    Pick<PickerToggleProps, 'caretAs' | 'readOnly' | 'plaintext'> {
   /** Configure shortcut options */
   ranges?: RangeType<Date>[];
 
@@ -150,6 +152,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
       showWeekNumbers,
       style,
       toggleAs,
+      caretAs: caretAsProp,
       disabledDate: disabledDateProp,
       renderValue,
       onChange,
@@ -548,8 +551,8 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
     }, [formatStr, formatDate, placeholder, renderValue, value]);
 
     const caretAs = useMemo(
-      () => (DateUtils.shouldOnlyTime(formatStr) ? IconClockO : IconCalendar),
-      [formatStr]
+      () => caretAsProp || (DateUtils.shouldOnlyTime(formatStr) ? IconClockO : IconCalendar),
+      [caretAsProp, formatStr]
     );
 
     return (

--- a/src/DatePicker/test/DatePickerSpec.js
+++ b/src/DatePicker/test/DatePickerSpec.js
@@ -7,6 +7,8 @@ import { getDOMNode, getInstance } from '@test/testUtils';
 import DatePicker from '../DatePicker';
 import { DateUtils } from '../../utils';
 
+import GearIcon from '@rsuite/icons/Gear';
+
 describe('DatePicker', () => {
   it('Should render a div with "rs-picker-date" class', () => {
     const instance = getDOMNode(<DatePicker />);
@@ -606,6 +608,12 @@ describe('DatePicker', () => {
       );
 
       expect(getByTestId('content')).to.have.text('Not selected');
+    });
+
+    it('Should render a custom caret', () => {
+      const { getByLabelText } = render(<DatePicker caretAs={GearIcon} />);
+
+      expect(getByLabelText('gear')).to.have.class('rs-icon');
     });
   });
 });

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -21,7 +21,8 @@ import {
   PositionChildProps,
   usePickerClassName,
   usePublicMethods,
-  useToggleKeyDownEvent
+  useToggleKeyDownEvent,
+  PickerToggleProps
 } from '../Picker';
 import {
   createChainedFunction,
@@ -50,7 +51,8 @@ type SelectedDatesState = [] | [Date] | [Date, Date];
 
 export interface DateRangePickerProps
   extends PickerBaseProps,
-    FormControlBaseProps<DateRange | null> {
+    FormControlBaseProps<DateRange | null>,
+    Pick<PickerToggleProps, 'caretAs' | 'readOnly' | 'plaintext'> {
   /** Configure shortcut options */
   ranges?: RangeType[];
 
@@ -155,6 +157,7 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
     showMeridian,
     style,
     toggleAs,
+    caretAs,
     value: valueProp,
     onChange,
     onClean,
@@ -786,8 +789,8 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
           hasValue={hasValue}
           active={isPickerToggleActive}
           placement={placement}
-          caretAs={IconCalendar}
           disabled={disabled}
+          caretAs={caretAs || IconCalendar}
         >
           {getDisplayString(value)}
         </PickerToggle>

--- a/src/DateRangePicker/test/DateRangePickerSpec.js
+++ b/src/DateRangePicker/test/DateRangePickerSpec.js
@@ -17,6 +17,7 @@ import {
 } from '../../utils/dateUtils';
 import DateRangePicker from '../DateRangePicker';
 import { isSameRange } from '../utils';
+import GearIcon from '@rsuite/icons/Gear';
 
 function setTimePickerValue(picker, calendarIndex, { hours, minutes, seconds }) {
   function generateTimeItem(calendarIndex, type, index) {
@@ -616,5 +617,11 @@ describe('DateRangePicker', () => {
     expect(console.warn).not.to.have.been.calledWith(
       sinon.match(/"caretComponent" property of "PickerToggle" has been deprecated/)
     );
+  });
+
+  it('Should render a custom caret', () => {
+    const { getByLabelText } = render(<DateRangePicker caretAs={GearIcon} />);
+
+    expect(getByLabelText('gear')).to.have.class('rs-icon');
   });
 });

--- a/src/Picker/index.ts
+++ b/src/Picker/index.ts
@@ -5,6 +5,7 @@ import {
   PositionChildProps
 } from './PickerToggleTrigger';
 
+import { PickerToggleProps } from './PickerToggle';
 import { PickerInstance, PickerComponent } from './types';
 
 export { default as DropdownMenu } from './DropdownMenu';
@@ -18,6 +19,12 @@ export { default as SearchBar } from './SearchBar';
 export { default as SelectedElement } from './SelectedElement';
 export { pickTriggerPropKeys, omitTriggerPropKeys };
 
-export type { OverlayTriggerInstance, PositionChildProps, PickerInstance, PickerComponent };
+export type {
+  OverlayTriggerInstance,
+  PositionChildProps,
+  PickerInstance,
+  PickerComponent,
+  PickerToggleProps
+};
 export * from './utils';
 export * from './propTypes';


### PR DESCRIPTION
fix  #2356 

```tsx
import { DateRangePicker } from 'rsuite';
import TimeIcon from '@rsuite/icons/Time';

return (
  <DateRangePicker caretAs={TimeIcon} />
)
```