### PR TITLE
fix(Form.Control): apply className to accepter component

### DIFF
--- a/src/FormControl/FormControl.tsx
+++ b/src/FormControl/FormControl.tsx
@@ -88,7 +88,6 @@ const FormControl: FormControlComponent = React.forwardRef((props: FormControlPr
     as: Component = 'div',
     accepter: AccepterComponent = Input,
     classPrefix = 'form-control',
-    className,
     checkAsync,
     checkTrigger,
     errorPlacement = 'bottomStart',
@@ -128,8 +127,8 @@ const FormControl: FormControlComponent = React.forwardRef((props: FormControlPr
   const formValue = useContext(FormValueContext);
   const val = isUndefined(value) ? formValue?.[name] : value;
 
-  const { withClassPrefix, prefix, merge } = useClassNames(classPrefix);
-  const classes = merge(className, withClassPrefix('wrapper'));
+  const { withClassPrefix, prefix } = useClassNames(classPrefix);
+  const classes = withClassPrefix('wrapper');
 
   const handleFieldChange = (value: any, event: React.SyntheticEvent) => {
     handleFieldCheck(value, trigger === 'change');

--- a/src/FormControl/test/FormControlSpec.js
+++ b/src/FormControl/test/FormControlSpec.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { getDOMNode } from '@test/testUtils';
 import Form from '../../Form';
 import FormControl from '../FormControl';
@@ -79,14 +79,14 @@ describe('FormControl', () => {
     ReactTestUtils.Simulate.blur(instance.querySelector('input'));
   });
 
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(
+  it('Should apply custom className to accepter component', () => {
+    render(
       <Form>
-        <FormControl className="custom" name="username" />
+        <FormControl className="custom" name="username" data-testid="input" />
       </Form>
     );
 
-    assert.include(instance.querySelector('.rs-form-control').className, 'custom');
+    expect(screen.getByTestId('input')).to.have.class('custom');
   });
 
   it('Should have a custom style', () => {


### PR DESCRIPTION
Pass `className` prop to accepter component instead of applying it on FormControl wrapper element. This used to work in v4 but seemed to be accidentally broken in v5.

v4
<img width="505" alt="image" src="https://user-images.githubusercontent.com/8225666/185075867-069ddb9b-02b8-42ef-be33-07c43b13e645.png">

v5
<img width="673" alt="image" src="https://user-images.githubusercontent.com/8225666/185075934-a1971ec5-6850-4515-a0f7-0f7e44daae5d.png">
