### PR TITLE
feat(DateRangePicker): supports placing predefined ranges on the left

### DIFF
--- a/docs/pages/_common/types/range.md
+++ b/docs/pages/_common/types/range.md
@@ -5,5 +5,9 @@ interface Range {
   label: React.ReactNode;
   value: Date | ((date: Date) => Date);
   closeOverlay?: boolean;
+
+  // Sets the position where the predefined range is displayed, the default is bottom.
+  // Only supported on DateRangePicker。
+  placement?: 'bottom' | 'left';
 }
 ```

--- a/docs/pages/components/date-range-picker/fragments/custom-shortcut-options.md
+++ b/docs/pages/components/date-range-picker/fragments/custom-shortcut-options.md
@@ -1,30 +1,134 @@
 <!--start-code-->
 
 ```js
-import { DateRangePicker } from 'rsuite';
+import { DateRangePicker, Stack } from 'rsuite';
 import subDays from 'date-fns/subDays';
+import startOfWeek from 'date-fns/startOfWeek';
+import endOfWeek from 'date-fns/endOfWeek';
 import addDays from 'date-fns/addDays';
+import startOfMonth from 'date-fns/startOfMonth';
+import endOfMonth from 'date-fns/endOfMonth';
+import addMonths from 'date-fns/addMonths';
+
+const predefinedRanges = [
+  {
+    label: 'Today',
+    value: [new Date(), new Date()],
+    placement: 'left'
+  },
+  {
+    label: 'Yesterday',
+    value: [addDays(new Date(), -1), addDays(new Date(), -1)],
+    placement: 'left'
+  },
+  {
+    label: 'This week',
+    value: [startOfWeek(new Date()), endOfWeek(new Date())],
+    placement: 'left'
+  },
+  {
+    label: 'Last 7 days',
+    value: [subDays(new Date(), 6), new Date()],
+    placement: 'left'
+  },
+  {
+    label: 'Last 30 days',
+    value: [subDays(new Date(), 29), new Date()],
+    placement: 'left'
+  },
+  {
+    label: 'This month',
+    value: [startOfMonth(new Date()), new Date()],
+    placement: 'left'
+  },
+  {
+    label: 'Last month',
+    value: [startOfMonth(addMonths(new Date(), -1)), endOfMonth(addMonths(new Date(), -1))],
+    placement: 'left'
+  },
+  {
+    label: 'This year',
+    value: [new Date(new Date().getFullYear(), 0, 1), new Date()],
+    placement: 'left'
+  },
+  {
+    label: 'Last year',
+    value: [new Date(new Date().getFullYear() - 1, 0, 1), new Date(new Date().getFullYear(), 0, 0)],
+    placement: 'left'
+  },
+  {
+    label: 'All time',
+    value: [new Date(new Date().getFullYear() - 1, 0, 1), new Date()],
+    placement: 'left'
+  },
+  {
+    label: 'Last week',
+    closeOverlay: false,
+    value: value => {
+      const [start = new Date()] = value || [];
+      return [
+        addDays(startOfWeek(start, { weekStartsOn: 0 }), -7),
+        addDays(endOfWeek(start, { weekStartsOn: 0 }), -7)
+      ];
+    },
+    appearance: 'default'
+  },
+  {
+    label: 'Next week',
+    closeOverlay: false,
+    value: value => {
+      const [start = new Date()] = value || [];
+      return [
+        addDays(startOfWeek(start, { weekStartsOn: 0 }), 7),
+        addDays(endOfWeek(start, { weekStartsOn: 0 }), 7)
+      ];
+    },
+    appearance: 'default'
+  }
+];
+
+const predefinedBottomRanges = [
+  {
+    label: 'Today',
+    value: [new Date(), new Date()]
+  },
+  {
+    label: 'Yesterday',
+    value: [addDays(new Date(), -1), addDays(new Date(), -1)]
+  },
+  {
+    label: 'This week',
+    value: [startOfWeek(new Date()), endOfWeek(new Date())]
+  },
+  {
+    label: 'Last 7 days',
+    value: [subDays(new Date(), 6), new Date()]
+  },
+  {
+    label: 'Last 30 days',
+    value: [subDays(new Date(), 29), new Date()]
+  }
+];
 
 const App = () => (
-  <div className="field">
+  <Stack direction="column" spacing={8} alignItems="flex-start">
     <DateRangePicker
-      ranges={[
-        {
-          label: 'Yesterday',
-          value: [addDays(new Date(), -1), addDays(new Date(), -1)]
-        },
-        {
-          label: 'Today',
-          value: [new Date(), new Date()]
-        },
-        {
-          label: 'Last 7 days ( closeOverlay:false )',
-          value: [subDays(new Date(), 6), new Date()],
-          closeOverlay: false
-        }
-      ]}
+      ranges={predefinedBottomRanges}
+      placeholder="Placement defaults to bottom"
+      style={{ width: 300 }}
     />
-  </div>
+    <DateRangePicker
+      ranges={predefinedRanges}
+      placeholder="Placement left"
+      style={{ width: 300 }}
+    />
+    <DateRangePicker
+      ranges={predefinedRanges}
+      showOneCalendar
+      placeholder="One calendar"
+      style={{ width: 300 }}
+    />
+  </Stack>
 );
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/docs/pages/components/date-range-picker/index.tsx
+++ b/docs/pages/components/date-range-picker/index.tsx
@@ -1,14 +1,32 @@
 import React from 'react';
-import { DateRangePicker, Button, Divider } from 'rsuite';
+import { DateRangePicker, Button, Divider, Stack } from 'rsuite';
 import DefaultPage from '@/components/Page';
+import startOfWeek from 'date-fns/startOfWeek';
+import endOfWeek from 'date-fns/endOfWeek';
 import addDays from 'date-fns/addDays';
+import startOfMonth from 'date-fns/startOfMonth';
+import endOfMonth from 'date-fns/endOfMonth';
 import subDays from 'date-fns/subDays';
 import isAfter from 'date-fns/isAfter';
+import addMonths from 'date-fns/addMonths';
 
 export default function Page() {
   return (
     <DefaultPage
-      dependencies={{ DateRangePicker, Button, Divider, addDays, subDays, isAfter }}
+      dependencies={{
+        Stack,
+        DateRangePicker,
+        Button,
+        Divider,
+        addDays,
+        subDays,
+        isAfter,
+        startOfWeek,
+        endOfWeek,
+        startOfMonth,
+        endOfMonth,
+        addMonths
+      }}
       sandboxDependencies={{ 'date-fns': '^2.13.0' }}
     />
   );

--- a/src/DatePicker/PredefinedRanges.tsx
+++ b/src/DatePicker/PredefinedRanges.tsx
@@ -1,0 +1,67 @@
+import React, { useCallback, useState } from 'react';
+import Button from '../Button';
+import Stack, { StackProps } from '../Stack';
+import { useUpdateEffect } from '../utils';
+import { getDefaultRanges, getRanges } from './utils';
+import { InnerRange, RangeType } from './types';
+import { CalendarLocale } from '../locales';
+
+export interface PredefinedRangesProps<T = any, Shortcut = T> extends StackProps {
+  ranges?: RangeType<Shortcut>[];
+  calendarDate: T;
+  locale: CalendarLocale;
+  disabledShortcut?: (value: T) => boolean;
+  onClickShortcut?: (value: Shortcut, closeOverlay: boolean, event: React.MouseEvent) => void;
+}
+
+const PredefinedRanges = React.forwardRef<HTMLDivElement, PredefinedRangesProps>((props, ref) => {
+  const {
+    className,
+    disabledShortcut,
+    onClickShortcut,
+    calendarDate,
+    ranges: rangesProp,
+    locale,
+    ...rest
+  } = props;
+  const [ranges, setRanges] = useState<InnerRange<any>[]>(getRanges(props));
+
+  useUpdateEffect(() => {
+    setRanges(getRanges({ ranges: rangesProp, calendarDate }));
+  }, [calendarDate, rangesProp]);
+
+  const hasLocaleKey = useCallback(
+    (key: React.ReactNode) => getDefaultRanges(calendarDate).some(item => item.label === key),
+    [calendarDate]
+  );
+
+  return (
+    <Stack className={className} ref={ref} alignItems="flex-start" spacing={4} {...rest}>
+      {ranges.map(({ value, closeOverlay, label, ...rest }, index: number) => {
+        const disabled = disabledShortcut?.(value);
+
+        const handleClickShortcut = (event: React.MouseEvent) => {
+          if (disabled) {
+            return;
+          }
+          onClickShortcut?.(value, closeOverlay !== false ? true : false, event);
+        };
+
+        return (
+          <Button
+            appearance="link"
+            size="sm"
+            key={index}
+            disabled={disabled}
+            onClick={handleClickShortcut}
+            {...rest}
+          >
+            {hasLocaleKey(label) && typeof label === 'string' ? locale?.[label] : label}
+          </Button>
+        );
+      })}
+    </Stack>
+  );
+});
+
+export default PredefinedRanges;

--- a/src/DatePicker/Toolbar.tsx
+++ b/src/DatePicker/Toolbar.tsx
@@ -1,27 +1,47 @@
-import React, { ReactNode, useCallback, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '../Button';
-import { useClassNames, useUpdateEffect } from '../utils';
-import { StandardProps } from '../@types/common';
-import { getDefaultRanges, getRanges } from './utils';
-import { InnerRange, RangeType } from './types';
-import { CalendarLocale } from '../locales';
+import { useClassNames } from '../utils';
+import PredefinedRanges, { PredefinedRangesProps } from './PredefinedRanges';
+import Stack from '../Stack';
 
 export type { RangeType } from './types';
 
-export interface ToolbarProps<T = any, Shortcut = T> extends StandardProps {
+export interface ToolbarProps<T = any, Shortcut = T> extends PredefinedRangesProps<T, Shortcut> {
   hideOkBtn?: boolean;
-  locale?: CalendarLocale;
-  calendarDate: T;
-  ranges?: RangeType<Shortcut>[];
   disabledOkBtn?: (value: T) => boolean;
-  disabledShortcut?: (value: T) => boolean;
   onOk?: (event: React.MouseEvent) => void;
-  onClickShortcut?: (value: Shortcut, closeOverlay: boolean, event: React.MouseEvent) => void;
 }
 
 type ToolbarComponent = React.ForwardRefExoticComponent<ToolbarProps> & {
   <T = any, Shortcut = T>(props: ToolbarProps<T, Shortcut>): React.ReactElement | null;
+};
+
+interface SubmitButtonProps {
+  calendarDate: any;
+  children: React.ReactNode;
+  hide?: boolean;
+  disabledOkBtn?: (value: any) => boolean;
+  onOk?: (event: React.MouseEvent) => void;
+}
+
+const SubmitButton = ({ hide, disabledOkBtn, calendarDate, onOk, children }: SubmitButtonProps) => {
+  if (hide) {
+    return null;
+  }
+
+  const disabled = disabledOkBtn?.(calendarDate);
+
+  return (
+    <Button
+      appearance="primary"
+      size="sm"
+      disabled={disabled}
+      onClick={disabled ? undefined : onOk}
+    >
+      {children}
+    </Button>
+  );
 };
 
 /**
@@ -37,76 +57,46 @@ const Toolbar: ToolbarComponent = React.forwardRef<HTMLDivElement, ToolbarProps>
     onOk,
     onClickShortcut,
     calendarDate,
-    ranges: rangesProp,
+    ranges,
     locale,
     ...rest
   } = props;
-  const [ranges, setRanges] = useState<InnerRange<any>[]>(getRanges(props));
+
   const { merge, prefix, withClassPrefix } = useClassNames(classPrefix);
 
-  useUpdateEffect(() => {
-    setRanges(getRanges({ ranges: rangesProp, calendarDate }));
-  }, [calendarDate, rangesProp]);
-
-  const hasLocaleKey = useCallback(
-    (key: ReactNode) => getDefaultRanges(calendarDate).some(item => item.label === key),
-    [calendarDate]
-  );
-
-  const renderOkButton = useCallback(() => {
-    if (hideOkBtn) {
-      return null;
-    }
-
-    const disabled = disabledOkBtn?.(calendarDate);
-
-    return (
-      <div className={prefix('right')}>
-        <Button
-          appearance="primary"
-          size="sm"
-          disabled={disabled}
-          onClick={disabled ? undefined : onOk}
-        >
-          {locale?.ok}
-        </Button>
-      </div>
-    );
-  }, [disabledOkBtn, hideOkBtn, locale, onOk, calendarDate, prefix]);
-
-  if (hideOkBtn && ranges.length === 0) {
+  if (hideOkBtn && ranges?.length === 0) {
     return null;
   }
 
   const classes = merge(className, withClassPrefix());
+
   return (
-    <div {...rest} ref={ref} className={classes}>
-      <div className={prefix('ranges')}>
-        {ranges.map(({ value, closeOverlay, label }, index: number) => {
-          const disabled = disabledShortcut?.(value);
-
-          const handleClickShortcut = (event: React.MouseEvent) => {
-            if (disabled) {
-              return;
-            }
-            onClickShortcut?.(value, closeOverlay !== false ? true : false, event);
-          };
-
-          return (
-            <Button
-              appearance="link"
-              size="sm"
-              key={index}
-              disabled={disabled}
-              onClick={handleClickShortcut}
-            >
-              {hasLocaleKey(label) && typeof label === 'string' ? locale?.[label] : label}
-            </Button>
-          );
-        })}
+    <Stack
+      ref={ref}
+      className={classes}
+      justifyContent="space-between"
+      alignItems="flex-start"
+      {...rest}
+    >
+      <PredefinedRanges
+        className={prefix('ranges')}
+        ranges={ranges}
+        calendarDate={calendarDate}
+        locale={locale}
+        disabledShortcut={disabledShortcut}
+        onClickShortcut={onClickShortcut}
+      />
+      <div className={prefix('right')}>
+        <SubmitButton
+          disabledOkBtn={disabledOkBtn}
+          hide={hideOkBtn}
+          calendarDate={calendarDate}
+          onOk={onOk}
+        >
+          {locale?.ok}
+        </SubmitButton>
       </div>
-      {renderOkButton()}
-    </div>
+    </Stack>
   );
 });
 

--- a/src/DatePicker/styles/index.less
+++ b/src/DatePicker/styles/index.less
@@ -19,18 +19,8 @@
 
 // Toolbar
 .rs-picker-toolbar {
-  .clearfix();
-
   padding: @calendar-picker-padding;
   border-top: 1px solid @calendar-toolbar-border-color;
-
-  &-ranges {
-    display: inline-block;
-  }
-
-  &-right {
-    float: right;
-  }
 }
 
 // Picker date

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -8,6 +8,8 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { FormControlBaseProps, PickerBaseProps } from '../@types/common';
 import { FormattedDate } from '../CustomProvider';
 import Toolbar from '../DatePicker/Toolbar';
+import PredefinedRanges from '../DatePicker/PredefinedRanges';
+import Stack from '../Stack';
 import { DateRangePickerLocale } from '../locales';
 import {
   omitTriggerPropKeys,
@@ -540,12 +542,18 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
    */
   const handleShortcutPageDate = useCallback(
     (value: DateRange, closeOverlay = false, event: React.SyntheticEvent) => {
-      handleValueUpdate(event, value, closeOverlay);
+      updateCalendarDateRange(value);
+
+      if (closeOverlay) {
+        handleValueUpdate(event, value, closeOverlay);
+      } else {
+        setSelectedDates(value ?? []);
+      }
 
       // End unfinished selections.
       hasDoneSelect.current = true;
     },
-    [handleValueUpdate]
+    [handleValueUpdate, updateCalendarDateRange]
   );
 
   const handleOK = useCallback(
@@ -742,29 +750,48 @@ const DateRangePicker: DateRangePicker = React.forwardRef((props: DateRangePicke
 
     return (
       <PickerOverlay
+        role="dialog"
         className={classes}
         ref={mergeRefs(overlayRef, speakerRef)}
         target={triggerRef}
         style={styles}
       >
         <div className={panelClasses}>
-          <div className={prefix('daterange-content')}>
-            <div className={prefix('daterange-header')}>{getDisplayString(selectedDates)}</div>
-            <div className={prefix(`daterange-calendar-${showOneCalendar ? 'single' : 'group'}`)}>
-              <Calendar index={0} {...calendarProps} />
-              {!showOneCalendar && <Calendar index={1} {...calendarProps} />}
-            </div>
-          </div>
-          <Toolbar<SelectedDatesState, DateRange>
-            locale={locale}
-            calendarDate={selectedDates}
-            disabledOkBtn={disabledOkButton}
-            disabledShortcut={disabledShortcutButton}
-            hideOkBtn={oneTap}
-            onOk={handleOK}
-            onClickShortcut={handleShortcutPageDate}
-            ranges={ranges}
-          />
+          <Stack alignItems="flex-start">
+            <PredefinedRanges
+              direction="column"
+              spacing={0}
+              className={prefix('daterange-predefined')}
+              ranges={ranges?.filter(range => range?.placement === 'left') || []}
+              calendarDate={calendarDate}
+              locale={locale}
+              disabledShortcut={disabledShortcutButton}
+              onClickShortcut={handleShortcutPageDate}
+            />
+            <>
+              <div className={prefix('daterange-content')}>
+                <div className={prefix('daterange-header')}>{getDisplayString(selectedDates)}</div>
+                <div
+                  className={prefix(`daterange-calendar-${showOneCalendar ? 'single' : 'group'}`)}
+                >
+                  <Calendar index={0} {...calendarProps} />
+                  {!showOneCalendar && <Calendar index={1} {...calendarProps} />}
+                </div>
+              </div>
+              <Toolbar<SelectedDatesState, DateRange>
+                locale={locale}
+                calendarDate={selectedDates}
+                disabledOkBtn={disabledOkButton}
+                disabledShortcut={disabledShortcutButton}
+                hideOkBtn={oneTap}
+                onOk={handleOK}
+                onClickShortcut={handleShortcutPageDate}
+                ranges={ranges?.filter(
+                  range => range?.placement === 'bottom' || range?.placement === undefined
+                )}
+              />
+            </>
+          </Stack>
         </div>
       </PickerOverlay>
     );

--- a/src/DateRangePicker/styles/index.less
+++ b/src/DateRangePicker/styles/index.less
@@ -10,7 +10,7 @@
 .rs-picker-daterange-menu {
   .rs-calendar {
     display: inline-block;
-    height: 278px;
+    height: 276px;
     padding-bottom: 12px;
 
     &:first-child {
@@ -33,10 +33,6 @@
     &-list {
       width: 185px;
     }
-  }
-
-  .rs-picker-toolbar {
-    margin-top: 4px;
   }
 
   .rs-picker-daterange-panel-show-one-calendar .rs-picker-toolbar {
@@ -70,4 +66,15 @@
   height: 274px;
   // Make sure group wrapper can put 2 date-panels even screen width is not enough.
   min-width: 492px;
+}
+
+// Predefined Ranges
+.rs-picker-daterange-predefined {
+  height: 366px;
+  border-right: 1px solid var(--rs-border-primary);
+  padding: 4px 0;
+
+  .rs-btn {
+    display: block;
+  }
 }

--- a/src/DateRangePicker/test/DateRangePickerSpec.js
+++ b/src/DateRangePicker/test/DateRangePickerSpec.js
@@ -692,6 +692,7 @@ describe('DateRangePicker', () => {
   it('Should not close picker', async () => {
     const onCloseSpy = sinon.spy();
     const onChangeSpy = sinon.spy();
+    const yesterday = addDays(new Date(), -1);
 
     const { getByRole } = render(
       <DateRangePicker
@@ -699,7 +700,7 @@ describe('DateRangePicker', () => {
         ranges={[
           {
             label: 'Yesterday',
-            value: [addDays(new Date(), -1), addDays(new Date(), -1)],
+            value: [yesterday, yesterday],
             closeOverlay: false
           }
         ]}
@@ -708,12 +709,14 @@ describe('DateRangePicker', () => {
       />
     );
 
-    act(() => {
-      userEvent.click(getByRole('button', { name: 'Yesterday' }));
-    });
+    fireEvent.click(getByRole('button', { name: 'Yesterday' }));
+
+    expect(getByRole('dialog').querySelector('.rs-picker-daterange-header')).to.text(
+      `${format(yesterday, 'yyyy-MM-dd')} ~ ${format(yesterday, 'yyyy-MM-dd')}`
+    );
 
     await waitFor(() => {
-      expect(onChangeSpy).to.calledOnce;
+      expect(onChangeSpy).to.not.called;
       expect(onCloseSpy).to.not.called;
     });
   });
@@ -747,5 +750,32 @@ describe('DateRangePicker', () => {
     expect(onSelectSpy).to.have.been.calledOnce;
     expect(getByRole('button', { name: '00:00:00' })).to.be.visible;
     expect(getByRole('button', { name: '23:59:59' })).to.be.visible;
+  });
+
+  it('Should render ranges on the left', () => {
+    const onCloseSpy = sinon.spy();
+    const onChangeSpy = sinon.spy();
+    const yesterday = addDays(new Date(), -1);
+
+    const { getByRole } = render(
+      <DateRangePicker
+        defaultOpen
+        ranges={[
+          {
+            label: 'Yesterday',
+            value: [yesterday, yesterday],
+            placement: 'left'
+          }
+        ]}
+        onChange={onChangeSpy}
+        onExit={onCloseSpy}
+      />
+    );
+
+    expect(
+      getByRole('dialog').querySelector('.rs-picker-daterange-predefined').firstChild.firstChild
+    ).to.equal(getByRole('button', { name: 'Yesterday' }));
+
+    expect(getByRole('dialog').querySelector('.rs-picker-toolbar-ranges button')).to.not.exist;
   });
 });

--- a/src/DateRangePicker/types.ts
+++ b/src/DateRangePicker/types.ts
@@ -7,8 +7,9 @@ export type DateRange = [Date, Date];
 
 export interface RangeType {
   label: React.ReactNode;
-  closeOverlay?: boolean;
   value: DateRange | ((value?: ValueType) => DateRange);
+  closeOverlay?: boolean;
+  placement?: 'bottom' | 'left';
 }
 
 export type DisabledDateFunction = (


### PR DESCRIPTION
```diff
<DateRangePicker
  ranges={[
    {
      label: 'Today',
      value: [new Date(), new Date()],
+     // Sets the position where the predefined range is displayed, the default is bottom.
+     // Only supported on DateRangePicker。
+     placement: 'left'
    }
  ]}
/>;
```
> https://rsuite-nextjs-git-feat-daterangepicker-rsuite.vercel.app/components/date-range-picker/#predefined-date-ranges

<img width="770" alt="image" src="https://user-images.githubusercontent.com/1203827/186440432-d8de4af5-9670-439a-b330-88dfd73b73e5.png">

<img width="780" alt="image" src="https://user-images.githubusercontent.com/1203827/186440508-07a3cbf3-b31d-45fa-89af-48e95917d072.png">


