### PR TITLE
fix(DateRangePicker): fix default time not working

### DIFF
--- a/docs/pages/components/date-picker/fragments/basic.md
+++ b/docs/pages/components/date-picker/fragments/basic.md
@@ -1,12 +1,16 @@
 <!--start-code-->
 
 ```js
-import { DatePicker } from 'rsuite';
+import { DatePicker, Stack } from 'rsuite';
 
 const App = () => (
-  <>
+  <Stack direction="column" alignItems="flex-start" spacing={6}>
+    <DatePicker format="yyyy-MM" />
     <DatePicker />
-  </>
+    <DatePicker format="yyyy-MM-dd HH:mm" />
+    <DatePicker format="yyyy-MM-dd HH:mm:ss" />
+    <DatePicker format="HH:mm:ss" />
+  </Stack>
 );
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/docs/pages/components/date-picker/fragments/format.md
+++ b/docs/pages/components/date-picker/fragments/format.md
@@ -6,6 +6,7 @@ import { DatePicker } from 'rsuite';
 const App = () => (
   <DatePicker
     format="yyyy-MM-dd HH:mm:ss"
+    calendarDefaultDate={new Date('2022-02-02 00:00:00')}
     ranges={[
       {
         label: 'Now',

--- a/docs/pages/components/date-picker/index.tsx
+++ b/docs/pages/components/date-picker/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DatePicker, Button, InputGroup, Input } from 'rsuite';
+import { DatePicker, Button, InputGroup, Input, Stack } from 'rsuite';
 import addDays from 'date-fns/addDays';
 import subDays from 'date-fns/subDays';
 import isBefore from 'date-fns/isBefore';
@@ -9,7 +9,7 @@ import DefaultPage from '@/components/Page';
 export default function Page() {
   return (
     <DefaultPage
-      dependencies={{ DatePicker, Button, InputGroup, Input, addDays, subDays, isBefore }}
+      dependencies={{ DatePicker, Button, InputGroup, Input, Stack, addDays, subDays, isBefore }}
       sandboxDependencies={{ 'date-fns': '^2.13.0' }}
     />
   );

--- a/docs/pages/components/date-range-picker/fragments/format-date-time.md
+++ b/docs/pages/components/date-range-picker/fragments/format-date-time.md
@@ -6,13 +6,24 @@ import { DateRangePicker } from 'rsuite';
 const App = () => (
   <div className="field">
     <p>Date Time Range</p>
-    <DateRangePicker format="yyyy-MM-dd HH:mm:ss" />
+    <DateRangePicker
+      format="yyyy-MM-dd HH:mm:ss"
+      defaultCalendarValue={[new Date('2022-02-01 00:00:00'), new Date('2022-03-01 23:59:59')]}
+    />
 
     <p>Time Range</p>
-    <DateRangePicker format="HH:mm:ss" ranges={[]} />
+    <DateRangePicker
+      format="HH:mm:ss"
+      ranges={[]}
+      defaultCalendarValue={[new Date('2022-02-01 00:00:00'), new Date('2022-03-01 23:59:59')]}
+    />
 
     <p>Meridian format</p>
-    <DateRangePicker format="yyyy-MM-dd hh:mm aa" showMeridian />
+    <DateRangePicker
+      format="yyyy-MM-dd hh:mm aa"
+      showMeridian
+      defaultCalendarValue={[new Date('2022-02-01 00:00:00'), new Date('2022-03-01 23:59:59')]}
+    />
   </div>
 );
 

--- a/src/Calendar/test/useCalendarDateSpec.js
+++ b/src/Calendar/test/useCalendarDateSpec.js
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react-hooks/dom';
+import { renderHook } from '@testing-library/react-hooks/dom';
 import useCalendarDate from '../useCalendarDate';
 import format from 'date-fns/format';
 
@@ -7,35 +7,50 @@ describe('useCalendarDate', () => {
     const { result } = renderHook(() =>
       useCalendarDate(new Date('07/01/2021'), new Date('08/01/2021'))
     );
-    assert.equal(format(result.current.calendarDate, 'yyyy-MM-dd'), '2021-07-01');
+
+    expect(format(result.current.calendarDate, 'yyyy-MM-dd')).to.equal('2021-07-01');
   });
 
   it('Should return default date', () => {
     const { result } = renderHook(() => useCalendarDate(undefined, new Date('08/01/2021')));
 
-    assert.equal(format(result.current.calendarDate, 'yyyy-MM-dd'), '2021-08-01');
+    expect(format(result.current.calendarDate, 'yyyy-MM-dd')).to.equal('2021-08-01');
   });
 
   it('Should update calendarDate when value is updated', () => {
     const { result, rerender } = renderHook(({ initialValue }) => useCalendarDate(initialValue), {
       initialProps: { initialValue: new Date('07/01/2021') }
     });
-    assert.equal(format(result.current.calendarDate, 'yyyy-MM-dd'), '2021-07-01');
+    expect(format(result.current.calendarDate, 'yyyy-MM-dd')).to.equal('2021-07-01');
 
     rerender({ initialValue: new Date('09/01/2021') });
 
-    assert.equal(format(result.current.calendarDate, 'yyyy-MM-dd'), '2021-09-01');
+    expect(format(result.current.calendarDate, 'yyyy-MM-dd')).to.equal('2021-09-01');
   });
 
   it('Should update calendarDate by `setCalendarDate`', () => {
     const { result } = renderHook(() => useCalendarDate(new Date('07/01/2021')));
 
-    assert.equal(format(result.current.calendarDate, 'yyyy-MM-dd'), '2021-07-01');
+    expect(format(result.current.calendarDate, 'yyyy-MM-dd')).to.equal('2021-07-01');
 
-    act(() => {
-      result.current.setCalendarDate(new Date('09/01/2021'));
-    });
+    result.current.setCalendarDate(new Date('09/01/2021'));
 
-    assert.equal(format(result.current.calendarDate, 'yyyy-MM-dd'), '2021-09-01');
+    expect(format(result.current.calendarDate, 'yyyy-MM-dd')).to.equal('2021-09-01');
+  });
+
+  it('Should reset the datetime', () => {
+    const { result } = renderHook(() =>
+      useCalendarDate(undefined, new Date('08/04/2022 00:00:10'))
+    );
+
+    result.current.setCalendarDate(new Date('09/01/2021'));
+
+    expect(format(result.current.calendarDate, 'yyyy-MM-dd')).to.equal('2021-09-01');
+
+    result.current.resetCalendarDate();
+
+    expect(format(result.current.calendarDate, 'yyyy-MM-dd HH:mm:ss')).to.equal(
+      '2022-08-04 00:00:10'
+    );
   });
 });

--- a/src/Calendar/useCalendarDate.ts
+++ b/src/Calendar/useCalendarDate.ts
@@ -15,6 +15,10 @@ const useCalendarDate = (value: Date | null | undefined, defaultDate: Date | und
     [calendarDate]
   );
 
+  const resetCalendarDate = useCallback(() => {
+    setValue(value ?? defaultDate ?? new Date());
+  }, [defaultDate, value]);
+
   useUpdateEffect(() => {
     if (value?.valueOf() !== valueRef.current?.valueOf()) {
       setCalendarDate(value ?? new Date());
@@ -22,7 +26,7 @@ const useCalendarDate = (value: Date | null | undefined, defaultDate: Date | und
     }
   }, [value]);
 
-  return { calendarDate, setCalendarDate };
+  return { calendarDate, setCalendarDate, resetCalendarDate };
 };
 
 export default useCalendarDate;

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -178,7 +178,10 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
     const { merge, prefix } = useClassNames(classPrefix);
 
     const [value, setValue] = useControlled(valueProp, defaultValue);
-    const { calendarDate, setCalendarDate } = useCalendarDate(valueProp, calendarDefaultDate);
+    const { calendarDate, setCalendarDate, resetCalendarDate } = useCalendarDate(
+      valueProp,
+      calendarDefaultDate
+    );
     const [inputState, setInputState] = useState<InputState>();
     const { calendarState, reset, openMonth, openTime } = useCalendarState();
     const [active, setActive] = useState<boolean>(false);
@@ -324,10 +327,10 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
      */
     const handleClean = useCallback(
       (event: React.SyntheticEvent) => {
-        setCalendarDate(new Date());
         updateValue(event, null);
+        resetCalendarDate();
       },
-      [setCalendarDate, updateValue]
+      [resetCalendarDate, updateValue]
     );
 
     /**

--- a/src/DatePicker/test/DatePickerSpec.js
+++ b/src/DatePicker/test/DatePickerSpec.js
@@ -652,4 +652,32 @@ describe('DatePicker', () => {
     userEvent.tab({ shift: true });
     expect(document.activeElement).to.value('2022-01-01');
   });
+
+  it('Should reset to default time after clicking clear button', () => {
+    const onChangeSpy = sinon.spy();
+    const { getByRole } = render(
+      <DatePicker
+        open
+        calendarDefaultDate={new Date('2022-02-02 00:00:00')}
+        onChange={onChangeSpy}
+        format="yyyy-MM-dd HH:mm:ss"
+        ranges={[
+          {
+            label: 'custom-day',
+            value: new Date('2022-02-02 12:00:00')
+          }
+        ]}
+      />
+    );
+
+    userEvent.click(getByRole('button', { name: 'custom-day' }));
+
+    expect(isSameDay(onChangeSpy.getCall(0).args[0], new Date('2022-02-02'))).to.be.true;
+    expect(getByRole('button', { name: '12:00:00' })).to.exist;
+
+    userEvent.click(getByRole('button', { name: /clear/i }));
+
+    expect(onChangeSpy).to.have.been.calledWith(null);
+    expect(getByRole('button', { name: '00:00:00' })).to.exist;
+  });
 });

--- a/src/DateRangePicker/test/DateRangePickerSpec.js
+++ b/src/DateRangePicker/test/DateRangePickerSpec.js
@@ -727,4 +727,25 @@ describe('DateRangePicker', () => {
 
     expect(onFocusSpy).to.have.been.calledOnce;
   });
+
+  it('Should leave time unchanged when defaultCalendarValue is set', () => {
+    const onSelectSpy = sinon.spy();
+    const { getByRole } = render(
+      <DateRangePicker
+        open
+        format="yyyy-MM-dd HH:mm:ss"
+        onSelect={onSelectSpy}
+        defaultCalendarValue={[new Date('2022-02-01 00:00:00'), new Date('2022-03-01 23:59:59')]}
+      />
+    );
+
+    expect(getByRole('button', { name: '00:00:00' })).to.be.visible;
+    expect(getByRole('button', { name: '23:59:59' })).to.be.visible;
+
+    fireEvent.click(getByRole('gridcell', { name: '07 Feb 2022' }).firstChild);
+
+    expect(onSelectSpy).to.have.been.calledOnce;
+    expect(getByRole('button', { name: '00:00:00' })).to.be.visible;
+    expect(getByRole('button', { name: '23:59:59' })).to.be.visible;
+  });
 });

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -43,6 +43,7 @@ export { default as startOfWeek } from 'date-fns/startOfWeek';
 export { default as subDays } from 'date-fns/subDays';
 export { default as isMatch } from 'date-fns/isMatch';
 export { default as isValid } from 'date-fns/isValid';
+export { default as set } from 'date-fns/set';
 
 const disabledTimeProps = ['disabledHours', 'disabledMinutes', 'disabledSeconds'];
 const hideTimeProps = ['hideHours', 'hideMinutes', 'hideSeconds'];


### PR DESCRIPTION
fix: https://github.com/rsuite/rsuite/discussions/2597#discussioncomment-3177984
- [x] The time of the end date must not be tampered with, when only the start date is selected.
- [x] The time on the calendar should revert to defaultCalendarValue when the clear button is clicked.  


