### PR TITLE
fix(gulp): dir contains '-' or '_ ' not replaced

### DIFF
--- a/scripts/proxyDirectories.js
+++ b/scripts/proxyDirectories.js
@@ -21,7 +21,7 @@ function findResources(options) {
   const resources = [];
   fs.readdirSync(dir).forEach(item => {
     const itemPath = path.resolve(dir, item);
-    const pathname = itemPath.replace(/[a-z0-9]*\//gi, '').replace('.ts', '');
+    const pathname = itemPath.replace(/[-_a-z0-9]*\//gi, '').replace('.ts', '');
 
     if (fs.statSync(itemPath).isDirectory()) {
       resources.push(pathname);


### PR DESCRIPTION
when i change project dir and build, i get the /lib/projectname-Button/
because my project dir contains '-'