### PR TITLE
docs(Stack): fix spacing doc initial value

### DIFF
--- a/docs/pages/components/stack/fragments/space.md
+++ b/docs/pages/components/stack/fragments/space.md
@@ -10,7 +10,7 @@ const App = () => {
     <Stack direction="column" spacing={20} alignItems="flex-start">
       <Stack spacing={12}>
         Spacing:
-        <Slider style={{ width: 300 }} onChange={value => setSize(value)} />
+        <Slider defaultValue={6} style={{ width: 300 }} onChange={value => setSize(value)} />
       </Stack>
       <Stack spacing={size}>
         Label:

--- a/docs/pages/components/stack/fragments/space.md
+++ b/docs/pages/components/stack/fragments/space.md
@@ -10,7 +10,7 @@ const App = () => {
     <Stack direction="column" spacing={20} alignItems="flex-start">
       <Stack spacing={12}>
         Spacing:
-        <Slider defaultValue={6} style={{ width: 300 }} onChange={value => setSize(value)} />
+        <Slider value={size} style={{ width: 300 }} onChange={value => setSize(value)} />
       </Stack>
       <Stack spacing={size}>
         Label:


### PR DESCRIPTION
## DOCS
in `spacing` example
Slider initial value(`undefined`) is different with useState(`6`)

```js
const [size, setSize] = useState(6);

<Slider style={{ width: 300 }} onChange={value => setSize(value)} />
```