### PR TITLE
feat(SelectPicker,CheckPicker): add `loading` prop

### DIFF
--- a/docs/pages/components/check-picker/en-US/index.md
+++ b/docs/pages/components/check-picker/en-US/index.md
@@ -34,6 +34,10 @@ Set the `sticky` property to put the selected in the options to the top.
 
 <!--{include:`block.md`}-->
 
+### Loading
+
+<!--{include:`loading.md`}-->
+
 ### Group
 
 <!--{include:`group.md`}-->

--- a/docs/pages/components/check-picker/en-US/index.md
+++ b/docs/pages/components/check-picker/en-US/index.md
@@ -34,7 +34,10 @@ Set the `sticky` property to put the selected in the options to the top.
 
 <!--{include:`block.md`}-->
 
-### Loading
+### Loading state
+
+When the picker is loading, a spinner is displayed to indicate the loading state.
+Clicking a loading picker won't open its options menu.
 
 <!--{include:`loading.md`}-->
 
@@ -102,6 +105,7 @@ Learn more in [Accessibility](/guide/accessibility).
 | label              | ReactNode                                                                                          | A label displayed at the beginning of toggle button         |
 | labelKey           | string `('label')`                                                                                 | Set label key in data                                       |
 | listProps          | [ListProps][listprops]                                                                             | List-related properties in `react-virtualized`              |
+| loading            | boolean `(false)`                                                                                  | Whether to display a loading state indicator                |
 | locale             | [PickerLocaleType](/guide/i18n/#pickers)                                                           | Locale text                                                 |
 | menuMaxHeight      | number `(320)`                                                                                     | The max height of Dropdown                                  |
 | menuClassName      | string                                                                                             | A css class to apply to the Menu DOM node.                  |

--- a/docs/pages/components/check-picker/fragments/loading.md
+++ b/docs/pages/components/check-picker/fragments/loading.md
@@ -1,0 +1,43 @@
+<!--start-code-->
+
+```js
+import { CheckPicker } from 'rsuite';
+
+const data = [
+  'Eugenia',
+  'Bryan',
+  'Linda',
+  'Nancy',
+  'Lloyd',
+  'Alice',
+  'Julia',
+  'Albert',
+  'Louisa',
+  'Lester',
+  'Lola',
+  'Lydia',
+  'Hal',
+  'Hannah',
+  'Harriet',
+  'Hattie',
+  'Hazel',
+  'Hilda'
+].map(item => ({ label: item, value: item }));
+
+const App = () => (
+  <>
+    <div style={{ display: 'flex', gap: 10, marginBottom: 10 }}>
+      <CheckPicker data={data} loading />
+      <CheckPicker data={data} loading style={{ width: 200 }} />
+    </div>
+    <div style={{ display: 'flex', gap: 10 }}>
+      <CheckPicker label="User" data={data} loading />
+      <CheckPicker label="User" data={data} loading style={{ width: 200 }} />
+    </div>
+  </>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/check-picker/zh-CN/index.md
+++ b/docs/pages/components/check-picker/zh-CN/index.md
@@ -34,7 +34,10 @@
 
 <!--{include:`block.md`}-->
 
-### 加载中
+### 加载中状态
+
+当选择器处于加载中状态时，会显示一个旋转效果作为提示。
+在加载中状态时，点击选择器不会展开选项菜单。
 
 <!--{include:`loading.md`}-->
 
@@ -102,6 +105,7 @@
 | label              | ReactNode                                                                         | 在按钮开头显示的标签                   |
 | labelKey           | string `('label')`                                                                | 设置选项显示内容在 `data` 中的 `key`   |
 | listProps          | [ListProps][listprops]                                                            | `react-virtualized` 中 List 的相关属性 |
+| loading            | boolean `(false)`                                                                 | 是否显示一个加载中状态指示器           |
 | locale             | [PickerLocaleType](/zh/guide/i18n/#pickers)                                       | 本地化的文本                           |
 | menuMaxHeight      | number `(320)`                                                                    | 设置 Dropdown 的最大高度               |
 | menuClassName      | string                                                                            | 应用于菜单 DOM 节点的 css class        |

--- a/docs/pages/components/check-picker/zh-CN/index.md
+++ b/docs/pages/components/check-picker/zh-CN/index.md
@@ -34,6 +34,10 @@
 
 <!--{include:`block.md`}-->
 
+### 加载中
+
+<!--{include:`loading.md`}-->
+
 ### 分组
 
 <!--{include:`group.md`}-->

--- a/docs/pages/components/select-picker/en-US/index.md
+++ b/docs/pages/components/select-picker/en-US/index.md
@@ -28,7 +28,10 @@ For a single data selection, support grouping.
 
 <!--{include:`block.md`}-->
 
-### Loading
+### Loading state
+
+When the picker is loading, a spinner is displayed to indicate the loading state.
+Clicking a loading picker won't open its options menu.
 
 <!--{include:`loading.md`}-->
 
@@ -89,6 +92,7 @@ Learn more in [Accessibility](/guide/accessibility).
 | label              | ReactNode                                                                                       | A label displayed at the beginning of toggle button         |
 | labelKey           | string `('label')`                                                                              | Set options to display the 'key' in 'data'                  |
 | listProps          | [ListProps][listprops]                                                                          | List-related properties in `react-virtualized`              |
+| loading            | boolean `(false)`                                                                               | Whether to display a loading state indicator                |
 | locale             | [PickerLocaleType](/guide/i18n/#pickers)                                                        | Locale text                                                 |
 | menuMaxHeight      | number `(320)`                                                                                  | Set the max height of the Dropdown                          |
 | menuClassName      | string                                                                                          | A css class to apply to the Menu DOM node.                  |

--- a/docs/pages/components/select-picker/en-US/index.md
+++ b/docs/pages/components/select-picker/en-US/index.md
@@ -28,6 +28,10 @@ For a single data selection, support grouping.
 
 <!--{include:`block.md`}-->
 
+### Loading
+
+<!--{include:`loading.md`}-->
+
 ### Group
 
 <!--{include:`group.md`}-->

--- a/docs/pages/components/select-picker/fragments/loading.md
+++ b/docs/pages/components/select-picker/fragments/loading.md
@@ -1,0 +1,26 @@
+<!--start-code-->
+
+```js
+import { SelectPicker } from 'rsuite';
+
+const data = ['Eugenia', 'Bryan', 'Linda', 'Nancy', 'Lloyd', 'Alice', 'Julia', 'Albert'].map(
+  item => ({ label: item, value: item })
+);
+
+const App = () => (
+  <>
+    <div style={{ display: 'flex', gap: 10, marginBottom: 10 }}>
+      <SelectPicker data={data} loading />
+      <SelectPicker data={data} loading style={{ width: 200 }} />
+    </div>
+    <div style={{ display: 'flex', gap: 10 }}>
+      <SelectPicker label="User" data={data} loading />
+      <SelectPicker label="User" data={data} loading style={{ width: 200 }} />
+    </div>
+  </>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/select-picker/zh-CN/index.md
+++ b/docs/pages/components/select-picker/zh-CN/index.md
@@ -28,7 +28,10 @@
 
 <!--{include:`block.md`}-->
 
-### 加载中
+### 加载中状态
+
+当选择器处于加载中状态时，会显示一个旋转效果作为提示。
+在加载中状态时，点击选择器不会展开选项菜单。
 
 <!--{include:`loading.md`}-->
 
@@ -92,6 +95,7 @@
 | label              | ReactNode                                                                                      | 在按钮开头显示的标签                   |
 | labelKey           | string `('label')`                                                                             | 设置选项显示内容在 `data` 中的 `key`   |
 | listProps          | [ListProps][listprops]                                                                         | `react-virtualized` 中 List 的相关属性 |
+| loading            | boolean `(false)`                                                                              | 是否显示一个加载中状态指示器           |
 | locale             | [PickerLocaleType](/zh/guide/i18n/#pickers)                                                    | 本地化的文本                           |
 | menuMaxHeight      | number `(320)`                                                                                 | 设置 Dropdown 的最大高度               |
 | menuClassName      | string                                                                                         | 应用于菜单 DOM 节点的 css class        |

--- a/docs/pages/components/select-picker/zh-CN/index.md
+++ b/docs/pages/components/select-picker/zh-CN/index.md
@@ -28,6 +28,10 @@
 
 <!--{include:`block.md`}-->
 
+### 加载中
+
+<!--{include:`loading.md`}-->
+
 ### 分组
 
 <!--{include:`group.md`}-->

--- a/src/CheckPicker/test/CheckPickerSpec.js
+++ b/src/CheckPicker/test/CheckPickerSpec.js
@@ -425,6 +425,29 @@ describe('CheckPicker', () => {
     });
   });
 
+  describe('Loading state', () => {
+    it('Should display a spinner when loading=true', () => {
+      render(<CheckPicker data={data} loading />);
+
+      expect(screen.getByTestId('spinner')).to.exist;
+    });
+
+    it('Should display label and spinner when label is specified', () => {
+      render(<CheckPicker label="User" data={data} loading />);
+
+      expect(screen.getByRole('combobox')).to.have.text('User');
+      expect(screen.getByTestId('spinner')).to.exist;
+    });
+
+    it('Should not open menu on click when loading=true', () => {
+      render(<CheckPicker data={data} loading />);
+
+      userEvent.click(screen.getByRole('combobox'));
+
+      expect(screen.queryByRole('listbox')).not.to.exist;
+    });
+  });
+
   describe('Plain text', () => {
     it("Should render selected options' labels (comma-separated) and selected options count", () => {
       const { getByTestId } = render(

--- a/src/Picker/PickerToggle.tsx
+++ b/src/Picker/PickerToggle.tsx
@@ -10,6 +10,8 @@ import useToggleCaret from '../utils/useToggleCaret';
 import { IconProps } from '@rsuite/icons/lib/Icon';
 import TextMask from '../MaskedInput/TextMask';
 import deprecatePropType from '../utils/deprecatePropType';
+import Loader from '../Loader';
+import Stack from '../Stack';
 
 type ValueType = string | number;
 
@@ -25,6 +27,7 @@ export interface PickerToggleProps extends ToggleButtonProps {
   readOnly?: boolean;
   plaintext?: boolean;
   tabIndex?: number;
+  loading?: boolean;
 
   // Renders an input and is editable
   editable?: boolean;
@@ -63,6 +66,7 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
       plaintext,
       hasValue,
       editable,
+      loading = false,
       cleanable: cleanableProp,
       tabIndex: tabIndexProp = editable ? -1 : 0,
       id,
@@ -110,7 +114,9 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
 
     const handleFocus = useCallback(
       (event: React.FocusEvent<HTMLElement>) => {
-        setActive(true);
+        if (!loading) {
+          setActive(true);
+        }
 
         if (editable) {
           // Avoid firing the onFocus event twice when DatePicker and DateRangePicker allow keyboard input.
@@ -126,7 +132,7 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
           onFocus?.(event);
         }
       },
-      [editable, onFocus]
+      [editable, loading, onFocus]
     );
 
     const handleBlur = useCallback(
@@ -224,42 +230,55 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
         // The debounce is set to 200 to solve the flicker caused by the switch between input and div.
         onBlur={!disabled ? debounce(handleBlur, 200) : null}
       >
-        <TextMask
-          mask={inputMask}
-          value={Array.isArray(inputValue) ? inputValue.toString() : inputValue}
-          onBlur={handleInputBlur}
-          onFocus={onInputFocus}
-          onChange={handleInputChange}
-          onKeyDown={handleInputKeyDown}
-          id={id}
-          aria-hidden={!inputFocused}
-          readOnly={!inputFocused}
-          disabled={disabled}
-          aria-controls={id ? `${id}-listbox` : undefined}
-          tabIndex={editable ? 0 : -1}
-          className={prefix('textbox', { 'read-only': !inputFocused })}
-          placeholder={inputPlaceholder}
-          render={renderInput}
-        />
-        {children ? (
-          <span
-            className={prefix(hasValue ? 'value' : 'placeholder')}
-            aria-placeholder={typeof children === 'string' ? children : undefined}
-          >
-            {label && <span className={prefix('label')}>{label}</span>}
-            {children}
-          </span>
-        ) : null}
-
-        {showCleanButton && (
-          <CloseButton
-            className={prefix`clean`}
-            tabIndex={-1}
-            locale={{ closeLabel: 'Clear' }}
-            onClick={handleClean}
-          />
-        )}
-        {caret && <Caret className={prefix`caret`} />}
+        <Stack>
+          {label && (
+            <Stack.Item>
+              <span className={prefix('label')}>{label}</span>
+            </Stack.Item>
+          )}
+          <Stack.Item grow={1}>
+            {loading ? (
+              <Loader style={{ display: 'block', padding: '1px 0' }} data-testid="spinner" />
+            ) : (
+              <>
+                <TextMask
+                  mask={inputMask}
+                  value={Array.isArray(inputValue) ? inputValue.toString() : inputValue}
+                  onBlur={handleInputBlur}
+                  onFocus={onInputFocus}
+                  onChange={handleInputChange}
+                  onKeyDown={handleInputKeyDown}
+                  id={id}
+                  aria-hidden={!inputFocused}
+                  readOnly={!inputFocused}
+                  disabled={disabled}
+                  aria-controls={id ? `${id}-listbox` : undefined}
+                  tabIndex={editable ? 0 : -1}
+                  className={prefix('textbox', { 'read-only': !inputFocused })}
+                  placeholder={inputPlaceholder}
+                  render={renderInput}
+                />
+                {children ? (
+                  <span
+                    className={prefix(hasValue ? 'value' : 'placeholder')}
+                    aria-placeholder={typeof children === 'string' ? children : undefined}
+                  >
+                    {children}
+                  </span>
+                ) : null}
+              </>
+            )}
+          </Stack.Item>
+          {showCleanButton && (
+            <CloseButton
+              className={prefix`clean`}
+              tabIndex={-1}
+              locale={{ closeLabel: 'Clear' }}
+              onClick={handleClean}
+            />
+          )}
+          {caret && <Caret className={prefix`caret`} />}
+        </Stack>
       </Component>
     );
   });

--- a/src/Picker/PickerToggleTrigger.tsx
+++ b/src/Picker/PickerToggleTrigger.tsx
@@ -37,18 +37,27 @@ export const omitTriggerPropKeys = [
   'preventOverflow'
 ];
 
-export const pickTriggerPropKeys = [...omitTriggerPropKeys, 'disabled', 'plaintext', 'readOnly'];
+export const pickTriggerPropKeys = [
+  ...omitTriggerPropKeys,
+  'disabled',
+  'plaintext',
+  'readOnly',
+  'loading'
+];
 
 const PickerToggleTrigger = React.forwardRef(
   (props: PickerToggleTriggerProps, ref: React.Ref<any>) => {
     const { pickerProps, speaker, placement, trigger = 'click', ...rest } = props;
+
+    const pickerTriggerProps = pick(pickerProps, pickTriggerPropKeys);
 
     return (
       <CustomConsumer>
         {context => (
           <OverlayTrigger
             {...rest}
-            {...pick(pickerProps, pickTriggerPropKeys)}
+            {...pickerTriggerProps}
+            disabled={pickerTriggerProps.disabled || pickerTriggerProps.loading}
             ref={ref}
             trigger={trigger}
             placement={placementPolyfill(placement, context?.rtl)}

--- a/src/Picker/styles/index.less
+++ b/src/Picker/styles/index.less
@@ -18,6 +18,10 @@
     max-width: 100%;
   }
 
+  &-toggle {
+    min-width: 75px;
+  }
+
   &-toggle.rs-btn {
     .rs-ripple-pond {
       display: none !important;

--- a/src/Picker/test/PickerToggleSpec.js
+++ b/src/Picker/test/PickerToggleSpec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import Toggle from '../PickerToggle';
@@ -52,6 +52,20 @@ describe('<PickerToggle>', () => {
       userEvent.click(getByRole('button', { name: /clear/i }));
 
       expect(onCleanSpy).to.have.been.called;
+    });
+  });
+
+  describe('Loading state', () => {
+    it('Should not apply active state on clicking when loading=true', () => {
+      render(
+        <Toggle loading data-testid="toggle">
+          Text
+        </Toggle>
+      );
+
+      userEvent.click(screen.getByTestId('toggle'));
+
+      expect(screen.getByTestId('toggle')).not.to.have.class('rs-picker-toggle-active');
     });
   });
 

--- a/src/SelectPicker/SelectPicker.tsx
+++ b/src/SelectPicker/SelectPicker.tsx
@@ -43,6 +43,9 @@ export interface SelectProps<T> {
   /** Set group condition key in data */
   groupBy?: string;
 
+  /** Whether to display an loading indicator on toggle button */
+  loading?: boolean;
+
   /** Whether dispaly search input box */
   searchable?: boolean;
 

--- a/src/SelectPicker/test/SelectPickerSpec.js
+++ b/src/SelectPicker/test/SelectPickerSpec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode, getInstance } from '@test/testUtils';
 import SelectPicker from '../SelectPicker';
@@ -54,6 +55,29 @@ describe('SelectPicker', () => {
   it('Should be disabled', () => {
     const instance = getDOMNode(<SelectPicker data={[]} disabled />);
     assert.ok(instance.className.match(/\bdisabled\b/));
+  });
+
+  describe('Loading state', () => {
+    it('Should display a spinner when loading=true', () => {
+      render(<SelectPicker data={data} loading />);
+
+      expect(screen.getByTestId('spinner')).to.exist;
+    });
+
+    it('Should display label and spinner when label is specified', () => {
+      render(<SelectPicker label="User" data={data} loading />);
+
+      expect(screen.getByRole('combobox')).to.have.text('User');
+      expect(screen.getByTestId('spinner')).to.exist;
+    });
+
+    it('Should not open menu on click when loading=true', () => {
+      render(<SelectPicker data={data} loading />);
+
+      userEvent.click(screen.getByRole('combobox'));
+
+      expect(screen.queryByRole('listbox')).not.to.exist;
+    });
   });
 
   it('Should output a button', () => {


### PR DESCRIPTION
Add this `loading` prop for indicating that a picker is preparing data and not ready for use.

https://rsuite-nextjs-git-feature-selectpicker-loading-rsuite.vercel.app/components/select-picker/#loading-state

<img width="826" alt="image" src="https://user-images.githubusercontent.com/8225666/195871655-513736d4-6805-4ff5-b897-d864f9034513.png">

```jsx
<SelectPicker data={data} loading />
<SelectPicker label="User" data={data} loading />
```