### PR TITLE
feat(Table): support for show full text when hovering over a cell

### DIFF
--- a/docs/pages/components/table/en-US/index.md
+++ b/docs/pages/components/table/en-US/index.md
@@ -267,6 +267,12 @@ In some cases, you need to merge the relationships between columns to organize y
 
 <!--{include:`summary.md`}-->
 
+### Show full text of cells
+
+Displays the cut text in its entirety when hovering over the cell.
+
+<!--{include:`full-text.md`}-->
+
 ### Word Wrap
 
 <!--{include:`word-wrap.md`}-->
@@ -380,6 +386,7 @@ scrollLeft: (left: number) => void;
 | colSpan       | number                                           | Merges column cells to merge when the `dataKey` value for the merged column is `null` or `undefined`.       |
 | fixed         | boolean &#124; 'left' &#124; 'right'             | Fixed column                                                                                                |
 | flexGrow      | number                                           | Set the column width automatically adjusts, when set `flexGrow` cannot set `resizable` and `width` property |
+| fullText      | boolean                                          | Whether to display the full text of the cell content when the mouse is hovered                              |
 | minWidth      | number`(200)`                                    | When you use `flexGrow`, you can set a minimum width by `minwidth`                                          |
 | onResize      | (columnWidth?: number, dataKey?: string) => void | Callback after column width change                                                                          |
 | resizable     | boolean                                          | Customizable Resize Column width                                                                            |

--- a/docs/pages/components/table/en-US/index.md
+++ b/docs/pages/components/table/en-US/index.md
@@ -269,7 +269,7 @@ In some cases, you need to merge the relationships between columns to organize y
 
 ### Show full text of cells
 
-Displays the cut text in its entirety when hovering over the cell.
+Display the hidden text in its entirety when hovering over the cell.
 
 <!--{include:`full-text.md`}-->
 

--- a/docs/pages/components/table/fragments/full-text.md
+++ b/docs/pages/components/table/fragments/full-text.md
@@ -1,0 +1,53 @@
+<!--start-code-->
+
+```js
+import { Table } from 'rsuite';
+import { mockUsers } from './mock';
+
+const { Column, HeaderCell, Cell } = Table;
+const data = mockUsers(20);
+
+const CompactCell = props => <Cell {...props} style={{ padding: 6 }} />;
+
+const App = () => {
+  return (
+    <div>
+      <Table height={400} data={data} bordered cellBordered rowHeight={34}>
+        <Column width={120} fixed fullText>
+          <HeaderCell>Name</HeaderCell>
+          <CompactCell dataKey="name" />
+        </Column>
+
+        <Column width={300} fullText>
+          <HeaderCell>Url</HeaderCell>
+          <CompactCell dataKey="avatar" />
+        </Column>
+
+        <Column width={130} fullText>
+          <HeaderCell>Company</HeaderCell>
+          <CompactCell dataKey="company" />
+        </Column>
+
+        <Column width={130} fullText>
+          <HeaderCell>Email</HeaderCell>
+          <CompactCell dataKey="email" />
+        </Column>
+
+        <Column width={130} fullText>
+          <HeaderCell>City</HeaderCell>
+          <CompactCell dataKey="city" />
+        </Column>
+
+        <Column width={130} fullText>
+          <HeaderCell>Street</HeaderCell>
+          <CompactCell dataKey="street" />
+        </Column>
+      </Table>
+    </div>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/table/zh-CN/index.md
+++ b/docs/pages/components/table/zh-CN/index.md
@@ -116,6 +116,12 @@ return (
 ...
 ```
 
+### 完整的文本
+
+在单元格内鼠标悬停时候把被切割的文本完整显示出来。
+
+<!--{include:`full-text.md`}-->
+
 ### 自动换行
 
 <!--{include:`word-wrap.md`}-->
@@ -376,6 +382,7 @@ scrollLeft: (left: number) => void;
 | colSpan       | number                                           | 合并列单元格，当被合并列的 `dataKey` 对应的值为 `null` 或者 `undefined`时，才会合并。 |
 | fixed         | boolean &#124; 'left' &#124; 'right'             | 固定列                                                                                |
 | flexGrow      | number                                           | 设置列宽自动调节，当设置了 `flexGrow` 就不能设置 `resizable` 与 `width` 属性          |
+| fullText      | boolean                                          | 鼠标悬停时是否显示单元格内容的全文                                                    |
 | minWidth      | number`(200)`                                    | 当使用了 `flexGrow` 以后，可以通过 `minWidth` 设置一个最小宽度                        |
 | onResize      | (columnWidth?: number, dataKey?: string) => void | 列宽改变后的回调                                                                      |
 | resizable     | boolean                                          | 可自定义调整列宽                                                                      |

--- a/docs/utils/mock.ts
+++ b/docs/utils/mock.ts
@@ -96,6 +96,7 @@ export function mockUsers(length: number) {
     const postcode = faker.address.zipCode();
     const phone = faker.phone.number();
     const amount = faker.finance.amount(1000, 90000);
+    const company = faker.company.companyName();
 
     const age = Math.floor(Math.random() * 30) + 18;
     const stars = Math.floor(Math.random() * 10000);
@@ -120,7 +121,8 @@ export function mockUsers(length: number) {
       followers,
       rating,
       progress,
-      amount
+      amount,
+      company
     };
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "lodash": "^4.17.11",
         "prop-types": "^15.8.1",
         "react-window": "^1.8.7",
-        "rsuite-table": "^5.7.2",
+        "rsuite-table": "^5.8.0",
         "schema-typed": "^2.0.3"
       },
       "devDependencies": {
@@ -20345,9 +20345,9 @@
       }
     },
     "node_modules/rsuite-table": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.7.2.tgz",
-      "integrity": "sha512-JwfxAR8lXVXM9PRQGJMbayciMcVFpHWExAhfY53h6JYKC7LfPeBx/Z6k4P7PO0grFkVGBdFW3ZgHxhCD1ur/eA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.8.0.tgz",
+      "integrity": "sha512-ZqRYbH8JM8hslN5eU6lGoyLjbHL9un8TMPNdk/4wyYxAM3k6EMKP21oJdNb3YHCy8U1HbWc8qS6Qn/nzCrGsDw==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",
@@ -40305,9 +40305,9 @@
       }
     },
     "rsuite-table": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.7.2.tgz",
-      "integrity": "sha512-JwfxAR8lXVXM9PRQGJMbayciMcVFpHWExAhfY53h6JYKC7LfPeBx/Z6k4P7PO0grFkVGBdFW3ZgHxhCD1ur/eA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.8.0.tgz",
+      "integrity": "sha512-ZqRYbH8JM8hslN5eU6lGoyLjbHL9un8TMPNdk/4wyYxAM3k6EMKP21oJdNb3YHCy8U1HbWc8qS6Qn/nzCrGsDw==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lodash": "^4.17.11",
     "prop-types": "^15.8.1",
     "react-window": "^1.8.7",
-    "rsuite-table": "^5.7.2",
+    "rsuite-table": "^5.8.0",
     "schema-typed": "^2.0.3"
   },
   "peerDependencies": {

--- a/src/Table/styles/index.less
+++ b/src/Table/styles/index.less
@@ -215,6 +215,18 @@
     }
   }
 
+  &-cell-full-text {
+    &:hover {
+      z-index: 1 !important;
+      width: auto !important;
+      box-shadow: inset @table-cell-hover-color 0px 0px 2px;
+
+      .rs-table-cell-content {
+        width: auto !important;
+      }
+    }
+  }
+
   &-cell-header-sortable &-cell-content {
     cursor: pointer;
   }

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -224,6 +224,7 @@
 @table-content-padding-horizontal:      10px; // @deprecated use @table-cell-padding-x instead
 @table-cell-padding-y:                  @table-body-content-padding-vertical;
 @table-cell-padding-x:                  @table-content-padding-horizontal;
+@table-cell-hover-color:                var(--rs-primary-500);
 
 @table-scrollbar-timing-duration:       0.1s;
 @table-scrollbar-width:                 10px;


### PR DESCRIPTION
Display the hidden text in its entirety when hovering over the cell.

https://user-images.githubusercontent.com/1203827/199677220-f1f2f5d8-544c-40cf-b4ac-91434f4c7317.mp4

## Usage

```tsx
<Column width={130} fullText>
  <HeaderCell>Name</HeaderCell>
  <Cell dataKey="name" />
</Column>
```

## dependencies

- https://github.com/rsuite/rsuite/pull/2858
- build(deps): bump rsuite-table from 5.7.2 to 5.8.0
