### PR TITLE
fix(AutoSizer): fix virtualized list width not being updated

### DIFF
--- a/src/CheckPicker/test/CheckPickerStylesSpec.js
+++ b/src/CheckPicker/test/CheckPickerStylesSpec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import CheckPicker from '../index';
 import { getStyle, inChrome } from '@test/testUtils';
 
@@ -31,5 +31,21 @@ describe('CheckPicker styles', () => {
       '.rs-picker-check-menu-items .rs-checkbox-checker label'
     );
     inChrome && assert.equal(getStyle(menuItemLabel, 'padding'), '8px 12px 8px 38px');
+  });
+
+  it('Should change the width of the virtualized list', done => {
+    const { getByRole } = render(
+      <CheckPicker
+        data={data}
+        style={{ width: 400 }}
+        virtualized
+        onOpen={() => {
+          expect(getByRole('listbox').firstChild.firstChild).to.style('width', '400px');
+          done();
+        }}
+      />
+    );
+
+    fireEvent.click(getByRole('combobox'));
   });
 });

--- a/src/Windowing/AutoSizer.tsx
+++ b/src/Windowing/AutoSizer.tsx
@@ -87,13 +87,8 @@ const AutoSizer = React.forwardRef<HTMLDivElement, AutoSizerProps>((props, ref) 
     }
   }, [disableHeight, disableWidth, getParentNode, height, onResize, width]);
 
-  useMount(() => {
-    if (getParentNode()) {
-      handleResize();
-    }
-  });
-
-  useElementResize(getParentNode, handleResize);
+  useMount(handleResize);
+  useElementResize(getParentNode(), handleResize);
 
   const outerStyle: React.CSSProperties = { overflow: 'visible' };
   const childParams: Size = { width: 0, height: 0 };


### PR DESCRIPTION

## before
The width of the virtualized list did not change with the width of the container.

![企业微信截图_59c421a6-e5e9-4171-b421-c51e0cb19801](https://user-images.githubusercontent.com/1203827/195779236-83ca7a5b-3c0d-4753-a389-731993fcc338.png)
