### PR TITLE
refactor(Sidenav): deprecate expanded prop of Sidenav.Toggle

### DIFF
--- a/src/Sidenav/SidenavToggle.tsx
+++ b/src/Sidenav/SidenavToggle.tsx
@@ -1,13 +1,19 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import IconButton from '../IconButton';
 import { useClassNames } from '../utils';
 import { WithAsProps, RsRefForwardingComponent } from '../@types/common';
 import AngleLeft from '@rsuite/icons/legacy/AngleLeft';
 import AngleRight from '@rsuite/icons/legacy/AngleRight';
+import deprecatePropType from '../utils/deprecatePropType';
+import { SidenavContext } from './Sidenav';
 
 export interface SidenavToggleProps extends WithAsProps {
-  /** Expand then nav */
+  /**
+   * Expand then nav
+   *
+   * @deprecated Use <Sidenav expanded> instead.
+   */
   expanded?: boolean;
 
   /** Callback function for menu state switching */
@@ -16,14 +22,24 @@ export interface SidenavToggleProps extends WithAsProps {
 
 const SidenavToggle: RsRefForwardingComponent<'div', SidenavToggleProps> = React.forwardRef(
   (props: SidenavToggleProps, ref) => {
+    const sidenav = useContext(SidenavContext);
+
+    if (!sidenav) {
+      throw new Error('<Sidenav.Toggle> must be rendered within a <Sidenav>');
+    }
+
     const {
       as: Component = 'div',
-      expanded,
+      expanded: DEPRECATED_expanded,
       className,
       classPrefix = 'sidenav-toggle',
       onToggle,
       ...rest
     } = props;
+
+    // if `expanded` prop is provided, it takes priority
+    const expanded = DEPRECATED_expanded ?? sidenav.expanded;
+
     const { merge, withClassPrefix } = useClassNames(classPrefix);
     const classes = merge(className, withClassPrefix({ collapsed: !expanded }));
     const Icon = expanded ? AngleLeft : AngleRight;
@@ -34,17 +50,22 @@ const SidenavToggle: RsRefForwardingComponent<'div', SidenavToggleProps> = React
 
     return (
       <Component {...rest} ref={ref} className={classes}>
-        <IconButton appearance="default" icon={<Icon />} onClick={handleToggle} />
+        <IconButton
+          appearance="default"
+          icon={<Icon />}
+          onClick={handleToggle}
+          aria-label={expanded ? 'Collapse' : 'Expand'}
+        />
       </Component>
     );
   }
 );
 
-SidenavToggle.displayName = 'SidenavToggle';
+SidenavToggle.displayName = 'Sidenav.Toggle';
 SidenavToggle.propTypes = {
   classPrefix: PropTypes.string,
   className: PropTypes.string,
-  expanded: PropTypes.bool,
+  expanded: deprecatePropType(PropTypes.bool, 'Use <Sidenav expanded> instead.'),
   onToggle: PropTypes.func
 };
 

--- a/src/Sidenav/test/SidenavToggleSpec.js
+++ b/src/Sidenav/test/SidenavToggleSpec.js
@@ -1,22 +1,47 @@
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
-import { getDOMNode } from '@test/testUtils';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { testStandardProps } from '@test/commonCases';
 import SidenavToggle from '../SidenavToggle';
+import Sidenav from '../Sidenav';
 
-describe('SidenavToggle', () => {
-  testStandardProps(<SidenavToggle />);
-
-  it('Should render a toggle', () => {
-    const instance = getDOMNode(<SidenavToggle />);
-    assert.include(instance.className, 'rs-sidenav-toggle');
+describe('Sidenav.Toggle', () => {
+  testStandardProps(<SidenavToggle />, {
+    renderOptions: {
+      wrapper: Sidenav
+    }
   });
 
-  it('Should call onToggle callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<SidenavToggle onToggle={doneOp} />);
-    ReactTestUtils.Simulate.click(instance.querySelector('.rs-btn-icon'));
+  it('Should have rs-sidenav-toggle className', () => {
+    const { getByTestId } = render(<SidenavToggle data-testid="toggle" />, { wrapper: Sidenav });
+
+    expect(getByTestId('toggle')).to.have.class('rs-sidenav-toggle');
+  });
+
+  it('Should render a "Collapse" button when Sidenav is expanded', () => {
+    const { getByRole } = render(<SidenavToggle />, {
+      wrapper: ({ children }) => <Sidenav expanded>{children}</Sidenav>
+    });
+
+    expect(getByRole('button', { name: 'Collapse' })).to.exist;
+  });
+
+  it('Should render an "Expand" button when Sidenav is collapsed', () => {
+    const { getByRole } = render(<SidenavToggle />, {
+      wrapper: ({ children }) => <Sidenav expanded={false}>{children}</Sidenav>
+    });
+
+    expect(getByRole('button', { name: 'Expand' })).to.exist;
+  });
+
+  it('Should call onToggle callback', () => {
+    const onToggle = sinon.spy();
+    const { getByRole } = render(<SidenavToggle onToggle={onToggle} />, {
+      wrapper: Sidenav
+    });
+
+    userEvent.click(getByRole('button', { name: 'Collapse' }));
+
+    expect(onToggle).to.have.been.calledWith(false);
   });
 });


### PR DESCRIPTION
Deprecate the standalone `expanded` prop on `<Sidenav.Toggle>`, instead inherit `expanded` prop from `Sidenav`.

Before

```jsx
<Sidenav expanded>
  <Sidenav.Toggle expanded />
</Sidenav>
```

After

```jsx
<Sidenav expanded>
  <Sidenav.Toggle />
</Sidenav>
```