### PR TITLE
feat(SelectPicker,CheckPicker): add label prop

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -12983,6 +12983,36 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@next/swc-android-arm-eabi": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.0.tgz",
+      "integrity": "sha512-hbneH8DNRB2x0Nf5fPCYoL8a0osvdTCe4pvOc9Rv5CpDsoOlf8BWBs2OWpeP0U2BktGvIsuUhmISmdYYGyrvTw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.0.tgz",
+      "integrity": "sha512-gRiAw8g3Akf6niTDLEm1Emfa7jXDjvaAj/crDO8hKASKA4Y1fS4kbi/tyWw5VtoFI4mUzRmCPmZ8eL0tBSG58A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   },
   "dependencies": {
@@ -22936,6 +22966,18 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "@next/swc-android-arm-eabi": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.0.tgz",
+      "integrity": "sha512-hbneH8DNRB2x0Nf5fPCYoL8a0osvdTCe4pvOc9Rv5CpDsoOlf8BWBs2OWpeP0U2BktGvIsuUhmISmdYYGyrvTw==",
+      "optional": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.0.tgz",
+      "integrity": "sha512-gRiAw8g3Akf6niTDLEm1Emfa7jXDjvaAj/crDO8hKASKA4Y1fS4kbi/tyWw5VtoFI4mUzRmCPmZ8eL0tBSG58A==",
+      "optional": true
     }
   }
 }

--- a/docs/pages/components/check-picker/en-US/index.md
+++ b/docs/pages/components/check-picker/en-US/index.md
@@ -12,6 +12,10 @@ Used for multiple data selection, support grouping.
 
 <!--{include:`basic.md`}-->
 
+### With a label
+
+<!--{include:`with-label.md`}-->
+
 ### Appearance
 
 <!--{include:`appearance.md`}-->
@@ -91,6 +95,7 @@ Learn more in [Accessibility](/guide/accessibility).
 | disabled           | boolean                                                                                            | Whether disabled component                                  |
 | disabledItemValues | [ValueType][value]                                                                                 | Disable item by value                                       |
 | groupBy            | string                                                                                             | Set group condition key in data                             |
+| label              | ReactNode                                                                                          | A label displayed at the beginning of toggle button         |
 | labelKey           | string `('label')`                                                                                 | Set label key in data                                       |
 | listProps          | [ListProps][listprops]                                                                             | List-related properties in `react-virtualized`              |
 | locale             | [PickerLocaleType](/guide/i18n/#pickers)                                                           | Locale text                                                 |

--- a/docs/pages/components/check-picker/fragments/with-label.md
+++ b/docs/pages/components/check-picker/fragments/with-label.md
@@ -1,0 +1,13 @@
+<!--start-code-->
+
+```js
+/**
+ * import data from
+ * https://github.com/rsuite/rsuite/blob/master/docs/public/data/users-role.json
+ */
+
+const instance = <CheckPicker label="User" data={data} style={{ width: 224 }} />;
+ReactDOM.render(instance);
+```
+
+<!--end-code-->

--- a/docs/pages/components/check-picker/zh-CN/index.md
+++ b/docs/pages/components/check-picker/zh-CN/index.md
@@ -12,6 +12,10 @@
 
 <!--{include:`basic.md`}-->
 
+### 具有标签
+
+<!--{include:`with-label.md`}-->
+
 ### 外观
 
 <!--{include:`appearance.md`}-->
@@ -91,6 +95,7 @@
 | disabled           | boolean                                                                           | 禁用组件                               |
 | disabledItemValues | [ValueType][value]                                                                | 禁用选项                               |
 | groupBy            | string                                                                            | 设置分组条件在 `data` 中的 `key`       |
+| label              | ReactNode                                                                         | 在按钮开头显示的标签                   |
 | labelKey           | string `('label')`                                                                | 设置选项显示内容在 `data` 中的 `key`   |
 | listProps          | [ListProps][listprops]                                                            | `react-virtualized` 中 List 的相关属性 |
 | locale             | [PickerLocaleType](/zh/guide/i18n/#pickers)                                       | 本地化的文本                           |

--- a/docs/pages/components/select-picker/en-US/index.md
+++ b/docs/pages/components/select-picker/en-US/index.md
@@ -12,6 +12,10 @@ For a single data selection, support grouping.
 
 <!--{include:`basic.md`}-->
 
+### With a label
+
+<!--{include:`with-label.md`}-->
+
 ### Appearance
 
 <!--{include:`appearance.md`}-->
@@ -78,6 +82,7 @@ Learn more in [Accessibility](/guide/accessibility).
 | disabled           | boolean                                                                                         | Whether or not component is disabled                        |
 | disabledItemValues | [ValueType][value][]                                                                            | Disable optional                                            |
 | groupBy            | string                                                                                          | Set grouping criteria 'key' in 'data'                       |
+| label              | ReactNode                                                                                       | A label displayed at the beginning of toggle button         |
 | labelKey           | string `('label')`                                                                              | Set options to display the 'key' in 'data'                  |
 | listProps          | [ListProps][listprops]                                                                          | List-related properties in `react-virtualized`              |
 | locale             | [PickerLocaleType](/guide/i18n/#pickers)                                                        | Locale text                                                 |

--- a/docs/pages/components/select-picker/fragments/with-label.md
+++ b/docs/pages/components/select-picker/fragments/with-label.md
@@ -1,0 +1,13 @@
+<!--start-code-->
+
+```js
+/**
+ * import data from
+ * https://github.com/rsuite/rsuite/blob/master/docs/public/data/users-role.json
+ */
+
+const instance = <SelectPicker label="User" data={data} style={{ width: 224 }} />;
+ReactDOM.render(instance);
+```
+
+<!--end-code-->

--- a/docs/pages/components/select-picker/zh-CN/index.md
+++ b/docs/pages/components/select-picker/zh-CN/index.md
@@ -12,6 +12,10 @@
 
 <!--{include:`basic.md`}-->
 
+### 具有标签
+
+<!--{include:`with-label.md`}-->
+
 ### 外观
 
 <!--{include:`appearance.md`}-->
@@ -81,6 +85,7 @@
 | disabled           | boolean                                                                                        | 禁用组件                               |
 | disabledItemValues | [ValueType][value][]                                                                           | 禁用选项                               |
 | groupBy            | string                                                                                         | 设置分组条件在 `data` 中的 `key`       |
+| label              | ReactNode                                                                                      | 在按钮开头显示的标签                   |
 | labelKey           | string `('label')`                                                                             | 设置选项显示内容在 `data` 中的 `key`   |
 | listProps          | [ListProps][listprops]                                                                         | `react-virtualized` 中 List 的相关属性 |
 | locale             | [PickerLocaleType](/zh/guide/i18n/#pickers)                                                    | 本地化的文本                           |

--- a/src/CheckPicker/test/CheckPickerSpec.js
+++ b/src/CheckPicker/test/CheckPickerSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ReactTestUtils from 'react-dom/test-utils';
 import { globalKey, getDOMNode, getInstance } from '@test/testUtils';
@@ -407,6 +407,22 @@ describe('CheckPicker', () => {
   it('Should call onClose callback by key="Tab"', done => {
     const instance = getInstance(<CheckPicker data={data} onClose={done} defaultOpen />);
     ReactTestUtils.Simulate.keyDown(instance.target, { key: 'Tab' });
+  });
+
+  describe('With a label', () => {
+    it('Should render a label before placeholder', () => {
+      render(<CheckPicker label="User" data={[]} data-testid="picker" />);
+
+      expect(screen.getByTestId('picker')).to.have.text('User: Select');
+    });
+
+    it('Should render a label before selected value', () => {
+      render(
+        <CheckPicker label="User" data={data} value={['Eugenia', 'Kariane']} data-testid="picker" />
+      );
+
+      expect(screen.getByTestId('picker')).to.have.text('User: Eugenia,Kariane2');
+    });
   });
 
   describe('Plain text', () => {

--- a/src/Picker/PickerToggle.tsx
+++ b/src/Picker/PickerToggle.tsx
@@ -42,6 +42,7 @@ export interface PickerToggleProps extends ToggleButtonProps {
   /** Custom caret component */
   caretAs?: React.ElementType;
   onClean?: (event: React.MouseEvent) => void;
+  label?: React.ReactNode;
 }
 
 const defaultInputMask = [];
@@ -77,6 +78,7 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
       placement = 'bottomStart',
       caretComponent,
       caretAs = caretComponent,
+      label,
       ...rest
     } = props;
 
@@ -204,12 +206,12 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
           placeholder={inputPlaceholder}
           render={(ref, props) => <input ref={mergeRefs(inputRef, ref)} {...props} />}
         />
-
         {children ? (
           <span
             className={prefix(hasValue ? 'value' : 'placeholder')}
             aria-placeholder={typeof children === 'string' ? children : undefined}
           >
+            {label && <span className={prefix('label')}>{label}: </span>}
             {children}
           </span>
         ) : null}

--- a/src/Picker/styles/index.less
+++ b/src/Picker/styles/index.less
@@ -213,6 +213,10 @@
   text-align: left;
   .ellipsis();
 
+  &-label {
+    color: var(--rs-text-primary);
+  }
+
   &-value {
     display: block;
     .ellipsis();

--- a/src/SelectPicker/test/SelectPickerSpec.js
+++ b/src/SelectPicker/test/SelectPickerSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode, getInstance } from '@test/testUtils';
 import SelectPicker from '../SelectPicker';
@@ -378,6 +378,20 @@ describe('SelectPicker', () => {
       document.activeElement,
       pickerRef.current.overlay.querySelector('.rs-picker-search-bar-input')
     );
+  });
+
+  describe('With a label', () => {
+    it('Should render a label before placeholder', () => {
+      render(<SelectPicker label="User" data={[]} data-testid="picker" />);
+
+      expect(screen.getByTestId('picker')).to.have.text('User: Select');
+    });
+
+    it('Should render a label before selected value', () => {
+      render(<SelectPicker label="User" data={data} value="Eugenia" data-testid="picker" />);
+
+      expect(screen.getByTestId('picker')).to.have.text('User: Eugenia');
+    });
   });
 
   describe('Plain text', () => {


### PR DESCRIPTION
Add `label` prop to allow users to display a label before picker placeholder and selected values.

<img width="249" alt="image" src="https://user-images.githubusercontent.com/8225666/177314185-af7432fb-b110-4909-aff7-9b48938fa44f.png">
<img width="253" alt="image" src="https://user-images.githubusercontent.com/8225666/177314226-4be8ee45-75ff-4075-8c40-8603930fa61e.png">
