### PR TITLE
perf(CheckTreePicker): improve performance when using large data 

### DIFF
--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback, useContext } from 'react';
+import React, { useState, useRef, useEffect, useCallback, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { isNil, pick, isFunction, omit, cloneDeep, isUndefined } from 'lodash';
@@ -439,11 +439,6 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
     ]
   );
 
-  const hasValue = () => {
-    const selectedValues = getSelectedItems(flattenNodes, value, 'valueKey');
-    return selectedValues.length > 0;
-  };
-
   const handleOpen = useCallback(() => {
     triggerRef.current?.open?.();
     setFocusItemValue(activeNode?.[valueKey]);
@@ -703,7 +698,7 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
         {
           ...node,
           /**
-           * spread operator dont copy unenumerable properties
+           * spread operator don't copy unenumerable properties
            * so we need to copy them manually
            */
           parent: node.parent,
@@ -863,13 +858,13 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
     );
   };
 
+  const selectedItems = useMemo(() => getSelectedItems(flattenNodes, value), [flattenNodes, value]);
   /**
    * 1.Have a value and the value is valid.
    * 2.Regardless of whether the value is valid, as long as renderValue is set, it is judged to have a value.
    */
-  let hasValidValue = hasValue() || (value.length > 0 && isFunction(renderValue));
+  let hasValidValue = selectedItems.length > 0 || (value.length > 0 && isFunction(renderValue));
   let selectedElement: React.ReactNode = placeholder;
-  const selectedItems = getSelectedItems(flattenNodes, value, valueKey);
 
   if (hasValidValue) {
     selectedElement = (

--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -13,8 +13,7 @@ import {
   useClassNames,
   useControlled,
   KEY_VALUES,
-  mergeRefs,
-  shallowEqual
+  mergeRefs
 } from '../utils';
 
 import {
@@ -266,10 +265,10 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
       value: node[valueKey],
       label: node[labelKey],
       layer,
-      focus: shallowEqual(focusItemValue, node[valueKey]),
+      focus: focusItemValue === node[valueKey],
       expand: node.expand,
       visible: node.visible,
-      loading: loadingNodeValues.some(item => shallowEqual(item, node[valueKey])),
+      loading: loadingNodeValues.some(item => item === node[valueKey]),
       disabled: getDisabledState(flattenNodes, node, { disabledItemValues, valueKey }),
       nodeData: node,
       checkState: node.checkState,
@@ -441,10 +440,8 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
   );
 
   const hasValue = () => {
-    const selectedValues = Object.keys(flattenNodes)
-      .map((refKey: string) => flattenNodes[refKey][valueKey])
-      .filter((item: any) => value.some(v => shallowEqual(v, item)));
-    return !!selectedValues.length;
+    const selectedValues = getSelectedItems(flattenNodes, value, 'valueKey');
+    return selectedValues.length > 0;
   };
 
   const handleOpen = useCallback(() => {

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -81,7 +81,9 @@ describe('CheckTreePicker', () => {
     );
 
     ReactTestUtils.Simulate.click(
-      instance.overlay.querySelector('div[data-ref="0-0"]  > .rs-check-tree-node-expand-icon')
+      instance.overlay.querySelector(
+        'div[data-ref="String_Master"]  > .rs-check-tree-node-expand-icon'
+      )
     );
     assert.equal(instance.overlay.querySelectorAll('.rs-check-tree-open').length, 1);
   });
@@ -161,7 +163,9 @@ describe('CheckTreePicker', () => {
   it('Should call `onChange` callback with 1 values', () => {
     const mockOnChange = sinon.spy();
     const instance = getInstance(<CheckTreePicker open onChange={mockOnChange} data={data} />);
-    ReactTestUtils.Simulate.change(instance.overlay.querySelector('div[data-key="0-0"] input'));
+    ReactTestUtils.Simulate.change(
+      instance.overlay.querySelector('div[data-key="String_Master"] input')
+    );
     expect(mockOnChange).to.have.been.calledWith(['Master']);
   });
 
@@ -221,7 +225,9 @@ describe('CheckTreePicker', () => {
   it('Should focus item by keyCode=38 ', () => {
     const tree = getInstance(<CheckTreePicker defaultOpen data={data} defaultExpandAll />);
 
-    ReactTestUtils.Simulate.change(tree.overlay.querySelector('div[data-key="0-0-1"] input'));
+    ReactTestUtils.Simulate.change(
+      tree.overlay.querySelector('div[data-key="String_tester1"] input')
+    );
     ReactTestUtils.Simulate.keyDown(tree.target, { key: KEY_VALUES.UP });
 
     assert.equal(tree.overlay.querySelector(itemFocusClassName).textContent, 'tester0');
@@ -234,7 +240,9 @@ describe('CheckTreePicker', () => {
     const tree = getInstance(
       <CheckTreePicker defaultOpen data={data} defaultExpandAll onChange={doneOp} />
     );
-    ReactTestUtils.Simulate.change(tree.overlay.querySelector('div[data-key="0-0-1"] input'));
+    ReactTestUtils.Simulate.change(
+      tree.overlay.querySelector('div[data-key="String_tester1"] input')
+    );
   });
 
   /**
@@ -243,10 +251,13 @@ describe('CheckTreePicker', () => {
   it('Should fold children node by keyCode=37', () => {
     const tree = getInstance(<CheckTreePicker defaultOpen data={data} defaultExpandAll />);
 
-    ReactTestUtils.Simulate.change(tree.overlay.querySelector('div[data-key="0-0"] input'));
+    ReactTestUtils.Simulate.change(
+      tree.overlay.querySelector('div[data-key="String_Master"] input')
+    );
     ReactTestUtils.Simulate.keyDown(tree.overlay, { key: KEY_VALUES.LEFT });
     assert.equal(
-      tree.overlay.querySelectorAll(`div[data-ref="0-0"] > ${itemExpandedClassName}`).length,
+      tree.overlay.querySelectorAll(`div[data-ref="String_Master"] > ${itemExpandedClassName}`)
+        .length,
       0
     );
   });
@@ -257,12 +268,15 @@ describe('CheckTreePicker', () => {
   it('Should change nothing when trigger on root node by keyCode=37', () => {
     const tree = getInstance(<CheckTreePicker defaultOpen data={data} defaultExpandAll />);
 
-    ReactTestUtils.Simulate.change(tree.overlay.querySelector('div[data-key="0-0"] input'));
+    ReactTestUtils.Simulate.change(
+      tree.overlay.querySelector('div[data-key="String_Master"] input')
+    );
     ReactTestUtils.Simulate.keyDown(tree.overlay, { key: KEY_VALUES.LEFT });
     assert.equal(tree.overlay.querySelector(itemFocusClassName).textContent, 'Master');
 
     assert.equal(
-      tree.overlay.querySelectorAll(`div[data-ref="0-0"] > ${itemExpandedClassName}`).length,
+      tree.overlay.querySelectorAll(`div[data-ref="String_Master"] > ${itemExpandedClassName}`)
+        .length,
       0
     );
   });
@@ -273,7 +287,9 @@ describe('CheckTreePicker', () => {
   it('Should focus on parentNode when trigger on leaf node by keyCode=37', () => {
     const tree = getInstance(<CheckTreePicker defaultOpen data={data} defaultExpandAll />);
 
-    ReactTestUtils.Simulate.change(tree.overlay.querySelector('div[data-key="0-0-0"] input'));
+    ReactTestUtils.Simulate.change(
+      tree.overlay.querySelector('div[data-key="String_tester0"] input')
+    );
     ReactTestUtils.Simulate.keyDown(tree.overlay, { key: KEY_VALUES.LEFT });
     assert.equal(tree.overlay.querySelector(itemFocusClassName).textContent, 'Master');
   });
@@ -284,10 +300,13 @@ describe('CheckTreePicker', () => {
   it('Should fold children node by keyCode=39', () => {
     const tree = getInstance(<CheckTreePicker defaultOpen data={data} />);
 
-    ReactTestUtils.Simulate.change(tree.overlay.querySelector('div[data-key="0-0"] input'));
+    ReactTestUtils.Simulate.change(
+      tree.overlay.querySelector('div[data-key="String_Master"] input')
+    );
     ReactTestUtils.Simulate.keyDown(tree.overlay, { key: KEY_VALUES.RIGHT });
     assert.equal(
-      tree.overlay.querySelectorAll(`div[data-ref="0-0"] > ${itemExpandedClassName}`).length,
+      tree.overlay.querySelectorAll(`div[data-ref="String_Master"] > ${itemExpandedClassName}`)
+        .length,
       1
     );
   });
@@ -298,7 +317,9 @@ describe('CheckTreePicker', () => {
   it('Should change nothing when trigger on leaf node by keyCode=39', () => {
     const tree = getInstance(<CheckTreePicker defaultOpen data={data} defaultExpandAll />);
 
-    ReactTestUtils.Simulate.change(tree.overlay.querySelector('div[data-key="0-0-0"] input'));
+    ReactTestUtils.Simulate.change(
+      tree.overlay.querySelector('div[data-key="String_tester0"] input')
+    );
     ReactTestUtils.Simulate.keyDown(tree.overlay, { key: KEY_VALUES.RIGHT });
     assert.equal(tree.overlay.querySelector(itemFocusClassName).textContent, 'tester0');
   });
@@ -309,7 +330,9 @@ describe('CheckTreePicker', () => {
   it('Should focus on first child node when node expanded by keyCode=39', () => {
     const tree = getInstance(<CheckTreePicker defaultOpen data={data} defaultExpandAll />);
 
-    ReactTestUtils.Simulate.change(tree.overlay.querySelector('div[data-key="0-0"] input'));
+    ReactTestUtils.Simulate.change(
+      tree.overlay.querySelector('div[data-key="String_Master"] input')
+    );
     ReactTestUtils.Simulate.keyDown(tree.overlay, { key: KEY_VALUES.RIGHT });
     assert.equal(tree.overlay.querySelector(itemFocusClassName).textContent, 'tester0');
   });
@@ -364,11 +387,13 @@ describe('CheckTreePicker', () => {
 
     ReactTestUtils.act(() => {
       ReactTestUtils.Simulate.click(
-        ref.current.overlay.querySelector('div[data-ref="0-1"]  > .rs-check-tree-node-expand-icon')
+        ref.current.overlay.querySelector(
+          'div[data-ref="String_async"]  > .rs-check-tree-node-expand-icon'
+        )
       );
     });
 
-    assert.ok(ref.current.overlay.querySelector('[data-key="0-1-0"]'));
+    assert.ok(ref.current.overlay.querySelector('[data-key="String_children1"]'));
   });
 
   it('Should trigger onChange and return correctly value', () => {
@@ -424,7 +449,9 @@ describe('CheckTreePicker', () => {
       />
     );
 
-    ReactTestUtils.Simulate.change(instance.overlay.querySelector('div[data-key="0-1-0"] input'));
+    ReactTestUtils.Simulate.change(
+      instance.overlay.querySelector('div[data-key="String_2-1"] input')
+    );
     expect(mockOnChange).to.have.been.calledWith(expectedValue);
   });
 
@@ -491,7 +518,9 @@ describe('CheckTreePicker', () => {
 
     ReactTestUtils.act(() => {
       ReactTestUtils.Simulate.click(
-        ref.current.overlay.querySelector('div[data-ref="0-0"]  > .rs-check-tree-node-expand-icon')
+        ref.current.overlay.querySelector(
+          'div[data-ref="String_Master"]  > .rs-check-tree-node-expand-icon'
+        )
       );
     });
 
@@ -572,7 +601,9 @@ describe('CheckTreePicker', () => {
 
   it('Should display indeterminate state when only one child node selected', () => {
     const instance = getInstance(<CheckTreePicker open defaultExpandAll data={data} />);
-    ReactTestUtils.Simulate.change(instance.overlay.querySelector('div[data-key="0-0-1-0"] input'));
+    ReactTestUtils.Simulate.change(
+      instance.overlay.querySelector('div[data-key="String_tester2"] input')
+    );
     assert.equal(instance.overlay.querySelectorAll('.rs-checkbox-indeterminate').length, 1);
   });
 
@@ -593,14 +624,14 @@ describe('CheckTreePicker', () => {
 
     ReactTestUtils.act(() => {
       ReactTestUtils.Simulate.change(
-        ref.current.overlay.querySelector('div[data-key="0-0-1"] input')
+        ref.current.overlay.querySelector('div[data-key="String_node-1"] input')
       );
     });
 
     assert.equal(checkItems.length, 1);
   });
 
-  it('Should item able to stringfy', () => {
+  it('Should item able to stringify', () => {
     const onSelectSpy = sinon.spy();
     const renderTreeNodeSpy = sinon.spy();
 
@@ -612,7 +643,9 @@ describe('CheckTreePicker', () => {
         renderTreeNode={renderTreeNodeSpy}
       />
     );
-    ReactTestUtils.Simulate.change(instance.overlay.querySelector('div[data-key="0-0"] input'));
+    ReactTestUtils.Simulate.change(
+      instance.overlay.querySelector('div[data-key="String_Master"] input')
+    );
 
     assert.doesNotThrow(() => JSON.stringify(data[0]));
     assert.doesNotThrow(() => JSON.stringify(onSelectSpy.firstCall.args[0]));

--- a/src/CheckTreePicker/utils.ts
+++ b/src/CheckTreePicker/utils.ts
@@ -1,7 +1,7 @@
 import { isNil, isUndefined } from 'lodash';
 import { CheckTreePickerProps, ValueType } from './CheckTreePicker';
 import { CHECK_STATE, CheckStateType } from '../utils';
-import { getChildrenByFlattenNodes } from '../utils/treeUtils';
+import { getChildrenByFlattenNodes, getNodeFormattedRefKey } from '../utils/treeUtils';
 import { attachParent } from '../utils/attachParent';
 
 export interface TreeNodeType {
@@ -163,8 +163,16 @@ export function getCheckTreePickerDefaultValue(value: any[], uncheckableItemValu
   return [];
 }
 
-export function getSelectedItems(nodes: TreeNodesType, values: ValueType, valueKey: string) {
-  return Object.values(nodes).filter((node: TreeNodeType) => values.includes(node[valueKey]));
+export function getSelectedItems(nodes: TreeNodesType, values: ValueType) {
+  const checkedItems: TreeNodeType[] = [];
+  values.forEach(value => {
+    const refKey = getNodeFormattedRefKey(value);
+    const node = nodes[refKey];
+    if (!isNil(node)) {
+      checkedItems.push(node);
+    }
+  });
+  return checkedItems;
 }
 
 export function getNodeCheckState({ nodes, node, cascade, childrenKey }: any): CheckStateType {

--- a/src/CheckTreePicker/utils.ts
+++ b/src/CheckTreePicker/utils.ts
@@ -1,6 +1,6 @@
 import { isNil, isUndefined } from 'lodash';
-import { CheckTreePickerProps } from './CheckTreePicker';
-import { shallowEqual, CHECK_STATE, CheckStateType } from '../utils';
+import { CheckTreePickerProps, ValueType } from './CheckTreePicker';
+import { CHECK_STATE, CheckStateType } from '../utils';
 import { getChildrenByFlattenNodes } from '../utils/treeUtils';
 import { attachParent } from '../utils/attachParent';
 
@@ -110,7 +110,7 @@ export function isNodeUncheckable(
   props: Required<Pick<CheckTreePickerProps, 'uncheckableItemValues' | 'valueKey'>>
 ) {
   const { uncheckableItemValues = [], valueKey } = props;
-  return uncheckableItemValues.some((value: any) => shallowEqual(node[valueKey], value));
+  return uncheckableItemValues.some((value: any) => node[valueKey] === value);
 }
 
 export function getFormattedTree(
@@ -151,7 +151,7 @@ export function getDisabledState(
   }
 
   return disabledItemValues.some(
-    (value: any) => node.refKey && shallowEqual(nodes[node.refKey][valueKey], value)
+    (value: any) => node.refKey && nodes[node.refKey][valueKey] === value
   );
 }
 
@@ -163,19 +163,8 @@ export function getCheckTreePickerDefaultValue(value: any[], uncheckableItemValu
   return [];
 }
 
-export function getSelectedItems(
-  nodes: TreeNodesType,
-  value: (string | number)[],
-  valueKey: string
-) {
-  const checkItems: TreeNodeType[] = [];
-  Object.keys(nodes).map((refKey: string) => {
-    const node = nodes[refKey];
-    if (value.some((value: any) => shallowEqual(node[valueKey], value))) {
-      checkItems.push(node);
-    }
-  });
-  return checkItems;
+export function getSelectedItems(nodes: TreeNodesType, values: ValueType, valueKey: string) {
+  return Object.values(nodes).filter((node: TreeNodeType) => values.includes(node[valueKey]));
 }
 
 export function getNodeCheckState({ nodes, node, cascade, childrenKey }: any): CheckStateType {

--- a/src/Tree/test/TreeSpec.js
+++ b/src/Tree/test/TreeSpec.js
@@ -97,8 +97,8 @@ describe('Tree', () => {
       const instance = getDOMNode(
         <Tree data={data} onDrop={onDropSpy} draggable defaultExpandAll />
       );
-      const dragTreeNode = instance.querySelector('span[data-key="0-0-0"]');
-      const dropTreeNode = instance.querySelector('span[data-key="0-0-1"]');
+      const dragTreeNode = instance.querySelector('span[data-key="String_tester0"]');
+      const dropTreeNode = instance.querySelector('span[data-key="String_tester1"]');
 
       Simulate.dragStart(dragTreeNode);
       Simulate.drop(dropTreeNode);

--- a/src/TreePicker/test/TreePickerSpec.js
+++ b/src/TreePicker/test/TreePickerSpec.js
@@ -90,7 +90,7 @@ describe('TreePicker', () => {
     );
 
     Simulate.click(
-      instance.overlay.querySelector('div[data-ref="0-0"]  > .rs-tree-node-expand-icon')
+      instance.overlay.querySelector('div[data-ref="String_Master"]  > .rs-tree-node-expand-icon')
     );
     assert.equal(instance.overlay.querySelectorAll('.rs-tree-open').length, 1);
   });
@@ -170,7 +170,7 @@ describe('TreePicker', () => {
     const onChangeSpy = sinon.spy();
     const instance = getInstance(<TreePicker open onChange={onChangeSpy} data={data} />);
 
-    Simulate.click(instance.overlay.querySelector('span[data-key="0-0"]'));
+    Simulate.click(instance.overlay.querySelector('span[data-key="String_Master"]'));
     assert.isTrue(onChangeSpy.calledOnce);
   });
 
@@ -211,7 +211,7 @@ describe('TreePicker', () => {
   it('Should focus item by keyCode=38 ', () => {
     const instance = getInstance(<TreePicker open data={data} defaultExpandAll value="tester1" />);
 
-    Simulate.click(instance.overlay.querySelector('span[data-key="0-0-1"]'));
+    Simulate.click(instance.overlay.querySelector('span[data-key="String_tester1"]'));
     Simulate.keyDown(instance.target, { key: KEY_VALUES.UP });
     assert.equal(instance.overlay.querySelector('.rs-tree-node-focus').textContent, 'tester0');
   });
@@ -223,7 +223,7 @@ describe('TreePicker', () => {
     const instance = getInstance(
       <TreePicker defaultOpen data={data} onChange={doneOp} defaultExpandAll />
     );
-    Simulate.click(instance.overlay.querySelector('span[data-key="0-0-1"]'));
+    Simulate.click(instance.overlay.querySelector('span[data-key="String_tester1"]'));
   });
 
   /**
@@ -232,7 +232,7 @@ describe('TreePicker', () => {
   it('Should fold children node by keyCode=37', () => {
     const tree = getInstance(<TreePicker defaultOpen data={data} defaultExpandAll />);
 
-    Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
+    Simulate.click(tree.overlay.querySelector('span[data-key="String_Master"]'));
     Simulate.keyDown(tree.overlay, { key: KEY_VALUES.LEFT });
     assert.equal(
       tree.overlay.querySelectorAll('div[data-ref="0-0"] > .rs-tree-node-expanded').length,
@@ -246,12 +246,13 @@ describe('TreePicker', () => {
   it('Should change nothing when trigger on root node by keyCode=37', () => {
     const tree = getInstance(<TreePicker defaultOpen data={data} defaultExpandAll />);
 
-    Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
+    Simulate.click(tree.overlay.querySelector('span[data-key="String_Master"]'));
     Simulate.keyDown(tree.overlay, { key: KEY_VALUES.LEFT });
     assert.equal(tree.overlay.querySelector('.rs-tree-node-focus').textContent, 'Master');
 
     assert.equal(
-      tree.overlay.querySelectorAll('div[data-ref="0-0"] > .rs-tree-node-expanded').length,
+      tree.overlay.querySelectorAll('div[data-ref="String_Master"] > .rs-tree-node-expanded')
+        .length,
       0
     );
   });
@@ -262,7 +263,7 @@ describe('TreePicker', () => {
   it('Should focus on parentNode when trigger on leaf node by keyCode=37', () => {
     const tree = getInstance(<TreePicker defaultOpen data={data} defaultExpandAll />);
 
-    Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
+    Simulate.click(tree.overlay.querySelector('span[data-key="String_Master"]'));
     Simulate.keyDown(tree.overlay, { key: KEY_VALUES.LEFT });
     assert.equal(tree.overlay.querySelector('.rs-tree-node-focus').textContent, 'Master');
   });
@@ -273,10 +274,11 @@ describe('TreePicker', () => {
   it('Should fold children node by keyCode=39', () => {
     const tree = getInstance(<TreePicker defaultOpen data={data} />);
 
-    Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
+    Simulate.click(tree.overlay.querySelector('span[data-key="String_Master"]'));
     Simulate.keyDown(tree.overlay, { key: KEY_VALUES.RIGHT });
     assert.equal(
-      tree.overlay.querySelectorAll('div[data-ref="0-0"] > .rs-tree-node-expanded').length,
+      tree.overlay.querySelectorAll('div[data-ref="String_Master"] > .rs-tree-node-expanded')
+        .length,
       1
     );
   });
@@ -287,7 +289,7 @@ describe('TreePicker', () => {
   it('Should change nothing when trigger on leaf node by keyCode=39', () => {
     const tree = getInstance(<TreePicker defaultOpen data={data} defaultExpandAll />);
 
-    Simulate.click(tree.overlay.querySelector('span[data-key="0-0-0"]'));
+    Simulate.click(tree.overlay.querySelector('span[data-key="String_tester0"]'));
     Simulate.keyDown(tree.overlay, { key: KEY_VALUES.RIGHT });
     assert.equal(tree.overlay.querySelector('.rs-tree-node-focus').textContent, 'tester0');
   });
@@ -298,7 +300,7 @@ describe('TreePicker', () => {
   it('Should focus on first child node when node expanded by keyCode=39', () => {
     const tree = getInstance(<TreePicker defaultOpen data={data} defaultExpandAll />);
 
-    Simulate.click(tree.overlay.querySelector('span[data-key="0-0"]'));
+    Simulate.click(tree.overlay.querySelector('span[data-key="String_Master"]'));
     Simulate.keyDown(tree.overlay, { key: KEY_VALUES.RIGHT });
     assert.equal(tree.overlay.querySelector('.rs-tree-node-focus').textContent, 'tester0');
   });
@@ -353,11 +355,13 @@ describe('TreePicker', () => {
 
     act(() => {
       Simulate.click(
-        ref.current.overlay.querySelector('div[data-ref="0-1"]  > .rs-tree-node-expand-icon')
+        ref.current.overlay.querySelector(
+          'div[data-ref="String_async"]  > .rs-tree-node-expand-icon'
+        )
       );
     });
 
-    assert.ok(ref.current.overlay.querySelector('[data-key="0-1-0"]'));
+    assert.ok(ref.current.overlay.querySelector('[data-key="String_children1"]'));
   });
 
   it('Should render one node when searchKeyword is `M`', () => {
@@ -441,7 +445,9 @@ describe('TreePicker', () => {
 
     act(() => {
       Simulate.click(
-        ref.current.picker.overlay.querySelector('div[data-ref="0-0"]  > .rs-tree-node-expand-icon')
+        ref.current.picker.overlay.querySelector(
+          'div[data-ref="String_Master"]  > .rs-tree-node-expand-icon'
+        )
       );
     });
 
@@ -550,7 +556,7 @@ describe('TreePicker', () => {
         renderTreeNode={renderTreeNodeSpy}
       />
     );
-    Simulate.click(instance.overlay.querySelector('span[data-key="0-0"]'));
+    Simulate.click(instance.overlay.querySelector('span[data-key="String_Master"]'));
 
     assert.doesNotThrow(() => JSON.stringify(data[0]));
     assert.doesNotThrow(() => JSON.stringify(onSelectSpy.firstCall.args[0]));

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -656,7 +656,8 @@ export function useFlattenTreeData({
         /**
          * because the value of the node's type is string or number,
          * so it can used as the key of the object directly
-         * to avoid number value is converted to string, we used `String_` or `Number_` prefix
+         * to avoid number value is converted to string. 1 and '1' will be convert to '1'
+         *  we used `String_` or `Number_` prefix
          */
         const refKey = getNodeFormattedRefKey(value);
         node.refKey = refKey;
@@ -686,8 +687,8 @@ export function useFlattenTreeData({
 
       Object.keys(nodes).forEach((refKey: string) => {
         const currentNode = nodes[refKey];
-        if (!isNil(currentNode.parent) && !isNil(currentNode.parent[valueKey])) {
-          const parentNode = nodes[currentNode.parent[valueKey]];
+        if (!isNil(currentNode.parent) && !isNil(currentNode.parent.refKey)) {
+          const parentNode = nodes[currentNode.parent.refKey];
           if (currentNode[key]) {
             if (!parentNode?.checkAll) {
               list.push(nodes[refKey][valueKey]);


### PR DESCRIPTION
There are two improvements

**1. Remove `shallowEqual` function**

After rsuite v5, the value type only supports `string | number`, so it's not need to use `shallowEqual`

**2. Reduce unnecessary traverse**
1. Change `refKey` to formatted value: `String_value` or `Numer_value`. The purpose is to get the node directly from the value key without traverse all data
2. Reduce `getSelectedItems()` loops.
3. Using `useMemo()`  to memorize data
