### PR TITLE
fix(DateRangePicker): fix end time not using time on second calendar

### DIFF
--- a/docs/pages/components/date-range-picker/fragments/controlled.md
+++ b/docs/pages/components/date-range-picker/fragments/controlled.md
@@ -1,12 +1,23 @@
 <!--start-code-->
 
 ```js
-import { DateRangePicker } from 'rsuite';
+import { DateRangePicker, Stack } from 'rsuite';
 
 const App = () => {
   const [value, setValue] = React.useState([new Date('2017-02-01'), new Date('2017-05-20')]);
 
-  return <DateRangePicker value={value} onChange={setValue} />;
+  return (
+    <Stack direction="column" spacing={8} alignItems="flex-start">
+      <DateRangePicker value={value} onChange={setValue} />
+
+      <DateRangePicker
+        value={value}
+        onChange={setValue}
+        format="yyyy-MM-dd HH:mm:ss"
+        defaultCalendarValue={[new Date('2022-02-01 00:00:00'), new Date('2022-05-01 23:59:59')]}
+      />
+    </Stack>
+  );
 };
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/docs/pages/components/date-range-picker/fragments/editable.md
+++ b/docs/pages/components/date-range-picker/fragments/editable.md
@@ -1,7 +1,7 @@
 <!--start-code-->
 
 ```js
-import { DatePicker, Stack } from 'rsuite';
+import { DateRangePicker } from 'rsuite';
 
 const App = () => (
   <>

--- a/docs/pages/components/date-range-picker/fragments/format-date-time.md
+++ b/docs/pages/components/date-range-picker/fragments/format-date-time.md
@@ -8,21 +8,21 @@ const App = () => (
     <p>Date Time Range</p>
     <DateRangePicker
       format="yyyy-MM-dd HH:mm:ss"
-      defaultCalendarValue={[new Date('2022-02-01 00:00:00'), new Date('2022-03-01 23:59:59')]}
+      defaultCalendarValue={[new Date('2022-02-01 00:00:00'), new Date('2022-05-01 23:59:59')]}
     />
 
     <p>Time Range</p>
     <DateRangePicker
       format="HH:mm:ss"
       ranges={[]}
-      defaultCalendarValue={[new Date('2022-02-01 00:00:00'), new Date('2022-03-01 23:59:59')]}
+      defaultCalendarValue={[new Date('2022-02-01 00:00:00'), new Date('2022-05-01 23:59:59')]}
     />
 
     <p>Meridian format</p>
     <DateRangePicker
       format="yyyy-MM-dd hh:mm aa"
       showMeridian
-      defaultCalendarValue={[new Date('2022-02-01 00:00:00'), new Date('2022-03-01 23:59:59')]}
+      defaultCalendarValue={[new Date('2022-02-01 00:00:00'), new Date('2022-05-01 23:59:59')]}
     />
   </div>
 );

--- a/docs/pages/components/date-range-picker/fragments/one-tap.md
+++ b/docs/pages/components/date-range-picker/fragments/one-tap.md
@@ -4,23 +4,21 @@
 import { DateRangePicker } from 'rsuite';
 import subDays from 'date-fns/subDays';
 
+const ranges = [
+  {
+    label: 'today',
+    value: [new Date(), new Date()]
+  },
+  {
+    label: 'yesterday',
+    value: [subDays(new Date(), 1), subDays(new Date(), 1)]
+  }
+];
+
 const App = () => (
   <div className="field">
     <p>Select Single Day</p>
-    <DateRangePicker
-      oneTap
-      showOneCalendar
-      ranges={[
-        {
-          label: 'today',
-          value: [new Date(), new Date()]
-        },
-        {
-          label: 'yesterday',
-          value: [subDays(new Date(), 1), subDays(new Date(), 1)]
-        }
-      ]}
-    />
+    <DateRangePicker oneTap showOneCalendar ranges={ranges} />
     <p>Select Single Week</p>
     <DateRangePicker oneTap showOneCalendar hoverRange="week" ranges={[]} />
     <p>Select Single Month</p>

--- a/src/DateRangePicker/test/DateRangePickerSpec.js
+++ b/src/DateRangePicker/test/DateRangePickerSpec.js
@@ -888,7 +888,7 @@ describe('DateRangePicker', () => {
     expect(onSelectSpy).to.have.been.calledTwice;
     expect(getByRole('button', { name: '00:00:00' })).to.be.visible;
     expect(getByRole('button', { name: '23:59:59' })).to.be.visible;
-    expect(getByRole('dialog').querySelector('.rs-picker-daterange-header')).to.text(
+    expect(getByRole('dialog').querySelector('.rs-picker-daterange-header')).to.have.text(
       '2022-02-07 00:00:00 ~ 2022-02-10 23:59:59'
     );
   });

--- a/src/DateRangePicker/test/DateRangePickerSpec.js
+++ b/src/DateRangePicker/test/DateRangePickerSpec.js
@@ -852,6 +852,15 @@ describe('DateRangePicker', () => {
     expect(onSelectSpy).to.have.been.calledOnce;
     expect(getByRole('button', { name: '00:00:00' })).to.be.visible;
     expect(getByRole('button', { name: '23:59:59' })).to.be.visible;
+
+    fireEvent.click(getByRole('gridcell', { name: '10 Feb 2022' }).firstChild);
+
+    expect(onSelectSpy).to.have.been.calledTwice;
+    expect(getByRole('button', { name: '00:00:00' })).to.be.visible;
+    expect(getByRole('button', { name: '23:59:59' })).to.be.visible;
+    expect(getByRole('dialog').querySelector('.rs-picker-daterange-header')).to.text(
+      '2022-02-07 00:00:00 ~ 2022-02-10 23:59:59'
+    );
   });
 
   it('Should the end time not change when the start date is clicked when controlled', () => {
@@ -873,6 +882,15 @@ describe('DateRangePicker', () => {
     expect(onSelectSpy).to.have.been.calledOnce;
     expect(getByRole('button', { name: '00:00:00' })).to.be.visible;
     expect(getByRole('button', { name: '23:59:59' })).to.be.visible;
+
+    fireEvent.click(getByRole('gridcell', { name: '10 Feb 2022' }).firstChild);
+
+    expect(onSelectSpy).to.have.been.calledTwice;
+    expect(getByRole('button', { name: '00:00:00' })).to.be.visible;
+    expect(getByRole('button', { name: '23:59:59' })).to.be.visible;
+    expect(getByRole('dialog').querySelector('.rs-picker-daterange-header')).to.text(
+      '2022-02-07 00:00:00 ~ 2022-02-10 23:59:59'
+    );
   });
 
   it('Should render ranges on the left', () => {

--- a/src/DateRangePicker/test/DateRangePickerSpec.js
+++ b/src/DateRangePicker/test/DateRangePickerSpec.js
@@ -858,7 +858,7 @@ describe('DateRangePicker', () => {
     expect(onSelectSpy).to.have.been.calledTwice;
     expect(getByRole('button', { name: '00:00:00' })).to.be.visible;
     expect(getByRole('button', { name: '23:59:59' })).to.be.visible;
-    expect(getByRole('dialog').querySelector('.rs-picker-daterange-header')).to.text(
+    expect(getByRole('dialog').querySelector('.rs-picker-daterange-header')).to.have.text(
       '2022-02-07 00:00:00 ~ 2022-02-10 23:59:59'
     );
   });


### PR DESCRIPTION
When a date range is selected on a calendar, the end time still uses the time on the first calendar. But the end time should always use the time on the second calendar.

fix: https://codesandbox.io/s/stoic-sun-fgw8er