### PR TITLE
feat(toaster): add support for useToaster

### DIFF
--- a/docs/pages/components/message/fragments/import.md
+++ b/docs/pages/components/message/fragments/import.md
@@ -1,7 +1,7 @@
 ```js
-import { Message, toaster } from 'rsuite';
+import { Message, useToaster } from 'rsuite';
 
 // or
 import Message from 'rsuite/Message';
-import toaster from 'rsuite/toaster';
+import { useToaster } from 'rsuite/toaster';
 ```

--- a/docs/pages/components/message/fragments/with-toaster.md
+++ b/docs/pages/components/message/fragments/with-toaster.md
@@ -1,11 +1,17 @@
 <!--start-code-->
 
 ```js
+/**
+ * import { useToaster } from 'rsuite';
+ */
+
 const App = () => {
   const [type, setType] = React.useState('info');
   const [placement, setPlacement] = React.useState('topCenter');
+  const toaster = useToaster();
+
   const message = (
-    <Message showIcon type={type} >
+    <Message showIcon type={type}>
       {type}: The message appears on the {placement}.
     </Message>
   );

--- a/docs/pages/components/message/index.tsx
+++ b/docs/pages/components/message/index.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { Message, Button, ButtonToolbar, SelectPicker, toaster } from 'rsuite';
+import { Message, Button, ButtonToolbar, SelectPicker, useToaster } from 'rsuite';
 import DefaultPage from '@/components/Page';
 
 export default function Page() {
-  return <DefaultPage dependencies={{ Message, Button, ButtonToolbar, SelectPicker, toaster }} />;
+  return (
+    <DefaultPage dependencies={{ Message, Button, ButtonToolbar, SelectPicker, useToaster }} />
+  );
 }

--- a/docs/pages/components/notification/fragments/import.md
+++ b/docs/pages/components/notification/fragments/import.md
@@ -1,7 +1,7 @@
 ```js
-import { Notification, toaster } from 'rsuite';
+import { Notification, useToaster } from 'rsuite';
 
 // or
 import Notification from 'rsuite/Notification';
-import toaster from 'rsuite/toaster';
+import { useToaster } from 'rsuite/toaster';
 ```

--- a/docs/pages/components/notification/fragments/with-toaster.md
+++ b/docs/pages/components/notification/fragments/with-toaster.md
@@ -1,12 +1,20 @@
 <!--start-code-->
 
 ```js
+/**
+ * import { useToaster } from 'rsuite';
+ */
+
 const App = () => {
   const [type, setType] = React.useState('info');
   const [placement, setPlacement] = React.useState('topStart');
+  const toaster = useToaster();
+
   const message = (
     <Notification type={type} header={type} closable>
       <Paragraph width={320} rows={3} />
+      <hr />
+      <Uploader />
     </Notification>
   );
 

--- a/docs/pages/components/notification/index.tsx
+++ b/docs/pages/components/notification/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { Notification, Button, ButtonToolbar, SelectPicker, toaster } from 'rsuite';
+import { Notification, Button, ButtonToolbar, SelectPicker, useToaster, Uploader } from 'rsuite';
 import DefaultPage from '@/components/Page';
 
 export default function Page() {
   return (
-    <DefaultPage dependencies={{ Notification, Button, ButtonToolbar, SelectPicker, toaster }} />
+    <DefaultPage
+      dependencies={{ Notification, Button, ButtonToolbar, SelectPicker, useToaster, Uploader }}
+    />
   );
 }

--- a/docs/pages/components/notification/zh-CN/toaster.md
+++ b/docs/pages/components/notification/zh-CN/toaster.md
@@ -1,4 +1,14 @@
-### toaster
+### useToaster
+
+```ts
+import { useToaster } from 'rsuite';
+
+return () => {
+  const toaster = useToaster();
+
+  ...
+};
+```
 
 #### toaster.push
 

--- a/src/CustomProvider/CustomProvider.tsx
+++ b/src/CustomProvider/CustomProvider.tsx
@@ -2,6 +2,8 @@ import React, { useEffect } from 'react';
 import { getClassNamePrefix, prefix } from '../utils/prefix';
 import { Locale } from '../locales';
 import { addClass, removeClass, canUseDOM } from '../DOMHelper';
+import ToastContainer, { ToastContainerInstance, toastPlacements } from '../toaster/ToastContainer';
+import { usePortal } from '../utils';
 
 export interface CustomValue<T = Locale> {
   /** Language configuration */
@@ -39,6 +41,11 @@ export interface CustomValue<T = Locale> {
    *
    * */
   parseDate: (dateString: string, formatString: string) => Date;
+
+  /**
+   * A Map of toast containers
+   */
+  toasters?: React.MutableRefObject<Map<string, ToastContainerInstance>>;
 }
 
 export interface CustomProviderProps<T = Locale> extends Partial<CustomValue<T>> {
@@ -50,16 +57,30 @@ export interface CustomProviderProps<T = Locale> extends Partial<CustomValue<T>>
 
   /** Primary content */
   children?: React.ReactNode;
+
+  /** Sets a container for toast rendering */
+  toastContainer?: HTMLElement | (() => HTMLElement | null) | null;
 }
 
 const CustomContext = React.createContext<CustomProviderProps>({});
 const { Consumer, Provider } = CustomContext;
 const themes = ['light', 'dark', 'high-contrast'];
 
-const CustomProvider = (props: CustomProviderProps) => {
-  const { children, classPrefix = getClassNamePrefix(), theme, ...rest } = props;
+const CustomProvider = (props: Omit<CustomProviderProps, 'toasters'>) => {
+  const {
+    children,
+    classPrefix = getClassNamePrefix(),
+    theme,
+    toastContainer: container,
+    ...rest
+  } = props;
+  const toasters = React.useRef(new Map<string, ToastContainerInstance>());
+  const { Portal } = usePortal({ container });
 
-  const value = React.useMemo(() => ({ classPrefix, theme, ...rest }), [classPrefix, theme, rest]);
+  const value = React.useMemo(
+    () => ({ classPrefix, theme, toasters, ...rest }),
+    [classPrefix, theme, rest]
+  );
 
   useEffect(() => {
     if (canUseDOM && theme) {
@@ -74,7 +95,23 @@ const CustomProvider = (props: CustomProviderProps) => {
     }
   }, [classPrefix, theme]);
 
-  return <Provider value={value}>{children}</Provider>;
+  return (
+    <Provider value={value}>
+      {children}
+
+      <Portal>
+        {toastPlacements.map(placement => (
+          <ToastContainer
+            key={placement}
+            placement={placement}
+            ref={ref => {
+              toasters.current.set(placement, ref);
+            }}
+          />
+        ))}
+      </Portal>
+    </Provider>
+  );
 };
 
 export { CustomContext, Consumer as CustomConsumer };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,7 +61,7 @@ export type { AvatarProps } from './Avatar';
 export { default as AvatarGroup } from './AvatarGroup';
 export type { AvatarGroupProps } from './AvatarGroup';
 
-export { default as toaster } from './toaster';
+export { default as toaster, useToaster } from './toaster';
 export type { Toaster } from './toaster';
 
 // Nav

--- a/src/toaster/ToastContainer.tsx
+++ b/src/toaster/ToastContainer.tsx
@@ -14,6 +14,15 @@ export type PlacementType =
   | 'bottomStart'
   | 'bottomEnd';
 
+export const toastPlacements: PlacementType[] = [
+  'topCenter',
+  'bottomCenter',
+  'topStart',
+  'topEnd',
+  'bottomStart',
+  'bottomEnd'
+];
+
 export interface ToastContainerProps extends WithAsProps {
   /** The placement of the message box */
   placement?: PlacementType;

--- a/src/toaster/index.tsx
+++ b/src/toaster/index.tsx
@@ -1,3 +1,5 @@
 import toaster from './toaster';
+
 export type { Toaster } from './toaster';
+export { default as useToaster } from './useToaster';
 export default toaster;

--- a/src/toaster/test/useToasterSpec.js
+++ b/src/toaster/test/useToasterSpec.js
@@ -6,9 +6,6 @@ import CustomProvider from '../../CustomProvider';
 import Uploader from '../../Uploader';
 import zhCN from '../../locales/zh_CN';
 
-const element = document.createElement('div');
-document.body.appendChild(element);
-
 afterEach(() => {
   sinon.restore();
 });
@@ -28,17 +25,21 @@ describe('useToaster', () => {
   it('Should render 2 containers', () => {
     const toaster = renderHook(() => useToaster()).result.current;
 
-    toaster.push(<div>topEnd</div>, {
-      container: element,
+    toaster.push(<div data-testid="msg-top-end">topEnd</div>, {
       placement: 'topEnd'
     });
-    toaster.push(<div>bottomEnd</div>, {
-      container: element,
+    toaster.push(<div data-testid="msg-bottom-end">bottomEnd</div>, {
       placement: 'bottomEnd'
     });
 
-    assert.exists(element.querySelector('.rs-toast-container.rs-toast-container-top-end'));
-    assert.exists(element.querySelector('.rs-toast-container.rs-toast-container-bottom-end'));
+    assert.equal(
+      screen.queryByTestId('msg-top-end').parentNode.className,
+      'rs-toast-container rs-toast-container-top-end'
+    );
+    assert.equal(
+      screen.queryByTestId('msg-bottom-end').parentNode.className,
+      'rs-toast-container rs-toast-container-bottom-end'
+    );
   });
 
   it('Should remove a message', () => {
@@ -77,7 +78,7 @@ describe('useToaster', () => {
       const toaster = useToaster();
       React.useEffect(() => {
         toaster.push(
-          <div data-testid="msg-1">
+          <div data-testid="msg-with-uploader">
             <Uploader action="/" />
           </div>
         );
@@ -91,7 +92,9 @@ describe('useToaster', () => {
       </CustomProvider>
     );
 
-    const uploaderBtn = screen.getByTestId('msg-1').querySelector('.rs-uploader-trigger-btn');
+    const uploaderBtn = screen
+      .getByTestId('msg-with-uploader')
+      .querySelector('.rs-uploader-trigger-btn');
     assert.equal(uploaderBtn.textContent, '上传');
   });
 });

--- a/src/toaster/test/useToasterSpec.js
+++ b/src/toaster/test/useToasterSpec.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks/dom';
+import useToaster from '../useToaster';
+import CustomProvider from '../../CustomProvider';
+import Uploader from '../../Uploader';
+import zhCN from '../../locales/zh_CN';
+
+const element = document.createElement('div');
+document.body.appendChild(element);
+
+afterEach(() => {
+  sinon.restore();
+});
+
+describe('useToaster', () => {
+  it('Should push a message', () => {
+    const toaster = renderHook(() => useToaster()).result.current;
+
+    toaster.push(<div data-testid="msg-1">message</div>);
+
+    const message = screen.queryByTestId('msg-1');
+
+    assert.include(message.className, 'rs-toast-fade-entered');
+    assert.equal(message.textContent, 'message');
+  });
+
+  it('Should render 2 containers', () => {
+    const toaster = renderHook(() => useToaster()).result.current;
+
+    toaster.push(<div>topEnd</div>, {
+      container: element,
+      placement: 'topEnd'
+    });
+    toaster.push(<div>bottomEnd</div>, {
+      container: element,
+      placement: 'bottomEnd'
+    });
+
+    assert.exists(element.querySelector('.rs-toast-container.rs-toast-container-top-end'));
+    assert.exists(element.querySelector('.rs-toast-container.rs-toast-container-bottom-end'));
+  });
+
+  it('Should remove a message', () => {
+    const toaster = renderHook(() => useToaster()).result.current;
+    const clock = sinon.useFakeTimers();
+
+    const key = toaster.push(<div data-testid="message">abc</div>);
+
+    const message = screen.queryByTestId('message');
+    assert.include(message.className, 'rs-toast-fade-entered');
+
+    toaster.remove(key);
+    assert.include(message.className, 'rs-toast-fade-exiting');
+
+    clock.tick(400);
+    assert.notExists(screen.queryByTestId('message'));
+  });
+
+  it('Should clear all message', () => {
+    const toaster = renderHook(() => useToaster()).result.current;
+    const clock = sinon.useFakeTimers();
+    toaster.push(<div data-testid="msg-3">3</div>);
+    toaster.push(<div data-testid="msg-4">4</div>);
+
+    assert.exists(screen.queryByTestId('msg-3'));
+    assert.exists(screen.queryByTestId('msg-4'));
+    toaster.clear();
+
+    clock.tick(400);
+    assert.notExists(screen.queryByTestId('msg-3'));
+    assert.notExists(screen.queryByTestId('msg-4'));
+  });
+
+  it('Should be localized on components rendered via toaster', () => {
+    const App = () => {
+      const toaster = useToaster();
+      React.useEffect(() => {
+        toaster.push(
+          <div data-testid="msg-1">
+            <Uploader action="/" />
+          </div>
+        );
+      });
+      return null;
+    };
+
+    render(
+      <CustomProvider locale={zhCN}>
+        <App />
+      </CustomProvider>
+    );
+
+    const uploaderBtn = screen.getByTestId('msg-1').querySelector('.rs-uploader-trigger-btn');
+    assert.equal(uploaderBtn.textContent, '上传');
+  });
+});

--- a/src/toaster/toaster.tsx
+++ b/src/toaster/toaster.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ToastContainer, { ToastContainerProps, ToastContainerInstance } from './ToastContainer';
 
-export type PlacementType = 'topStart' | 'topEnd' | 'bottomStart' | 'bottomEnd';
 export interface Toaster {
   /**
    * Add a message to the container.

--- a/src/toaster/useToaster.ts
+++ b/src/toaster/useToaster.ts
@@ -3,23 +3,26 @@ import toaster from './toaster';
 import { ToastContainerProps } from './ToastContainer';
 import { useCustom } from '../utils';
 
+/**
+ * Hook to use the toaster
+ * @returns toaster { push, remove, clear }
+ */
 const useToaster = () => {
   const { toasters } = useCustom();
 
   return {
-    push: (message: React.ReactNode, options: ToastContainerProps = {}) => {
-      if (toasters) {
-        return toasters?.current.get(options.placement || 'topCenter')?.push(message);
-      }
-      return toaster.push(message, options);
+    push: (message: React.ReactNode, options?: ToastContainerProps) => {
+      const customToaster = toasters?.current?.get(options?.placement || 'topCenter');
+
+      return customToaster ? customToaster.push(message) : toaster.push(message, options);
     },
     remove: (key: string) => {
       toasters
-        ? Array.from(toasters?.current).forEach(([, c]) => c?.remove(key))
+        ? Array.from(toasters.current).forEach(([, c]) => c?.remove(key))
         : toaster.remove(key);
     },
     clear: () => {
-      toasters ? Array.from(toasters?.current).forEach(([, c]) => c?.clear()) : toaster.clear();
+      toasters ? Array.from(toasters.current).forEach(([, c]) => c?.clear()) : toaster.clear();
     }
   };
 };

--- a/src/toaster/useToaster.ts
+++ b/src/toaster/useToaster.ts
@@ -1,0 +1,27 @@
+import React from 'react';
+import toaster from './toaster';
+import { ToastContainerProps } from './ToastContainer';
+import { useCustom } from '../utils';
+
+const useToaster = () => {
+  const { toasters } = useCustom();
+
+  return {
+    push: (message: React.ReactNode, options: ToastContainerProps = {}) => {
+      if (toasters) {
+        return toasters?.current.get(options.placement || 'topCenter')?.push(message);
+      }
+      return toaster.push(message, options);
+    },
+    remove: (key: string) => {
+      toasters
+        ? Array.from(toasters?.current).forEach(([, c]) => c?.remove(key))
+        : toaster.remove(key);
+    },
+    clear: () => {
+      toasters ? Array.from(toasters?.current).forEach(([, c]) => c?.clear()) : toaster.clear();
+    }
+  };
+};
+
+export default useToaster;

--- a/src/utils/useCustom.ts
+++ b/src/utils/useCustom.ts
@@ -16,19 +16,24 @@ const getDefaultRTL = () =>
  * A hook to get custom configuration of `<CustomProvider>`
  * @param keys
  */
-function useCustom<T = any>(keys: string | string[], overrideLocale?): CustomValue<T> {
+function useCustom<T = any>(keys?: string | string[], overrideLocale?): CustomValue<T> {
   const {
     locale = defaultLocale,
     rtl = getDefaultRTL(),
     formatDate,
-    parseDate
+    parseDate,
+    toasters
   } = useContext(CustomContext);
 
   let componentLocale: T = {
     // Public part locale
     ...locale?.common,
     // Part of the locale of the component itself
-    ...(typeof keys === 'string' ? locale?.[keys] : mergeObject(keys.map(key => locale?.[key])))
+    ...(typeof keys === 'string'
+      ? locale?.[keys]
+      : typeof keys === 'object'
+      ? mergeObject(keys.map(key => locale?.[key]))
+      : {})
   };
 
   // Component custom locale
@@ -53,6 +58,7 @@ function useCustom<T = any>(keys: string | string[], overrideLocale?): CustomVal
   return {
     locale: componentLocale,
     rtl,
+    toasters,
     formatDate: formatDate || defaultFormatDate,
     parseDate: parseDate || defaultParseDate
   };


### PR DESCRIPTION
### About `useToaster`

The implementation principle of `toaster` is to render `Message` and `Notification` to a separate DOM tree through `ReactDOM.render`.
Doing so will cause a problem, components inside `Message` and `Notification` will not be able to obtain the context value provided by `CustomProvider`, including the implementation of localization functions will become very complicated.

To solve this problem, use `ReactDOM.createPortal` instead of `ReactDOM.render` to share context. So the `useToaster` hook was added to replace toaster.

----

Before
```tsx
import { toaster } from 'rsuite';

toaster.push(<Notification>message</Notification>, {
  placement: 'topEnd'
});
 
```

After

```tsx
import { useToaster } from 'rsuite';

const toaster = useToaster();

toaster.push(<Notification>message</Notification>, {
  placement: 'topEnd'
});

```

----

### Complete example

<img width="171" alt="image" src="https://user-images.githubusercontent.com/1203827/171481053-10ea02b0-beb3-4477-ad88-3a74c439e823.png">

```tsx
import { useToaster, CustomProvider, Notification, Uploader } from 'rsuite';
import zhCN from 'rsuite/locales/zh_CN';

const App = () => {
  const toaster = useToaster();

  const handleClick = () => {
    toaster.push(
      <Notification header="消息">
        <Uploader action="/" />
      </Notification>
    );
  };

  return (
    <div>
      <button onClick={handleClick}>push</button>
    </div>
  );
};

render(
  <CustomProvider locale={zhCN}>
    <App />
  </CustomProvider>
);
```








