### PR TITLE
fix(CheckTreePicker): fix children node can't uncheck when setting virtualized (#2782)

### DIFF
--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -761,7 +761,17 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
         expandItemValues.includes(node[valueKey])
       );
       const nodeProps = {
-        ...getTreeNodeProps({ ...node, expand }, layer),
+        ...getTreeNodeProps(
+          {
+            ...node,
+            /**
+             * spread operator don't copy unenumerable properties
+             * so we need to copy them manually
+             */ parent: node.parent,
+            expand
+          },
+          layer
+        ),
         hasChildren: node.hasChildren
       };
 

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -639,4 +639,27 @@ describe('CheckTreePicker', () => {
     expect(onChangeSpy.firstCall.args[0]).to.include('Master');
     expect(onChangeSpy.secondCall.args[0]).to.include('tester1');
   });
+
+  it('Should children can be removed when setting virtualized', () => {
+    const onChangeSpy = sinon.spy();
+    const screen = render(
+      <CheckTreePicker open virtualized defaultExpandAll data={data} onChange={onChangeSpy} />
+    );
+
+    fireEvent.click(screen.getByText('Master'), {
+      target: {
+        checked: true
+      }
+    });
+
+    fireEvent.click(screen.getByText('tester0'), {
+      target: {
+        checked: false
+      }
+    });
+
+    expect(onChangeSpy.callCount).to.equal(2);
+    expect(onChangeSpy.firstCall.args[0]).to.include('Master');
+    expect(onChangeSpy.secondCall.args[0]).to.include('tester1');
+  });
 });


### PR DESCRIPTION
The reason for this Problem is the same as #2621.
But this Pull Request is forgotten to handle the virtualized mode. 


Closes #2782 