### PR TITLE
fix(Sidenav): remove underline from focused sidenav item

### DIFF
--- a/src/Sidenav/styles/index.less
+++ b/src/Sidenav/styles/index.less
@@ -170,7 +170,8 @@
   outline: 0;
   overflow: hidden;
 
-  &:hover {
+  &:hover,
+  &:focus {
     text-decoration: none;
   }
 


### PR DESCRIPTION
Before
<img width="336" alt="image" src="https://user-images.githubusercontent.com/8225666/157185544-1b9f10c5-14ac-44eb-ba32-0b8e3274b91a.png">

After
<img width="314" alt="image" src="https://user-images.githubusercontent.com/8225666/157185580-9b743ea7-2109-4e6c-8205-9fa6937e0cb1.png">
