### PR TITLE
fix(Sidenav): remove subtle item bg when focused by mouse

### DIFF
--- a/src/Sidenav/styles/index.less
+++ b/src/Sidenav/styles/index.less
@@ -571,7 +571,7 @@
     background-color: transparent;
 
     &:hover,
-    &:focus {
+    &:focus-visible {
       background-color: var(--rs-sidenav-subtle-hover-bg);
       color: var(--rs-sidenav-subtle-hover-text);
     }

--- a/src/Sidenav/styles/index.less
+++ b/src/Sidenav/styles/index.less
@@ -20,8 +20,8 @@
   list-style: none;
   padding: 0;
 
-  > .rs-sidenav-item,
-  > .rs-dropdown .rs-dropdown-toggle,
+  .rs-sidenav-item,
+  .rs-dropdown-toggle,
   .rs-dropdown-item,
   .rs-dropdown-item-toggle {
     padding: @sidenav-padding-vertical @sidenav-padding-horizontal;
@@ -562,13 +562,13 @@
 // Subtle Sidenav
 .rs-sidenav-subtle {
   background-color: transparent;
-  color: var(--rs-sidenav-subtle-text);
 
   .rs-sidenav-item,
-  .rs-dropdown .rs-dropdown-toggle,
-  .rs-dropdown .rs-dropdown-item:not(.rs-dropdown-item-submenu),
+  .rs-dropdown-toggle,
+  .rs-dropdown-item,
   .rs-sidenav-toggle-button {
     background-color: transparent;
+    color: var(--rs-sidenav-subtle-text);
 
     &:hover,
     &:focus-visible {
@@ -605,7 +605,7 @@
     color: var(--rs-sidenav-subtle-text);
 
     &:hover,
-    &:focus {
+    &:focus-visible {
       background-color: var(--rs-sidenav-subtle-hover-bg);
       color: var(--rs-sidenav-subtle-hover-text);
     }
@@ -622,8 +622,6 @@
 .rs-sidenav-subtle.rs-sidenav-collapse-out {
   // Set active Level1 style
   .rs-dropdown.rs-dropdown-selected-within .rs-dropdown-toggle {
-    color: var(--rs-sidenav-subtle-text);
-
     &:hover {
       background-color: var(--rs-sidenav-subtle-hover-bg);
     }


### PR DESCRIPTION
Before
<img width="266" alt="image" src="https://user-images.githubusercontent.com/8225666/170859069-ea4abe69-a14d-4794-b28b-8c263621c33c.png">

After
<img width="272" alt="image" src="https://user-images.githubusercontent.com/8225666/170859085-e2b39d3e-3a25-4ef3-8ead-1f4043ad318c.png">
