### PR TITLE
fix(pickers): the focused item should be within the container's viewport

### DIFF
--- a/src/Cascader/test/CascaderSpec.tsx
+++ b/src/Cascader/test/CascaderSpec.tsx
@@ -5,6 +5,7 @@ import Cascader from '../Cascader';
 import Button from '../../Button';
 import { getDOMNode, getInstance } from '@test/testUtils';
 import { PickerHandle } from '../../Picker';
+import '../styles/index.less';
 
 const items = [
   {
@@ -656,5 +657,19 @@ describe('Cascader', () => {
     // Click on the leaf node
     fireEvent.click(getByRole('treeitem', { name: '1' }));
     expect(getByRole('tree').querySelectorAll('.rs-picker-cascader-menu-column')).to.length(1);
+  });
+
+  it('Should update scroll position when the focus is not within the viewport', () => {
+    const instance = getInstance(<Cascader defaultOpen data={items} menuHeight={72} />);
+
+    fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
+    fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
+    fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
+
+    expect(instance.overlay.querySelector('[data-type="column"]').scrollTop).to.equal(36);
+
+    fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
+
+    expect(instance.overlay.querySelector('[data-type="column"]').scrollTop).to.equal(0);
   });
 });

--- a/src/Cascader/test/CascaderSpec.tsx
+++ b/src/Cascader/test/CascaderSpec.tsx
@@ -659,17 +659,47 @@ describe('Cascader', () => {
     expect(getByRole('tree').querySelectorAll('.rs-picker-cascader-menu-column')).to.length(1);
   });
 
-  it('Should update scroll position when the focus is not within the viewport', () => {
-    const instance = getInstance(<Cascader defaultOpen data={items} menuHeight={72} />);
+  describe('Focus item', () => {
+    it('Should update scroll position when the focus is not within the viewport', () => {
+      const instance = getInstance(<Cascader defaultOpen data={items} menuHeight={72} />);
 
-    fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
-    fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
-    fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
+      fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
+      fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
+      fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
 
-    expect(instance.overlay.querySelector('[data-type="column"]').scrollTop).to.equal(36);
+      expect(instance.overlay.querySelector('[data-type="column"]').scrollTop).to.equal(36);
 
-    fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
+      fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
 
-    expect(instance.overlay.querySelector('[data-type="column"]').scrollTop).to.equal(0);
+      expect(instance.overlay.querySelector('[data-type="column"]').scrollTop).to.equal(0);
+    });
+
+    it('Should be switched to sub-selection using the left and right keys', () => {
+      const instance = getInstance(<Cascader defaultOpen data={items} />);
+
+      fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
+      fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
+      fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
+
+      let focusItems = instance.overlay.querySelectorAll('.rs-picker-cascader-menu-item-focus');
+
+      expect(focusItems).to.length(1);
+      expect(focusItems[0]).to.have.text('3');
+
+      fireEvent.keyDown(instance.target, { key: 'ArrowRight' });
+
+      focusItems = instance.overlay.querySelectorAll('.rs-picker-cascader-menu-item-focus');
+
+      expect(focusItems).to.length(2);
+      expect(focusItems[1]).to.have.text('3-1');
+
+      fireEvent.keyDown(instance.target, { key: 'ArrowLeft' });
+      fireEvent.keyDown(instance.target, { key: 'ArrowUp' });
+
+      focusItems = instance.overlay.querySelectorAll('.rs-picker-cascader-menu-item-focus');
+
+      expect(focusItems).to.length(1);
+      expect(focusItems[0]).to.have.text('2');
+    });
   });
 });

--- a/src/CheckPicker/test/CheckPickerSpec.tsx
+++ b/src/CheckPicker/test/CheckPickerSpec.tsx
@@ -253,7 +253,7 @@ describe('CheckPicker', () => {
     expect(instance.overlay.querySelector(itemFocusClassName)).to.text('Kariane');
   });
 
-  it('Should update scroll position when the focus is not within the viewport', () => {
+  it('Should update scroll position when the focus is not within the viewport and key=ArrowDown', () => {
     const instance = getInstance(
       <CheckPicker defaultOpen data={data} defaultValue={['Eugenia']} menuMaxHeight={72} />
     );
@@ -266,10 +266,21 @@ describe('CheckPicker', () => {
     fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
 
     expect(instance.overlay.querySelector('[role="listbox"]').scrollTop).to.equal(0);
+  });
 
+  it('Should update scroll position when the focus is not within the viewport and key=ArrowUp', () => {
+    const instance = getInstance(
+      <CheckPicker defaultOpen data={data} defaultValue={['Eugenia']} menuMaxHeight={72} />
+    );
+
+    fireEvent.keyDown(instance.target, { key: 'ArrowUp' });
     fireEvent.keyDown(instance.target, { key: 'ArrowUp' });
 
     expect(instance.overlay.querySelector('[role="listbox"]').scrollTop).to.equal(36);
+
+    fireEvent.keyDown(instance.target, { key: 'ArrowUp' });
+
+    expect(instance.overlay.querySelector('[role="listbox"]').scrollTop).to.equal(0);
   });
 
   it('Should focus item by key=ArrowUp ', () => {

--- a/src/CheckPicker/test/CheckPickerSpec.tsx
+++ b/src/CheckPicker/test/CheckPickerSpec.tsx
@@ -5,6 +5,7 @@ import { globalKey, getDOMNode, getInstance } from '@test/testUtils';
 
 import CheckPicker from '../CheckPicker';
 import Button from '../../Button';
+import '../styles/index.less';
 
 const namespace = `${globalKey}-picker`;
 const itemFocusClassName = '.rs-check-item-focus';
@@ -250,6 +251,25 @@ describe('CheckPicker', () => {
     fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
 
     expect(instance.overlay.querySelector(itemFocusClassName)).to.text('Kariane');
+  });
+
+  it('Should update scroll position when the focus is not within the viewport', () => {
+    const instance = getInstance(
+      <CheckPicker defaultOpen data={data} defaultValue={['Eugenia']} menuMaxHeight={72} />
+    );
+
+    fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
+    fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
+
+    expect(instance.overlay.querySelector('[role="listbox"]').scrollTop).to.equal(36);
+
+    fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
+
+    expect(instance.overlay.querySelector('[role="listbox"]').scrollTop).to.equal(0);
+
+    fireEvent.keyDown(instance.target, { key: 'ArrowUp' });
+
+    expect(instance.overlay.querySelector('[role="listbox"]').scrollTop).to.equal(36);
   });
 
   it('Should focus item by key=ArrowUp ', () => {

--- a/src/Picker/utils.ts
+++ b/src/Picker/utils.ts
@@ -205,7 +205,7 @@ function isVisible(element: HTMLElement, container: HTMLElement, direction: 'top
   return bottom - height < containerBottom;
 }
 
-function scrollTo(container: HTMLElement, direction: 'top' | 'bottom', step = 36) {
+function scrollTo(container: HTMLElement, direction: 'top' | 'bottom', step: number) {
   const { scrollTop } = container;
   container.scrollTop = direction === 'top' ? scrollTop - step : scrollTop + step;
 }


### PR DESCRIPTION
When we operate the options through the up and down keys of the keyboard, the options that are not in the visible area should automatically scroll to the visible area, so that we can see the content of the options. 


## Fixed components

- Autocomplete, fix https://github.com/rsuite/rsuite/issues/2872
- SelectPicker
- CheckPicker
- InputPicker
- TagPicker 
- Cascader
- MutiCascader


## Demo

### before

https://user-images.githubusercontent.com/1203827/205265558-6865af20-75e7-479d-a0c2-abb084d18e28.mp4

### after


https://user-images.githubusercontent.com/1203827/205265990-d2cf3f0f-f676-4579-b26a-d69b286ff87f.mp4

