### PR TITLE
docs(Tooltip,Popover): fixed TS declarations not being clickable

### DIFF
--- a/docs/pages/components/popover/en-US/index.md
+++ b/docs/pages/components/popover/en-US/index.md
@@ -58,8 +58,6 @@ You can enable the `Popover` to follow the cursor by setting `followCursor={true
 
 ## Props
 
-<!--{include:(_common/types/placement-all.md)}-->
-
 ### `<Popover>`
 
 | Property    | Type `(Default)`     | Description                            |
@@ -71,3 +69,4 @@ You can enable the `Popover` to follow the cursor by setting `followCursor={true
 | visible     | boolean              | The component is visible by default.   |
 
 <!--{include:(components/whisper/en-US/props.md)}-->
+<!--{include:(_common/types/placement-all.md)}-->

--- a/docs/pages/components/popover/zh-CN/index.md
+++ b/docs/pages/components/popover/zh-CN/index.md
@@ -69,3 +69,4 @@
 | visible     | boolean              | 组件默认可见的     |
 
 <!--{include:(components/whisper/zh-CN/props.md)}-->
+<!--{include:(_common/types/placement-all.md)}-->

--- a/docs/pages/components/tooltip/en-US/index.md
+++ b/docs/pages/components/tooltip/en-US/index.md
@@ -63,8 +63,6 @@ You can enable the `Tooltip` to follow the cursor by setting `followCursor={true
 
 ## Props
 
-<!--{include:(_common/types/placement-all.md)}-->
-
 ### `<Tooltip>`
 
 | Property    | Type `(Default)`     | Description                           |
@@ -75,3 +73,4 @@ You can enable the `Tooltip` to follow the cursor by setting `followCursor={true
 | visible     | boolean              | The component is visible by default   |
 
 <!--{include:(components/whisper/en-US/props.md)}-->
+<!--{include:(_common/types/placement-all.md)}-->

--- a/docs/pages/components/tooltip/zh-CN/index.md
+++ b/docs/pages/components/tooltip/zh-CN/index.md
@@ -63,8 +63,6 @@
 
 ## Props
 
-<!--{include:(_common/types/placement-all.md)}-->
-
 ### `<Tooltip>`
 
 | 属性名称    | 类型 `(默认值)`      | 描述               |
@@ -75,3 +73,4 @@
 | visible     | boolean              | 组件默认可见的     |
 
 <!--{include:(components/whisper/zh-CN/props.md)}-->
+<!--{include:(_common/types/placement-all.md)}-->

--- a/docs/pages/components/whisper/en-US/index.md
+++ b/docs/pages/components/whisper/en-US/index.md
@@ -15,3 +15,4 @@ Bind an event to an element, and display a overlay when triggered.
 ## Props
 
 <!--{include:(components/whisper/en-US/props.md)}-->
+<!--{include:(_common/types/placement-all.md)}-->

--- a/docs/pages/components/whisper/en-US/props.md
+++ b/docs/pages/components/whisper/en-US/props.md
@@ -1,41 +1,30 @@
 ### `<Whisper>`
 
-```ts
-type Trigger =
-  | Array<'click' | 'contextMenu' | 'hover' | 'focus' | 'active'>
-  | 'click'
-  | 'contextMenu'
-  | 'hover'
-  | 'focus'
-  | 'active'
-  | 'none';
-```
-
-| Property        | Type `(Default)`                          | Description                                                                                                  |
-| --------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| container       | HTMLElement &#124; (() => HTMLElement)    | Sets the rendering container                                                                                 |
-| controlId       | string                                    | Set the `id` on `<Overlay>` and `aria-describedby` on `<Whisper>`                                            |
-| delay           | number                                    | Delay time (ms) Time                                                                                         |
-| delayClose      | number                                    | Delay close time (ms) Time                                                                                   |
-| delayOpen       | number                                    | Delay open time (ms) Time                                                                                    |
-| enterable       | boolean                                   | Whether mouse is allowed to enter the floating layer of popover,when the value of `trigger` is set to`hover` |
-| followCursor    | boolean                                   | Whether enable `speaker` to follow the cursor                                                                |
-| full            | boolean                                   | The content full the container                                                                               |
-| onBlur          | () => void                                | Lose Focus callback function                                                                                 |
-| onClick         | () => void                                | Click on the callback function                                                                               |
-| onClose         | () => void                                | Callback fired when close component                                                                          |
-| onEnter         | () => void                                | Callback fired before the overlay transitions in                                                             |
-| onEntered       | () => void                                | Callback fired after the overlay finishes transitioning in                                                   |
-| onEntering      | () => void                                | Callback fired as the overlay begins to transition in                                                        |
-| onExit          | () => void                                | Callback fired right before the overlay transitions out                                                      |
-| onExited        | () => void                                | Callback fired after the overlay finishes transitioning out                                                  |
-| onExiting       | () => void                                | Callback fired as the overlay begins to transition out                                                       |
-| onFocus         | () => void                                | Callback function to get focus                                                                               |
-| onOpen          | () => void                                | Callback fired when open component                                                                           |
-| placement       | Placement `('right')`                     | Dispaly placement                                                                                            |
-| preventOverflow | boolean                                   | Prevent floating element overflow                                                                            |
-| speaker \*      | Tooltip &#124;Popover &#124; ReactElement | Displayed component                                                                                          |
-| trigger         | Trigger `(['hover','focus'])`             | Triggering events                                                                                            |
+| Property        | Type `(Default)`                                         | Description                                                                                                  |
+| --------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| container       | HTMLElement &#124; (() => HTMLElement)                   | Sets the rendering container                                                                                 |
+| controlId       | string                                                   | Set the `id` on `<Overlay>` and `aria-describedby` on `<Whisper>`                                            |
+| delay           | number                                                   | Delay time (ms) Time                                                                                         |
+| delayClose      | number                                                   | Delay close time (ms) Time                                                                                   |
+| delayOpen       | number                                                   | Delay open time (ms) Time                                                                                    |
+| enterable       | boolean                                                  | Whether mouse is allowed to enter the floating layer of popover,when the value of `trigger` is set to`hover` |
+| followCursor    | boolean                                                  | Whether enable `speaker` to follow the cursor                                                                |
+| full            | boolean                                                  | The content full the container                                                                               |
+| onBlur          | () => void                                               | Lose Focus callback function                                                                                 |
+| onClick         | () => void                                               | Click on the callback function                                                                               |
+| onClose         | () => void                                               | Callback fired when close component                                                                          |
+| onEnter         | () => void                                               | Callback fired before the overlay transitions in                                                             |
+| onEntered       | () => void                                               | Callback fired after the overlay finishes transitioning in                                                   |
+| onEntering      | () => void                                               | Callback fired as the overlay begins to transition in                                                        |
+| onExit          | () => void                                               | Callback fired right before the overlay transitions out                                                      |
+| onExited        | () => void                                               | Callback fired after the overlay finishes transitioning out                                                  |
+| onExiting       | () => void                                               | Callback fired as the overlay begins to transition out                                                       |
+| onFocus         | () => void                                               | Callback function to get focus                                                                               |
+| onOpen          | () => void                                               | Callback fired when open component                                                                           |
+| placement       | [Placement](#code-ts-placement-code) `('right')`         | Dispaly placement                                                                                            |
+| preventOverflow | boolean                                                  | Prevent floating element overflow                                                                            |
+| speaker \*      | Tooltip &#124; Popover &#124; ReactElement               | Displayed component                                                                                          |
+| trigger         | [Trigger](#code-ts-placement-code) `(['hover','focus'])` | Triggering events                                                                                            |
 
 ### Whisper methods
 
@@ -73,4 +62,17 @@ Update overlay position
 
 ```ts
 updatePosition: () => void
+```
+
+### `ts:Trigger`
+
+```ts
+type Trigger =
+  | Array<'click' | 'contextMenu' | 'hover' | 'focus' | 'active'>
+  | 'click'
+  | 'contextMenu'
+  | 'hover'
+  | 'focus'
+  | 'active'
+  | 'none';
 ```

--- a/docs/pages/components/whisper/zh-CN/index.md
+++ b/docs/pages/components/whisper/zh-CN/index.md
@@ -15,3 +15,4 @@
 ## Props
 
 <!--{include:(components/whisper/zh-CN/props.md)}-->
+<!--{include:(_common/types/placement-all.md)}-->

--- a/docs/pages/components/whisper/zh-CN/props.md
+++ b/docs/pages/components/whisper/zh-CN/props.md
@@ -1,41 +1,30 @@
 ### `<Whisper>`
 
-```ts
-type Trigger =
-  | Array<'click' | 'contextMenu' | 'hover' | 'focus' | 'active'>
-  | 'click'
-  | 'contextMenu'
-  | 'hover'
-  | 'focus'
-  | 'active'
-  | 'none';
-```
-
-| 属性名称        | 类型 `(默认值)`                           | 描述                                                                      |
-| --------------- | ----------------------------------------- | ------------------------------------------------------------------------- |
-| container       | HTMLElement &#124; (() => HTMLElement)    | 设置渲染的容器                                                            |
-| controlId       | string                                    | 设置 `id` 到 `<Overlay>`上，并且设置 `aria-describedby` 到 `<Whisper>` 上 |
-| delay           | number                                    | 延迟时间 (ms)                                                             |
-| delayClose      | number                                    | 延迟关闭时间 (ms)                                                         |
-| delayOpen       | number                                    | 延迟打开时间 (ms)                                                         |
-| enterable       | boolean                                   | 当 `trigger` 值为 `hover`时候，鼠标是否可进入提示框浮层中                 |
-| followCursor    | boolean                                   | 是否启用光标跟随                                                          |
-| full            | boolean                                   | 撑满容器                                                                  |
-| onBlur          | () => void                                | 失去焦点回调函数                                                          |
-| onClick         | () => void                                | 点击的回调函数                                                            |
-| onClose         | () => void                                | 关闭回调函数                                                              |
-| onEnter         | () => void                                | 显示前动画过渡的回调函数                                                  |
-| onEntered       | () => void                                | 显示后动画过渡的回调函数                                                  |
-| onEntering      | () => void                                | 显示中动画过渡的回调函数                                                  |
-| onExit          | () => void                                | 退出前动画过渡的回调函数                                                  |
-| onExited        | () => void                                | 退出后动画过渡的回调函数                                                  |
-| onExiting       | () => void                                | 退出中动画过渡的回调函数                                                  |
-| onFocus         | () => void                                | 获取焦点的回调函数                                                        |
-| onOpen          | () => void                                | 打开回调函数                                                              |
-| placement       | Placement `('right')`                     | 显示位置                                                                  |
-| preventOverflow | boolean                                   | 防止浮动元素溢出                                                          |
-| speaker \*      | Tooltip &#124;Popover &#124; ReactElement | 展示的元素                                                                |
-| trigger         | Trigger `(['hover','focus'])`             | 触发事件,可以通过数组配置多事件                                           |
+| 属性名称        | 类型 `(默认值)`                                          | 描述                                                                      |
+| --------------- | -------------------------------------------------------- | ------------------------------------------------------------------------- |
+| container       | HTMLElement &#124; (() => HTMLElement)                   | 设置渲染的容器                                                            |
+| controlId       | string                                                   | 设置 `id` 到 `<Overlay>`上，并且设置 `aria-describedby` 到 `<Whisper>` 上 |
+| delay           | number                                                   | 延迟时间 (ms)                                                             |
+| delayClose      | number                                                   | 延迟关闭时间 (ms)                                                         |
+| delayOpen       | number                                                   | 延迟打开时间 (ms)                                                         |
+| enterable       | boolean                                                  | 当 `trigger` 值为 `hover`时候，鼠标是否可进入提示框浮层中                 |
+| followCursor    | boolean                                                  | 是否启用光标跟随                                                          |
+| full            | boolean                                                  | 撑满容器                                                                  |
+| onBlur          | () => void                                               | 失去焦点回调函数                                                          |
+| onClick         | () => void                                               | 点击的回调函数                                                            |
+| onClose         | () => void                                               | 关闭回调函数                                                              |
+| onEnter         | () => void                                               | 显示前动画过渡的回调函数                                                  |
+| onEntered       | () => void                                               | 显示后动画过渡的回调函数                                                  |
+| onEntering      | () => void                                               | 显示中动画过渡的回调函数                                                  |
+| onExit          | () => void                                               | 退出前动画过渡的回调函数                                                  |
+| onExited        | () => void                                               | 退出后动画过渡的回调函数                                                  |
+| onExiting       | () => void                                               | 退出中动画过渡的回调函数                                                  |
+| onFocus         | () => void                                               | 获取焦点的回调函数                                                        |
+| onOpen          | () => void                                               | 打开回调函数                                                              |
+| placement       | [Placement](#code-ts-placement-code) `('right')`         | 显示位置                                                                  |
+| preventOverflow | boolean                                                  | 防止浮动元素溢出                                                          |
+| speaker \*      | Tooltip &#124; Popover &#124; ReactElement               | 展示的元素                                                                |
+| trigger         | [Trigger](#code-ts-placement-code) `(['hover','focus'])` | 触发事件,可以通过数组配置多事件                                           |
 
 ### Whisper methods
 
@@ -73,4 +62,17 @@ close: (delay?: number) => void
 
 ```ts
 updatePosition: () => void
+```
+
+### `ts:Trigger`
+
+```ts
+type Trigger =
+  | Array<'click' | 'contextMenu' | 'hover' | 'focus' | 'active'>
+  | 'click'
+  | 'contextMenu'
+  | 'hover'
+  | 'focus'
+  | 'active'
+  | 'none';
 ```


### PR DESCRIPTION
before

![image](https://user-images.githubusercontent.com/1203827/187184846-5c7c4a26-96b7-42d1-8cb7-3ece70affb56.png)

after

![image](https://user-images.githubusercontent.com/1203827/187184958-2332d22f-4f59-4c14-9341-38c803bac57d.png)
