### PR TITLE
fix(Cascader): infer value and onChange types from data

### DIFF
--- a/src/Cascader/test/Cascader.test.tsx
+++ b/src/Cascader/test/Cascader.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { expectType } from 'ts-expect';
+import { PickerInstance } from '../../Picker';
+import Cascader from '../Cascader';
+
+// Infer value and onChange types from data
+const numberValuedData = [{ label: 'One', value: 1 }];
+
+<Cascader data={numberValuedData} value={1} />;
+// @ts-expect-error should not accept string value
+<Cascader data={numberValuedData} value="1" />;
+<Cascader
+  data={numberValuedData}
+  onChange={newValue => {
+    expectType<number | null>(newValue);
+  }}
+/>;
+
+const stringValuedData = [{ label: 'One', value: 'One' }];
+
+<Cascader data={stringValuedData} value="1" />;
+// @ts-expect-error should not accept number value
+<Cascader data={stringValuedData} value={1} />;
+<Cascader
+  data={stringValuedData}
+  onChange={newValue => {
+    expectType<string | null>(newValue);
+  }}
+/>;
+
+const pickerRef = React.createRef<PickerInstance>();
+
+<Cascader ref={pickerRef} data={[]} />;


### PR DESCRIPTION
`value` and `onChange(value)` type are now inferred from `data` item's `value` property.