### PR TITLE
fix(pickers): fix text overflow issue on option values

### DIFF
--- a/src/Picker/PickerToggle.tsx
+++ b/src/Picker/PickerToggle.tsx
@@ -236,7 +236,7 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
               <span className={prefix('label')}>{label}</span>
             </Stack.Item>
           )}
-          <Stack.Item grow={1}>
+          <Stack.Item grow={1} style={{ overflow: 'hidden' }}>
             {loading ? (
               <Loader style={{ display: 'block', padding: '1px 0' }} data-testid="spinner" />
             ) : (


### PR DESCRIPTION
before

![image](https://user-images.githubusercontent.com/1203827/196865966-4b9fb431-510d-4177-949b-7833cac4a846.png)


after

![image](https://user-images.githubusercontent.com/1203827/196865991-e481c509-336c-4130-8c50-2ebd7ab57cf1.png)
