### PR TITLE
refactor(ButtonToolbar): use `Stack` as a container to adapt mobile

### DIFF
--- a/src/Button/test/ButtonStylesSpec.tsx
+++ b/src/Button/test/ButtonStylesSpec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import Button from '../Button';
 import ButtonToolbar from '../../ButtonToolbar';
 import { getDOMNode, getDefaultPalette, toRGB, getStyle, itChrome } from '@test/testUtils';
@@ -83,7 +83,7 @@ describe('Button styles', () => {
   });
 
   itChrome('Button should render the correct padding', () => {
-    const { getAllByRole } = render(
+    render(
       <ButtonToolbar>
         <Button size="lg">Large</Button>
         <Button size="md">Medium</Button>
@@ -91,7 +91,7 @@ describe('Button styles', () => {
         <Button size="xs">Xsmall</Button>
       </ButtonToolbar>
     );
-    const buttons = getAllByRole('button');
+    const buttons = screen.getAllByRole('button');
 
     const lg = buttons[0];
     const md = buttons[1];
@@ -153,7 +153,7 @@ describe('Button styles', () => {
   });
 
   it('Disabled button should render the correct opacity', () => {
-    const { getAllByRole } = render(
+    render(
       <ButtonToolbar>
         <Button appearance="default" disabled>
           Default
@@ -172,7 +172,7 @@ describe('Button styles', () => {
         </Button>
       </ButtonToolbar>
     );
-    const buttons = getAllByRole('button');
+    const buttons = screen.getAllByRole('button');
     const defaultButton = buttons[0];
     const primaryButton = buttons[1];
     const linkButton = buttons[2];

--- a/src/Button/test/ButtonStylesSpec.tsx
+++ b/src/Button/test/ButtonStylesSpec.tsx
@@ -83,20 +83,21 @@ describe('Button styles', () => {
   });
 
   itChrome('Button should render the correct padding', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    render(
-      <ButtonToolbar ref={instanceRef}>
+    const { getAllByRole } = render(
+      <ButtonToolbar>
         <Button size="lg">Large</Button>
         <Button size="md">Medium</Button>
         <Button size="sm">Small</Button>
         <Button size="xs">Xsmall</Button>
       </ButtonToolbar>
     );
-    const buttons = getDOMNode(instanceRef.current).children;
+    const buttons = getAllByRole('button');
+
     const lg = buttons[0];
     const md = buttons[1];
     const sm = buttons[2];
     const xs = buttons[3];
+
     assert.equal(getStyle(lg, 'padding'), '10px 16px', 'Large button padding');
     assert.equal(getStyle(md, 'padding'), '8px 12px', 'Middle button padding');
     assert.equal(getStyle(sm, 'padding'), '5px 10px', 'Small button padding');
@@ -152,9 +153,8 @@ describe('Button styles', () => {
   });
 
   it('Disabled button should render the correct opacity', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    render(
-      <ButtonToolbar ref={instanceRef}>
+    const { getAllByRole } = render(
+      <ButtonToolbar>
         <Button appearance="default" disabled>
           Default
         </Button>
@@ -172,7 +172,7 @@ describe('Button styles', () => {
         </Button>
       </ButtonToolbar>
     );
-    const buttons = getDOMNode(instanceRef.current).children;
+    const buttons = getAllByRole('button');
     const defaultButton = buttons[0];
     const primaryButton = buttons[1];
     const linkButton = buttons[2];

--- a/src/ButtonToolbar/ButtonToolbar.tsx
+++ b/src/ButtonToolbar/ButtonToolbar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useClassNames } from '../utils';
 import { WithAsProps, RsRefForwardingComponent } from '../@types/common';
+import Stack, { StackProps } from '../Stack';
 
 export interface ButtonToolbarProps extends WithAsProps {
   /**
@@ -12,19 +13,22 @@ export interface ButtonToolbarProps extends WithAsProps {
   role?: string;
 }
 
-const ButtonToolbar: RsRefForwardingComponent<'div', ButtonToolbarProps> = React.forwardRef(
+const ButtonToolbar: RsRefForwardingComponent<typeof Stack, ButtonToolbarProps> = React.forwardRef(
   (props: ButtonToolbarProps, ref) => {
     const {
       className,
       classPrefix = 'btn-toolbar',
-      as: Component = 'div',
+      as: Component = Stack,
       role = 'toolbar',
       ...rest
     } = props;
 
+    const stackProps: StackProps | null =
+      Component === Stack ? { wrap: true, spacing: 10, childrenRenderMode: 'clone' } : null;
+
     const { withClassPrefix, merge } = useClassNames(classPrefix);
     const classes = merge(className, withClassPrefix());
-    return <Component {...rest} role={role} ref={ref} className={classes} />;
+    return <Component {...stackProps} {...rest} role={role} ref={ref} className={classes} />;
   }
 );
 

--- a/src/ButtonToolbar/styles/index.less
+++ b/src/ButtonToolbar/styles/index.less
@@ -8,8 +8,4 @@
 .rs-btn-toolbar {
   // Clear whitespace
   line-height: 0;
-
-  > :not(:first-child):not(.rs-btn-block) {
-    margin-left: 10px;
-  }
 }

--- a/src/ButtonToolbar/test/ButtonToolbar.text.tsx
+++ b/src/ButtonToolbar/test/ButtonToolbar.text.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ButtonToolbar from '../ButtonToolbar';
+
+<ButtonToolbar spacing={20} alignItems="flex-end" />;
+
+// @ts-expect-error should not have a spacing prop
+<ButtonToolbar as="div" spacing={20} alignItems="flex-end" />;
+
+// @ts-expect-error should not have a alignItems prop
+<ButtonToolbar as="div" alignItems="flex-end" />;

--- a/src/ButtonToolbar/test/ButtonToolbarSpec.tsx
+++ b/src/ButtonToolbar/test/ButtonToolbarSpec.tsx
@@ -1,24 +1,53 @@
 import React from 'react';
-import { getDOMNode } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
+import { render } from '@testing-library/react';
 
 import Button from '../../Button';
-import ButtonGroup from '../../ButtonGroup';
 import ButtonToolbar from '../ButtonToolbar';
 
 describe('ButtonToolbar', () => {
   testStandardProps(<ButtonToolbar />);
 
   it('Should output a button toolbar', () => {
-    const instance = getDOMNode(
+    const { getByRole } = render(<ButtonToolbar />);
+
+    expect(getByRole('toolbar')).to.tagName('DIV');
+    expect(getByRole('toolbar')).to.have.class('rs-btn-toolbar');
+  });
+
+  it('Should have flex property by default', () => {
+    const { getByRole } = render(
       <ButtonToolbar>
-        <ButtonGroup>
-          <Button>Title</Button>
-        </ButtonGroup>
+        <Button />
       </ButtonToolbar>
     );
-    assert.equal(instance.nodeName, 'DIV');
-    assert.ok(instance.className.match(/\bbtn-toolbar\b/));
-    assert.equal(instance.getAttribute('role'), 'toolbar');
+
+    expect(getByRole('toolbar')).to.be.style('flex-wrap', 'wrap');
+    expect(getByRole('toolbar')).to.be.style('gap', '10px');
+    expect(getByRole('toolbar')).to.have.class('rs-stack');
+    expect(getByRole('button')).to.have.class('rs-stack-item');
+  });
+
+  it('Should not have flex property when changing `as`', () => {
+    const { getByRole } = render(
+      <ButtonToolbar as="div">
+        <Button />
+      </ButtonToolbar>
+    );
+
+    expect(getByRole('toolbar')).to.not.have.style('flex-wrap', 'wrap');
+    expect(getByRole('toolbar')).to.not.have.style('gap', '10px');
+    expect(getByRole('button')).to.not.have.class('rs-stack-item');
+  });
+
+  it('Should render 2 buttons', () => {
+    const { getAllByRole } = render(
+      <ButtonToolbar>
+        <Button />
+        <Button />
+      </ButtonToolbar>
+    );
+
+    expect(getAllByRole('button')).to.have.length(2);
   });
 });

--- a/src/ButtonToolbar/test/ButtonToolbarStyleSpec.tsx
+++ b/src/ButtonToolbar/test/ButtonToolbarStyleSpec.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import ButtonToolbar from '../ButtonToolbar';
-import Button from '../../Button';
-
 import { getDOMNode, getStyle } from '@test/testUtils';
 
 import '../styles/index.less';
@@ -12,16 +10,5 @@ describe('ButtonToolbar styles', () => {
     const instanceRef = React.createRef<HTMLDivElement>();
     render(<ButtonToolbar ref={instanceRef} />);
     assert.equal(getStyle(getDOMNode(instanceRef.current), 'line-height'), '0px');
-  });
-
-  it('Should render the correct margin left', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    render(
-      <ButtonToolbar ref={instanceRef}>
-        <Button>Title</Button>
-        <Button>Title</Button>
-      </ButtonToolbar>
-    );
-    assert.equal(getStyle(getDOMNode(instanceRef.current).children[1], 'marginLeft'), '10px');
   });
 });

--- a/src/Stack/Stack.tsx
+++ b/src/Stack/Stack.tsx
@@ -30,6 +30,11 @@ export interface StackProps extends WithAsProps {
    * Define whether the children in the stack are forced onto one line or can wrap onto multiple lines
    */
   wrap?: boolean;
+
+  /**
+   * The render mode of the children.
+   */
+  childrenRenderMode?: 'clone' | 'wrap';
 }
 
 export interface StackComponent extends RsRefForwardingComponent<'div', StackProps> {
@@ -41,6 +46,7 @@ const Stack = React.forwardRef((props: StackProps, ref: React.Ref<HTMLDivElement
     as: Component = 'div',
     alignItems = 'center',
     classPrefix = 'stack',
+    childrenRenderMode = 'wrap',
     className,
     children,
     direction,
@@ -55,12 +61,12 @@ const Stack = React.forwardRef((props: StackProps, ref: React.Ref<HTMLDivElement
   const { rtl } = useCustom('Stack');
   const { withClassPrefix, merge, prefix } = useClassNames(classPrefix);
   const classes = merge(className, withClassPrefix());
-  const isSupportGridGap = isSupportFlexGap();
+  const isSupportGap = isSupportFlexGap();
 
-  const gridGap = Array.isArray(spacing) ? spacing : [spacing, 0];
+  const flexGap = Array.isArray(spacing) ? spacing : [spacing, spacing];
   const itemStyles: React.CSSProperties = {
-    [rtl ? 'marginLeft' : 'marginRight']: gridGap[0],
-    marginBottom: gridGap[1]
+    [rtl ? 'marginLeft' : 'marginRight']: flexGap[0],
+    marginBottom: flexGap[1]
   };
 
   const styles = {
@@ -68,7 +74,7 @@ const Stack = React.forwardRef((props: StackProps, ref: React.Ref<HTMLDivElement
     justifyContent,
     flexDirection: direction,
     flexWrap: wrap ? 'wrap' : undefined,
-    gap: isSupportGridGap ? spacing : undefined,
+    gap: isSupportGap ? spacing : undefined,
     ...style
   };
 
@@ -83,18 +89,18 @@ const Stack = React.forwardRef((props: StackProps, ref: React.Ref<HTMLDivElement
     <Component {...rest} ref={ref} className={classes} style={styles}>
       {React.Children.map(filterChildren as React.ReactElement[], (child, index) => {
         const childNode =
-          child.type !== StackItem ? (
+          childrenRenderMode === 'wrap' && child.type !== StackItem ? (
             <StackItem
               key={index}
               className={prefix('item')}
-              style={!isSupportGridGap ? itemStyles : undefined}
+              style={!isSupportGap ? itemStyles : undefined}
             >
               {child}
             </StackItem>
           ) : (
             React.cloneElement(child, {
               className: merge(prefix('item'), child.props.className),
-              style: !isSupportGridGap
+              style: !isSupportGap
                 ? {
                     ...itemStyles,
                     ...child.props.style

--- a/src/Stack/test/StackSpec.tsx
+++ b/src/Stack/test/StackSpec.tsx
@@ -9,13 +9,13 @@ describe('Stack', () => {
   it('Should output a stack', () => {
     const { getByTestId } = render(<Stack data-testid="test"></Stack>);
 
-    assert.equal(getByTestId('test').className, 'rs-stack');
+    expect(getByTestId('test')).to.have.class('rs-stack');
   });
 
   it('Should be wrap', () => {
     const { getByTestId } = render(<Stack data-testid="test" wrap></Stack>);
 
-    assert.equal(getByTestId('test').style.flexWrap, 'wrap');
+    expect(getByTestId('test')).to.have.style('flex-wrap', 'wrap');
   });
 
   it('Should have a gap style', () => {
@@ -25,9 +25,9 @@ describe('Stack', () => {
       </Stack>
     );
 
-    assert.equal(getByTestId('test').style.gap, '10px');
-    assert.isEmpty((getByTestId('test').children[0] as HTMLElement).style.marginRight);
-    assert.isEmpty((getByTestId('test').children[0] as HTMLElement).style.marginBottom);
+    expect(getByTestId('test')).to.style('gap', '10px');
+    expect((getByTestId('test').firstChild as HTMLElement).style.marginRight).to.be.empty;
+    expect((getByTestId('test').firstChild as HTMLElement).style.marginBottom).to.be.empty;
   });
 
   it('Should have a align-items style', () => {
@@ -39,12 +39,14 @@ describe('Stack', () => {
     const { getByTestId } = render(
       <Stack data-testid="test" justifyContent="space-around"></Stack>
     );
-    assert.equal(getByTestId('test').style.justifyContent, 'space-around');
+
+    expect(getByTestId('test')).to.have.style('justify-content', 'space-around');
   });
 
   it('Should be displayed in vertical columns', () => {
     const { getByTestId } = render(<Stack data-testid="test" direction="column"></Stack>);
-    assert.equal(getByTestId('test').style.flexDirection, 'column');
+
+    expect(getByTestId('test')).to.have.style('flex-direction', 'column');
   });
 
   it('Should have a divider', () => {
@@ -55,8 +57,8 @@ describe('Stack', () => {
       </Stack>
     );
 
-    assert.equal(getByTestId('test').children.length, 3);
-    assert.equal(getByTestId('test').children[1].textContent, '|');
+    expect(getByTestId('test').children).to.length(3);
+    expect(getByTestId('test').children[1].textContent).to.equal('|');
   });
 
   it('Should not render empty child', () => {
@@ -69,7 +71,28 @@ describe('Stack', () => {
         {[1, 2]}
       </Stack>
     );
-
     expect(getByTestId('test').children).to.length(4);
+  });
+
+  it('Should wrap children', () => {
+    const { getByTestId } = render(
+      <Stack data-testid="test">
+        <button />
+      </Stack>
+    );
+
+    expect(getByTestId('test').firstChild).to.tagName('DIV');
+    expect(getByTestId('test').firstChild).to.have.class('rs-stack-item');
+  });
+
+  it('Should clone children', () => {
+    const { getByTestId } = render(
+      <Stack data-testid="test" childrenRenderMode="clone">
+        <button />
+      </Stack>
+    );
+
+    expect(getByTestId('test').firstChild).to.tagName('BUTTON');
+    expect(getByTestId('test').firstChild).to.have.class('rs-stack-item');
   });
 });


### PR DESCRIPTION
## before

![image](https://user-images.githubusercontent.com/1203827/206152387-99dd4515-35fb-4dff-8bbd-e3af98a55091.png)


## after

![image](https://user-images.githubusercontent.com/1203827/206152707-46db606b-13e8-4dee-8fb8-2d638aa2030a.png)
