### PR TITLE
SidenavToggle icon doesn't match its expand status

### DIFF
--- a/src/Sidenav/SidenavToggle.tsx
+++ b/src/Sidenav/SidenavToggle.tsx
@@ -26,7 +26,7 @@ const SidenavToggle: RsRefForwardingComponent<'div', SidenavToggleProps> = React
     } = props;
     const { merge, withClassPrefix } = useClassNames(classPrefix);
     const classes = merge(className, withClassPrefix({ collapsed: !expanded }));
-    const Icon = expanded ? AngleRight : AngleLeft;
+    const Icon = expanded ? AngleLeft : AngleRight;
 
     const handleToggle = (event: React.MouseEvent) => {
       onToggle?.(!expanded, event);


### PR DESCRIPTION
When the `Sidenav` is expanded, the icon should be the left arrow, meaning that clicking on it will close the Sidenav, whereas in reality the icon is the right arrow in the expanded state, which makes it difficult for the user to understand the meaning of the icon in this scenario.


Here is `SidenavToggle` usage code.
<img width="462" alt="image" src="https://user-images.githubusercontent.com/19839331/169756299-7247a0c3-b0a5-4666-8c84-be40855a39e9.png">

The figure below should show the **left** arrow (in the expanded state)
<img width="284" alt="image" src="https://user-images.githubusercontent.com/19839331/169756226-a9d8ba57-2d09-4a75-9bc9-686675d97a69.png">

The figure below should show the **right** arrow (in the unexpanded state)
<img width="109" alt="image" src="https://user-images.githubusercontent.com/19839331/169756251-919842f3-45ff-435c-b6a6-ebf0ca60fab0.png">

There are sample: https://codesandbox.io/s/vibrant-snyder-kx3fnp?file=/src/index.tsx
