### PR TITLE
Fixed Triggering onSelect twice on Dropdown Menu

### DIFF
--- a/src/Dropdown/DropdownMenu.tsx
+++ b/src/Dropdown/DropdownMenu.tsx
@@ -106,16 +106,7 @@ const DropdownMenu = React.forwardRef<
 
     return (
       <DropdownContext.Provider value={contextValue}>
-        <Menubar
-          vertical
-          onActivateItem={event => {
-            const { eventKey, eventKeyType } = (event.target as HTMLElement).dataset;
-
-            // Only cast number type for now
-            const eventKeyToEmit = eventKeyType === 'number' ? Number(eventKey) : eventKey;
-            onSelect?.(eventKeyToEmit as any, event);
-          }}
-        >
+        <Menubar vertical>
           {(menubar, menubarRef: React.Ref<HTMLElement>) => (
             <ul ref={mergeRefs(menubarRef, ref)} className={classes} {...menubar} {...rest}>
               {children}

--- a/src/Dropdown/test/DropdownMenuSpec.js
+++ b/src/Dropdown/test/DropdownMenuSpec.js
@@ -234,7 +234,7 @@ describe('<Dropdown.Menu>', () => {
     assert.isNotNull(instance.querySelector('.rs-dropdown-item-submenu'));
   });
 
-  it('Should call onSelect callback with correct `eventKey` once', () => {
+  it('Should call Dropdown.Menu onSelect callback once', () => {
     const onSelectSpy = sinon.spy();
 
     const { getByTestId } = render(
@@ -251,9 +251,7 @@ describe('<Dropdown.Menu>', () => {
       </DropdownMenu>
     );
 
-    act(() => {
-      userEvent.click(getByTestId('item-1'));
-    });
+    userEvent.click(getByTestId('item-1'));
 
     expect(onSelectSpy.callCount).to.be.eq(1);
   });

--- a/src/Dropdown/test/DropdownMenuSpec.js
+++ b/src/Dropdown/test/DropdownMenuSpec.js
@@ -234,7 +234,7 @@ describe('<Dropdown.Menu>', () => {
     assert.isNotNull(instance.querySelector('.rs-dropdown-item-submenu'));
   });
 
-  it('Should call Dropdown.Menu onSelect callback once', () => {
+  it('Should call Dropdown.Menu onSelect callback only once', () => {
     const onSelectSpy = sinon.spy();
 
     const { getByTestId } = render(
@@ -242,12 +242,8 @@ describe('<Dropdown.Menu>', () => {
         <DropdownItem data-testid="item-1" eventKey={1}>
           1
         </DropdownItem>
-        <DropdownItem data-testid="item-2" eventKey={2}>
-          2
-        </DropdownItem>
-        <DropdownItem data-testid="item-3" eventKey={3}>
-          3
-        </DropdownItem>
+        <DropdownItem eventKey={2}>2</DropdownItem>
+        <DropdownItem eventKey={3}>3</DropdownItem>
       </DropdownMenu>
     );
 

--- a/src/Dropdown/test/DropdownMenuSpec.js
+++ b/src/Dropdown/test/DropdownMenuSpec.js
@@ -252,6 +252,23 @@ describe('<Dropdown.Menu>', () => {
     expect(onSelectSpy.callCount).to.be.eq(1);
   });
 
+  it('Should highlight menu item when hover', () => {
+    const { getByTestId } = render(
+      <DropdownMenu>
+        <DropdownItem data-testid="item-1">1</DropdownItem>
+        <DropdownItem>2</DropdownItem>
+        <DropdownItem>3</DropdownItem>
+        <DropdownItem>4</DropdownItem>
+      </DropdownMenu>
+    );
+
+    const menuItem = getByTestId('item-1');
+
+    userEvent.hover(menuItem);
+
+    expect(menuItem).to.have.class('rs-dropdown-item-focus');
+  });
+
   it('Should call onSelect callback with correct `eventKey`', () => {
     const onSelectSpy = sinon.spy();
 

--- a/src/Dropdown/test/DropdownMenuSpec.js
+++ b/src/Dropdown/test/DropdownMenuSpec.js
@@ -235,14 +235,10 @@ describe('<Dropdown.Menu>', () => {
   });
 
   it('Should call onSelect callback with correct `eventKey` once', () => {
-    const selectedValues = [];
+    const onSelectSpy = sinon.spy();
 
     const { getByTestId } = render(
-      <DropdownMenu
-        onSelect={eventKey => {
-          selectedValues.push(eventKey);
-        }}
-      >
+      <DropdownMenu onSelect={onSelectSpy}>
         <DropdownItem data-testid="item-1" eventKey={1}>
           1
         </DropdownItem>
@@ -259,7 +255,7 @@ describe('<Dropdown.Menu>', () => {
       userEvent.click(getByTestId('item-1'));
     });
 
-    expect(selectedValues.length).to.be.eq(1);
+    expect(onSelectSpy.callCount).to.be.eq(1);
   });
 
   it('Should call onSelect callback with correct `eventKey`', () => {

--- a/src/Dropdown/test/DropdownMenuSpec.js
+++ b/src/Dropdown/test/DropdownMenuSpec.js
@@ -256,10 +256,7 @@ describe('<Dropdown.Menu>', () => {
     );
 
     act(() => {
-      const menuItem = getByTestId('item-1');
-      Simulate.click(menuItem, {
-        bubbles: true
-      });
+      userEvent.click(getByTestId('item-1'));
     });
 
     expect(selectedValues.length).to.be.eq(1);

--- a/src/Dropdown/test/DropdownMenuSpec.js
+++ b/src/Dropdown/test/DropdownMenuSpec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactTestUtils, { act, Simulate } from 'react-dom/test-utils';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { getDOMNode } from '@test/testUtils';
 import DropdownMenu from '../DropdownMenu';
 import DropdownItem from '../DropdownItem';
@@ -237,20 +237,27 @@ describe('<Dropdown.Menu>', () => {
   it('Should call onSelect callback with correct `eventKey` once', () => {
     const selectedValues = [];
 
-    const instance = getDOMNode(
+    const { getByTestId } = render(
       <DropdownMenu
         onSelect={eventKey => {
           selectedValues.push(eventKey);
         }}
       >
-        <DropdownItem eventKey={1}>1</DropdownItem>
-        <DropdownItem eventKey={2}>2</DropdownItem>
-        <DropdownItem eventKey={3}>3</DropdownItem>
+        <DropdownItem data-testid="item-1" eventKey={1}>
+          1
+        </DropdownItem>
+        <DropdownItem data-testid="item-2" eventKey={2}>
+          2
+        </DropdownItem>
+        <DropdownItem data-testid="item-3" eventKey={3}>
+          3
+        </DropdownItem>
       </DropdownMenu>
     );
 
     act(() => {
-      Simulate.click(instance.querySelectorAll('[role^="menuitem"]')[2], {
+      const menuItem = getByTestId('item-1');
+      Simulate.click(menuItem, {
         bubbles: true
       });
     });

--- a/src/Dropdown/test/DropdownMenuSpec.js
+++ b/src/Dropdown/test/DropdownMenuSpec.js
@@ -234,6 +234,30 @@ describe('<Dropdown.Menu>', () => {
     assert.isNotNull(instance.querySelector('.rs-dropdown-item-submenu'));
   });
 
+  it('Should call onSelect callback with correct `eventKey` once', () => {
+    const selectedValues = [];
+
+    const instance = getDOMNode(
+      <DropdownMenu
+        onSelect={eventKey => {
+          selectedValues.push(eventKey);
+        }}
+      >
+        <DropdownItem eventKey={1}>1</DropdownItem>
+        <DropdownItem eventKey={2}>2</DropdownItem>
+        <DropdownItem eventKey={3}>3</DropdownItem>
+      </DropdownMenu>
+    );
+
+    act(() => {
+      Simulate.click(instance.querySelectorAll('[role^="menuitem"]')[2], {
+        bubbles: true
+      });
+    });
+
+    expect(selectedValues.length).to.be.eq(1);
+  });
+
   it('Should call onSelect callback with correct `eventKey`', () => {
     const onSelectSpy = sinon.spy();
 


### PR DESCRIPTION
The issue is `onSelect` is triggered twice.

```tsx
export default function Dropdown() {
  const handleSelect = (eventKey: any) => {
    console.log(eventKey);
  };
  return (
    <>
      <Dropdown.Menu onSelect={handleSelect}>
        <Dropdown.Item eventKey={3}>Download As...</Dropdown.Item>
        <Dropdown.Item eventKey={4}>Export PDF</Dropdown.Item>
        <Dropdown.Item eventKey={5}>Export HTML</Dropdown.Item>
        <Dropdown.Item eventKey={6}>Settings</Dropdown.Item>
        <Dropdown.Item eventKey={7}>About</Dropdown.Item>
      </Dropdown.Menu>
    </>
  );
}
```

Or Check the following Code Sandbox 

https://codesandbox.io/s/react-typescript-forked-iybjwt?file=/src/App.tsx

Click on any item on the dropdown then check the console log