### PR TITLE
fix(Dropdown.Menu): fix unexpected highlight item when focus moving in

### DIFF
--- a/src/Dropdown/test/DropdownMenuSpec.js
+++ b/src/Dropdown/test/DropdownMenuSpec.js
@@ -294,6 +294,21 @@ describe('<Dropdown.Menu>', () => {
     expect(onSelectSpy).to.have.been.calledWith(3);
   });
 
+  it('Should not move visual focus to first item when focus on an focusable element within', () => {
+    const { getByTestId } = render(
+      <DropdownMenu data-testid="menu">
+        <DropdownItem panel>
+          <input data-testid="input" />
+        </DropdownItem>
+        <DropdownItem data-testid="item1">Item 1</DropdownItem>
+      </DropdownMenu>
+    );
+
+    fireEvent.focus(getByTestId('input'), { bubbles: true });
+
+    expect(getByTestId('menu')).not.to.have.attr('aria-activedescendant');
+  });
+
   it('Should have a custom className', () => {
     const instance = getDOMNode(<DropdownMenu className="custom" />);
     assert.include(instance.className, 'custom');

--- a/src/Menu/Menubar.tsx
+++ b/src/Menu/Menubar.tsx
@@ -5,6 +5,7 @@ import MenuContext, { MenuActionTypes, MoveFocusTo } from './MenuContext';
 import { KEY_VALUES, useCustom } from '../utils';
 import { isFocusEntering, isFocusLeaving } from '../utils/events';
 import useMenu from './useMenu';
+import { isFocusableElement } from '../utils/dom';
 
 export interface MenubarProps {
   /** Whether menubar is arranged in vertical form, defaults to false */
@@ -29,7 +30,11 @@ export default function Menubar({ vertical = false, children, onActivateItem }: 
   const onFocus = useCallback(
     (event: React.FocusEvent) => {
       // Focus moves inside Menubar
-      if (isFocusEntering(event)) {
+      if (
+        isFocusEntering(event) &&
+        // Skip if focus is moving to a focusable element within this menu
+        !(event.target !== event.currentTarget && isFocusableElement(event.target))
+      ) {
         if (activeItemIndex === null) {
           dispatch({ type: MenuActionTypes.MoveFocus, to: MoveFocusTo.First });
         }

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -22,7 +22,7 @@ const focusableSelector = [
   )
   .join(',');
 
-export function isFocusableElement(element: HTMLElement) {
+export function isFocusableElement(element: Element) {
   if (element === document.body) return false;
 
   return element.matches(focusableSelector);


### PR DESCRIPTION
```jsx
<Dropdown.Menu>
  <Dropdown.Item panel>
    <Input />
  </Dropdown.Item>
  <Dropdown.Item>Item 1</Dropdown.Item>
</Dropdown.Menu>
```
Before

https://user-images.githubusercontent.com/8225666/165904206-33bc5db8-7355-4524-a13c-3554c7987e94.mov

After

https://user-images.githubusercontent.com/8225666/165904214-17b0898c-1996-4814-ab5e-77f5eb6e9fb9.mov

