### PR TITLE
fix(DateRangePicker): improved experience for date range selection

### DIFF
--- a/src/DateRangePicker/Calendar.tsx
+++ b/src/DateRangePicker/Calendar.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useCallback, useState } from 'react';
-import { addMonths, isAfter, isSameMonth, setDate } from '../utils/dateUtils';
+import { addMonths, isSameMonth } from '../utils/dateUtils';
 import CalendarCore, {
   CalendarProps as CalendarCoreProps,
   CalendarState
@@ -18,14 +18,6 @@ type OmitCalendarCoreTypes =
   | 'format'
   | 'locale'
   | 'onToggleMeridian';
-
-/**
- * Omit the time in the date, which is used to compare and judge the date.
- * eg: isAfter/isBefore
- */
-function omitTime(date: Date) {
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
-}
 
 export interface CalendarProps extends WithAsProps, Omit<CalendarCoreProps, OmitCalendarCoreTypes> {
   calendarDate?: DateRange;
@@ -45,7 +37,6 @@ export interface CalendarProps extends WithAsProps, Omit<CalendarCoreProps, Omit
   onToggleMeridian: (index: number, event: React.MouseEvent) => void;
   onMouseMove?: (date: Date) => void;
   onSelect?: (date: Date, event: React.SyntheticEvent) => void;
-  showOneCalendar?: boolean;
   showWeekNumbers?: boolean;
   value?: [] | [Date] | [Date, Date];
 }
@@ -62,7 +53,6 @@ const Calendar: RsRefForwardingComponent<'div', CalendarProps> = React.forwardRe
       onChangeCalendarDate,
       onChangeCalendarTime,
       onToggleMeridian,
-      showOneCalendar,
       value = [],
       ...rest
     } = props;
@@ -131,37 +121,6 @@ const Calendar: RsRefForwardingComponent<'div', CalendarProps> = React.forwardRe
       onMoveBackward?.(addMonths(getCalendarDate(), -1));
     }, [getCalendarDate, onMoveBackward]);
 
-    const disabledBackward = useCallback(() => {
-      // Do not disable the Backward button on the first calendar.
-      if (index === 0) {
-        return false;
-      }
-
-      const startDate = setDate(addMonths(calendarDate[0], 1), 1);
-      const endDate = setDate(omitTime(calendarDate[1]), 1);
-      const after = isAfter(endDate, startDate);
-
-      return !after;
-    }, [calendarDate, index]);
-
-    const disabledForward = useCallback(() => {
-      // If only one calendar is displayed, do not disable
-      if (showOneCalendar) {
-        return false;
-      }
-
-      // Do not disable the Forward button on the second calendar.
-      if (index === 1) {
-        return false;
-      }
-
-      const startDate = setDate(addMonths(omitTime(calendarDate[0]), 1), 1);
-      const endDate = setDate(omitTime(calendarDate[1]), 1);
-      const after = isAfter(endDate, startDate);
-
-      return !after;
-    }, [calendarDate, index, showOneCalendar]);
-
     const disabledMonth = useCallback(
       (date: Date) => disabledDate?.(date, value, DATERANGE_DISABLED_TARGET.CALENDAR),
       [disabledDate, value]
@@ -173,9 +132,7 @@ const Calendar: RsRefForwardingComponent<'div', CalendarProps> = React.forwardRe
         format={format}
         calendarState={calendarState}
         dateRange={value}
-        disabledBackward={disabledBackward()}
         disabledDate={disabledMonth}
-        disabledForward={disabledForward()}
         inSameMonth={inSameMonth}
         index={index}
         limitEndYear={limitEndYear}

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -224,9 +224,12 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
    * Call this function to update the calendar panel rendering benchmark value.
    * If params `value` is not passed, it defaults to [new Date(), addMonth(new Date(), 1)].
    */
-  const updateCalendarDate = useCallback((value: SelectedDatesState | null) => {
-    setCalendarDate(getCalendarDate({ value }));
-  }, []);
+  const updateCalendarDateRange = useCallback(
+    (value: SelectedDatesState | null, calendarKey?: 'start' | 'end') => {
+      setCalendarDate(getCalendarDate({ value, calendarKey }));
+    },
+    []
+  );
 
   // if valueProp changed then update selectValue/hoverValue
   useEffect(() => {
@@ -426,7 +429,7 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
           : [nextSelectDates[0] as Date, nextSelectDates[0] as Date]
       );
       setSelectedDates(nextSelectDates);
-      updateCalendarDate(nextSelectDates);
+      updateCalendarDateRange(nextSelectDates);
       onSelect?.(date, event);
       hasDoneSelect.current = !hasDoneSelect.current;
     },
@@ -437,7 +440,7 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
       onSelect,
       oneTap,
       selectedDates,
-      updateCalendarDate
+      updateCalendarDateRange
     ]
   );
 
@@ -453,16 +456,17 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
     doneSelected && setHoverDateRange(null);
   }, [selectedDates]);
 
-  const handleChangeCalendarDate = useCallback(
+  const updateSingleCalendarDate = useCallback(
     (index: number, date: Date) => {
       const nextCalendarDate = Array.from(calendarDate);
       nextCalendarDate[index] = date;
-      updateCalendarDate(nextCalendarDate as DateRange);
+
+      updateCalendarDateRange(nextCalendarDate as DateRange, index === 0 ? 'start' : 'end');
     },
-    [calendarDate, updateCalendarDate]
+    [calendarDate, updateCalendarDateRange]
   );
 
-  const handleChangeCalendarTime = useCallback(
+  const updateSingleCalendarTime = useCallback(
     (index: number, date: Date) => {
       setSelectedDates(prev => {
         const next: SelectedDatesState = [...prev];
@@ -481,9 +485,9 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
 
         return next;
       });
-      handleChangeCalendarDate(index, date);
+      updateSingleCalendarDate(index, date);
     },
-    [handleChangeCalendarDate]
+    [updateSingleCalendarDate]
   );
 
   /**
@@ -532,10 +536,10 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
 
   const handleClean = useCallback(
     (event: React.MouseEvent) => {
-      updateCalendarDate(null);
+      updateCalendarDateRange(null);
       handleValueUpdate(event, null);
     },
-    [handleValueUpdate, updateCalendarDate]
+    [handleValueUpdate, updateCalendarDateRange]
   );
 
   /**
@@ -573,10 +577,10 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
 
       setHoverDateRange(selectValue);
       setSelectedDates(selectValue);
-      updateCalendarDate(selectValue);
+      updateCalendarDateRange(selectValue);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [character, rangeFormatStr, updateCalendarDate]
+    [character, rangeFormatStr, updateCalendarDateRange]
   );
 
   /**
@@ -608,8 +612,8 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
     }
 
     setSelectedDates(value ?? []);
-    updateCalendarDate(nextCalendarDate);
-  }, [defaultCalendarValue, updateCalendarDate, setSelectedDates, value]);
+    updateCalendarDateRange(nextCalendarDate);
+  }, [defaultCalendarValue, updateCalendarDateRange, setSelectedDates, value]);
 
   const handleEntered = useCallback(() => {
     onOpen?.();
@@ -696,7 +700,7 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
     });
     const styles = { ...menuStyle, left, top };
 
-    const panelProps = {
+    const calendarProps = {
       calendarDate,
       disabledDate: handleDisabledDate,
       format: formatStr,
@@ -704,12 +708,11 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
       isoWeek,
       limitEndYear,
       locale,
-      showOneCalendar,
       showWeekNumbers,
       value: selectedDates,
       showMeridian,
-      onChangeCalendarDate: handleChangeCalendarDate,
-      onChangeCalendarTime: handleChangeCalendarTime,
+      onChangeCalendarDate: updateSingleCalendarDate,
+      onChangeCalendarTime: updateSingleCalendarTime,
       onMouseMove: handleMouseMove,
       onSelect: handleSelectDate,
       onToggleMeridian: handleToggleMeridian,
@@ -727,8 +730,8 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
           <div className={prefix('daterange-content')}>
             <div className={prefix('daterange-header')}>{getDisplayString(selectedDates)}</div>
             <div className={prefix(`daterange-calendar-${showOneCalendar ? 'single' : 'group'}`)}>
-              <Calendar index={0} {...panelProps} />
-              {!showOneCalendar && <Calendar index={1} {...panelProps} />}
+              <Calendar index={0} {...calendarProps} />
+              {!showOneCalendar && <Calendar index={1} {...calendarProps} />}
             </div>
           </div>
           <Toolbar<SelectedDatesState, DateRange>

--- a/src/DateRangePicker/test/utilsSpec.js
+++ b/src/DateRangePicker/test/utilsSpec.js
@@ -1,0 +1,48 @@
+import { getCalendarDate } from '../utils';
+import { isSameMonth, getMonth } from '../../utils/dateUtils';
+
+describe('DateRangePicker - utils - getCalendarDate', () => {
+  it('Should not be a date range of the same month', () => {
+    const value = [new Date(), new Date()];
+    const rangeDate = getCalendarDate({ value });
+
+    expect(isSameMonth(value[0], value[1])).to.be.true;
+    expect(isSameMonth(rangeDate[0], rangeDate[1])).to.be.false;
+  });
+
+  it('Should end date plus one month', () => {
+    const value = [new Date(), new Date()];
+    const rangeDate = getCalendarDate({ value, calendarKey: 'start' });
+
+    expect(getMonth(value[0])).to.be.equal(getMonth(rangeDate[0]));
+    expect(getMonth(value[1])).to.not.be.equal(getMonth(rangeDate[1]));
+    expect(getMonth(rangeDate[1]) - getMonth(rangeDate[0])).to.be.equal(1);
+  });
+
+  it('Should start date minus one month', () => {
+    const value = [new Date(), new Date()];
+    const rangeDate = getCalendarDate({ value, calendarKey: 'end' });
+
+    expect(getMonth(value[0])).to.not.be.equal(getMonth(rangeDate[0]));
+    expect(getMonth(value[1])).to.be.equal(getMonth(rangeDate[1]));
+    expect(getMonth(rangeDate[1]) - getMonth(rangeDate[0])).to.be.equal(1);
+  });
+
+  it('Should be create end date from start date', () => {
+    const value = [new Date()];
+    const rangeDate = getCalendarDate({ value });
+
+    expect(rangeDate[0]).to.instanceOf(Date);
+    expect(rangeDate[1]).to.instanceOf(Date);
+    expect(getMonth(rangeDate[1]) - getMonth(rangeDate[0])).to.be.equal(1);
+  });
+
+  it('Should create start and end dates by default', () => {
+    const value = [];
+    const rangeDate = getCalendarDate({ value });
+
+    expect(rangeDate[0]).to.instanceOf(Date);
+    expect(rangeDate[1]).to.instanceOf(Date);
+    expect(getMonth(rangeDate[1]) - getMonth(rangeDate[0])).to.be.equal(1);
+  });
+});

--- a/src/DateRangePicker/utils.ts
+++ b/src/DateRangePicker/utils.ts
@@ -5,15 +5,24 @@ export const setTimingMargin = (date, way = 'left'): Date =>
   way === 'right' ? DateUtils.endOfDay(date) : DateUtils.startOfDay(date);
 
 export function getCalendarDate({
-  value
+  value,
+  calendarKey = 'start'
 }: {
   value: [] | [Date] | [Date, Date] | null;
+  calendarKey?: 'start' | 'end';
 }): DateRange {
   // Update calendarDate if the value is not null
   value = value ?? [];
+
   if (value[0] && value[1]) {
-    const sameMonth = DateUtils.isSameMonth(value[0], value[1]);
-    return [value[0], sameMonth ? DateUtils.addMonths(value[1], 1) : value[1]];
+    const startMonth = DateUtils.getMonth(value[0]);
+    const endMonth = DateUtils.getMonth(value[1]);
+
+    if (calendarKey === 'start') {
+      return [value[0], startMonth >= endMonth ? DateUtils.addMonths(value[0], 1) : value[1]];
+    } else if (calendarKey === 'end') {
+      return [startMonth >= endMonth ? DateUtils.addMonths(value[1], -1) : value[0], value[1]];
+    }
 
     // If only the start date
   } else if (value[0]) {


### PR DESCRIPTION
There is currently a limitation in the calendar. The start date and the end date cannot be the same month, which will result in no way to turn to the next month when selecting the start date, and the month of the end date must be changed. This experience can be confusing to users, so this restriction is lifted.

When the start month and end month are the same month, the other calendar will automatically update to the adjacent month.

Before

https://user-images.githubusercontent.com/1203827/181158188-17508a12-7645-4f24-b3b7-077e25c3ea81.mp4

After

https://user-images.githubusercontent.com/1203827/181158369-52ce1be1-4918-42f6-ba87-521dbe07f8d0.mp4


