### PR TITLE
fix(TreePicker,CheckTreePicker): fix value being cleared internally when value is controlled

### DIFF
--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -512,16 +512,18 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
       }
 
       setActiveNode(null);
-      setValue([]);
       setFocusItemValue(null);
 
-      unSerializeList({
-        nodes: flattenNodes,
-        key: 'check',
-        value: [],
-        cascade,
-        uncheckableItemValues
-      });
+      if (!isControlled) {
+        setValue([]);
+        unSerializeList({
+          nodes: flattenNodes,
+          key: 'check',
+          value: [],
+          cascade,
+          uncheckableItemValues
+        });
+      }
 
       onChange?.([], event);
     },
@@ -533,7 +535,8 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
       onChange,
       setValue,
       unSerializeList,
-      uncheckableItemValues
+      uncheckableItemValues,
+      isControlled
     ]
   );
 

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -715,20 +715,16 @@ describe('CheckTreePicker', () => {
   });
 
   it('Should remove all value when click clean button and value is unControlled', () => {
-    const ref = React.createRef();
-    render(<CheckTreePicker ref={ref} defaultOpen data={data} defaultValue={['Master']} />);
+    render(<CheckTreePicker defaultOpen data={data} defaultValue={['Master']} />);
 
     fireEvent.click(screen.getByLabelText('Clear'));
-    expect(ref.current.target.querySelector('.rs-picker-toggle-value')).to.equal(null);
+    expect(screen.getByRole('combobox')).to.text('Select');
   });
 
   it('Should persist value when click clean button and value is controlled', () => {
-    const ref = React.createRef();
-    render(<CheckTreePicker ref={ref} defaultOpen data={data} value={['Master']} />);
+    render(<CheckTreePicker defaultOpen data={data} value={['Master']} />);
 
     fireEvent.click(screen.getByLabelText('Clear'));
-    expect(
-      ref.current.target.querySelector('.rs-picker-toggle-value .rs-picker-value-item').textContent
-    ).to.equal('Master (All)');
+    expect(screen.getByRole('combobox')).to.text('Master (All)1');
   });
 });

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -713,4 +713,22 @@ describe('CheckTreePicker', () => {
     });
     expect(screen.getByRole('combobox')).to.have.text('Master (All)1');
   });
+
+  it('Should remove all value when click clean button and value is unControlled', () => {
+    const ref = React.createRef();
+    render(<CheckTreePicker ref={ref} defaultOpen data={data} defaultValue={['Master']} />);
+
+    fireEvent.click(screen.getByLabelText('Clear'));
+    expect(ref.current.target.querySelector('.rs-picker-toggle-value')).to.equal(null);
+  });
+
+  it('Should persist value when click clean button and value is controlled', () => {
+    const ref = React.createRef();
+    render(<CheckTreePicker ref={ref} defaultOpen data={data} value={['Master']} />);
+
+    fireEvent.click(screen.getByLabelText('Clear'));
+    expect(
+      ref.current.target.querySelector('.rs-picker-toggle-value .rs-picker-value-item').textContent
+    ).to.equal('Master (All)');
+  });
 });

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -635,10 +635,12 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
       if (target.matches('div[role="searchbox"] > input') || disabled || !cleanable) {
         return;
       }
-      setValue(null);
+      if (!isControlled) {
+        setValue(null);
+      }
       onChange?.(nullValue, event);
     },
-    [cleanable, disabled, onChange, setValue]
+    [cleanable, disabled, onChange, setValue, isControlled]
   );
 
   const onPickerKeydown = useToggleKeyDownEvent({

--- a/src/TreePicker/test/TreePickerSpec.js
+++ b/src/TreePicker/test/TreePickerSpec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render as testRender, fireEvent, screen } from '@testing-library/react';
 import { act, Simulate } from 'react-dom/test-utils';
+import { fireEvent, render as rtlRender } from '@testing-library/react';
 import { getDOMNode, getInstance, render } from '@test/testUtils';
 import TreePicker from '../TreePicker';
 import { KEY_VALUES } from '../../utils';
@@ -580,5 +581,25 @@ describe('TreePicker', () => {
       code: 'Backspace'
     });
     expect(screen.getByRole('combobox')).to.have.text('Master');
+  });
+
+  it('Should remove all value when click clean button and value is unControlled', () => {
+    const ref = React.createRef();
+    const screen = testRender(
+      <TreePicker ref={ref} defaultOpen data={data} defaultValue={'Master'} />
+    );
+
+    fireEvent.click(screen.getByLabelText('Clear'));
+    expect(ref.current.target.querySelector('.rs-picker-toggle-value')).to.equal(null);
+  });
+
+  it('Should persist value when click clean button and value is controlled', () => {
+    const ref = React.createRef();
+    const screen = rtlRender(<TreePicker ref={ref} defaultOpen data={data} value={'Master'} />);
+
+    fireEvent.click(screen.getByLabelText('Clear'));
+    expect(ref.current.target.querySelector('.rs-picker-toggle-value').textContent).to.equal(
+      'Master'
+    );
   });
 });

--- a/src/TreePicker/test/TreePickerSpec.js
+++ b/src/TreePicker/test/TreePickerSpec.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render as testRender, fireEvent, screen } from '@testing-library/react';
 import { act, Simulate } from 'react-dom/test-utils';
-import { fireEvent, render as rtlRender } from '@testing-library/react';
 import { getDOMNode, getInstance, render } from '@test/testUtils';
 import TreePicker from '../TreePicker';
 import { KEY_VALUES } from '../../utils';
@@ -584,22 +583,16 @@ describe('TreePicker', () => {
   });
 
   it('Should remove all value when click clean button and value is unControlled', () => {
-    const ref = React.createRef();
-    const screen = testRender(
-      <TreePicker ref={ref} defaultOpen data={data} defaultValue={'Master'} />
-    );
+    testRender(<TreePicker defaultOpen data={data} defaultValue={'Master'} />);
 
     fireEvent.click(screen.getByLabelText('Clear'));
-    expect(ref.current.target.querySelector('.rs-picker-toggle-value')).to.equal(null);
+    expect(screen.getByRole('combobox')).to.text('Select');
   });
 
   it('Should persist value when click clean button and value is controlled', () => {
-    const ref = React.createRef();
-    const screen = rtlRender(<TreePicker ref={ref} defaultOpen data={data} value={'Master'} />);
+    testRender(<TreePicker defaultOpen data={data} value={'Master'} />);
 
     fireEvent.click(screen.getByLabelText('Clear'));
-    expect(ref.current.target.querySelector('.rs-picker-toggle-value').textContent).to.equal(
-      'Master'
-    );
+    expect(screen.getByRole('combobox')).to.text('Master');
   });
 });


### PR DESCRIPTION
## Problem
If the value is controlled, the developer should handle all the `value`. 
When clicking the clean icon, the checktreepicker will remove all values internally, whether value controlled or not.

## Solution
When clicking the clean icon, if the value is controlled, CheckTreePicker shouldn't remove all values.

Closes #2784 