### PR TITLE
fix(Whisper): specify speaker function argument types

### DIFF
--- a/src/Overlay/Overlay.tsx
+++ b/src/Overlay/Overlay.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useCallback, useContext } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import Position, { PositionProps } from './Position';
+import Position, { PositionChildProps, PositionProps } from './Position';
 import { TypeAttributes, AnimationEventProps, CursorPosition } from '../@types/common';
 import { mergeRefs, useRootClose } from '../utils';
 import Fade from '../Animation/Fade';
@@ -9,7 +9,12 @@ import OverlayContext from './OverlayContext';
 
 export interface OverlayProps extends AnimationEventProps {
   container?: HTMLElement | (() => HTMLElement | null) | null;
-  children: React.ReactElement | ((props: any, ref) => React.ReactElement);
+  children:
+    | React.ReactElement
+    | ((
+        props: PositionChildProps & React.HTMLAttributes<HTMLElement>,
+        ref: React.RefCallback<HTMLElement>
+      ) => React.ReactElement);
   childrenProps?: React.HTMLAttributes<HTMLElement>;
   className?: string;
   containerPadding?: number;

--- a/src/Overlay/OverlayTrigger.tsx
+++ b/src/Overlay/OverlayTrigger.tsx
@@ -18,7 +18,7 @@ import {
   StandardProps,
   TypeAttributes
 } from '../@types/common';
-import { PositionInstance } from './Position';
+import { PositionChildProps, PositionInstance } from './Position';
 import { isUndefined } from 'lodash';
 import OverlayContext from './OverlayContext';
 
@@ -58,7 +58,15 @@ export interface OverlayTriggerProps extends StandardProps, AnimationEventProps 
   containerPadding?: number;
 
   /** display element */
-  speaker: React.ReactElement | ((props: any, ref: React.RefObject<any>) => React.ReactElement);
+  speaker:
+    | React.ReactElement
+    | ((
+        props: PositionChildProps &
+          Pick<React.HTMLAttributes<HTMLElement>, 'id' | 'onMouseEnter' | 'onMouseLeave'> & {
+            onClose: (delay?: number) => NodeJS.Timeout | void;
+          },
+        ref: React.RefCallback<HTMLElement>
+      ) => React.ReactElement);
 
   /** Prevent floating element overflow */
   preventOverflow?: boolean;
@@ -417,7 +425,10 @@ const OverlayTrigger = React.forwardRef(
         open
       };
 
-      const speakerProps: React.HTMLAttributes<HTMLElement> = {
+      const speakerProps: Pick<
+        React.HTMLAttributes<HTMLElement>,
+        'id' | 'onMouseEnter' | 'onMouseLeave'
+      > = {
         id: controlId
       };
 

--- a/src/Overlay/Position.tsx
+++ b/src/Overlay/Position.tsx
@@ -25,10 +25,12 @@ export interface PositionChildProps {
   className: string;
   left?: number;
   top?: number;
+  arrowOffsetLeft?: number;
+  arrowOffsetTop?: number;
 }
 
 export interface PositionProps {
-  children: (props: PositionChildProps, ref) => React.ReactElement;
+  children: (props: PositionChildProps, ref: React.RefObject<HTMLElement>) => React.ReactElement;
   className?: string;
   container?: HTMLElement | (() => HTMLElement | null) | null;
   containerPadding?: number;
@@ -60,8 +62,8 @@ const usePosition = (
   const defaultPosition = {
     positionLeft: 0,
     positionTop: 0,
-    arrowOffsetLeft: null,
-    arrowOffsetTop: null
+    arrowOffsetLeft: undefined,
+    arrowOffsetTop: undefined
   };
   const [position, setPosition] = useState<PositionType>(defaultPosition);
   const utils = useMemo(
@@ -167,7 +169,7 @@ export interface PositionInstance {
 
 const Position = React.forwardRef((props: PositionProps, ref) => {
   const { children, className, followCursor, cursorPosition } = props;
-  const childRef = React.useRef<HTMLElement | null>(null);
+  const childRef = React.useRef<HTMLElement>(null);
 
   const [position, updatePosition] = usePosition(props, childRef);
   const { positionClassName, arrowOffsetLeft, arrowOffsetTop, positionLeft, positionTop } =

--- a/src/Overlay/positionUtils.ts
+++ b/src/Overlay/positionUtils.ts
@@ -21,8 +21,8 @@ type Offset = {
 export interface PositionType {
   positionLeft?: number;
   positionTop?: number;
-  arrowOffsetLeft?: null | number;
-  arrowOffsetTop?: null | number;
+  arrowOffsetLeft?: number;
+  arrowOffsetTop?: number;
   positionClassName?: string;
 }
 

--- a/src/Picker/PickerToggleTrigger.tsx
+++ b/src/Picker/PickerToggleTrigger.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import pick from 'lodash/pick';
 import OverlayTrigger, {
   OverlayTriggerInstance,
+  OverlayTriggerProps,
   OverlayTriggerType
 } from '../Overlay/OverlayTrigger';
 import { PositionChildProps } from '../Overlay/Position';
@@ -12,13 +13,13 @@ import { TypeAttributes, AnimationEventProps } from '../@types/common';
 export type { OverlayTriggerInstance, PositionChildProps };
 
 export interface PickerToggleTriggerProps
-  extends Omit<AnimationEventProps, 'onEntering' | 'onExiting'> {
+  extends Omit<AnimationEventProps, 'onEntering' | 'onExiting'>,
+    Pick<OverlayTriggerProps, 'speaker'> {
   placement?: TypeAttributes.Placement;
   pickerProps: any;
   open?: boolean;
   trigger?: OverlayTriggerType | OverlayTriggerType[];
   children: React.ReactElement | ((props: any, ref) => React.ReactElement);
-  speaker: React.ReactElement | ((props: any, ref: React.RefObject<any>) => React.ReactElement);
 }
 
 export const omitTriggerPropKeys = [

--- a/src/Whisper/test/Whisper.test.tsx
+++ b/src/Whisper/test/Whisper.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { expectType } from 'ts-expect';
 import Whisper, { WhisperInstance } from '../Whisper';
 
 const whisperRef = React.createRef<WhisperInstance>();
@@ -14,3 +15,18 @@ whisperRef.current?.close();
 whisperRef.current?.close(300);
 
 whisperRef.current?.updatePosition();
+
+// speaker function types
+<Whisper
+  speaker={(props, ref) => {
+    expectType<number | undefined>(props.arrowOffsetLeft);
+    expectType<number | undefined>(props.arrowOffsetLeft);
+    expectType<((...args: any[]) => any) | undefined>(props.onMouseEnter);
+    expectType<((...args: any[]) => any) | undefined>(props.onMouseLeave);
+    expectType<(...args: any[]) => any>(props.onClose);
+
+    return <div ref={ref} {...props}></div>;
+  }}
+>
+  <div></div>
+</Whisper>;


### PR DESCRIPTION
Let users know what props will be passed in when using `speaker` function
<img width="613" alt="image" src="https://user-images.githubusercontent.com/8225666/175483564-5841245b-8be5-473f-b17a-1981854e3d27.png">
