### PR TITLE
fix(Panel): allow custom header in collapsible panels

### DIFF
--- a/src/Panel/Panel.tsx
+++ b/src/Panel/Panel.tsx
@@ -146,22 +146,18 @@ const Panel: RsRefForwardingComponent<'div', PanelProps> = React.forwardRef(
       if (!header) {
         return null;
       }
-      let content: React.ReactNode;
+
+      let panelTitleElement: React.ReactNode;
 
       if (!React.isValidElement(header) || Array.isArray(header)) {
-        content = collapsible ? (
-          <>
-            <AngleDownIcon rotate={expanded ? 180 : 0} />
-            <span className={prefix('title')} role="presentation">
-              <span className={expanded ? undefined : 'collapsed'}>{header}</span>
-            </span>
-          </>
-        ) : (
-          header
+        panelTitleElement = (
+          <span className={prefix('title')} role="presentation">
+            <span className={expanded ? undefined : 'collapsed'}>{header}</span>
+          </span>
         );
       } else {
         const className = merge(prefix('title'), get(header, 'props.className'));
-        content = React.cloneElement<any>(header, { className });
+        panelTitleElement = React.cloneElement<any>(header, { className });
       }
 
       return (
@@ -173,7 +169,8 @@ const Panel: RsRefForwardingComponent<'div', PanelProps> = React.forwardRef(
           onClick={collapsible ? handleSelect : undefined}
           tabIndex={-1}
         >
-          {content}
+          {panelTitleElement}
+          {collapsible && <AngleDownIcon rotate={expanded ? 180 : 0} data-testid="caret icon" />}
         </div>
       );
     };

--- a/src/Panel/test/PanelSpec.js
+++ b/src/Panel/test/PanelSpec.js
@@ -70,6 +70,16 @@ describe('Panel', () => {
       userEvent.click(getByText('abc'));
       expect(onSelectSpy).to.have.been.calledWith(undefined);
     });
+
+    it('Should not hide caret icon when header prop is passed an element', () => {
+      render(
+        <Panel header={<span>Panel title</span>} bordered collapsible>
+          Panel content
+        </Panel>
+      );
+
+      expect(screen.getByTestId('caret icon')).to.exist;
+    });
   });
 
   it('Should pass transition callbacks to Collapse', async () => {

--- a/src/Panel/test/PanelSpec.js
+++ b/src/Panel/test/PanelSpec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-import { render } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getDOMNode } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
@@ -72,39 +72,38 @@ describe('Panel', () => {
     });
   });
 
-  it('Should pass transition callbacks to Collapse', done => {
-    let count = 0;
-    const increment = () => {
-      count += 1;
-    };
-    const ref = React.createRef();
-    let title;
+  it('Should pass transition callbacks to Collapse', async () => {
+    const onEnter = sinon.spy();
+    const onEntering = sinon.spy();
+    const onEntered = sinon.spy();
+    const onExit = sinon.spy();
+    const onExiting = sinon.spy();
+    const onExited = sinon.spy();
+
     render(
       <Panel
         collapsible
         defaultExpanded={false}
         header="Click me"
-        onExit={increment}
-        onExiting={increment}
-        onExited={() => {
-          increment();
-          if (count === 6) {
-            done();
-          }
-        }}
-        onEnter={increment}
-        onEntering={increment}
-        onEntered={() => {
-          increment();
-          ReactTestUtils.Simulate.click(title.firstChild);
-        }}
-        ref={ref}
+        onEnter={onEnter}
+        onEntering={onEntering}
+        onEntered={onEntered}
+        onExit={onExit}
+        onExiting={onExiting}
+        onExited={onExited}
       >
         Panel content
       </Panel>
     );
 
-    title = ref.current.querySelector('.rs-panel-title');
-    ReactTestUtils.Simulate.click(title.firstChild);
+    userEvent.click(screen.getByText('Click me'));
+    await waitFor(() => expect(onEnter).to.have.been.called);
+    await waitFor(() => expect(onEntering).to.have.been.called);
+    await waitFor(() => expect(onEntered).to.have.been.called);
+
+    userEvent.click(screen.getByText('Click me'));
+    await waitFor(() => expect(onExit).to.have.been.called);
+    await waitFor(() => expect(onExiting).to.have.been.called);
+    await waitFor(() => expect(onExited).to.have.been.called);
   });
 });


### PR DESCRIPTION
### The issue

When passing an element as Panel's `header`, the caret icon disappears in a collapsible panel.

<img width="771" alt="image" src="https://user-images.githubusercontent.com/8225666/180757294-66134b35-b6f4-49c2-bd50-8f706ee71d50.png">

```jsx
<Panel header={<span>Panel title</span>} bordered collapsible>
  Panel content
</Panel>
```

### This fix
Same JSX results in

<img width="767" alt="image" src="https://user-images.githubusercontent.com/8225666/180918646-a4a63d18-6b16-490a-aef7-8f1400a983b8.png">

Note the caret icon displayed on the right-hand side.