### PR TITLE
fix(Dropdown.Menu): fix custom className overriding rsuite classNames

### DIFF
--- a/src/Dropdown/DropdownMenu.tsx
+++ b/src/Dropdown/DropdownMenu.tsx
@@ -70,6 +70,7 @@ const DropdownMenu = React.forwardRef<
     activeKey,
     onSelect,
     classPrefix = 'dropdown-menu',
+    className,
     children,
     ...rest
   } = props;
@@ -109,7 +110,7 @@ const DropdownMenu = React.forwardRef<
   // <Dropdown.Menu> is used outside of <Dropdown>
   // renders a vertical `menubar`
   if (!dropdown) {
-    const classes = merge(props.className, withClassPrefix());
+    const classes = merge(className, withClassPrefix());
 
     return (
       <DropdownContext.Provider value={contextValue}>
@@ -126,7 +127,7 @@ const DropdownMenu = React.forwardRef<
 
   // Parent menu exists. This is a submenu.
   // Should render a `menuitem` that controls this submenu.
-  const { icon, className, disabled, ...menuProps } = omit(rest, ['trigger']);
+  const { icon, disabled, ...menuProps } = omit(rest, ['trigger']);
 
   const Icon = rtl ? AngleLeft : AngleRight;
 

--- a/src/Dropdown/test/DropdownMenuSpec.js
+++ b/src/Dropdown/test/DropdownMenuSpec.js
@@ -333,8 +333,8 @@ describe('<Dropdown.Menu>', () => {
   });
 
   it('Should have a custom className', () => {
-    const instance = getDOMNode(<DropdownMenu className="custom" />);
-    assert.include(instance.className, 'custom');
+    const { getByTestId } = render(<DropdownMenu className="custom" data-testid="menu" />);
+    expect(getByTestId('menu')).to.have.class('custom').and.to.have.class('rs-dropdown-menu');
   });
 
   it('Should have a custom style', () => {


### PR DESCRIPTION
Custom `className` was overriding rsuite classNames.

```jsx
<Dropdown.Menu className="custom" />
```

Before
<img width="403" alt="image" src="https://user-images.githubusercontent.com/8225666/189085244-699d5da8-1c3e-43ce-958d-08c6a98c76c5.png">

After
<img width="406" alt="image" src="https://user-images.githubusercontent.com/8225666/189085310-e20f5ead-d5ef-41ac-9de5-3d889a28892b.png">

