### PR TITLE
fix(InputNumber): fix pattern props not working

### DIFF
--- a/src/InputNumber/InputNumber.tsx
+++ b/src/InputNumber/InputNumber.tsx
@@ -275,7 +275,7 @@ const InputNumber = React.forwardRef((props: InputNumberProps, ref) => {
     <Input
       {...(htmlInputProps as Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>)}
       type="number"
-      autoComplete="off"
+      autoComplete={htmlInputProps?.pattern ? 'hidden' : 'off'}
       step={step}
       inputRef={inputRef}
       onChange={handleChange}


### PR DESCRIPTION
## steps to reproduce

1. go to https://rsuitejs.com/components/input-number/
2. replace Input component with:
```jsx
 <InputNumber pattern="[0-9]"/>
```
3. type `12.3` (note: there's a dot)

## Actual

InputNumber has value `12.3`

## Expected

InputNumber value does not contains a dot.
Numbers with decimals shouldn't be allowed, as defined in the pattern.