### PR TITLE
feat(DateRangePicker): expose calendars renderTitle

### DIFF
--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -100,6 +100,9 @@ export interface DateRangePickerProps
 
   /** Custom render value */
   renderValue?: (value: DateRange, format: string) => React.ReactNode;
+
+  /** Custom render for calendar title */
+  renderTitle?: (date: Date) => React.ReactNode;
 }
 
 export interface DateRangePicker extends PickerComponent<DateRangePickerProps> {
@@ -168,6 +171,7 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
     onOk,
     onOpen,
     onSelect,
+    renderTitle,
     ...rest
   } = props;
   const { merge, prefix } = useClassNames(classPrefix);
@@ -705,7 +709,8 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
       onChangeCalendarTime: handleChangeCalendarTime,
       onMouseMove: handleMouseMove,
       onSelect: handleSelectDate,
-      onToggleMeridian: handleToggleMeridian
+      onToggleMeridian: handleToggleMeridian,
+      renderTitle
     };
 
     return (

--- a/src/DateRangePicker/test/DateRangePickerSpec.js
+++ b/src/DateRangePicker/test/DateRangePickerSpec.js
@@ -640,7 +640,7 @@ describe('DateRangePicker', () => {
 
     const [firstTitle, secondTitle] = getAllByTestId('calendar-title');
 
-    expect(firstTitle.innerText).to.equal('1 - 2022');
-    expect(secondTitle.innerText).to.equal('2 - 2022');
+    expect(firstTitle).to.have.text('1 - 2022');
+    expect(secondTitle).to.have.text('2 - 2022');
   });
 });

--- a/src/DateRangePicker/test/DateRangePickerSpec.js
+++ b/src/DateRangePicker/test/DateRangePickerSpec.js
@@ -624,4 +624,23 @@ describe('DateRangePicker', () => {
 
     expect(getByLabelText('gear')).to.have.class('rs-icon');
   });
+
+  it('Should render a custom calendar title', () => {
+    const { getAllByTestId } = render(
+      <DateRangePicker
+        value={[new Date(2022, 1, 1), new Date(2022, 2, 2)]}
+        open
+        renderTitle={date => (
+          <span data-testid="calendar-title">
+            {date.getMonth()} - {date.getFullYear()}
+          </span>
+        )}
+      />
+    );
+
+    const [firstTitle, secondTitle] = getAllByTestId('calendar-title');
+
+    expect(firstTitle.innerText).to.equal('1 - 2022');
+    expect(secondTitle.innerText).to.equal('2 - 2022');
+  });
 });


### PR DESCRIPTION
Exposing the already existent renderTitle for calendars in DateRangePicker to allow custom titles.