### PR TITLE
feat(Nav.Menu): add `openDirection` prop

### DIFF
--- a/docs/pages/components/nav/en-US/index.md
+++ b/docs/pages/components/nav/en-US/index.md
@@ -39,8 +39,6 @@ Provides a list of various forms of navigation menus, which can be landscape and
 
 <!--{include:`dropdown.md`}-->
 
-> Use the `<Dropdown>` component directly when using multi-level navigation.
-
 ### With Icon
 
 <!--{include:`icon.md`}-->
@@ -86,11 +84,12 @@ Provides a list of various forms of navigation menus, which can be landscape and
 
 ### `<Nav.Menu>`
 
-| Property | Type `(Default)`                                     | Description                             |
-| -------- | ---------------------------------------------------- | --------------------------------------- |
-| title    | ReactNode                                            | Content of the item that opens the menu |
-| icon     | ReactElement                                         | Icon of the item that opens the menu    |
-| onClose  | (event: React.SyntheticEvent) => void                | Callback when menu closes               |
-| onOpen   | (event: React.SyntheticEvent) => void                | Callback when menu opens                |
-| onToggle | (open: boolean, event: React.SyntheticEvent) => void | Callback when menu opens/closes         |
-| noCaret  | boolean `(false)`                                    | Whether to hide the caret icon          |
+| Property      | Type `(Default)`                                     | Description                                                    |
+| ------------- | ---------------------------------------------------- | -------------------------------------------------------------- |
+| icon          | ReactElement                                         | Icon of the item that opens the menu                           |
+| noCaret       | boolean `(false)`                                    | Whether to hide the caret icon                                 |
+| onClose       | (event: React.SyntheticEvent) => void                | Callback when menu closes                                      |
+| onOpen        | (event: React.SyntheticEvent) => void                | Callback when menu opens                                       |
+| onToggle      | (open: boolean, event: React.SyntheticEvent) => void | Callback when menu opens/closes                                |
+| openDirection | "start"&#124;"end" `("end")`                         | Direction that menu opens towards (only available on submenus) |
+| title         | ReactNode                                            | Content of the item that opens the menu                        |

--- a/docs/pages/components/nav/zh-CN/index.md
+++ b/docs/pages/components/nav/zh-CN/index.md
@@ -43,8 +43,6 @@
 
 <!--{include:`dropdown.md`}-->
 
-> 当使用多级导航时，直接使用 `<Dropdown>` 组件。
-
 ### 设置图标
 
 <!--{include:`icon.md`}-->
@@ -90,11 +88,12 @@
 
 ### `<Nav.Menu>`
 
-| 属性名称 | 类型                                                 | 描述                  |
-| -------- | ---------------------------------------------------- | --------------------- |
-| icon     | ReactElement                                         | 展开菜单的导航项图标  |
-| noCaret  | boolean `(false)`                                    | 是否隐藏小箭头图标    |
-| onClose  | (event: React.SyntheticEvent) => void                | 菜单关闭时的回调      |
-| onOpen   | (event: React.SyntheticEvent) => void                | 菜单开启时的回调      |
-| onToggle | (open: boolean, event: React.SyntheticEvent) => void | 菜单开启/关闭时的回调 |
-| title    | ReactNode                                            | 展开菜单的导航项内容  |
+| 属性名称      | 类型                                                 | 描述                            |
+| ------------- | ---------------------------------------------------- | ------------------------------- |
+| icon          | ReactElement                                         | 展开菜单的导航项图标            |
+| noCaret       | boolean `(false)`                                    | 是否隐藏小箭头图标              |
+| onClose       | (event: React.SyntheticEvent) => void                | 菜单关闭时的回调                |
+| onOpen        | (event: React.SyntheticEvent) => void                | 菜单开启时的回调                |
+| onToggle      | (open: boolean, event: React.SyntheticEvent) => void | 菜单开启/关闭时的回调           |
+| openDirection | "start"&#124;"end" `("end")`                         | 菜单开启的方向 (仅适用于子菜单) |
+| title         | ReactNode                                            | 展开菜单的导航项内容            |

--- a/docs/pages/components/navbar/fragments/basic.md
+++ b/docs/pages/components/navbar/fragments/basic.md
@@ -11,7 +11,10 @@ const instance = (
       <Nav.Menu title="About">
         <Nav.Item>Company</Nav.Item>
         <Nav.Item>Team</Nav.Item>
-        <Nav.Item>Contact</Nav.Item>
+        <Nav.Menu title="Contact">
+          <Nav.Item>Via email</Nav.Item>
+          <Nav.Item>Via telephone</Nav.Item>
+        </Nav.Menu>
       </Nav.Menu>
     </Nav>
     <Nav pullRight>

--- a/src/Dropdown/styles/index.less
+++ b/src/Dropdown/styles/index.less
@@ -223,6 +223,11 @@
 
   .rs-dropdown-menu {
     left: 100%;
+
+    &[data-direction='start'] {
+      left: unset;
+      right: 100%;
+    }
   }
 
   // Open

--- a/src/Nav/NavDropdownMenu.tsx
+++ b/src/Nav/NavDropdownMenu.tsx
@@ -10,13 +10,26 @@ import AngleLeft from '@rsuite/icons/legacy/AngleLeft';
 import AngleRight from '@rsuite/icons/legacy/AngleRight';
 import useCustom from '../utils/useCustom';
 import NavContext from './NavContext';
+import deprecatePropType from '../utils/deprecatePropType';
 
 export interface NavDropdownMenuProps<T = any> extends StandardProps {
   /** Define the title as a submenu */
   title?: React.ReactNode;
 
-  /** The submenu expands from the left and defaults to the right */
+  /**
+   * The submenu expands from the left and defaults to the right
+   * @deprecated Use openDirection="start" instead
+   */
   pullLeft?: boolean;
+
+  /**
+   * Direction that the sub-menu open towards
+   * - start: towards the head of the reading direction (right by default, left in RTL)
+   * - end: towards the end of the reading direction (left by default, right in RTL)
+   *
+   * @default 'end'
+   */
+  openDirection?: 'start' | 'end';
 
   /**
    *  Only used for setting the default expand state when it's a submenu.
@@ -47,7 +60,15 @@ const NavDropdownMenu = React.forwardRef<
     throw new Error('<Nav.Dropdown.Menu> should be used within a <Nav> component.');
   }
 
-  const { onToggle, eventKey, title, classPrefix = 'dropdown-menu', children, ...rest } = props;
+  const {
+    onToggle,
+    eventKey,
+    title,
+    classPrefix = 'dropdown-menu',
+    children,
+    openDirection = 'end',
+    ...rest
+  } = props;
 
   const { rtl } = useCustom('DropdownMenu');
 
@@ -117,6 +138,7 @@ const NavDropdownMenu = React.forwardRef<
             ref={popupRef}
             className={menuClassName}
             hidden={!open}
+            data-direction={openDirection}
             {...popupProps}
             {...menuProps}
           >
@@ -154,7 +176,8 @@ NavDropdownMenu.propTypes = {
   children: PropTypes.node,
   icon: PropTypes.any,
   classPrefix: PropTypes.string,
-  pullLeft: PropTypes.bool,
+  pullLeft: deprecatePropType(PropTypes.bool, 'Use openDirection="start" instead.'),
+  openDirection: PropTypes.oneOf(['start', 'end']),
   title: PropTypes.node,
   open: PropTypes.bool,
   eventKey: PropTypes.any,

--- a/src/Nav/test/Nav.test.tsx
+++ b/src/Nav/test/Nav.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Navbar from '../../Navbar';
+import Nav from '../Nav';
+
+<Navbar>
+  <Nav>
+    <Nav.Menu title="Menu">
+      <Nav.Menu title="Submenu" openDirection="start">
+        <Nav.Item>Submenu item</Nav.Item>
+      </Nav.Menu>
+    </Nav.Menu>
+  </Nav>
+</Navbar>;

--- a/src/Navbar/NavbarDropdownMenu.tsx
+++ b/src/Navbar/NavbarDropdownMenu.tsx
@@ -10,13 +10,26 @@ import useCustom from '../utils/useCustom';
 import { NavbarContext } from '.';
 import Disclosure from '../Disclosure';
 import NavContext from '../Nav/NavContext';
+import deprecatePropType from '../utils/deprecatePropType';
 
 export interface NavbarDropdownMenuProps<T = any> extends StandardProps {
   /** Define the title as a submenu */
   title?: React.ReactNode;
 
-  /** The submenu expands from the left and defaults to the right */
+  /**
+   * The submenu expands from the left and defaults to the right
+   * @deprecated Use openDirection="start" instead.
+   */
   pullLeft?: boolean;
+
+  /**
+   * Direction that the sub-menu open towards
+   * - start: towards the head of the reading direction (right by default, left in RTL)
+   * - end: towards the end of the reading direction (left by default, right in RTL)
+   *
+   * @default 'end'
+   */
+  openDirection?: 'start' | 'end';
 
   /**
    *  Only used for setting the default expand state when it's a submenu.
@@ -61,7 +74,15 @@ const NavbarDropdownMenu = React.forwardRef<
     );
   }
 
-  const { onToggle, eventKey, title, classPrefix = 'dropdown-menu', children, ...rest } = props;
+  const {
+    onToggle,
+    eventKey,
+    title,
+    classPrefix = 'dropdown-menu',
+    children,
+    openDirection = 'end',
+    ...rest
+  } = props;
 
   const { rtl } = useCustom('DropdownMenu');
 
@@ -135,6 +156,7 @@ const NavbarDropdownMenu = React.forwardRef<
                     ref={elementRef as any}
                     className={menuClassName}
                     hidden={!open}
+                    data-direction={openDirection}
                     {...menuProps}
                   >
                     {children}
@@ -157,7 +179,8 @@ NavbarDropdownMenu.propTypes = {
   children: PropTypes.node,
   icon: PropTypes.any,
   classPrefix: PropTypes.string,
-  pullLeft: PropTypes.bool,
+  pullLeft: deprecatePropType(PropTypes.bool, 'Use openDirection="start" instead.'),
+  openDirection: PropTypes.oneOf(['start', 'end']),
   title: PropTypes.node,
   open: PropTypes.bool,
   eventKey: PropTypes.any,


### PR DESCRIPTION
Close #2267

Add `openDirection` prop for specifying the opening direction of a submenu.

`openDirection="end"` (default), submenu opens towards the tail of reading direction (right by default, left in RTL)
<img width="253" alt="image" src="https://user-images.githubusercontent.com/8225666/171586700-419d5aca-bead-4460-a77c-229c7b4526fc.png">

`openDirection="start"`, submenu opens towards the head of reading direction (left by default, right in RTL)
<img width="227" alt="image" src="https://user-images.githubusercontent.com/8225666/171586767-f9b40093-9951-46fe-afee-2ce4e21aab64.png">
