### PR TITLE
fix(Toggle): add missing properties to onChange event target

### DIFF
--- a/src/Toggle/Toggle.tsx
+++ b/src/Toggle/Toggle.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { useClassNames, useControlled, useCustom } from '../utils';
+import { partitionHTMLProps, useClassNames, useControlled, useCustom } from '../utils';
 import { WithAsProps, TypeAttributes, RsRefForwardingComponent } from '../@types/common';
 import Plaintext from '../Plaintext';
 import { ToggleLocale } from '../locales';
@@ -71,6 +71,8 @@ const Toggle: RsRefForwardingComponent<'label', ToggleProps> = React.forwardRef<
   const inner = checked ? checkedChildren : unCheckedChildren;
   const label = checked ? locale.on : locale.off;
 
+  const [htmlInputProps, restProps] = partitionHTMLProps(rest);
+
   const handleInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       if (disabled || readOnly || loading) {
@@ -89,8 +91,9 @@ const Toggle: RsRefForwardingComponent<'label', ToggleProps> = React.forwardRef<
   }
 
   return (
-    <label ref={ref} className={classes} {...rest}>
+    <label ref={ref} className={classes} {...restProps}>
       <input
+        {...htmlInputProps}
         ref={inputRef}
         type="checkbox"
         checked={checkedProp}

--- a/src/Toggle/test/ToggleSpec.js
+++ b/src/Toggle/test/ToggleSpec.js
@@ -53,6 +53,28 @@ describe('Toggle', () => {
       expect(onChangeSpy).to.have.been.calledWith(false);
     });
 
+    it('Should emit ChangeEvent with correct target name, type and checked state', () => {
+      const onChange = sinon.spy();
+
+      const { getByTestId, rerender } = render(
+        <Toggle name="toggle" onChange={onChange} data-testid="toggle" />
+      );
+      userEvent.click(getByTestId('toggle'));
+
+      let event = onChange.getCall(0).args[1];
+      expect(event.target).to.have.property('name', 'toggle');
+      expect(event.target).to.have.property('type', 'checkbox');
+      expect(event.target).to.have.property('checked', true);
+
+      rerender(<Toggle name="toggle" defaultChecked onChange={onChange} data-testid="toggle" />);
+      userEvent.click(getByTestId('toggle'));
+
+      event = onChange.getCall(1).args[1];
+      expect(event.target).to.have.property('name', 'toggle');
+      expect(event.target).to.have.property('type', 'checkbox');
+      expect(event.target).to.have.property('checked', false);
+    });
+
     it('Should toggle with the Space key', () => {
       const onChangeSpy = sinon.spy();
 


### PR DESCRIPTION
Before

<img width="894" alt="image" src="https://user-images.githubusercontent.com/8225666/160749632-a16a95ad-909e-472f-8279-3379bc4dca29.png">

After

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/8225666/160749828-4438408e-2240-4efe-88f5-c2ae7474a5a0.png">
