### PR TITLE
fix(TreePicker,CheckTreePicker): fix `renderExtraFooter` causing the …

### DIFF
--- a/docs/pages/components/check-picker/fragments/extra-footer.md
+++ b/docs/pages/components/check-picker/fragments/extra-footer.md
@@ -44,7 +44,6 @@ const App = () => {
         renderExtraFooter={() => (
           <div style={footerStyles}>
             <Checkbox
-              inline
               indeterminate={value.length > 0 && value.length < allValue.length}
               checked={value.length === allValue.length}
               onChange={handleCheckAll}

--- a/docs/pages/components/check-tree-picker/en-US/index.md
+++ b/docs/pages/components/check-tree-picker/en-US/index.md
@@ -42,6 +42,10 @@ The cascade attribute can set whether or not CheckTreePicker can consider the ca
 
 <!--{include:`async.md`}-->
 
+### Extra footer
+
+<!--{include:`extra-footer.md`}-->
+
 ## Accessibility
 
 Learn more in [Accessibility](/guide/accessibility).

--- a/docs/pages/components/check-tree-picker/fragments/extra-footer.md
+++ b/docs/pages/components/check-tree-picker/fragments/extra-footer.md
@@ -1,0 +1,39 @@
+<!--start-code-->
+
+```js
+import { CheckTreePicker, Checkbox } from 'rsuite';
+import { mockTreeData } from './mock';
+
+const data = mockTreeData({
+  limits: [4, 6, 6],
+  labels: (layer, value, faker) => {
+    const methodName = ['jobArea', 'jobType', 'firstName'];
+    return faker.name[methodName[layer]]();
+  }
+});
+
+const App = () => (
+  <>
+    <CheckTreePicker
+      virtualized
+      defaultExpandAll
+      data={data}
+      style={{ width: 280 }}
+      renderExtraFooter={() => (
+        <div
+          style={{
+            padding: '10px 2px',
+            borderTop: '1px solid #e5e5e5'
+          }}
+        >
+          <Checkbox inline>Check all</Checkbox>
+        </div>
+      )}
+    />
+  </>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/check-tree-picker/index.tsx
+++ b/docs/pages/components/check-tree-picker/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CheckTreePicker, Button, Toggle } from 'rsuite';
+import { CheckTreePicker, Button, Toggle, Checkbox } from 'rsuite';
 import SpinnerIcon from '@rsuite/icons/legacy/Spinner';
 import PeoplesIcon from '@rsuite/icons/Peoples';
 import AdminIcon from '@rsuite/icons/Admin';
@@ -25,6 +25,7 @@ export default function Page() {
   return (
     <DefaultPage
       dependencies={{
+        Checkbox,
         CheckTreePicker,
         Button,
         Toggle,

--- a/docs/pages/components/check-tree-picker/zh-CN/index.md
+++ b/docs/pages/components/check-tree-picker/zh-CN/index.md
@@ -42,6 +42,10 @@
 
 <!--{include:`async.md`}-->
 
+### 自定义页脚
+
+<!--{include:`extra-footer.md`}-->
+
 ## 无障碍设计
 
 了解更多有关[无障碍设计](/zh/guide/accessibility)的信息。

--- a/docs/pages/components/tree-picker/en-US/index.md
+++ b/docs/pages/components/tree-picker/en-US/index.md
@@ -40,6 +40,10 @@
 
 <!--{include:`async.md`}-->
 
+### Extra footer
+
+<!--{include:`extra-footer.md`}-->
+
 ## Accessibility
 
 Learn more in [Accessibility](/guide/accessibility).

--- a/docs/pages/components/tree-picker/fragments/extra-footer.md
+++ b/docs/pages/components/tree-picker/fragments/extra-footer.md
@@ -1,0 +1,39 @@
+<!--start-code-->
+
+```js
+import { TreePicker } from 'rsuite';
+import { mockTreeData } from './mock';
+
+const data = mockTreeData({
+  limits: [6, 6, 4],
+  labels: (layer, value, faker) => {
+    const methodName = ['jobArea', 'jobType', 'firstName'];
+    return faker.name[methodName[layer]]();
+  }
+});
+
+const App = () => (
+  <>
+    <TreePicker
+      virtualized
+      defaultExpandAll
+      data={data}
+      style={{ width: 246 }}
+      renderExtraFooter={() => (
+        <div
+          style={{
+            padding: 10,
+            borderTop: '1px solid #e5e5e5'
+          }}
+        >
+          Extra footer
+        </div>
+      )}
+    />
+  </>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/tree-picker/zh-CN/index.md
+++ b/docs/pages/components/tree-picker/zh-CN/index.md
@@ -40,6 +40,10 @@
 
 <!--{include:`async.md`}-->
 
+### 自定义页脚
+
+<!--{include:`extra-footer.md`}-->
+
 ## 无障碍设计
 
 了解更多有关[无障碍设计](/zh/guide/accessibility)的信息。

--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -73,7 +73,6 @@ import {
 
 import { TreeBaseProps } from '../Tree/Tree';
 import { FormControlPickerProps, ItemDataType } from '../@types/common';
-import { maxTreeHeight } from '../TreePicker/TreePicker';
 
 export type ValueType = (string | number)[];
 export interface CheckTreePickerProps<T = ValueType>
@@ -129,6 +128,7 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
     expandItemValues: controlledExpandItemValues,
     defaultExpandItemValues = emptyArray,
     height = 360,
+    menuMaxHeight = 320,
     menuStyle,
     searchable = true,
     virtualized = false,
@@ -813,7 +813,7 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
         <div className={treeNodesClass}>
           {virtualized ? (
             <AutoSizer
-              defaultHeight={inline ? height : maxTreeHeight}
+              defaultHeight={inline ? height : menuMaxHeight}
               style={{ width: 'auto', height: 'auto' }}
             >
               {({ height, width }) => (
@@ -841,13 +841,12 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
     const { left, top, className } = positionProps;
     const classes = classNames(className, menuClassName, prefix('check-tree-menu'));
     const mergedMenuStyle = { ...menuStyle, left, top };
-    const styles = virtualized ? { height, ...mergedMenuStyle } : { ...mergedMenuStyle };
 
     return (
       <PickerOverlay
         autoWidth={menuAutoWidth}
         className={classes}
-        style={styles}
+        style={mergedMenuStyle}
         ref={mergeRefs(overlayRef, speakerRef)}
         onKeyDown={onPickerKeydown}
         target={triggerRef}

--- a/src/CheckTreePicker/styles/index.less
+++ b/src/CheckTreePicker/styles/index.less
@@ -164,9 +164,6 @@
 }
 
 .rs-picker-menu {
-  display: flex;
-  flex-direction: column;
-
   &.rs-check-tree-menu {
     padding-top: @picker-menu-padding;
 

--- a/src/DatePicker/styles/index.less
+++ b/src/DatePicker/styles/index.less
@@ -32,6 +32,11 @@
       height: 286px;
     }
   }
+
+  &-menu {
+    display: flex;
+    flex-direction: column;
+  }
 }
 
 // Calendar in DatePicker popup

--- a/src/DateRangePicker/styles/index.less
+++ b/src/DateRangePicker/styles/index.less
@@ -8,6 +8,9 @@
 // ----------------------
 
 .rs-picker-daterange-menu {
+  display: flex;
+  flex-direction: column;
+
   .rs-calendar {
     display: inline-block;
     height: 274px;

--- a/src/DateRangePicker/test/DateRangePickerStylesSpec.js
+++ b/src/DateRangePicker/test/DateRangePickerStylesSpec.js
@@ -7,19 +7,16 @@ import getWidth from 'dom-lib/getWidth';
 import '../styles/index.less';
 
 describe('DateRangePicker styles', () => {
-  it('Should render the correct styles', call => {
-    const instanceRef = React.createRef();
-    render(<DateRangePicker ref={instanceRef} open />);
+  it('Should render the correct styles', () => {
+    const { getByLabelText } = render(<DateRangePicker open />);
 
-    const toggleDom = instanceRef.current.target;
-    assert.isNotNull(toggleDom.querySelector('[aria-label="calendar"]'));
-    call();
+    expect(getByLabelText('calendar').tagName).to.equal('svg');
   });
 
   it('Should keep size in `block` mode', function () {
     const instance = getInstance(<DateRangePicker block defaultOpen />);
 
-    assert.ok(instance.root.className.includes('rs-picker-block'));
-    assert.equal(getWidth(instance.overlay), 492);
+    expect(instance.root).to.have.class('rs-picker-block');
+    expect(getWidth(instance.overlay)).to.equal(492);
   });
 });

--- a/src/Picker/styles/index.less
+++ b/src/Picker/styles/index.less
@@ -277,8 +277,6 @@
   overflow: hidden;
   // Remove transition
   transition: none;
-  display: flex;
-  flex-direction: column;
 
   .high-contrast-mode({
     border: 1px solid var(--rs-border-primary);

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -65,9 +65,6 @@ import { FormControlPickerProps, ItemDataType } from '../@types/common';
 
 import TreeContext from '../Tree/TreeContext';
 
-// default value for virtualized
-export const maxTreeHeight = 320;
-
 export interface TreePickerProps<T = number | string>
   extends TreeBaseProps<T, ItemDataType>,
     TreeDragProps,
@@ -117,11 +114,12 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
     value: controlledValue,
     locale: overrideLocale,
     height = 360,
+    menuMaxHeight = 320,
+    menuStyle,
     className,
     disabled,
     placement = 'bottomStart',
     cleanable = true,
-    menuStyle,
     searchable = true,
     virtualized = false,
     classPrefix = 'picker',
@@ -781,7 +779,7 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
         <div className={treePrefix('nodes')}>
           {virtualized ? (
             <AutoSizer
-              defaultHeight={inline ? height : maxTreeHeight}
+              defaultHeight={inline ? height : menuMaxHeight}
               style={{ width: 'auto', height: 'auto' }}
             >
               {({ height, width }) => (
@@ -809,13 +807,12 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
     const { left, top, className } = positionProps;
     const classes = merge(className, menuClassName, prefix('tree-menu'));
     const mergedMenuStyle = { ...menuStyle, left, top };
-    const styles = virtualized ? { height, ...mergedMenuStyle } : { ...mergedMenuStyle };
 
     return (
       <PickerOverlay
         autoWidth={menuAutoWidth}
         className={classes}
-        style={styles}
+        style={mergedMenuStyle}
         ref={mergeRefs(overlayRef, speakerRef)}
         onKeyDown={onPickerKeydown}
         target={triggerRef}


### PR DESCRIPTION
…last option to be invisible

fix: https://github.com/rsuite/rsuite/issues/2733


https://github.com/rsuite/rsuite/pull/1476/files#diff-28c7e8e25892c192e8b1d5e190e7aed969d6f91a5e50a7505e9a4fe946201fe4R153-R154
https://github.com/rsuite/rsuite/pull/1476/files#diff-28c7e8e25892c192e8b1d5e190e7aed969d6f91a5e50a7505e9a4fe946201fe4R153-R154

@SevenOutman `display: flex` is set for the menu in both TreePicker and CheckTreePicker styles. This is the main reason why `renderExtraFooter` is not visible. When I remove `display: flex` , the style of the component doesn't change, so I don't know what is the purpose of setting `display: flex` on the menu in TreePicker and CheckTreePicker? Are there other risks if I remove it?

