### PR TITLE
fix(Dropdown.Menu): de-highlight item when mouse leaving

### DIFF
--- a/src/Dropdown/test/DropdownMenuSpec.js
+++ b/src/Dropdown/test/DropdownMenuSpec.js
@@ -267,6 +267,10 @@ describe('<Dropdown.Menu>', () => {
     userEvent.hover(menuItem);
 
     expect(menuItem).to.have.class('rs-dropdown-item-focus');
+
+    userEvent.unhover(menuItem);
+
+    expect(menuItem).not.to.have.class('rs-dropdown-item-focus');
   });
 
   it('Should call onSelect callback with correct `eventKey`', () => {

--- a/src/Menu/MenuItem.tsx
+++ b/src/Menu/MenuItem.tsx
@@ -129,6 +129,7 @@ function MenuItem(props: MenuItemProps) {
   if (menuState?.role === 'menubar') {
     menuitemProps.onMouseDown = handleMouseDown;
     menuitemProps.onMouseOver = handleMouseMove;
+    menuitemProps.onMouseLeave = handleMouseLeave;
   }
 
   return children(menuitemProps, menuitemRef);


### PR DESCRIPTION
Before

https://user-images.githubusercontent.com/8225666/162677534-90c1b924-419e-4e9a-9aa8-513b5fbf10c9.mov

After

https://user-images.githubusercontent.com/8225666/162677558-fc6b43bd-5900-4522-8580-ee9a24c814da.mov
