### PR TITLE
fix(TreePicker, CheckTreePicker): ignore backspace when setting cleanable=false or disabled=true

### DIFF
--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -507,7 +507,7 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
     (event: React.SyntheticEvent) => {
       const target = event.target as Element;
       // exclude searchBar
-      if (target.matches('div[role="searchbox"] > input')) {
+      if (target.matches('div[role="searchbox"] > input') || disabled || !cleanable) {
         return;
       }
 
@@ -525,7 +525,16 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
 
       onChange?.([], event);
     },
-    [cascade, flattenNodes, onChange, setValue, unSerializeList, uncheckableItemValues]
+    [
+      cascade,
+      cleanable,
+      disabled,
+      flattenNodes,
+      onChange,
+      setValue,
+      unSerializeList,
+      uncheckableItemValues
+    ]
   );
 
   const handleFocusItem = useCallback(

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.js
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode, getInstance } from '@test/testUtils';
 import CheckTreePicker from '../CheckTreePicker';
@@ -694,5 +694,23 @@ describe('CheckTreePicker', () => {
     expect(onChangeSpy.callCount).to.equal(2);
     expect(onChangeSpy.firstCall.args[0]).to.include('Master');
     expect(onChangeSpy.secondCall.args[0]).to.include('tester1');
+  });
+
+  it('Should not clean values when setting disabled=true', () => {
+    render(<CheckTreePicker open value={[data[0].value]} disabled data={data} />);
+    fireEvent.keyDown(screen.getByRole('combobox'), {
+      key: 'Backspace',
+      code: 'Backspace'
+    });
+    expect(screen.getByRole('combobox')).to.have.text('Master (All)1');
+  });
+
+  it('Should not clean values when setting cleanable=false', () => {
+    render(<CheckTreePicker open value={[data[0].value]} data={data} />);
+    fireEvent.keyDown(screen.getByRole('combobox'), {
+      key: 'Backspace',
+      code: 'Backspace'
+    });
+    expect(screen.getByRole('combobox')).to.have.text('Master (All)1');
   });
 });

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -632,13 +632,13 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
       const nullValue: any = null;
       const target = event.target as Element;
       // exclude searchBar
-      if (target.matches('div[role="searchbox"] > input')) {
+      if (target.matches('div[role="searchbox"] > input') || disabled || !cleanable) {
         return;
       }
       setValue(null);
       onChange?.(nullValue, event);
     },
-    [onChange, setValue]
+    [cleanable, disabled, onChange, setValue]
   );
 
   const onPickerKeydown = useToggleKeyDownEvent({

--- a/src/TreePicker/test/TreePickerSpec.js
+++ b/src/TreePicker/test/TreePickerSpec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { render as testRender, fireEvent, screen } from '@testing-library/react';
 import { act, Simulate } from 'react-dom/test-utils';
 import { getDOMNode, getInstance, render } from '@test/testUtils';
 import TreePicker from '../TreePicker';
@@ -561,5 +562,23 @@ describe('TreePicker', () => {
     assert.doesNotThrow(() => JSON.stringify(data[0]));
     assert.doesNotThrow(() => JSON.stringify(onSelectSpy.firstCall.args[0]));
     assert.doesNotThrow(() => JSON.stringify(renderTreeNodeSpy.firstCall.args[0]));
+  });
+
+  it('Should not clean values when setting disabled=true', () => {
+    testRender(<TreePicker open value={data[0].value} disabled data={data} />);
+    fireEvent.keyDown(screen.getByRole('combobox'), {
+      key: 'Backspace',
+      code: 'Backspace'
+    });
+    expect(screen.getByRole('combobox')).to.have.text('Master');
+  });
+
+  it('Should not clean values when setting cleanable=false', () => {
+    testRender(<TreePicker open value={data[0].value} data={data} />);
+    fireEvent.keyDown(screen.getByRole('combobox'), {
+      key: 'Backspace',
+      code: 'Backspace'
+    });
+    expect(screen.getByRole('combobox')).to.have.text('Master');
   });
 });


### PR DESCRIPTION
## Problem
When CheckTreePicker, TreePicker setting `cleanable=false` or `disabled=true` prop, the backspace operation still works.
It's not expected behavior.

