### PR TITLE
fix(InputNumber): fix `scrollable` not working

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,7 +3,7 @@
  * Run all tests: `npm run tdd`
  * Run all styles tests: `M=styles npm run tdd`
  * Run a component test: `M=Button npm run tdd`
- * Run a test of a file: `F=src/Picker/test/PickerToggleSpec.js npm run tdd`
+ * Run a test of a file: `F=src/Picker/test/PickerToggleSpec.tsx npm run tdd`
  */
 
 /**

--- a/src/InputNumber/InputNumber.tsx
+++ b/src/InputNumber/InputNumber.tsx
@@ -226,6 +226,11 @@ const InputNumber = React.forwardRef((props: InputNumberProps, ref) => {
 
   const handleWheel = useCallback(
     (event: React.WheelEvent<HTMLInputElement>) => {
+      if (!scrollable) {
+        event.preventDefault();
+        return;
+      }
+
       if (!disabled && !readOnly && event.target === document.activeElement) {
         event.preventDefault();
         const delta: number = event['wheelDelta'] || -event.deltaY || -event?.detail;
@@ -240,7 +245,7 @@ const InputNumber = React.forwardRef((props: InputNumberProps, ref) => {
 
       onWheel?.(event);
     },
-    [disabled, handleStepDown, handleStepUp, onWheel, readOnly]
+    [disabled, handleStepDown, handleStepUp, onWheel, readOnly, scrollable]
   );
 
   const handleChange = useCallback(
@@ -263,7 +268,7 @@ const InputNumber = React.forwardRef((props: InputNumberProps, ref) => {
 
   useEffect(() => {
     let wheelListener: ReturnType<typeof on>;
-    if (inputRef.current && scrollable) {
+    if (inputRef.current) {
       wheelListener = on(inputRef.current, 'wheel', handleWheel, { passive: false });
     }
     return () => {

--- a/src/InputNumber/test/InputNumberSpec.tsx
+++ b/src/InputNumber/test/InputNumberSpec.tsx
@@ -148,6 +148,17 @@ describe('InputNumber', () => {
     assert.isTrue(onWheelSpy.calledOnce);
   });
 
+  it('Should not call onWheel callback', () => {
+    const onWheelSpy = sinon.spy();
+    const { container } = render(<InputNumber onWheel={onWheelSpy} scrollable={false} />);
+    const input = container.querySelector('.rs-input') as HTMLInputElement;
+
+    input.focus();
+    input.dispatchEvent(new WheelEvent('wheel', { deltaY: 10 }));
+
+    expect(onWheelSpy).not.to.have.been.called;
+  });
+
   it('Should call onChange callback when is control component', () => {
     const onChnageSpy = sinon.spy();
     const instance = getDOMNode(<InputNumber onChange={onChnageSpy} value={2} />);

--- a/src/InputNumber/test/InputNumberSpec.tsx
+++ b/src/InputNumber/test/InputNumberSpec.tsx
@@ -148,7 +148,7 @@ describe('InputNumber', () => {
     assert.isTrue(onWheelSpy.calledOnce);
   });
 
-  it('Should not call onWheel callback', () => {
+  it('Should not call onWheel callback when `scrollable` is false', () => {
     const onWheelSpy = sinon.spy();
     const { container } = render(<InputNumber onWheel={onWheelSpy} scrollable={false} />);
     const input = container.querySelector('.rs-input') as HTMLInputElement;


### PR DESCRIPTION
Cannot block the default onWheel event when `scrollable = false`. This will cause the value to be updated. The issue occurs with the latest versions of chrome and edge browsers. 

fix https://github.com/rsuite/rsuite/issues/2903.

