### PR TITLE
refactor(Table): improve cellprops type for better extended usage

### DIFF
--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -8,15 +8,15 @@ export interface TableInstance extends React.Component<TableProps> {
   scrollLeft: (left: number) => void;
 }
 
-export interface CellProps extends StandardProps {
+export interface CellProps<T = any> extends StandardProps {
   /** Data binding key, but also a sort of key */
-  dataKey?: string;
+  dataKey?: string | keyof T;
 
   /** Row Number */
   rowIndex?: number;
 
   /** Row Data */
-  rowData?: any;
+  rowData?: T;
 }
 
 interface TableComponent


### PR DESCRIPTION
This PR is an improvement over the exported types for the Table Cell props. 
Current issue is that when a consumer wants to create their own custom cells all sense of typing is lost because of very unrestricted types. With this type we keep the possibility of open types (so keeping backward compatibility) but add the possibility of being more restrictive and have better typing .