### PR TITLE
fix(DatePicker): fix issues with focus event

### DIFF
--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -576,7 +576,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
             as={toggleAs}
             ref={targetRef}
             appearance={appearance}
-            input
+            editable
             inputValue={value ? formatDate(value, formatStr) : ''}
             inputPlaceholder={
               typeof placeholder === 'string' && placeholder ? placeholder : formatStr

--- a/src/DatePicker/test/DatePickerSpec.js
+++ b/src/DatePicker/test/DatePickerSpec.js
@@ -467,6 +467,8 @@ describe('DatePicker', () => {
       fireEvent.focus(input);
     });
 
+    console.log('onFocusSpy: ', onFocusSpy.args[0][0].target);
+
     expect(onFocusSpy).to.have.been.calledOnce;
     expect(getByRole('combobox')).to.have.class('rs-picker-toggle-active');
   });

--- a/src/DatePicker/test/DatePickerSpec.js
+++ b/src/DatePicker/test/DatePickerSpec.js
@@ -467,8 +467,6 @@ describe('DatePicker', () => {
       fireEvent.focus(input);
     });
 
-    console.log('onFocusSpy: ', onFocusSpy.args[0][0].target);
-
     expect(onFocusSpy).to.have.been.calledOnce;
     expect(getByRole('combobox')).to.have.class('rs-picker-toggle-active');
   });
@@ -642,5 +640,23 @@ describe('DatePicker', () => {
 
       expect(getByLabelText('gear')).to.have.class('rs-icon');
     });
+  });
+
+  it('Should switch to the previous or next element via the tab key', () => {
+    render(
+      <>
+        <DatePicker data-testid="picker-1" value={new Date('2022-01-01')} />
+        <DatePicker data-testid="picker-2" value={new Date('2022-01-02')} />
+      </>
+    );
+
+    userEvent.tab();
+    expect(document.activeElement).to.value('2022-01-01');
+
+    userEvent.tab();
+    expect(document.activeElement).to.value('2022-01-02');
+
+    userEvent.tab({ shift: true });
+    expect(document.activeElement).to.value('2022-01-01');
   });
 });

--- a/src/DatePicker/test/DatePickerSpec.js
+++ b/src/DatePicker/test/DatePickerSpec.js
@@ -240,13 +240,8 @@ describe('DatePicker', () => {
     const onCleanSpy = sinon.spy();
     const { getByRole } = render(<DatePicker defaultValue={new Date()} onClean={onCleanSpy} />);
 
-    act(() => {
-      fireEvent.focus(getByRole('combobox'));
-    });
-
-    act(() => {
-      fireEvent.click(getByRole('button', { name: /clear/i }));
-    });
+    fireEvent.focus(getByRole('combobox'));
+    fireEvent.click(getByRole('button', { name: /clear/i }));
 
     expect(onCleanSpy).to.calledOnce;
     expect(getByRole('combobox')).to.have.class('rs-picker-toggle-active');
@@ -463,9 +458,7 @@ describe('DatePicker', () => {
     const { getByRole } = render(<DatePicker onFocus={onFocusSpy} defaultValue={new Date()} />);
     const input = getByRole('combobox').querySelector('input');
 
-    act(() => {
-      fireEvent.focus(input);
-    });
+    fireEvent.focus(input);
 
     expect(onFocusSpy).to.have.been.calledOnce;
     expect(getByRole('combobox')).to.have.class('rs-picker-toggle-active');

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -785,7 +785,7 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
           as={toggleAs}
           ref={targetRef}
           appearance={appearance}
-          input
+          editable
           inputMask={DateUtils.getDateMask(rangeFormatStr)}
           inputValue={value ? (getDisplayString(value, true) as string) : ''}
           inputPlaceholder={

--- a/src/DateRangePicker/test/DateRangePickerSpec.js
+++ b/src/DateRangePicker/test/DateRangePickerSpec.js
@@ -1,6 +1,6 @@
 import { getDOMNode, getInstance } from '@test/testUtils';
 import React from 'react';
-import { render, act, waitFor } from '@testing-library/react';
+import { render, act, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ReactTestUtils from 'react-dom/test-utils';
 import {
@@ -716,5 +716,15 @@ describe('DateRangePicker', () => {
       expect(onChangeSpy).to.calledOnce;
       expect(onCloseSpy).to.not.called;
     });
+  });
+
+  it('Should call onFocus callback', () => {
+    const onFocusSpy = sinon.spy();
+    const { getByRole } = render(<DateRangePicker onFocus={onFocusSpy} />);
+    const input = getByRole('combobox').querySelector('input');
+
+    fireEvent.focus(input);
+
+    expect(onFocusSpy).to.have.been.calledOnce;
   });
 });

--- a/src/Picker/PickerToggle.tsx
+++ b/src/Picker/PickerToggle.tsx
@@ -62,11 +62,11 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
       readOnly,
       plaintext,
       hasValue,
+      editable,
       cleanable: cleanableProp,
-      tabIndex = 0,
+      tabIndex: tabIndexProp = editable ? -1 : 0,
       id,
       value,
-      editable,
       inputPlaceholder,
       inputValue: inputValueProp,
       inputMask = defaultInputMask,
@@ -119,8 +119,7 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
           }
 
           // Force the input to be focused and editable.
-          if (document.activeElement !== inputRef.current) {
-            // TODO: Please fix `Shift + Tab` not focusing the previous focusable element.
+          if (document.activeElement === comboboxRef.current) {
             inputRef.current?.focus();
           }
         } else {
@@ -207,6 +206,8 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
     // When the component is read-only or disabled, the input is not interactive.
     const inputFocused = readOnly || disabled ? false : editable && activeState;
 
+    const tabIndex = disabled ? undefined : tabIndexProp;
+
     return (
       <Component
         role="combobox"
@@ -217,7 +218,7 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
         {...rest}
         ref={mergeRefs(comboboxRef, ref)}
         disabled={disabled}
-        tabIndex={disabled ? undefined : tabIndex}
+        tabIndex={tabIndex}
         className={classes}
         onFocus={!disabled ? handleFocus : null}
         // The debounce is set to 200 to solve the flicker caused by the switch between input and div.
@@ -235,7 +236,7 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
           readOnly={!inputFocused}
           disabled={disabled}
           aria-controls={id ? `${id}-listbox` : undefined}
-          tabIndex={-1}
+          tabIndex={editable ? 0 : -1}
           className={prefix('textbox', { 'read-only': !inputFocused })}
           placeholder={inputPlaceholder}
           render={renderInput}

--- a/src/Picker/PickerToggle.tsx
+++ b/src/Picker/PickerToggle.tsx
@@ -25,7 +25,9 @@ export interface PickerToggleProps extends ToggleButtonProps {
   readOnly?: boolean;
   plaintext?: boolean;
   tabIndex?: number;
-  input?: boolean;
+
+  // Renders an input and is editable
+  editable?: boolean;
   inputPlaceholder?: string;
   inputMask?: (string | RegExp)[];
   onInputChange?: (value: string, event: React.ChangeEvent) => void;
@@ -64,7 +66,7 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
       tabIndex = 0,
       id,
       value,
-      input,
+      editable,
       inputPlaceholder,
       inputValue: inputValueProp,
       inputMask = defaultInputMask,
@@ -83,6 +85,7 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
     } = props;
 
     const inputRef = useRef<HTMLInputElement>(null);
+    const comboboxRef = useRef<HTMLDivElement>(null);
     const [activeState, setActive] = useState(false);
     const { withClassPrefix, merge, prefix } = useClassNames(classPrefix);
     const getInputValue = useCallback(
@@ -97,8 +100,10 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
     const [inputValue, setInputValue] = useState(getInputValue);
 
     useEffect(() => {
-      const value = getInputValue();
-      setInputValue(value);
+      if (comboboxRef.current) {
+        const value = getInputValue();
+        setInputValue(value);
+      }
     }, [getInputValue]);
 
     const classes = merge(className, withClassPrefix({ active: activeProp || activeState }));
@@ -106,23 +111,39 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
     const handleFocus = useCallback(
       (event: React.FocusEvent<HTMLElement>) => {
         setActive(true);
-        onFocus?.(event);
-        if (input) {
-          inputRef.current?.focus();
+
+        if (editable) {
+          // Avoid firing the onFocus event twice when DatePicker and DateRangePicker allow keyboard input.
+          if (event.target === inputRef.current) {
+            onFocus?.(event);
+          }
+
+          // Force the input to be focused and editable.
+          if (document.activeElement !== inputRef.current) {
+            // TODO: Please fix `Shift + Tab` not focusing the previous focusable element.
+            inputRef.current?.focus();
+          }
+        } else {
+          onFocus?.(event);
         }
       },
-      [input, onFocus]
+      [editable, onFocus]
     );
 
     const handleBlur = useCallback(
       (event: React.FocusEvent<HTMLElement>) => {
-        if (inputRef.current && document.activeElement !== inputRef.current) {
+        if (inputRef.current && !editable) {
           setActive(false);
-          inputRef.current.blur();
         }
+
+        // When activeElement is an input, it remains active.
+        if (editable && inputRef.current && document.activeElement !== inputRef.current) {
+          setActive(false);
+        }
+
         onBlur?.(event);
       },
-      [onBlur]
+      [editable, onBlur]
     );
 
     const handleInputBlur = (event: React.FocusEvent<HTMLElement>) => {
@@ -134,9 +155,11 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
       (event: React.MouseEvent<HTMLSpanElement>) => {
         event.stopPropagation();
         onClean?.(event);
-        setActive(false);
+
+        // When the value is cleared, the current component is still in focus.
+        editable ? inputRef.current?.focus() : comboboxRef.current?.focus();
       },
-      [onClean]
+      [editable, onClean]
     );
 
     const handleInputChange = useCallback(
@@ -150,11 +173,22 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
 
     const handleInputKeyDown = useCallback(
       (event: React.KeyboardEvent<HTMLInputElement>) => {
-        if (input && event.key === KEY_VALUES.ENTER) {
+        if (editable && event.key === KEY_VALUES.ENTER) {
           onInputPressEnter?.(event);
         }
       },
-      [onInputPressEnter, input]
+      [onInputPressEnter, editable]
+    );
+
+    const renderInput = useCallback(
+      (ref, props) => (
+        <input
+          ref={mergeRefs(inputRef, ref)}
+          style={{ pointerEvents: editable ? undefined : 'none' }}
+          {...props}
+        />
+      ),
+      [editable]
     );
 
     const ToggleCaret = useToggleCaret(placement);
@@ -171,7 +205,7 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
     const showCleanButton = cleanableProp && hasValue && !readOnly;
 
     // When the component is read-only or disabled, the input is not interactive.
-    const inputFocused = readOnly || disabled ? false : input && activeState;
+    const inputFocused = readOnly || disabled ? false : editable && activeState;
 
     return (
       <Component
@@ -181,7 +215,7 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
         aria-disabled={disabled}
         aria-owns={id ? `${id}-listbox` : undefined}
         {...rest}
-        ref={ref}
+        ref={mergeRefs(comboboxRef, ref)}
         disabled={disabled}
         tabIndex={disabled ? undefined : tabIndex}
         className={classes}
@@ -204,7 +238,7 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
           tabIndex={-1}
           className={prefix('textbox', { 'read-only': !inputFocused })}
           placeholder={inputPlaceholder}
-          render={(ref, props) => <input ref={mergeRefs(inputRef, ref)} {...props} />}
+          render={renderInput}
         />
         {children ? (
           <span

--- a/src/Picker/styles/index.less
+++ b/src/Picker/styles/index.less
@@ -120,7 +120,6 @@
 
   &-read-only {
     opacity: 0;
-    pointer-events: none;
   }
 }
 

--- a/src/Picker/styles/index.less
+++ b/src/Picker/styles/index.less
@@ -104,6 +104,7 @@
     padding-right: 32px;
     color: var(--rs-text-primary);
     background-color: var(--rs-input-bg);
+    outline: none;
   }
 
   &.rs-btn-lg &-textbox {


### PR DESCRIPTION
### fix: https://github.com/rsuite/rsuite/issues/2625
fix not opening calendar picker when focused
- Contains components: DatePicker, DateRangePicker
- Browser:  Firefox

### fix: https://github.com/rsuite/rsuite/discussions/2607 
The onFocus event will be triggered twice on click.


### fix a11y
fix not switching the previous element when pressing `Shift` + `Tab`