### PR TITLE
fix(Tooltip): should use the default text alignment

### DIFF
--- a/src/Tooltip/styles/index.less
+++ b/src/Tooltip/styles/index.less
@@ -16,7 +16,6 @@
   max-width: @tooltip-max-width;
   padding: 2px 10px;
   color: var(--rs-tooltip-text);
-  text-align: center; // TODO: remove align center?
   background-color: var(--rs-tooltip-bg);
   border-radius: @tooltip-border-radius;
   overflow-wrap: break-word;


### PR DESCRIPTION
## before

![image](https://user-images.githubusercontent.com/1203827/205869164-e5051e32-457d-4fce-9576-5fbc5e75c6f2.png)


## after 

![image](https://user-images.githubusercontent.com/1203827/205869254-eb30dcda-c496-4644-9a42-fb83efa7c8d5.png)
