### PR TITLE
fix(SelectPicker): add caretAs prop to SelectPickerProps interface

### DIFF
--- a/src/CheckPicker/CheckPicker.tsx
+++ b/src/CheckPicker/CheckPicker.tsx
@@ -49,7 +49,7 @@ export type ValueType = (number | string)[];
 export interface CheckPickerProps<T>
   extends FormControlPickerProps<T[], PickerLocale, ItemDataType<T>>,
     MultipleSelectProps<T>,
-    Pick<PickerToggleProps, 'label'> {
+    Pick<PickerToggleProps, 'label' | 'caretAs'> {
   /** Top the selected option in the options */
   sticky?: boolean;
 

--- a/src/CheckPicker/test/CheckPicker.test.tsx
+++ b/src/CheckPicker/test/CheckPicker.test.tsx
@@ -38,3 +38,5 @@ const pickerRef = React.createRef<PickerInstance>();
 
 // With a label
 <CheckPicker label="User" data={[]} />;
+
+<CheckPicker caretAs={() => <div />} data={[]} />;

--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -33,7 +33,8 @@ import {
   PositionChildProps,
   listPickerPropTypes,
   PickerComponent,
-  useToggleKeyDownEvent
+  useToggleKeyDownEvent,
+  PickerToggleProps
 } from '../Picker';
 
 import {
@@ -77,7 +78,8 @@ import { maxTreeHeight } from '../TreePicker/TreePicker';
 export type ValueType = (string | number)[];
 export interface CheckTreePickerProps<T = ValueType>
   extends TreeBaseProps<T, ItemDataType>,
-    FormControlPickerProps<T, PickerLocale, ItemDataType> {
+    FormControlPickerProps<T, PickerLocale, ItemDataType>,
+    Pick<PickerToggleProps, 'caretAs'> {
   /** Tree node cascade */
   cascade?: boolean;
 

--- a/src/CheckTreePicker/test/CheckTreePicker.test.tsx
+++ b/src/CheckTreePicker/test/CheckTreePicker.test.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import CheckTreePicker from '../CheckTreePicker';
+
+<CheckTreePicker caretAs={() => <div />} data={[]} />;

--- a/src/InputPicker/InputPicker.tsx
+++ b/src/InputPicker/InputPicker.tsx
@@ -42,7 +42,8 @@ import {
   OverlayTriggerInstance,
   PositionChildProps,
   PickerComponent,
-  listPickerPropTypes
+  listPickerPropTypes,
+  PickerToggleProps
 } from '../Picker';
 
 import Tag, { TagProps } from '../Tag';
@@ -83,7 +84,8 @@ interface InputItemDataType extends ItemDataType {
 export type ValueType = any;
 export interface InputPickerProps<T = ValueType>
   extends FormControlPickerProps<T, InputPickerLocale, InputItemDataType>,
-    SelectProps<T> {
+    SelectProps<T>,
+    Pick<PickerToggleProps, 'caretAs'> {
   tabIndex?: number;
 
   /** Settings can create new options */

--- a/src/InputPicker/test/InputPicker.test.tsx
+++ b/src/InputPicker/test/InputPicker.test.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import InputPicker from '../InputPicker';
+
+<InputPicker caretAs={() => <div />} data={[]} />;

--- a/src/SelectPicker/SelectPicker.tsx
+++ b/src/SelectPicker/SelectPicker.tsx
@@ -102,7 +102,7 @@ export interface MultipleSelectProps<T> extends Omit<SelectProps<T>, 'renderValu
 export interface SelectPickerProps<T>
   extends FormControlPickerProps<T, PickerLocale, ItemDataType<T>>,
     SelectProps<T>,
-    Pick<PickerToggleProps, 'label'> {}
+    Pick<PickerToggleProps, 'caretAs' | 'label'> {}
 
 const emptyArray = [];
 

--- a/src/SelectPicker/test/SelectPicker.test.tsx
+++ b/src/SelectPicker/test/SelectPicker.test.tsx
@@ -52,3 +52,5 @@ type SortDirection = 'asc' | 'desc';
     expectType<SortDirection | null>(value);
   }}
 />;
+
+<SelectPicker caretAs={() => <div />} data={[]} />;

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -56,7 +56,8 @@ import {
   omitTriggerPropKeys,
   PositionChildProps,
   PickerComponent,
-  useToggleKeyDownEvent
+  useToggleKeyDownEvent,
+  PickerToggleProps
 } from '../Picker';
 
 import { TreeDragProps, TreeBaseProps, DropData } from '../Tree/Tree';
@@ -70,7 +71,8 @@ export const maxTreeHeight = 320;
 export interface TreePickerProps<T = number | string>
   extends TreeBaseProps<T, ItemDataType>,
     TreeDragProps,
-    FormControlPickerProps<T, PickerLocale, ItemDataType> {
+    FormControlPickerProps<T, PickerLocale, ItemDataType>,
+    Pick<PickerToggleProps, 'caretAs'> {
   /** The height of Dropdown */
   height?: number;
 

--- a/src/TreePicker/test/TreePicker.test.tsx
+++ b/src/TreePicker/test/TreePicker.test.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import TreePicker from '../TreePicker';
+
+<TreePicker caretAs={() => <div />} data={[]} />;


### PR DESCRIPTION
The `caretAs` prop is missing on the `SelectPickerProps`, because of this when you use the `SelectPicker` component in a TS project, it gives an error that `caretAs` is not a valid prop.

The docs specify the `SelectPicker` component admits the prop in question.

https://rsuitejs.com/components/select-picker/#props