### PR TITLE
docs(usage): remove `ReactDOM.render` for react 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,13 @@ yarn add rsuite
 
 Here's a simple example
 
-```js
+```jsx
 import { Button } from 'rsuite';
 import 'rsuite/styles/index.less'; // or 'rsuite/dist/rsuite.min.css'
 
-ReactDOM.render(<Button>Button</Button>, mountNode);
+function App() {
+  return <Button appearance="primary">Hello World</Button>;
+}
 ```
 
 [**Live preview on CodeSandbox**][live-preview-on-codesandbox]

--- a/README_zh.md
+++ b/README_zh.md
@@ -50,11 +50,13 @@ npm i rsuite --save
 
 这里有一个简单的示例：
 
-```js
+```jsx
 import { Button } from 'rsuite';
 import 'rsuite/styles/index.less'; // or 'rsuite/dist/rsuite.min.css'
 
-ReactDOM.render(<Button>Button</Button>, mountNode);
+function App() {
+  return <Button appearance="primary">Hello World</Button>;
+}
 ```
 
 您可以在 [CodeSandbox][live-preview-on-codesandbox] 上查看该示例。

--- a/docs/pages/guide/usage/en-US/index.md
+++ b/docs/pages/guide/usage/en-US/index.md
@@ -23,18 +23,12 @@ $ yarn add rsuite
 The following is a simple example of using a default button component.
 
 ```jsx
-import React from 'react';
-import ReactDOM from 'react-dom';
 import { Button } from 'rsuite';
-
-// import default style
 import 'rsuite/styles/index.less'; // or 'rsuite/dist/rsuite.min.css'
 
 function App() {
-  return <Button>Hello World</Button>;
+  return <Button appearance="primary">Hello World</Button>;
 }
-
-ReactDOM.render(<App />, document.getElementById('root'));
 ```
 
 ## Online example

--- a/docs/pages/guide/usage/zh-CN/index.md
+++ b/docs/pages/guide/usage/zh-CN/index.md
@@ -23,18 +23,12 @@ $ yarn add rsuite
 以下是一个简单的例子，使用一个默认按钮组件。
 
 ```jsx
-import React from 'react';
-import ReactDOM from 'react-dom';
 import { Button } from 'rsuite';
-
-// import default style
 import 'rsuite/styles/index.less'; // or 'rsuite/dist/rsuite.min.css'
 
 function App() {
-  return <Button>Hello World</Button>;
+  return <Button appearance="primary">Hello World</Button>;
 }
-
-ReactDOM.render(<App />, document.getElementById('root'));
 ```
 
 ## 在线示例


### PR DESCRIPTION

```diff
- ReactDOM.render(<App />, document.getElementById('root'));
```
`ReactDOM.render` can only run on versions prior to react 18. It was removed to avoid ambiguity in the documentation guide.