### PR TITLE
fix(Button): remove underline when hovered

### DIFF
--- a/src/Button/styles/index.less
+++ b/src/Button/styles/index.less
@@ -35,6 +35,7 @@
   .button-activated({
     color: var(--rs-btn-default-hover-text);
     background-color: var(--rs-btn-default-hover-bg);
+    text-decoration: none;
   });
 
   .button-pressed({


### PR DESCRIPTION
Before
<img width="94" alt="image" src="https://user-images.githubusercontent.com/8225666/171379368-c0122f71-6ecc-40b5-9d5d-421f6be579d4.png">

After
<img width="92" alt="image" src="https://user-images.githubusercontent.com/8225666/171379412-e73eef18-179b-41b5-840b-1dea347c8222.png">
