### PR TITLE
fix(treelike): fix data item stringify throw error

### DIFF
--- a/src/Cascader/test/CascaderSpec.js
+++ b/src/Cascader/test/CascaderSpec.js
@@ -563,4 +563,24 @@ describe('Cascader', () => {
       expect(getByTestId('content')).to.have.text('Not selected');
     });
   });
+
+  it('Should item able to stringfy', () => {
+    const onSelectSpy = sinon.spy();
+    const renderMenuItemSpy = sinon.spy();
+
+    const instance = getInstance(
+      <Cascader
+        defaultOpen
+        data={items}
+        onSelect={onSelectSpy}
+        renderMenuItem={renderMenuItemSpy}
+      />
+    );
+    const checkbox = instance.overlay.querySelectorAll('.rs-picker-cascader-menu-item')[2];
+    ReactTestUtils.Simulate.click(checkbox);
+
+    assert.doesNotThrow(() => JSON.stringify(items[2]));
+    assert.doesNotThrow(() => JSON.stringify(onSelectSpy.firstCall.args[1]));
+    assert.doesNotThrow(() => JSON.stringify(renderMenuItemSpy.lastCall.args[1]));
+  });
 });

--- a/src/Cascader/utils.ts
+++ b/src/Cascader/utils.ts
@@ -4,6 +4,7 @@ import { shallowEqual, useUpdateEffect } from '../utils';
 import { CascaderProps } from './Cascader';
 import { ItemDataType } from '../@types/common';
 import { findNodeOfTree } from '../utils/treeUtils';
+import { attachParent } from '../utils/attachParent';
 
 export function getColumnsAndPaths<T extends ItemDataType>(data: T[], value, options) {
   const { childrenKey, valueKey, isAttachChildren } = options;
@@ -19,7 +20,7 @@ export function getColumnsAndPaths<T extends ItemDataType>(data: T[], value, opt
         const node = findNode(children);
 
         if (node) {
-          columns.push(children.map(item => ({ ...item, parent: items[i] })));
+          columns.push(children.map(item => attachParent(item, items[i])));
           paths.push(node.active);
 
           return { items, active: items[i] };

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -599,4 +599,23 @@ describe('CheckTreePicker', () => {
 
     assert.equal(checkItems.length, 1);
   });
+
+  it('Should item able to stringfy', () => {
+    const onSelectSpy = sinon.spy();
+    const renderTreeNodeSpy = sinon.spy();
+
+    const instance = getInstance(
+      <CheckTreePicker
+        defaultOpen
+        data={data}
+        onSelect={onSelectSpy}
+        renderTreeNode={renderTreeNodeSpy}
+      />
+    );
+    ReactTestUtils.Simulate.change(instance.overlay.querySelector('div[data-key="0-0"] input'));
+
+    assert.doesNotThrow(() => JSON.stringify(data[0]));
+    assert.doesNotThrow(() => JSON.stringify(onSelectSpy.firstCall.args[0]));
+    assert.doesNotThrow(() => JSON.stringify(renderTreeNodeSpy.firstCall.args[0]));
+  });
 });

--- a/src/CheckTreePicker/utils.ts
+++ b/src/CheckTreePicker/utils.ts
@@ -2,6 +2,7 @@ import { isNil, isUndefined } from 'lodash';
 import { CheckTreePickerProps } from './CheckTreePicker';
 import { shallowEqual, CHECK_STATE, CheckStateType } from '../utils';
 import { getChildrenByFlattenNodes } from '../utils/treeUtils';
+import { attachParent } from '../utils/attachParent';
 
 export interface TreeNodeType {
   uncheckable?: boolean;
@@ -128,7 +129,7 @@ export function getFormattedTree(
       formatted.check = curNode.check;
       formatted.expand = curNode.expand;
       formatted.uncheckable = curNode.uncheckable;
-      formatted.parent = curNode.parent;
+      attachParent(formatted, curNode.parent);
       formatted.checkState = checkState;
       if (node[childrenKey]?.length > 0) {
         formatted[childrenKey] = getFormattedTree(formatted[childrenKey], nodes, props);

--- a/src/MultiCascader/test/MultiCascaderSpec.js
+++ b/src/MultiCascader/test/MultiCascaderSpec.js
@@ -331,6 +331,26 @@ describe('MultiCascader', () => {
     assert.equal(onSelectSpy.firstCall.lastArg.target, checkbox);
   });
 
+  it('Should item able to stringfy', () => {
+    const onSelectSpy = sinon.spy();
+    const renderMenuItemSpy = sinon.spy();
+
+    const instance = getInstance(
+      <MultiCascader
+        defaultOpen
+        data={items}
+        onSelect={onSelectSpy}
+        renderMenuItem={renderMenuItemSpy}
+      />
+    );
+    const checkbox = instance.overlay.querySelectorAll('.rs-checkbox')[2];
+    ReactTestUtils.Simulate.click(checkbox);
+
+    assert.doesNotThrow(() => JSON.stringify(items[2]));
+    assert.doesNotThrow(() => JSON.stringify(onSelectSpy.firstCall.args[1]));
+    assert.doesNotThrow(() => JSON.stringify(renderMenuItemSpy.lastCall.args[1]));
+  });
+
   it('Should call onCheck callback ', () => {
     const onCheckSpy = sinon.spy();
     const instance = getInstance(<MultiCascader data={items} defaultOpen onCheck={onCheckSpy} />);

--- a/src/MultiCascader/utils.ts
+++ b/src/MultiCascader/utils.ts
@@ -5,6 +5,7 @@ import slice from 'lodash/slice';
 import { MultiCascaderProps, ValueType } from './MultiCascader';
 import { ItemDataType } from '../@types/common';
 import { flattenTree } from '../utils/treeUtils';
+import { attachParent } from '../utils/attachParent';
 
 export interface ItemType extends ItemDataType {
   parent?: ItemType;
@@ -171,8 +172,7 @@ export function useFlattenData(data: ItemDataType[], itemKeys: ItemKeys) {
   const addFlattenData = useCallback(
     (children: ItemDataType[], parent: ItemDataType) => {
       const nodes = children.map(child => {
-        child.parent = parent;
-        return child;
+        return attachParent(child, parent);
       });
 
       parent[childrenKey] = nodes;

--- a/src/TreePicker/test/TreePickerSpec.js
+++ b/src/TreePicker/test/TreePickerSpec.js
@@ -537,4 +537,23 @@ describe('TreePicker', () => {
     ref.current.list.scrollToRow(2);
     assert.isTrue(onScrollSpy.calledOnce);
   });
+
+  it('Should item able to stringfy', () => {
+    const onSelectSpy = sinon.spy();
+    const renderTreeNodeSpy = sinon.spy();
+
+    const instance = getInstance(
+      <TreePicker
+        defaultOpen
+        data={data}
+        onSelect={onSelectSpy}
+        renderTreeNode={renderTreeNodeSpy}
+      />
+    );
+    Simulate.click(instance.overlay.querySelector('span[data-key="0-0"]'));
+
+    assert.doesNotThrow(() => JSON.stringify(data[0]));
+    assert.doesNotThrow(() => JSON.stringify(onSelectSpy.firstCall.args[0]));
+    assert.doesNotThrow(() => JSON.stringify(renderTreeNodeSpy.firstCall.args[0]));
+  });
 });

--- a/src/utils/attachParent.ts
+++ b/src/utils/attachParent.ts
@@ -1,0 +1,10 @@
+export function attachParent<T>(data: T, parent: T): T {
+  // mark "parent" unenumable
+  Object.defineProperty(data, 'parent', {
+    value: parent,
+    writable: false,
+    enumerable: false,
+    configurable: true
+  });
+  return data;
+}

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -10,6 +10,7 @@ import { shouldDisplay } from '../Picker';
 import reactToString from './reactToString';
 import { ListInstance } from '../Picker/VirtualizedList';
 import { TREE_NODE_PADDING, TREE_NODE_ROOT_PADDING } from './constants';
+import { attachParent } from './attachParent';
 
 type PartialTreeProps = Partial<TreePickerProps | CheckTreePickerProps>;
 
@@ -51,9 +52,8 @@ export function flattenTree(
 
     data.forEach((item: any, index: number) => {
       const node: any = typeof executor === 'function' ? executor(item, index) : item;
-      node.parent = parent;
 
-      flattenData.push({ ...node });
+      flattenData.push(attachParent(node, parent));
 
       if (item[childrenKey]) {
         traverse(item[childrenKey], item);


### PR DESCRIPTION
## TypeError: Converting circular structure to JSON
![截屏2022-07-20 下午3 38 13](https://user-images.githubusercontent.com/14308293/179924830-ccc91296-1ebe-48e6-8c1b-083c82be2513.png)
### Affectd Component

- [x] Cascader
- [x] MultiCascader
- [x] TreePicker
- [x] CheckTreePicker

### Reason
during render, each data item will be add a `parent` props, which has a children collection includes current item, cause a circular reference
```ts
const parent = {
  name: 'parent',
  children: [{
    name: 'child-1',
  },{
    name: 'child-2',
  }]
}

parent.children.forEach(child => {
  child.parent = parent;
})
```

### Solution
[JSON.stringify][1] only serialized enumerable properties. using [Object.defineProperty][2] mark `parent` as `enumerable: false`.

```js
const parent = {
  name: 'parent',
  children: [{
    name: 'child-1',
  },{
    name: 'child-2',
  }]
}

parent.children.forEach(child => {
  Object.defineProperty(child, 'parent', {
    value: parent,
    writable: false,
    enumerable: false,
    configurable: true
  })
})
```


[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description
[2]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty