### PR TITLE
fix(CheckTreePicker): fix duplicated key when data changed (#2486)

### DIFF
--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -616,17 +616,13 @@ describe('CheckTreePicker', () => {
   it('Should not has duplicated key when data changed', () => {
     const TestApp = React.forwardRef((props, ref) => {
       const pickerRef = React.useRef();
-      const [treeData, setTreeData] = React.useState(originMockData);
       React.useImperativeHandle(ref, () => {
         return {
-          picker: pickerRef.current,
-          setTreeData
+          picker: pickerRef.current
         };
       });
-      return <CheckTreePicker ref={pickerRef} {...props} data={treeData} open />;
+      return <CheckTreePicker ref={pickerRef} {...props} open />;
     });
-
-    TestApp.displayName = 'TestApp';
 
     let checkItems = [];
     const mockRenderValue = (values, checkedItems, selectedElement) => {
@@ -634,11 +630,11 @@ describe('CheckTreePicker', () => {
       return selectedElement;
     };
     const ref = React.createRef();
-    render(<TestApp ref={ref} renderValue={mockRenderValue} />);
+    const { rerender } = render(
+      <TestApp ref={ref} data={originMockData} renderValue={mockRenderValue} />
+    );
 
-    ReactTestUtils.act(() => {
-      ref.current.setTreeData(changedMockData);
-    });
+    rerender(<TestApp ref={ref} data={changedMockData} renderValue={mockRenderValue} />);
 
     ReactTestUtils.act(() => {
       ReactTestUtils.Simulate.change(

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -5,37 +5,10 @@ import { getDOMNode, getInstance } from '@test/testUtils';
 import CheckTreePicker from '../CheckTreePicker';
 import { KEY_VALUES } from '../../utils';
 import { assert } from 'chai';
-import { originMockData, changedMockData } from './mocks';
+import { data, originMockData, changedMockData } from './mocks';
 
 const itemFocusClassName = '.rs-check-tree-node-focus';
 const itemExpandedClassName = '.rs-check-tree-node-expanded';
-
-const data = [
-  {
-    label: 'Master',
-    value: 'Master',
-    children: [
-      {
-        label: 'tester0',
-        value: 'tester0'
-      },
-      {
-        label: 'tester1',
-        value: 'tester1',
-        children: [
-          {
-            label: 'tester2',
-            value: 'tester2'
-          }
-        ]
-      }
-    ]
-  },
-  {
-    label: 'Disabled node',
-    value: 'disabled'
-  }
-];
 
 describe('CheckTreePicker', () => {
   it('Should render default value', () => {
@@ -499,50 +472,40 @@ describe('CheckTreePicker', () => {
   });
 
   it('Should fold all the node when toggle master node', () => {
-    const TestApp = React.forwardRef((props, ref) => {
-      const pickerRef = React.useRef();
-      const [expandItemValues, setExpandItemValues] = React.useState(['Master']);
-      React.useImperativeHandle(ref, () => {
-        return {
-          picker: pickerRef.current,
-          setExpandItemValues
-        };
-      });
-      return (
-        <CheckTreePicker
-          ref={pickerRef}
-          {...props}
-          data={data}
-          open
-          expandItemValues={expandItemValues}
-        />
-      );
-    });
-
-    TestApp.displayName = 'TestApp';
-
-    let expandItemValues = [];
+    let expandItemValues = ['Master'];
     const mockOnExpand = values => {
       expandItemValues = values;
     };
     const ref = React.createRef();
-    render(<TestApp ref={ref} onExpand={mockOnExpand} />);
+    const { rerender } = render(
+      <CheckTreePicker
+        ref={ref}
+        data={data}
+        open
+        expandItemValues={expandItemValues}
+        onExpand={mockOnExpand}
+      />
+    );
 
-    assert.ok(ref.current.picker.overlay.querySelector('.rs-check-tree-node-expanded'));
+    assert.ok(ref.current.overlay.querySelector('.rs-check-tree-node-expanded'));
 
     ReactTestUtils.act(() => {
       ReactTestUtils.Simulate.click(
-        ref.current.picker.overlay.querySelector(
-          'div[data-ref="0-0"]  > .rs-check-tree-node-expand-icon'
-        )
+        ref.current.overlay.querySelector('div[data-ref="0-0"]  > .rs-check-tree-node-expand-icon')
       );
     });
 
-    ReactTestUtils.act(() => {
-      ref.current.setExpandItemValues(expandItemValues);
-    });
+    rerender(
+      <CheckTreePicker
+        ref={ref}
+        data={data}
+        open
+        expandItemValues={expandItemValues}
+        onExpand={mockOnExpand}
+      />
+    );
 
-    assert.ok(!ref.current.picker.overlay.querySelector('.rs-check-tree-node-expanded'));
+    assert.ok(!ref.current.overlay.querySelector('.rs-check-tree-node-expanded'));
   });
 
   it('Should render the specified menu content by `searchBy`', () => {
@@ -614,16 +577,6 @@ describe('CheckTreePicker', () => {
   });
 
   it('Should not has duplicated key when data changed', () => {
-    const TestApp = React.forwardRef((props, ref) => {
-      const pickerRef = React.useRef();
-      React.useImperativeHandle(ref, () => {
-        return {
-          picker: pickerRef.current
-        };
-      });
-      return <CheckTreePicker ref={pickerRef} {...props} open />;
-    });
-
     let checkItems = [];
     const mockRenderValue = (values, checkedItems, selectedElement) => {
       checkItems = checkedItems;
@@ -631,14 +584,16 @@ describe('CheckTreePicker', () => {
     };
     const ref = React.createRef();
     const { rerender } = render(
-      <TestApp ref={ref} data={originMockData} renderValue={mockRenderValue} />
+      <CheckTreePicker ref={ref} open data={originMockData} renderValue={mockRenderValue} />
     );
 
-    rerender(<TestApp ref={ref} data={changedMockData} renderValue={mockRenderValue} />);
+    rerender(
+      <CheckTreePicker open ref={ref} data={changedMockData} renderValue={mockRenderValue} />
+    );
 
     ReactTestUtils.act(() => {
       ReactTestUtils.Simulate.change(
-        ref.current.picker.overlay.querySelector('div[data-key="0-0-1"] input')
+        ref.current.overlay.querySelector('div[data-key="0-0-1"] input')
       );
     });
 

--- a/src/CheckTreePicker/test/mocks.js
+++ b/src/CheckTreePicker/test/mocks.js
@@ -1,0 +1,38 @@
+export const originMockData = [
+  {
+    value: 'root-node',
+    label: 'root-node',
+    children: [
+      {
+        value: 'node-1',
+        label: 'node-1',
+        children: [{ value: 'node-1-1', label: 'node-1-1' }]
+      },
+      {
+        value: 'node-2',
+        label: 'node-2',
+        children: [{ value: 'node-2-1', label: 'node-2-1' }]
+      }
+    ]
+  }
+];
+
+export const changedMockData = [
+  {
+    value: 'root-node',
+    label: 'root-node',
+    children: [
+      {
+        value: 'node-1',
+        label: 'node-1',
+        children: [{ value: 'node-1-1', label: 'node-1-1' }]
+      },
+      { value: 'node-2-1', label: 'node-2-1' },
+      {
+        value: 'node-2',
+        label: 'node-2',
+        children: []
+      }
+    ]
+  }
+];

--- a/src/CheckTreePicker/test/mocks.js
+++ b/src/CheckTreePicker/test/mocks.js
@@ -1,3 +1,30 @@
+export const data = [
+  {
+    label: 'Master',
+    value: 'Master',
+    children: [
+      {
+        label: 'tester0',
+        value: 'tester0'
+      },
+      {
+        label: 'tester1',
+        value: 'tester1',
+        children: [
+          {
+            label: 'tester2',
+            value: 'tester2'
+          }
+        ]
+      }
+    ]
+  },
+  {
+    label: 'Disabled node',
+    value: 'disabled'
+  }
+];
+
 export const originMockData = [
   {
     value: 'root-node',

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -643,7 +643,7 @@ export function useFlattenTreeData({
     dispatch(Object.create(null));
   }, [dispatch]);
 
-  const { current: flattenNodes = {} } = useRef<TreeNodesType>({});
+  const flattenNodes = useRef<TreeNodesType>({});
 
   const flattenTreeData = useCallback(
     (treeData: TreeNodeType[], ref: string, parent?: TreeNodeType, layer = 1) => {
@@ -655,8 +655,7 @@ export function useFlattenTreeData({
         const refKey = `${ref}-${index}`;
 
         node.refKey = refKey;
-
-        flattenNodes[refKey] = {
+        flattenNodes.current[refKey] = {
           layer,
           [labelKey]: node[labelKey],
           [valueKey]: node[valueKey],
@@ -666,14 +665,14 @@ export function useFlattenTreeData({
           ...node
         };
         if (parent) {
-          flattenNodes[refKey].parent = omit(parent, 'parent', 'children');
+          flattenNodes.current[refKey].parent = omit(parent, 'parent', 'children');
         }
         flattenTreeData(node[childrenKey], refKey, node, layer + 1);
       });
 
-      callback?.(flattenNodes);
+      callback?.(flattenNodes.current);
     },
-    [childrenKey, valueKey, labelKey, callback, uncheckableItemValues, flattenNodes]
+    [childrenKey, valueKey, labelKey, callback, uncheckableItemValues]
   );
 
   const serializeListOnlyParent = useCallback(
@@ -778,12 +777,14 @@ export function useFlattenTreeData({
   };
 
   useEffect(() => {
+    // when data is changed, should clear the flattenNodes, avoid duplicate keys
+    flattenNodes.current = {};
     flattenTreeData(data, '0');
   }, [data]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     forceUpdate,
-    flattenNodes,
+    flattenNodes: flattenNodes.current,
     flattenTreeData,
     serializeListOnlyParent,
     unSerializeList,


### PR DESCRIPTION
When node in data changes position, it's equivalent to changing the data. And selected this node again. Will getting duplicated key error in selected list.
![image](https://user-images.githubusercontent.com/12592949/169986980-0203944e-3cff-40d6-90a0-146a3f28b6ff.png)

Fix #2486 