### PR TITLE
fix(InputGroup.Addon): extend props from as element

### DIFF
--- a/src/InputGroup/InputGroupAddon.tsx
+++ b/src/InputGroup/InputGroupAddon.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useClassNames } from '../utils';
-import { WithAsProps } from '../@types/common';
+import { RsRefForwardingComponent, WithAsProps } from '../@types/common';
 
 export interface InputGroupAddonProps extends WithAsProps, React.HTMLAttributes<HTMLSpanElement> {
   /** An Input group addon can show that it is disabled */
   disabled?: boolean;
 }
 
-const InputGroupAddon = React.forwardRef(
+const InputGroupAddon: RsRefForwardingComponent<'span', InputGroupAddonProps> = React.forwardRef(
   (props: InputGroupAddonProps, ref: React.Ref<HTMLSpanElement>) => {
     const {
       as: Component = 'span',

--- a/src/InputGroup/test/InputGroup.test.tsx
+++ b/src/InputGroup/test/InputGroup.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { InputGroup } from '../..';
+
+<InputGroup>
+  <InputGroup.Addon as="label" htmlFor="input"></InputGroup.Addon>
+  <input id="input" />
+</InputGroup>;


### PR DESCRIPTION
Allow `<InputGroup.Addon>` to receive additional props passed down to `as` element so that users could use it as label for an input

<img width="650" alt="image" src="https://user-images.githubusercontent.com/8225666/175502419-4aec3e48-1159-4764-b3ea-7f73fc2af038.png">
