### PR TITLE
fix(Form.HelpText): change font size to 12px

### DIFF
--- a/src/FormHelpText/styles/index.less
+++ b/src/FormHelpText/styles/index.less
@@ -10,8 +10,8 @@
   color: var(--rs-text-secondary); // lighten the text some for contrast
   //Sometimes help info is more than one line，so height can't set a fixed value
   min-height: @line-height-computed;
-  line-height: @line-height-base;
-  font-size: @font-size-base;
+  line-height: @line-height-small;
+  font-size: @font-size-small;
 
   &-tooltip {
     display: inline-flex;

--- a/src/FormHelpText/test/FormHelpTextStylesSpec.tsx
+++ b/src/FormHelpText/test/FormHelpTextStylesSpec.tsx
@@ -12,5 +12,8 @@ describe('FormHelpText styles', () => {
     const dom = getDOMNode(instanceRef.current);
     assert.equal(getStyle(dom, 'display'), 'block', 'FormHelpText display');
     assert.equal(getStyle(dom, 'color'), toRGB('#8e8e93'), 'FormHelpText color');
+
+    expect(dom).to.have.style('font-size', '12px');
+    expect(dom).to.have.style('line-height', '20px');
   });
 });


### PR DESCRIPTION
Form.HelpText should have had a fontSize of `12px`, according to design materials. https://www.figma.com/file/uEq9QBplcKUYZrcWWA3RK2/NXT-UI?node-id=0%3A9099&t=H5h3Dd3AnJVgbAbz-4