### PR TITLE
fix(NavMenu): fix `noCaret` has No Effect on a Sub-menu

### DIFF
--- a/src/Nav/NavDropdownMenu.tsx
+++ b/src/Nav/NavDropdownMenu.tsx
@@ -31,6 +31,9 @@ export interface NavDropdownMenuProps<T = any> extends StandardProps {
    */
   openDirection?: 'start' | 'end';
 
+  /** No caret variation */
+  noCaret?: boolean;
+
   /**
    *  Only used for setting the default expand state when it's a submenu.
    */
@@ -67,6 +70,7 @@ const NavDropdownMenu = React.forwardRef<
     classPrefix = 'dropdown-menu',
     children,
     openDirection = 'end',
+    noCaret,
     ...rest
   } = props;
 
@@ -124,7 +128,7 @@ const NavDropdownMenu = React.forwardRef<
               >
                 {icon && React.cloneElement(icon, { className: prefix('menu-icon') })}
                 {title}
-                <Icon className={prefix`toggle-icon`} />
+                {!noCaret && <Icon className={prefix`toggle-icon`} />}
               </div>
             );
           }}
@@ -178,6 +182,7 @@ NavDropdownMenu.propTypes = {
   classPrefix: PropTypes.string,
   pullLeft: deprecatePropType(PropTypes.bool, 'Use openDirection="start" instead.'),
   openDirection: PropTypes.oneOf(['start', 'end']),
+  noCaret: PropTypes.bool,
   title: PropTypes.node,
   open: PropTypes.bool,
   eventKey: PropTypes.any,

--- a/src/Nav/test/NavMenuSpec.tsx
+++ b/src/Nav/test/NavMenuSpec.tsx
@@ -48,6 +48,19 @@ describe('<Nav.Menu>', () => {
 
       expect(getByText('Submenu item')).to.be.visible;
     });
+
+    it('Should render a nested submenu without a arrow icon', () => {
+      const { getByText } = render(
+        <Nav.Menu title="Menu">
+          <Nav.Menu title="Submenu" noCaret />
+        </Nav.Menu>,
+        {
+          wrapper: Nav
+        }
+      );
+
+      expect(getByText('Submenu').querySelector('.rs-dropdown-menu-toggle-icon')).to.not.exist;
+    });
   });
 
   context('Within <Navbar>', () => {


### PR DESCRIPTION
当 `<Nav.Menu>` 组件被嵌套时，会返回 `NavDropdownMenu` 组件，但是 `NavDropdownMenu` 并没有支持通过 `noCaret `属性配置小箭头图标的隐藏，因此此处通过为 `NavDropdownMenu` 组件接收 `noCaret` 属性并根据该属性控制是否显示小箭头图标。
问题来源:  [#2959](https://github.com/rsuite/rsuite/issues/2959)

修改前后示例：

**修改前**
![image](https://user-images.githubusercontent.com/112228030/205554807-fef5c49a-898a-48f6-afe2-426c2dc4fedf.png)
**修改后**
![image](https://user-images.githubusercontent.com/112228030/205554888-d0195885-c61b-4938-b521-57664a5d8878.png)

