### PR TITLE
fix: fix selectPicker when search is controlled and exit Dropdown without resetting external search

### DIFF
--- a/src/SelectPicker/SelectPicker.d.ts
+++ b/src/SelectPicker/SelectPicker.d.ts
@@ -36,7 +36,7 @@ export interface SelectProps<ValueType = any> {
   onGroupTitleClick?: (event: React.SyntheticEvent<any>) => void;
 
   /** Called when searching */
-  onSearch?: (searchKeyword: string, event: React.SyntheticEvent<any>) => void;
+  onSearch?: (searchKeyword: string, event?: React.SyntheticEvent<any>) => void;
 
   /** Called when clean */
   onClean?: (event: React.SyntheticEvent<any>) => void;

--- a/src/SelectPicker/SelectPicker.tsx
+++ b/src/SelectPicker/SelectPicker.tsx
@@ -282,7 +282,7 @@ class SelectPicker extends React.Component<SelectPickerProps, SelectPickerState>
       searchKeyword: '',
       active: false
     });
-
+    this.props.onSearch?.('');
     this.props.onClose?.();
   };
 

--- a/src/SelectPicker/test/SelectPickerSpec.js
+++ b/src/SelectPicker/test/SelectPickerSpec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { globalKey, getDOMNode, getInstance } from '@test/testUtils';
 
@@ -323,5 +323,29 @@ describe('SelectPicker', () => {
     const list = getDOMNode(instance.menuContainerRef.current).querySelectorAll('a');
     assert.equal(list.length, 1);
     assert.ok(list[0].innerText, 'Louisa');
+  });
+
+  it('Search should be reset when controlled and should be turned off', () => {
+    let searchRef = '';
+    const Wrapper = React.forwardRef((props, ref) => {
+      const [search, setSearch] = useState(searchRef);
+      searchRef = search;
+      return (
+        <div ref={ref}>
+          <button id="exit">exit</button>
+          <Dropdown onSearch={setSearch} data={data} searchBy={(a, b, c) => c.value === 'Louisa'} />
+        </div>
+      );
+    });
+    Wrapper.displayName = 'WrapperSelectPicker';
+    const instance = getInstance(<Wrapper />);
+    const searchbox = getDOMNode(instance.searchBarContainerRef.current);
+    const input = searchbox.querySelector(searchInputClassName);
+    const exit = searchbox.querySelector('#exit');
+
+    ReactTestUtils.Simulate.change(input, { target: { value: 'a' } });
+    assert.equal(searchRef, 'a');
+    ReactTestUtils.Simulate.click(exit);
+    assert.equal(searchRef, '1');
   });
 });


### PR DESCRIPTION
Fix selectPicker when search is controlled and exit Dropdown without resetting external search
But there are other problems:
<br/>
1. When search and data are controlled => Input searchword => The selected value will be disappear 
&nbsp;&nbsp;&nbsp;&nbsp;<img width="313" alt="image" src="https://user-images.githubusercontent.com/53305259/159238914-ec0940f8-20f7-4f38-81ff-189b567f70af.png">
&nbsp;&nbsp;&nbsp;&nbsp;<img width="354" alt="image" src="https://user-images.githubusercontent.com/53305259/159238951-14d187a0-0339-40dd-b62f-fc334475725d.png">

&nbsp;&nbsp;&nbsp;&nbsp;I think the cause of this problem is the data is controlled, when searchWord was changed the data will be change ,then,the value is not in the data 
&nbsp;&nbsp;&nbsp;&nbsp;So, Maybe we  can keep a value item inside.     
  

2. When I want to customize my search, I passed an onSeach props,and I must pass a searchBy props` const searchBy = () => true;`, Otherwise, it will still be handled internally