### PR TITLE
fix(Nav): fix incorrect height of <Nav.Menu>, fix #2678

### DIFF
--- a/src/Nav/styles/index.less
+++ b/src/Nav/styles/index.less
@@ -15,6 +15,7 @@
   // Rest dropdown height
   .rs-dropdown > .rs-dropdown-toggle {
     height: 36px;
+    vertical-align: bottom;
   }
 
   // Ripple

--- a/src/Nav/test/NavStylesSpec.js
+++ b/src/Nav/test/NavStylesSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import Nav from '../Nav';
 import { getDOMNode, getStyle } from '@test/testUtils';
 
@@ -23,5 +23,20 @@ describe('Nav styles', () => {
     );
 
     expect(getByRole('button')).to.have.style('background-color', 'rgba(0, 0, 0, 0)');
+  });
+
+  describe('Issue #2678', () => {
+    it('Height of <Nav.Menu> should be consistent with that of <Nav.Item> (36px)', () => {
+      render(
+        <Nav>
+          <Nav.Item>Item A</Nav.Item>
+          <Nav.Menu title="Item-B" data-testid="menu">
+            <Nav.Item>Item B-A</Nav.Item>
+          </Nav.Menu>
+        </Nav>
+      );
+
+      expect(screen.getByTestId('menu')).to.have.style('height', '36px');
+    });
   });
 });


### PR DESCRIPTION
Before

<img width="838" alt="image" src="https://user-images.githubusercontent.com/1203827/187180370-e5490c57-d2c8-4d3d-8293-bf70824bace6.png">

After

<img width="568" alt="image" src="https://user-images.githubusercontent.com/8225666/189842597-0b4b4a63-2d85-4346-9d1e-cf6bb56ec936.png">
