### PR TITLE
fix(Sidenav): correct subtle Sidenav item hover styles

### DIFF
--- a/src/Sidenav/styles/index.less
+++ b/src/Sidenav/styles/index.less
@@ -535,12 +535,13 @@
   color: var(--rs-sidenav-subtle-text);
 
   .rs-sidenav-item,
-  .rs-dropdown .rs-dropdown-toggle {
+  .rs-dropdown .rs-dropdown-toggle,
+  .rs-dropdown .rs-dropdown-item:not(.rs-dropdown-item-submenu) {
     background-color: transparent;
 
     &:hover,
     &:focus {
-      background-color: transparent;
+      background-color: var(--rs-sidenav-subtle-hover-bg);
       color: var(--rs-sidenav-subtle-hover-text);
     }
   }


### PR DESCRIPTION
After

<img width="273" alt="image" src="https://user-images.githubusercontent.com/8225666/169971196-28cd2c58-c39b-4710-8d2f-79de5b886c9a.png">

Before

<img width="241" alt="image" src="https://user-images.githubusercontent.com/8225666/169971293-dc9c5183-0eff-49ee-8a95-971cbc9acde5.png">
