### PR TITLE
fix(Stack): filter children that should not be rendered

### DIFF
--- a/src/Stack/Stack.tsx
+++ b/src/Stack/Stack.tsx
@@ -75,29 +75,35 @@ const Stack = React.forwardRef((props: StackProps, ref: React.Ref<HTMLDivElement
 
   return (
     <Component {...rest} ref={ref} className={classes} style={styles}>
-      {React.Children.map(children as React.ReactElement[], (child, index) => {
-        const childNode =
-          child.type !== StackItem ? (
-            <StackItem
-              className={prefix('item')}
-              style={!isSupportGridGap ? itemStyles : undefined}
-            >
-              {child}
-            </StackItem>
-          ) : (
-            React.cloneElement(child, {
-              className: merge(prefix('item'), child.props.className),
-              style: !isSupportGridGap
-                ? {
-                    ...itemStyles,
-                    ...child.props.style
-                  }
-                : child.props.style
-            })
-          );
+      {
+        /*
+         * toArray remove undefined, null and boolean
+         */
+        (React.Children.toArray(children) as React.ReactElement[]).map((child, index) => {
+          const childNode =
+            child.type !== StackItem ? (
+              <StackItem
+                key={index}
+                className={prefix('item')}
+                style={!isSupportGridGap ? itemStyles : undefined}
+              >
+                {child}
+              </StackItem>
+            ) : (
+              React.cloneElement(child, {
+                className: merge(prefix('item'), child.props.className),
+                style: !isSupportGridGap
+                  ? {
+                      ...itemStyles,
+                      ...child.props.style
+                    }
+                  : child.props.style
+              })
+            );
 
-        return [childNode, index < count - 1 ? divider : null];
-      })}
+          return [childNode, index < count - 1 ? divider : null];
+        })
+      }
     </Component>
   );
 }) as unknown as StackComponent;

--- a/src/Stack/Stack.tsx
+++ b/src/Stack/Stack.tsx
@@ -57,7 +57,6 @@ const Stack = React.forwardRef((props: StackProps, ref: React.Ref<HTMLDivElement
   const classes = merge(className, withClassPrefix());
   const isSupportGridGap = isSupportFlexGap();
 
-  const count = React.Children.count(children);
   const gridGap = Array.isArray(spacing) ? spacing : [spacing, 0];
   const itemStyles: React.CSSProperties = {
     [rtl ? 'marginLeft' : 'marginRight']: gridGap[0],
@@ -77,6 +76,8 @@ const Stack = React.forwardRef((props: StackProps, ref: React.Ref<HTMLDivElement
    * toArray remove undefined, null and boolean
    */
   const filterChildren = React.Children.toArray(children);
+
+  const count = filterChildren.length;
 
   return (
     <Component {...rest} ref={ref} className={classes} style={styles}>

--- a/src/Stack/Stack.tsx
+++ b/src/Stack/Stack.tsx
@@ -73,37 +73,37 @@ const Stack = React.forwardRef((props: StackProps, ref: React.Ref<HTMLDivElement
     ...style
   };
 
+  /*
+   * toArray remove undefined, null and boolean
+   */
+  const filterChildren = React.Children.toArray(children);
+
   return (
     <Component {...rest} ref={ref} className={classes} style={styles}>
-      {
-        /*
-         * toArray remove undefined, null and boolean
-         */
-        (React.Children.toArray(children) as React.ReactElement[]).map((child, index) => {
-          const childNode =
-            child.type !== StackItem ? (
-              <StackItem
-                key={index}
-                className={prefix('item')}
-                style={!isSupportGridGap ? itemStyles : undefined}
-              >
-                {child}
-              </StackItem>
-            ) : (
-              React.cloneElement(child, {
-                className: merge(prefix('item'), child.props.className),
-                style: !isSupportGridGap
-                  ? {
-                      ...itemStyles,
-                      ...child.props.style
-                    }
-                  : child.props.style
-              })
-            );
+      {React.Children.map(filterChildren as React.ReactElement[], (child, index) => {
+        const childNode =
+          child.type !== StackItem ? (
+            <StackItem
+              key={index}
+              className={prefix('item')}
+              style={!isSupportGridGap ? itemStyles : undefined}
+            >
+              {child}
+            </StackItem>
+          ) : (
+            React.cloneElement(child, {
+              className: merge(prefix('item'), child.props.className),
+              style: !isSupportGridGap
+                ? {
+                    ...itemStyles,
+                    ...child.props.style
+                  }
+                : child.props.style
+            })
+          );
 
-          return [childNode, index < count - 1 ? divider : null];
-        })
-      }
+        return [childNode, index < count - 1 ? divider : null];
+      })}
     </Component>
   );
 }) as unknown as StackComponent;

--- a/src/Stack/test/StackSpec.js
+++ b/src/Stack/test/StackSpec.js
@@ -58,4 +58,18 @@ describe('Stack', () => {
     assert.equal(getByTestId('test').children.length, 3);
     assert.equal(getByTestId('test').children[1].textContent, '|');
   });
+
+  it('Should not render empty child', () => {
+    const { getByTestId } = render(
+      <Stack data-testid="test">
+        {0}
+        {null}
+        {false}
+        {''}
+        {[1, 2]}
+      </Stack>
+    );
+
+    expect(getByTestId('test').children.length).to.equal(4);
+  });
 });

--- a/src/Stack/test/StackSpec.js
+++ b/src/Stack/test/StackSpec.js
@@ -70,6 +70,6 @@ describe('Stack', () => {
       </Stack>
     );
 
-    expect(getByTestId('test').children.length).to.equal(4);
+    expect(getByTestId('test').children).to.length(4);
   });
 });


### PR DESCRIPTION
## CHANGES
use `React.Children.toArray` remove empty children like `null`, `undefined` & `boolean` value.

## ISSUE
close #2731 