### PR TITLE
fix(CheckTreePicker): fix uncheckable style errors

### DIFF
--- a/src/CheckTreePicker/styles/index.less
+++ b/src/CheckTreePicker/styles/index.less
@@ -92,7 +92,7 @@
   }
 
   // Uncheckable state
-  &-all-uncheckable > .rs-check-item .rs-checkbox-checker > label {
+  &-all-uncheckable .rs-check-item .rs-checkbox-checker > label {
     padding-left: 22px; // 10px + 12px
 
     &::before {

--- a/src/CheckTreePicker/test/CheckTreePickerStylesSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerStylesSpec.js
@@ -46,4 +46,21 @@ describe('CheckTreePicker styles', () => {
     const itemLabel = document.body.querySelector('.rs-check-tree .rs-checkbox-checker label');
     assert.equal(getStyle(itemLabel, 'padding'), '8px 12px 8px 32px');
   });
+
+  itChrome('Should render the correct styles when first level data is unchecked', () => {
+    const instanceRef = React.createRef();
+    render(
+      <CheckTreePicker
+        data={[
+          { value: 1, label: '1', children: [{ value: 2, label: '2' }] },
+          { value: 3, label: '3' }
+        ]}
+        uncheckableItemValues={[1, 3]}
+        ref={instanceRef}
+        open
+      />
+    );
+    const itemLabel = document.body.querySelector('.rs-check-tree .rs-checkbox-checker label');
+    assert.equal(getStyle(itemLabel, 'padding'), '8px 12px 8px 22px');
+  });
 });


### PR DESCRIPTION
**Problem**

when first level of data is in the uncheckable state, the padding-left value of the node label is incorrect.

![image](https://user-images.githubusercontent.com/12592949/188534122-75981540-6420-4251-8922-0e7332cfe436.png)


**Expected**

the padding-left value should be correct.

![image](https://user-images.githubusercontent.com/12592949/188534047-2c8b9f80-f3cf-4030-8d19-84d890f1d6ee.png)


