### PR TITLE
feat(Dropdown): add `open` and `defaultOpen` props

### DIFF
--- a/docs/pages/components/dropdown/en-US/index.md
+++ b/docs/pages/components/dropdown/en-US/index.md
@@ -95,6 +95,7 @@ The default value of the `toggleAs` property of`Dropdown` is `Button`. You can s
 | --------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------- |
 | activeKey       | string                                                 | The option to activate the state, corresponding to the `eventkey` in the Dropdown.item. |
 | classPrefix     | string `('dropdown')`                                  | The prefix of the component CSS class                                                   |
+| defaultOpen     | boolean `(false)`                                      | Whether Dropdown is initially open                                                      |
 | disabled        | boolean                                                | Whether or not component is disabled                                                    |
 | icon            | Element&lt;typeof Icon&gt;                             | Set the icon                                                                            |
 | menuStyle       | CSSProperties                                          | The style of the menu.                                                                  |
@@ -102,6 +103,7 @@ The default value of the `toggleAs` property of`Dropdown` is `Button`. You can s
 | onOpen          | () => void                                             | Menu Pop-up callback function                                                           |
 | onSelect        | (eventKey: string, event) => void                      | Selected callback function                                                              |
 | onToggle        | (open?: boolean) => void                               | Callback function for menu state switching.                                             |
+| open            | boolean                                                | Whether Dropdown is open (controlled)                                                   |
 | placement       | [Placement](#code-ts-placement-code) `('bottomStart')` | The placement of Menu                                                                   |
 | renderToggle    | (props, ref) => any;                                   | Custom Toggle                                                                           |
 | title           | ReactNode                                              | Menu defaults to display content.                                                       |

--- a/docs/pages/components/dropdown/zh-CN/index.md
+++ b/docs/pages/components/dropdown/zh-CN/index.md
@@ -95,6 +95,7 @@
 | --------------- | ------------------------------------------------------ | ------------------------------------------------ |
 | activeKey       | string                                                 | 激活状态的选项，对应 Dropdown.Item 中的 eventKey |
 | classPrefix     | string `('dropdown')`                                  | 组件 CSS 类的前缀                                |
+| defaultOpen     | boolean `(false)`                                      | 菜单是否初始开启                                 |
 | disabled        | boolean                                                | 禁用组件                                         |
 | icon            | Element&lt;typeof Icon&gt;                             | 设置图标                                         |
 | menuStyle       | CSSProperties                                          | 菜单样式                                         |
@@ -102,6 +103,7 @@
 | onOpen          | () => void                                             | 菜单弹出的回调函数                               |
 | onSelect        | (eventKey: string, event) => void                      | 选择后的回调函数                                 |
 | onToggle        | (open?: boolean) => void                               | 菜单状态切换的回调函数                           |
+| open            | boolean                                                | 菜单是否开启 (受控)                              |
 | placement       | [Placement](#code-ts-placement-code) `('bottomStart')` | 菜单显示位置                                     |
 | renderToggle    | (props, ref) => any;                                   | 自定义 Toggle                                    |
 | title           | ReactNode                                              | 菜单默认显示内容                                 |

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -60,8 +60,7 @@ export interface DropdownProps<T = any>
   noCaret?: boolean;
 
   /**
-   * Open the menu and control it
-   * @deprecated
+   * Controlled open state
    */
   open?: boolean;
   /**
@@ -123,6 +122,7 @@ const Dropdown: DropdownComponent = React.forwardRef<HTMLElement>((props: Dropdo
     placement = 'bottomStart',
     toggleAs,
     toggleClassName,
+    open,
     defaultOpen,
     classPrefix = 'dropdown',
     className,
@@ -293,6 +293,7 @@ const Dropdown: DropdownComponent = React.forwardRef<HTMLElement>((props: Dropdo
   return (
     <DropdownContext.Provider value={dropdownContextValue}>
       <Menu
+        open={open}
         defaultOpen={defaultOpen}
         menuButtonText={title}
         renderMenuButton={renderMenuButton}

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -64,6 +64,10 @@ export interface DropdownProps<T = any>
    * @deprecated
    */
   open?: boolean;
+  /**
+   * Whether dropdown is initially open
+   */
+  defaultOpen?: boolean;
 
   /**
    * @deprecated
@@ -119,6 +123,7 @@ const Dropdown: DropdownComponent = React.forwardRef<HTMLElement>((props: Dropdo
     placement = 'bottomStart',
     toggleAs,
     toggleClassName,
+    defaultOpen,
     classPrefix = 'dropdown',
     className,
     disabled,
@@ -288,6 +293,7 @@ const Dropdown: DropdownComponent = React.forwardRef<HTMLElement>((props: Dropdo
   return (
     <DropdownContext.Provider value={dropdownContextValue}>
       <Menu
+        defaultOpen={defaultOpen}
         menuButtonText={title}
         renderMenuButton={renderMenuButton}
         openMenuOn={menuButtonTriggers}

--- a/src/Dropdown/test/DropdownSpec.js
+++ b/src/Dropdown/test/DropdownSpec.js
@@ -62,6 +62,24 @@ describe('<Dropdown>', () => {
     expect(getByRole('menu')).to.be.visible;
   });
 
+  it('Should display/hide menu according to controlled `open` prop', () => {
+    const { getByRole, queryByRole, rerender } = render(
+      <Dropdown title="Menu" open>
+        <Dropdown.Item>Item 1</Dropdown.Item>
+      </Dropdown>
+    );
+
+    expect(getByRole('menu')).to.be.visible;
+
+    rerender(
+      <Dropdown title="Menu" open={false}>
+        <Dropdown.Item>Item 1</Dropdown.Item>
+      </Dropdown>
+    );
+
+    expect(queryByRole('menu')).not.to.exist;
+  });
+
   it('Should toggle the menu on mouseEnter/mouseLeave button given trigger "hover"', () => {
     const { root, button, menu } = renderDropdown(
       <Dropdown trigger="hover">

--- a/src/Dropdown/test/DropdownSpec.js
+++ b/src/Dropdown/test/DropdownSpec.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import ReactTestUtils, { act, Simulate } from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { getDOMNode } from '@test/testUtils';
 import Dropdown from '../Dropdown';
 import Button from '../../Button';
@@ -30,41 +32,34 @@ function renderDropdown(ui) {
 
 describe('<Dropdown>', () => {
   it('Should render a button that controls a popup menu', () => {
-    const instance = getDOMNode(
+    const { getByRole } = render(
       <Dropdown title="Menu">
-        <Dropdown.Item>1</Dropdown.Item>
-        <Dropdown.Item>2</Dropdown.Item>
-        {null}
-        <div>abc</div>
+        <Dropdown.Item>Item 1</Dropdown.Item>
       </Dropdown>
     );
 
-    const button = instance.querySelector('[role="button"]');
-    expect(button, 'The button').not.to.be.null;
-    expect(button.textContent, 'Button text').to.equal('Menu');
-    assert.equal(button.getAttribute('aria-haspopup'), 'menu', 'The button controls a popup menu');
-
-    const menu = instance.querySelector('[role="menu"]');
-
-    assert.isTrue(menu.hidden, 'The menu is closed initially.');
+    expect(getByRole('button')).to.have.text('Menu').and.to.have.attr('aria-haspopup', 'menu');
   });
 
   it('Should open the menu when button is clicked', () => {
-    const instance = getDOMNode(
-      <Dropdown>
+    const { getByRole } = render(
+      <Dropdown title="Menu">
         <Dropdown.Item>Item 1</Dropdown.Item>
-        <Dropdown.Item>Item 2</Dropdown.Item>
-        <Dropdown.Item>Item 3</Dropdown.Item>
       </Dropdown>
     );
-    const button = instance.querySelector('[role="button"]');
-    ReactTestUtils.act(() => {
-      ReactTestUtils.Simulate.click(button);
-    });
+    userEvent.click(getByRole('button', { name: 'Menu' }));
 
-    const menu = instance.querySelector('[role="menu"]');
+    expect(getByRole('menu')).to.be.visible;
+  });
 
-    assert.isFalse(menu.hidden, 'The menu is opened');
+  it('Should open menu initially when defaultOpen=true', () => {
+    const { getByRole } = render(
+      <Dropdown title="Menu" defaultOpen>
+        <Dropdown.Item>Item 1</Dropdown.Item>
+      </Dropdown>
+    );
+
+    expect(getByRole('menu')).to.be.visible;
   });
 
   it('Should toggle the menu on mouseEnter/mouseLeave button given trigger "hover"', () => {

--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -11,6 +11,11 @@ import { isFocusLeaving } from '../utils/events';
 import { isFocusableElement } from '../utils/dom';
 
 export interface MenuProps {
+  /**
+   * Whether dropdown is initially open
+   */
+  defaultOpen?: boolean;
+
   disabled?: boolean;
 
   children: (
@@ -29,7 +34,7 @@ export interface MenuProps {
     ref: React.Ref<HTMLUListElement>
   ) => React.ReactElement<React.HTMLAttributes<HTMLUListElement>>;
 
-  openMenuOn?: MenuButtonTrigger[];
+  openMenuOn?: readonly MenuButtonTrigger[];
   onToggleMenu?: (open: boolean, event: React.SyntheticEvent) => void;
 }
 
@@ -51,29 +56,28 @@ export interface MenuHandle {
   dispatch: MenuContextProps[1];
 }
 
-const defaultOpenMenuOn = ['click'];
+const defaultOpenMenuOn = ['click'] as const;
 
 /**
  * Headless ARIA `menu`
  */
-function Menu(props: MenuProps & React.HTMLAttributes<HTMLUListElement>) {
-  const {
-    disabled,
-    children,
-    openMenuOn = defaultOpenMenuOn,
-    menuButtonText,
-    renderMenuButton,
-    renderMenuPopup,
-    onToggleMenu
-  } = props;
-
+function Menu({
+  disabled,
+  children,
+  openMenuOn = defaultOpenMenuOn,
+  defaultOpen = false,
+  menuButtonText,
+  renderMenuButton,
+  renderMenuPopup,
+  onToggleMenu
+}: MenuProps & React.HTMLAttributes<HTMLUListElement>) {
   const buttonElementRef = useRef<HTMLButtonElement>(null);
   const menuElementRef = useRef<HTMLUListElement>(null);
 
   const parentMenu = useContext(MenuContext);
   const isSubmenu = !!parentMenu;
 
-  const menu = useMenu();
+  const menu = useMenu({ open: defaultOpen });
   const [{ open, items, activeItemIndex }, dispatch] = menu;
 
   const { rtl } = useCustom('Menu');

--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -16,6 +16,11 @@ export interface MenuProps {
    */
   defaultOpen?: boolean;
 
+  /**
+   * Controlled open state
+   */
+  open?: boolean;
+
   disabled?: boolean;
 
   children: (
@@ -66,6 +71,7 @@ function Menu({
   children,
   openMenuOn = defaultOpenMenuOn,
   defaultOpen = false,
+  open: openProp,
   menuButtonText,
   renderMenuButton,
   renderMenuPopup,
@@ -78,7 +84,10 @@ function Menu({
   const isSubmenu = !!parentMenu;
 
   const menu = useMenu({ open: defaultOpen });
-  const [{ open, items, activeItemIndex }, dispatch] = menu;
+  const [{ open: openState, items, activeItemIndex }, dispatch] = menu;
+
+  const openControlled = typeof openProp !== 'undefined';
+  const open = openControlled ? openProp : openState;
 
   const { rtl } = useCustom('Menu');
 

--- a/src/Menu/test/MenuSpec.js
+++ b/src/Menu/test/MenuSpec.js
@@ -8,6 +8,28 @@ afterEach(() => {
 });
 
 describe('<Menu>', () => {
+  it('Should open menu initially when defaultOpen=true', () => {
+    const { getByRole } = render(
+      <Menu
+        defaultOpen
+        renderMenuButton={(buttonProps, buttonRef) => (
+          <button ref={buttonRef} {...buttonProps} data-testid="button">
+            Button
+          </button>
+        )}
+        renderMenuPopup={({ open, ...popupProps }, popupRef) => (
+          <ul ref={popupRef} {...popupProps} hidden={!open} data-testid="menu" />
+        )}
+      >
+        {(containerProps, containerRef) => (
+          <div ref={containerRef} {...containerProps} data-testid="container" />
+        )}
+      </Menu>
+    );
+
+    expect(getByRole('menu')).to.be.visible;
+  });
+
   it('Closes menu and moves focus to button when clicking outside', () => {
     const { getByTestId } = render(
       <div data-testid="div">

--- a/src/Menu/test/MenuSpec.js
+++ b/src/Menu/test/MenuSpec.js
@@ -30,6 +30,48 @@ describe('<Menu>', () => {
     expect(getByRole('menu')).to.be.visible;
   });
 
+  it('Should display/hide menu according to controlled `open` prop', () => {
+    const { getByRole, queryByRole, rerender } = render(
+      <Menu
+        open
+        renderMenuButton={(buttonProps, buttonRef) => (
+          <button ref={buttonRef} {...buttonProps} data-testid="button">
+            Button
+          </button>
+        )}
+        renderMenuPopup={({ open, ...popupProps }, popupRef) => (
+          <ul ref={popupRef} {...popupProps} hidden={!open} data-testid="menu" />
+        )}
+      >
+        {(containerProps, containerRef) => (
+          <div ref={containerRef} {...containerProps} data-testid="container" />
+        )}
+      </Menu>
+    );
+
+    expect(getByRole('menu')).to.be.visible;
+
+    rerender(
+      <Menu
+        open={false}
+        renderMenuButton={(buttonProps, buttonRef) => (
+          <button ref={buttonRef} {...buttonProps} data-testid="button">
+            Button
+          </button>
+        )}
+        renderMenuPopup={({ open, ...popupProps }, popupRef) => (
+          <ul ref={popupRef} {...popupProps} hidden={!open} data-testid="menu" />
+        )}
+      >
+        {(containerProps, containerRef) => (
+          <div ref={containerRef} {...containerProps} data-testid="container" />
+        )}
+      </Menu>
+    );
+
+    expect(queryByRole('menu')).not.to.exist;
+  });
+
   it('Closes menu and moves focus to button when clicking outside', () => {
     const { getByTestId } = render(
       <div data-testid="div">


### PR DESCRIPTION
Adding controlled open state for `<Dropdown>`