### PR TITLE
Fix/CheckTreePicker children cant remove after parent be selected

### DIFF
--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -706,7 +706,7 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
         {
           ...node,
           /**
-           * spread operator dont copy enumerable properties
+           * spread operator dont copy unenumerable properties
            * so we need to copy them manually
            */
           parent: node.parent,

--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -702,7 +702,18 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
         ? !!children
         : hasVisibleChildren(node, childrenKey);
     const nodeProps = {
-      ...getTreeNodeProps({ ...node, expand }, layer),
+      ...getTreeNodeProps(
+        {
+          ...node,
+          /**
+           * spread operator dont copy enumerable properties
+           * so we need to copy them manually
+           */
+          parent: node.parent,
+          expand
+        },
+        layer
+      ),
       hasChildren: visibleChildren
     };
 

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -618,4 +618,18 @@ describe('CheckTreePicker', () => {
     assert.doesNotThrow(() => JSON.stringify(onSelectSpy.firstCall.args[0]));
     assert.doesNotThrow(() => JSON.stringify(renderTreeNodeSpy.firstCall.args[0]));
   });
+
+  it('Should children can be removed', () => {
+    const onChangeSpy = sinon.spy();
+    const instance = getInstance(
+      <CheckTreePicker defaultOpen data={data} onChange={onChangeSpy} />
+    );
+
+    ReactTestUtils.Simulate.change(instance.overlay.querySelector('div[data-key="0-0"] input'));
+    ReactTestUtils.Simulate.change(instance.overlay.querySelector('div[data-key="0-0-0"] input'));
+
+    expect(onChangeSpy.callCount).to.equal(2);
+    expect(onChangeSpy.firstCall.args[0]).to.include('Master');
+    expect(onChangeSpy.secondCall.args[0]).to.include('tester1');
+  });
 });

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode, getInstance } from '@test/testUtils';
 import CheckTreePicker from '../CheckTreePicker';
@@ -621,12 +621,19 @@ describe('CheckTreePicker', () => {
 
   it('Should children can be removed', () => {
     const onChangeSpy = sinon.spy();
-    const instance = getInstance(
-      <CheckTreePicker defaultOpen data={data} onChange={onChangeSpy} />
-    );
+    const screen = render(<CheckTreePicker defaultOpen data={data} onChange={onChangeSpy} />);
 
-    ReactTestUtils.Simulate.change(instance.overlay.querySelector('div[data-key="0-0"] input'));
-    ReactTestUtils.Simulate.change(instance.overlay.querySelector('div[data-key="0-0-0"] input'));
+    fireEvent.click(screen.getByText('Master'), {
+      target: {
+        checked: true
+      }
+    });
+
+    fireEvent.click(screen.getByText('tester0'), {
+      target: {
+        checked: false
+      }
+    });
 
     expect(onChangeSpy.callCount).to.equal(2);
     expect(onChangeSpy.firstCall.args[0]).to.include('Master');


### PR DESCRIPTION
## Bug

https://user-images.githubusercontent.com/1203827/181491497-67cf958f-c303-4467-9c10-7103973da9ea.mp4

## Cause
CheckTreeNode's `nodeData` is missing `parent` property because Spread Operator only copies enumerable properties
```ts
getTreeNodeProps({ ...node, expand}, layer),
```
`parent` marked as unenumerable(#2606)



## Fix
copy `parent` manually 
```ts
getTreeNodeProps({ ...node,  parent: node.parent,  expand}, layer),
```