### PR TITLE
fix(Stack): fix spacing compat for chrome under 84

### DIFF
--- a/src/Stack/Stack.tsx
+++ b/src/Stack/Stack.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useClassNames, useCustom, isIE } from '../utils';
+import { useClassNames, useCustom, isSupportFlexGap } from '../utils';
 import { WithAsProps } from '../@types/common';
 
 export interface StackProps extends WithAsProps {
@@ -50,7 +50,7 @@ const Stack = React.forwardRef((props: StackProps, ref: React.Ref<HTMLDivElement
   const { rtl } = useCustom('Stack');
   const { withClassPrefix, merge, prefix } = useClassNames(classPrefix);
   const classes = merge(className, withClassPrefix());
-  const isSupportGridGap = !isIE();
+  const isSupportGridGap = isSupportFlexGap();
 
   const count = React.Children.count(children);
   const gridGap = Array.isArray(spacing) ? spacing : [spacing, 0];

--- a/src/utils/BrowserDetection.ts
+++ b/src/utils/BrowserDetection.ts
@@ -17,7 +17,7 @@ export const isEdge = () => canUseDOM && !isIE() && 'styleMedia' in window;
 
 export const getChromeVersion = () => {
   if (canUseDOM) {
-    const match = window.navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./); 
+    const match = window.navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
     return match ? parseFloat(match[2]) : false;
   }
 
@@ -26,9 +26,7 @@ export const getChromeVersion = () => {
 
 export const getSafariVersion = () => {
   if (canUseDOM) {
-    const match =
-      !!window.navigator.userAgent.match(/Safari\//) &&
-      window.navigator.userAgent.match(/Version\/([0-9]+)\./);
+    const match = window.navigator.userAgent.match(/Version\/([\d\.]+).*Safari/);
     return match ? parseFloat(match[1]) : false;
   }
   return false;

--- a/src/utils/BrowserDetection.ts
+++ b/src/utils/BrowserDetection.ts
@@ -17,7 +17,7 @@ export const isEdge = () => canUseDOM && !isIE() && 'styleMedia' in window;
 
 export const getChromeVersion = () => {
   if (canUseDOM) {
-    const match = window.navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
+    const match = window.navigator.userAgent.match(/Chrom(e|ium)\/([\d\.]+)\./);
     return match ? parseFloat(match[2]) : false;
   }
 

--- a/src/utils/BrowserDetection.ts
+++ b/src/utils/BrowserDetection.ts
@@ -17,8 +17,8 @@ export const isEdge = () => canUseDOM && !isIE() && 'styleMedia' in window;
 
 export const getChromeVersion = () => {
   if (canUseDOM) {
-    const match = window.navigator.userAgent.match(/Chrome\/([0-9]+)\./);
-    return match ? parseFloat(match[1]) : false;
+    const match = window.navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./); 
+    return match ? parseFloat(match[2]) : false;
   }
 
   return false;

--- a/src/utils/BrowserDetection.ts
+++ b/src/utils/BrowserDetection.ts
@@ -14,3 +14,47 @@ export const isIE11 = () =>
 
 // Edge 20+
 export const isEdge = () => canUseDOM && !isIE() && 'styleMedia' in window;
+
+export const getChromeVersion = () => {
+  if (canUseDOM) {
+    const match = window.navigator.userAgent.match(/Chrome\/([0-9]+)\./);
+    return match ? parseFloat(match[1]) : false;
+  }
+
+  return false;
+};
+
+export const getSafariVersion = () => {
+  if (canUseDOM) {
+    const match =
+      !!window.navigator.userAgent.match(/Safari\//) &&
+      window.navigator.userAgent.match(/Version\/([0-9]+)\./);
+    return match ? parseFloat(match[1]) : false;
+  }
+  return false;
+};
+
+/**
+ * flexbox-gap compatibility
+ * @see https://caniuse.com/flexbox-gap
+ */
+export const isSupportFlexGap = () => {
+  if (isIE()) {
+    return false;
+  }
+  const chromeVersion = getChromeVersion();
+  const safariVersion = getSafariVersion();
+
+  // edge consider as chrome
+  if (chromeVersion) {
+    // flex-gap is support in Chrome 84+
+    return chromeVersion >= 84;
+  }
+
+  if (safariVersion) {
+    // flex-gap is support in Safari 14.1+
+    return safariVersion >= 14.1;
+  }
+
+  return true;
+};


### PR DESCRIPTION
## ISSUES

`spacing` under **chrome 71**
![截屏2022-09-14 上午9 58 22](https://user-images.githubusercontent.com/14308293/190041492-7b22f521-8682-40a6-8328-f2c6bfe0c9af.png)

flexbox-gap compat
- Chrome 84+
- Safari 14.1+
> compatibility table https://caniuse.com/flexbox-gap

## CHANGES
add `isSupportFlexGap` for Stack to check browser support