### PR TITLE
build(deps): bump schema-typed from 2.0.2 to 2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "prop-types": "^15.7.2",
         "react-virtualized": "^9.22.3",
         "rsuite-table": "^5.6.0",
-        "schema-typed": "^2.0.2"
+        "schema-typed": "^2.0.3"
       },
       "devDependencies": {
         "@babel/cli": "^7.7.0",
@@ -21034,9 +21034,9 @@
       }
     },
     "node_modules/schema-typed": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.0.2.tgz",
-      "integrity": "sha512-E8GAANjZ8oYwyQJEyf/93W1QERTCwu8N7aMUbgBWbYvqzZE8f/kAZaL5D9knr7yLEgMnwJQ4pd8x8EVZ0PpzUA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.0.3.tgz",
+      "integrity": "sha512-4KckVnJjTtVugYpSAoQrcH4quE4yIVTvI/nHEqtwdceBr/ZCuH2LfV8/gaZFrYU7cwwyufLKaswt28aqQ1T9ww==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       }
@@ -41615,9 +41615,9 @@
       }
     },
     "schema-typed": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.0.2.tgz",
-      "integrity": "sha512-E8GAANjZ8oYwyQJEyf/93W1QERTCwu8N7aMUbgBWbYvqzZE8f/kAZaL5D9knr7yLEgMnwJQ4pd8x8EVZ0PpzUA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.0.3.tgz",
+      "integrity": "sha512-4KckVnJjTtVugYpSAoQrcH4quE4yIVTvI/nHEqtwdceBr/ZCuH2LfV8/gaZFrYU7cwwyufLKaswt28aqQ1T9ww==",
       "requires": {
         "@babel/runtime": "^7.16.0"
       }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "prop-types": "^15.7.2",
     "react-virtualized": "^9.22.3",
     "rsuite-table": "^5.6.0",
-    "schema-typed": "^2.0.2"
+    "schema-typed": "^2.0.3"
   },
   "peerDependencies": {
     "react": ">=16.8.0",


### PR DESCRIPTION
## [2.0.3](https://github.com/rsuite/schema-typed/compare/2.0.2...2.0.3) (2022-06-30)


### Bug Fixes

* **ObjectType:** specifies type of property `object` in the `ObjectType` check result ([#46](https://github.com/rsuite/schema-typed/issues/46)) ([0571e09](https://github.com/rsuite/schema-typed/commit/0571e097217b0c999acaf9e5780bdd289aa46a46))

