### PR TITLE
feat(List): allow sort with non-adjacent collection

### DIFF
--- a/docs/pages/components/list/en-US/index.md
+++ b/docs/pages/components/list/en-US/index.md
@@ -36,6 +36,12 @@ Used to display a set of data
 
 <!--{include:`collection.md`}-->
 
+#### Fixed Item Sort
+
+> based on `collection`, Item can fixed during sort order.
+
+<!--{include:`sort-fixed.md`}-->
+
 ### Custom
 
 <!--{include:`custom.md`}-->

--- a/docs/pages/components/list/fragments/sort-fixed.md
+++ b/docs/pages/components/list/fragments/sort-fixed.md
@@ -1,0 +1,36 @@
+<!--start-code-->
+
+```js
+import { List } from 'rsuite';
+
+const BrowserList = ['Chrome', 'Edge', 'FireFox', 'Safari'];
+
+const App = () => {
+  const [data, setData] = React.useState(BrowserList);
+
+  const handleSortEnd = ({ oldIndex, newIndex }) =>
+    setData(prvData => {
+      const moveData = prvData.splice((oldIndex - 1) / 2, 1);
+      const newData = [...prvData];
+      newData.splice((newIndex - 1) / 2, 0, moveData[0]);
+      return newData;
+    }, []);
+
+  return (
+    <List sortable onSort={handleSortEnd}>
+      {data.flatMap((browser, index) => [
+        <List.Item key={index} index={index * 2} collection="order" disabled>
+          {index + 1}
+        </List.Item>,
+        <List.Item key={browser} index={index * 2 + 1}>
+          {browser}
+        </List.Item>
+      ])}
+    </List>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/list/zh-CN/index.md
+++ b/docs/pages/components/list/zh-CN/index.md
@@ -36,6 +36,12 @@
 
 <!--{include:`collection.md`}-->
 
+#### 固定项
+
+> 基于`分组排序`，列表中的项在排序时固定位置
+
+<!--{include:`sort-fixed.md`}-->
+
 ### 自定义列表
 
 <!--{include:`custom.md`}-->

--- a/src/List/helper/useSortHelper.ts
+++ b/src/List/helper/useSortHelper.ts
@@ -139,7 +139,6 @@ const useSortHelper = (config: SortConfig) => {
           const aTop = activeNodeOffsetEdge.top || 0;
           const cTop = containerScrollDelta.top || 0;
           const sortingOffsetY = aTop + activeNodeHolderTranslate.y + cTop;
-          const activeNodeHeight = parseFloat(activeNodeStyle.height) || 0;
 
           for (let i = 0, len = listItemManagerRefs.length; i < len; i++) {
             const currentNode = listItemManagerRefs[i].node;
@@ -180,10 +179,13 @@ const useSortHelper = (config: SortConfig) => {
               currentNodeIndex > activeNodeOldIndex &&
               sortingOffsetY + offsetY >= curEdgeOffsetTop
             ) {
-              translate.y = -activeNodeHeight;
+              const yOffset = (prvNode.edgeOffset?.top || 0) - curEdgeOffsetTop;
+
+              translate.y = yOffset;
+
               animatedNodesOffset[currentNodeIndex] = {
                 x: 0,
-                y: currentNode.offsetHeight
+                y: -yOffset
               };
               activeNodeNextIndex = currentNodeIndex;
             } else if (
@@ -191,10 +193,12 @@ const useSortHelper = (config: SortConfig) => {
               currentNodeIndex < activeNodeOldIndex &&
               sortingOffsetY <= curEdgeOffsetTop + offsetY
             ) {
-              translate.y = activeNodeHeight;
+              const yOffset = (nextNode.edgeOffset?.top || 0) - curEdgeOffsetTop;
+
+              translate.y = yOffset;
               animatedNodesOffset[currentNodeIndex] = {
                 x: 0,
-                y: -currentNode.offsetHeight
+                y: -yOffset
               };
               if (activeNodeNextIndex === -1) {
                 activeNodeNextIndex = currentNodeIndex;


### PR DESCRIPTION
## Features
in the previous list, elements can be sorted by `collection`. but the same collection cannot be separated. which mean you can only group member along with each other.

this PR only changes the ListItem animation style, fulfilling cross collection sort has to change the `onSort` callback

### example
```js
const handleSort = ({ collection, oldIndex, newIndex }) =>
    setData(prvData => {
      const moveData = prvData[oldIndex];
      const siblingData = prvData.filter(
        (item, index) => item.collection === collection && index !== oldIndex
      );
      const newData = [...prvData].map((item, index) => {
        if (item.collection == collection) {
          if (index === newIndex) {
            return moveData;
          }
          return siblingData.shift();
        }
        return item;
      });
      return newData;
    }, []);
```


### before
- group A(1)
- group A(2)
- group B(1)
- group B(2)

### after
- group A(1)
- group B(1)
- group B(2)
- group A(2)

## Video
https://user-images.githubusercontent.com/14308293/188780833-60e11e0d-a503-4e09-923b-2ea8ea2b70be.mov

https://rsuite-nextjs-git-feat-sort-corss-collection-rsuite.vercel.app/components/list/#fixed-item-sort


