### PR TITLE
fix(InputGroup): fix icons not being vertically centered within the input

### DIFF
--- a/docs/pages/components/input/fragments/masked-input.md
+++ b/docs/pages/components/input/fragments/masked-input.md
@@ -105,6 +105,7 @@ const App = () => {
           <SelectPicker
             defaultValue={option.name}
             cleanable={false}
+            searchable={false}
             data={options}
             labelKey="name"
             valueKey="name"
@@ -122,6 +123,7 @@ const App = () => {
           <SelectPicker
             value={placeholderChar}
             cleanable={false}
+            searchable={false}
             data={placeholderChars}
             onChange={setPlaceholderChar}
             style={{ width: 200 }}

--- a/src/InputGroup/styles/index.less
+++ b/src/InputGroup/styles/index.less
@@ -165,7 +165,7 @@
       top: 0;
       background: none;
       border: none;
-      padding: 11px 13px 8px 13px;
+      padding: 10px 13px 8px 13px;
     }
 
     .rs-input-group-btn ~ input.rs-input,

--- a/src/InputGroup/styles/index.less
+++ b/src/InputGroup/styles/index.less
@@ -165,7 +165,11 @@
       top: 0;
       background: none;
       border: none;
-      padding: 10px 13px 8px 13px;
+      padding: 10px 13px;
+
+      &.rs-input-group-btn {
+        padding: 8px 13px;
+      }
     }
 
     .rs-input-group-btn ~ input.rs-input,


### PR DESCRIPTION
<img width="408" alt="image" src="https://user-images.githubusercontent.com/1203827/187343909-a3d83060-f162-46cf-a1fc-f8c592b4ee36.png">
