### PR TITLE
docs(Form): remove typo

### DIFF
--- a/docs/pages/components/form/en-US/index.md
+++ b/docs/pages/components/form/en-US/index.md
@@ -114,7 +114,7 @@ HTML:
 | onChange         | (formValue: object, event) => void                            | Callback fired when data changing                                                                          |
 | onCheck          | (formError: object) => void                                   | Callback fired when data cheking                                                                           |
 | onError          | (formError: object) => void                                   | Callback fired when error checking                                                                         |
-| plaintext        | boolean `(false)`                                             | Render the form as plain text 本                                                                           |
+| plaintext        | boolean `(false)`                                             | Render the form as plain text                                                                              |
 | readOnly         | boolean `(false)`                                             | Make the form readonly                                                                                     |
 
 ### Form methods


### PR DESCRIPTION
Chinese appears in English documents

<img width="954" alt="image" src="https://user-images.githubusercontent.com/12592949/191479595-56cd1add-6b49-4ef1-8f9c-35a11d274f70.png">

See: https://rsuitejs.com/components/form/#code-lt-form-gt-code