### PR TITLE
fix(Checkbox): correct checked state in onChange callback

### DIFF
--- a/docs/pages/components/checkbox/fragments/checkbox-group.md
+++ b/docs/pages/components/checkbox/fragments/checkbox-group.md
@@ -4,11 +4,13 @@
 const instance = (
   <CheckboxGroup name="checkboxList">
     <p>Group1</p>
-    <Checkbox>Item A</Checkbox>
-    <Checkbox>Item B</Checkbox>
+    <Checkbox value="A">Item A</Checkbox>
+    <Checkbox value="B">Item B</Checkbox>
     <p>Group2</p>
-    <Checkbox>Item C</Checkbox>
-    <Checkbox disabled>Item D</Checkbox>
+    <Checkbox value="C">Item C</Checkbox>
+    <Checkbox value="D" disabled>
+      Item D
+    </Checkbox>
   </CheckboxGroup>
 );
 ReactDOM.render(instance);

--- a/docs/pages/components/checkbox/fragments/checkbox-groupinline.md
+++ b/docs/pages/components/checkbox/fragments/checkbox-groupinline.md
@@ -3,10 +3,12 @@
 ```js
 const instance = (
   <CheckboxGroup inline name="checkboxList">
-    <Checkbox>Item A</Checkbox>
-    <Checkbox>Item B</Checkbox>
-    <Checkbox>Item C</Checkbox>
-    <Checkbox disabled>Item D</Checkbox>
+    <Checkbox value="A">Item A</Checkbox>
+    <Checkbox value="B">Item B</Checkbox>
+    <Checkbox value="C">Item C</Checkbox>
+    <Checkbox value="D" disabled>
+      Item D
+    </Checkbox>
   </CheckboxGroup>
 );
 

--- a/src/CheckPicker/test/CheckPickerSpec.js
+++ b/src/CheckPicker/test/CheckPickerSpec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ReactTestUtils from 'react-dom/test-utils';
 import { globalKey, getDOMNode, getInstance } from '@test/testUtils';
 
@@ -164,14 +165,16 @@ describe('CheckPicker', () => {
     assert.equal(instance.querySelector(placeholderClassName).textContent, 'test');
   });
 
-  it('Should call `onChange` callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getInstance(
-      <CheckPicker defaultOpen onChange={doneOp} data={[{ label: '1', value: '1' }]} />
+  it('Should call `onChange` callback with correct value', () => {
+    const onChange = sinon.spy();
+    const { getByText } = render(
+      <CheckPicker defaultOpen onChange={onChange} data={[{ label: 'Option 1', value: '1' }]} />
     );
-    ReactTestUtils.Simulate.change(instance.overlay.querySelectorAll('input')[1]);
+
+    userEvent.click(getByText('Option 1'));
+
+    expect(onChange).to.have.been.calledOnce;
+    expect(onChange.getCall(0).args[0]).to.eql(['1']);
   });
 
   it('Should call `onClean` callback', done => {

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -130,7 +130,7 @@ const Checkbox: RsRefForwardingComponent<'div', CheckboxProps> = React.forwardRe
 
     const handleChange = useCallback(
       (event: React.ChangeEvent<HTMLInputElement>) => {
-        const nextChecked = !event.target.checked;
+        const nextChecked = event.target.checked;
 
         if (disabled || readOnly) {
           return;

--- a/src/Checkbox/test/CheckboxSpec.js
+++ b/src/Checkbox/test/CheckboxSpec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { getDOMNode } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import Checkbox from '../Checkbox';
@@ -65,23 +66,28 @@ describe('Checkbox', () => {
     assert.equal(input.tagName, 'INPUT');
   });
 
-  it('Should call onChange callback with correct value', done => {
-    const value = 'Test';
-    const doneOp = data => {
-      try {
-        assert.equal(data, value);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should call onChange callback with correct value and checked state', () => {
+    const onChange = sinon.spy();
 
-    const instance = getDOMNode(
-      <Checkbox onChange={doneOp} value={value}>
-        Title
+    const { getByLabelText, rerender } = render(
+      <Checkbox onChange={onChange} value="Test">
+        Checkbox
       </Checkbox>
     );
-    ReactTestUtils.Simulate.change(instance.querySelector('input'));
+
+    userEvent.click(getByLabelText('Checkbox'));
+
+    expect(onChange).to.have.been.calledWith('Test', true);
+
+    rerender(
+      <Checkbox onChange={onChange} value="Test" defaultChecked>
+        Checkbox
+      </Checkbox>
+    );
+
+    userEvent.click(getByLabelText('Checkbox'));
+
+    expect(onChange).to.have.been.calledWith('Test', false);
   });
 
   it('Should call onClick callback', done => {
@@ -106,40 +112,6 @@ describe('Checkbox', () => {
     };
     const instance = getDOMNode(<Checkbox onFocus={doneOp} />);
     ReactTestUtils.Simulate.focus(instance.querySelector('input'));
-  });
-
-  it('Should be checked with change', done => {
-    const doneOp = (value, checked) => {
-      try {
-        assert.isTrue(checked);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
-
-    const instance = getDOMNode(<Checkbox onChange={doneOp}>Title</Checkbox>);
-
-    ReactTestUtils.Simulate.change(instance.querySelector('input'));
-  });
-
-  it('Should be unchecked with change', done => {
-    const doneOp = (value, checked) => {
-      try {
-        assert.isFalse(checked);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
-
-    const instance = getDOMNode(
-      <Checkbox onChange={doneOp} checked>
-        Title
-      </Checkbox>
-    );
-
-    ReactTestUtils.Simulate.change(instance.querySelector('input'));
   });
 
   describe('Plain text', () => {

--- a/src/CheckboxGroup/test/CheckboxGroupSpec.js
+++ b/src/CheckboxGroup/test/CheckboxGroupSpec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
@@ -120,27 +121,20 @@ describe('CheckboxGroup', () => {
     expect(getByLabelText('Checkbox 4')).to.be.checked;
   });
 
-  it('Should call onChange callback with correct value', done => {
-    const instance = getDOMNode(
-      <CheckboxGroup
-        onChange={value => {
-          try {
-            assert.deepEqual(value, [3]);
-            done();
-          } catch (err) {
-            done(err);
-          }
-        }}
-      >
-        <Checkbox value={1}>Test1</Checkbox>
-        <Checkbox value={2}>Test2</Checkbox>
-        <Checkbox value={3}>Test2</Checkbox>
-        <Checkbox value={4}>Test2</Checkbox>
+  it('Should call onChange callback with correct value', () => {
+    const onChange = sinon.spy();
+    const { getByLabelText } = render(
+      <CheckboxGroup onChange={onChange}>
+        <Checkbox value={1}>Option 1</Checkbox>
+        <Checkbox value={2}>Option 2</Checkbox>
+        <Checkbox value={3}>Option 3</Checkbox>
+        <Checkbox value={4}>Option 4</Checkbox>
       </CheckboxGroup>
     );
 
-    const checkboxs = instance.querySelectorAll(`.${globalKey}checkbox`);
-    ReactTestUtils.Simulate.change(checkboxs[2].querySelector('input'));
+    userEvent.click(getByLabelText('Option 3'));
+
+    expect(onChange).to.have.been.calledWith([3]);
   });
 
   it('Should call onChange callback', done => {


### PR DESCRIPTION
> ## 🚨 HOTFIX
> 
> It's suggested that a new version is released as soon as this fix is merged.

Checkbox onChange callback is called with a wrong `checked` argument since #2419. See https://github.com/rsuite/rsuite/pull/2419/files#diff-bc30c797bcd9835ab75d581b4e2584161a4f00e7350bc299b943fe02283dcc16R133

The flaky test cases that were not able to find this issue are also updated. 