### PR TITLE
Add test case and documentation for `ref` attribute of `Button`

### DIFF
--- a/docs/pages/components/button/en-US/index.md
+++ b/docs/pages/components/button/en-US/index.md
@@ -91,6 +91,18 @@ The buttons are laid out horizontally in the button set and are equally wide.
 
 <!--{include:`justified.md`}-->
 
+## Accessing DOM
+
+The underlying `<button>` element is accessible via `ref` attribute of `Button`.
+
+```tsx
+function App() {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  return <Button ref={buttonRef}>Text</Button>;
+}
+```
+
 ## Props
 
 ### `<Button>`

--- a/docs/pages/components/button/zh-CN/index.md
+++ b/docs/pages/components/button/zh-CN/index.md
@@ -91,7 +91,17 @@
 
 <!--{include:`justified.md`}-->
 
-## Props
+## 访问 DOM
+
+`Button` 组件所渲染的 `<button>` 元素可通过 `ref` 属性访问。
+
+```tsx
+function App() {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  return <Button ref={buttonRef}>Text</Button>;
+}
+```
 
 ## Props
 

--- a/src/Button/test/ButtonSpec.js
+++ b/src/Button/test/ButtonSpec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
 import { getDOMNode, getInstance } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import Button from '../Button';
@@ -103,5 +104,13 @@ describe('Button', () => {
     assert.equal(instance.nodeName, 'SPAN');
 
     assert.equal(instance2.getAttribute('role'), 'combobox');
+  });
+
+  it('Should access the underlying <button> element via `ref` attribute', () => {
+    const buttonRef = React.createRef();
+
+    render(<Button ref={buttonRef}>Text</Button>);
+
+    expect(buttonRef.current).to.have.tagName('button');
   });
 });


### PR DESCRIPTION
Add "Accessing DOM" section for `Button` documentation. https://rsuite-nextjs-git-test-button-ref-rsuite.vercel.app/components/button/#accessing-dom

<img width="571" alt="image" src="https://user-images.githubusercontent.com/8225666/189842897-e793447d-a003-4d05-b93a-e33f3f5c1b2e.png">
