### PR TITLE
fix:  when data changes Cannot close

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,6 +20,7 @@ const webpackConfig = {
       '@test': path.resolve(__dirname, './test')
     }
   },
+  devtool:'inline-source-map',
   plugins: [
     new webpack.DefinePlugin({
       'process.env': {

--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -144,7 +144,8 @@ class CheckTreePicker extends React.Component<CheckTreePickerProps, CheckTreePic
         check: nextValue,
         expand: nextExpandItemValues
       },
-      props
+      props,
+      true
     );
 
     this.state = {
@@ -582,7 +583,7 @@ class CheckTreePicker extends React.Component<CheckTreePickerProps, CheckTreePic
     return list;
   }
 
-  unserializeLists(lists: any, nextProps: CheckTreePickerProps = this.props) {
+  unserializeLists(lists: any, nextProps: CheckTreePickerProps = this.props, initial = false) {
     const { valueKey, cascade, uncheckableItemValues = [] } = nextProps;
     const expandAll = getExpandAll(nextProps);
     // Reset values to false
@@ -613,7 +614,7 @@ class CheckTreePicker extends React.Component<CheckTreePickerProps, CheckTreePic
               }
             });
           } else {
-            this.nodes[refKey][listKey] = expandAll;
+            this.nodes[refKey][listKey] = initial ? expandAll : false;
           }
         }
       });

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -567,45 +567,65 @@ describe('CheckTreePicker', () => {
       4
     );
   });
-  it('Should expand when has props defaultExpandAll and data change', () => {
-    const Wrapper = React.forwardRef((props, ref) => {
-      const nextData = [
-        {
-          label: 'Fujian',
-          value: 3,
-          children: [
-            {
-              label: 'Fuzhou',
-              value: 36
-            }
-          ]
-        },
-        {
-          label: 'Guangdong',
-          value: 4,
-          children: [
-            {
-              label: 'Guangzhou',
-              value: 45
-            }
-          ]
-        }
-      ];
-      const [willChangeData, setData] = useState(data);
-      const handleClick = () => {
-        setData(nextData);
+
+  describe('data change', () => {
+    const renderStart = () => {
+      const containerRef = React.createRef();
+      const Wrapper = () => {
+        const nextData = [
+          {
+            label: 'Fujian',
+            value: 3,
+            children: [
+              {
+                label: 'Fuzhou',
+                value: 36
+              }
+            ]
+          },
+          {
+            label: 'Guangdong',
+            value: 4,
+            children: [
+              {
+                label: 'Guangzhou',
+                value: 45
+              }
+            ]
+          }
+        ];
+        const [willChangeData, setData] = useState(data);
+        const handleClick = () => {
+          setData(nextData);
+        };
+        return (
+          <div ref={containerRef}>
+            <button onClick={handleClick} className="change-data">
+              change data
+            </button>
+            <CheckTreePicker inline defaultExpandAll data={willChangeData} />
+          </div>
+        );
       };
-      return (
-        <div ref={ref}>
-          <button onClick={handleClick} className="change-data">
-            change data
-          </button>
-          <CheckTreePicker inline defaultExpandAll data={willChangeData} />
-        </div>
-      );
+      ReactTestUtils.act(() => {
+        ReactDOM.render(<Wrapper />, container);
+      });
+      return containerRef.current;
+    };
+
+    it('Should expand when has props defaultExpandAll', () => {
+      const container = renderStart();
+      ReactTestUtils.Simulate.click(container.querySelector('.change-data'));
+      expect(container.querySelectorAll('.rs-check-tree-open').length).to.equal(2);
     });
-    const instance = getDOMNode(<Wrapper />);
-    ReactTestUtils.Simulate.click(instance.querySelector('.change-data'));
-    expect(instance.querySelectorAll('.rs-check-tree-open').length).to.equal(2);
+
+    it('Should be all closed, when click close icon', () => {
+      const container = renderStart();
+      ReactTestUtils.Simulate.click(container.querySelector('.change-data'));
+      container.querySelectorAll('.rs-check-tree-node-expand-icon').forEach(element => {
+        ReactTestUtils.Simulate.click(element);
+      });
+      expect(container.querySelectorAll('.rs-check-tree-open').length).to.equal(0);
+    });
   });
 });


### PR DESCRIPTION
example: https://stackblitz.com/edit/react-c42wf5?file=package.json,src%2Findex.js

When click the close icon of label1, and then click the close icon of label2, It will be open all.

I think it has always existed.Then this [pr](https://github.com/rsuite/rsuite/pull/2372) exposed it.
