### PR TITLE
refactor(utils): make Picker utils generic

### DIFF
--- a/src/AutoComplete/test/utilsSpec.ts
+++ b/src/AutoComplete/test/utilsSpec.ts
@@ -1,0 +1,51 @@
+import Sinon from 'sinon';
+import { shouldDisplay } from '../utils';
+
+describe('shouldDisplay(filterBy, value)', () => {
+  const data = [
+    {
+      label: 'AutoComplete',
+      value: 'autocomplete'
+    },
+    {
+      label: 'SelectPicker',
+      value: 'selectpicker'
+    }
+  ];
+  context('filterBy is a function', () => {
+    it('Should call `filterBy` with each item and `value`', () => {
+      const filterBy = Sinon.spy();
+      const keyword = 'keyword';
+      data.filter(shouldDisplay(filterBy, keyword));
+
+      for (const item of data) {
+        expect(filterBy).to.have.been.calledWith(keyword, item);
+      }
+    });
+    it('Should filter the items with which `filterBy` returns true', () => {
+      const filterBy = (_keyword, item) => {
+        return item.value === 'autocomplete';
+      };
+      expect(data.filter(shouldDisplay(filterBy, ''))).to.eql([
+        {
+          label: 'AutoComplete',
+          value: 'autocomplete'
+        }
+      ]);
+    });
+  });
+
+  context('filterBy is undefined', () => {
+    it('Should filter nothing if `value` is empty', () => {
+      expect(data.filter(shouldDisplay(undefined, ''))).to.eql([]);
+    });
+    it('Should filter the items whose `label` property matches `value` keyword', () => {
+      expect(data.filter(shouldDisplay(undefined, 'select'))).to.eql([
+        {
+          label: 'SelectPicker',
+          value: 'selectpicker'
+        }
+      ]);
+    });
+  });
+});

--- a/src/AutoComplete/utils.ts
+++ b/src/AutoComplete/utils.ts
@@ -1,5 +1,4 @@
 import trim from 'lodash/trim';
-import { ItemDataType } from '../@types/common';
 
 export function transformData(data: any[]) {
   if (!data) {
@@ -19,11 +18,11 @@ export function transformData(data: any[]) {
   });
 }
 
-export const shouldDisplay = (
-  filterBy: ((value: string, item: ItemDataType) => boolean) | undefined,
-  value: any
+export const shouldDisplay = <TItem extends { label: string }>(
+  filterBy: ((value: string, item: TItem) => boolean) | undefined,
+  value: string
 ) => {
-  return (item: any) => {
+  return (item: TItem) => {
     if (typeof filterBy === 'function') {
       return filterBy(value, item);
     }
@@ -31,7 +30,7 @@ export const shouldDisplay = (
     if (!trim(value)) {
       return false;
     }
-    const keyword = (value || '').toLocaleLowerCase();
+    const keyword = value.toLocaleLowerCase();
     return `${item.label}`.toLocaleLowerCase().indexOf(keyword) >= 0;
   };
 };

--- a/src/Cascader/Cascader.tsx
+++ b/src/Cascader/Cascader.tsx
@@ -357,7 +357,7 @@ const Cascader = React.forwardRef(<T extends number | string>(props: CascaderPro
 
   const handleSelect = (
     node: ItemDataType,
-    cascadePaths: ItemDataType[],
+    cascadePaths: ItemDataType<T>[],
     isLeafNode: boolean,
     event: React.MouseEvent
   ) => {
@@ -378,13 +378,13 @@ const Cascader = React.forwardRef(<T extends number | string>(props: CascaderPro
           node.loading = false;
           node[childrenKey] = data;
           if (targetRef.current) {
-            addColumn(data, columnIndex);
+            addColumn(data as ItemDataType<T>[], columnIndex);
           }
         });
       } else {
         node.loading = false;
         node[childrenKey] = children;
-        addColumn(children as ItemDataType[], columnIndex);
+        addColumn(children as ItemDataType<T>[], columnIndex);
       }
     } else if (node[childrenKey]?.length) {
       addColumn(node[childrenKey], columnIndex);
@@ -425,7 +425,7 @@ const Cascader = React.forwardRef(<T extends number | string>(props: CascaderPro
    */
   const handleSearchRowSelect = (
     node: ItemDataType,
-    nodes: ItemDataType[],
+    nodes: ItemDataType<T>[],
     event: React.SyntheticEvent
   ) => {
     const nextValue = node[valueKey];
@@ -549,7 +549,8 @@ const Cascader = React.forwardRef(<T extends number | string>(props: CascaderPro
             cascadeData={columnData}
             cascadePaths={selectedPaths}
             activeItemValue={value}
-            onSelect={handleSelect}
+            // FIXME make onSelect generic
+            onSelect={handleSelect as any}
             renderMenu={renderMenu}
             renderMenuItem={renderMenuItem}
           />

--- a/src/Cascader/utils.ts
+++ b/src/Cascader/utils.ts
@@ -1,18 +1,16 @@
 import { useState, useMemo } from 'react';
 import slice from 'lodash/slice';
 import { shallowEqual, useUpdateEffect } from '../utils';
-import { CascaderProps } from './Cascader';
-import { ItemDataType } from '../@types/common';
 import { findNodeOfTree } from '../utils/treeUtils';
 import { attachParent } from '../utils/attachParent';
 
-export function getColumnsAndPaths<T extends ItemDataType>(data: T[], value, options) {
+export function getColumnsAndPaths<T extends Record<string, unknown>>(data: T[], value, options) {
   const { childrenKey, valueKey, isAttachChildren } = options;
-  const columns: ItemDataType[][] = [];
+  const columns: T[][] = [];
   const paths: T[] = [];
   const findNode = (items: T[]): { items: T[]; active: T } | null => {
     for (let i = 0; i < items.length; i += 1) {
-      const children = items[i][childrenKey];
+      const children = items[i][childrenKey] as T[] | undefined;
 
       if (shallowEqual(items[i][valueKey], value)) {
         return { items, active: items[i] };
@@ -50,8 +48,15 @@ export function getColumnsAndPaths<T extends ItemDataType>(data: T[], value, opt
   return { columns, paths };
 }
 
-export function usePaths(props: CascaderProps) {
-  const { data, valueKey, childrenKey, value } = props;
+type UsePathsParams<T> = {
+  data: T[];
+  valueKey: string;
+  childrenKey: string;
+  value: unknown;
+};
+
+export function usePaths<T extends Record<string, unknown>>(params: UsePathsParams<T>) {
+  const { data, valueKey, childrenKey, value } = params;
 
   const { columns, paths } = useMemo(
     () => getColumnsAndPaths(data, value, { valueKey, childrenKey }),
@@ -62,17 +67,17 @@ export function usePaths(props: CascaderProps) {
   const [columnData, setColumnData] = useState(columns);
 
   // The path after cascading data selection.
-  const [selectedPaths, setSelectedPaths] = useState<ItemDataType[]>(paths);
+  const [selectedPaths, setSelectedPaths] = useState<T[]>(paths);
 
   // The path corresponding to the selected value.
-  const [valueToPaths, setValueToPaths] = useState<ItemDataType[]>(paths);
+  const [valueToPaths, setValueToPaths] = useState<T[]>(paths);
 
   /**
    * Add a list of options to the cascading panel. Used for lazy loading options.
    * @param column
    * @param index The index of the current column.
    */
-  function addColumn(column: ItemDataType[], index: number) {
+  function addColumn(column: T[], index: number) {
     setColumnData([...slice(columnData, 0, index), column]);
   }
 

--- a/src/CheckPicker/CheckPicker.tsx
+++ b/src/CheckPicker/CheckPicker.tsx
@@ -316,7 +316,9 @@ const CheckPicker = React.forwardRef(
       let filteredStickyItems: TreeNodeType[] = [];
 
       if (stickyItems) {
-        filteredStickyItems = filterNodesOfTree(stickyItems, item => checkShouldDisplay(item));
+        filteredStickyItems = filterNodesOfTree(stickyItems as typeof data, item =>
+          checkShouldDisplay(item)
+        );
         items = filterNodesOfTree(data, item => {
           return checkShouldDisplay(item) && !stickyItems.some(v => v[valueKey] === item[valueKey]);
         });

--- a/src/MultiCascader/utils.ts
+++ b/src/MultiCascader/utils.ts
@@ -17,12 +17,16 @@ interface ItemKeys {
   childrenKey: string;
 }
 
+type MayHasParent<T extends Record<string, unknown>> = T & {
+  parent?: MayHasParent<T>;
+};
+
 /**
  * Get all parents of a node
  * @param node
  */
-export const getParents = (node: ItemType) => {
-  let parents: ItemType[] = [];
+export const getParents = <T extends Record<string, unknown>>(node: MayHasParent<T>) => {
+  let parents: MayHasParent<T>[] = [];
 
   if (!node.parent) {
     return parents;
@@ -59,10 +63,6 @@ export const isSomeChildChecked = <T extends Record<string, unknown>>(
     }
     return false;
   });
-};
-
-type MayHasParent<T extends Record<string, unknown>> = T & {
-  parent?: MayHasParent<T>;
 };
 
 /**

--- a/src/MultiCascader/utils.ts
+++ b/src/MultiCascader/utils.ts
@@ -169,14 +169,12 @@ export const removeAllChildrenValue = <T>(
  * A hook to flatten tree structure data
  * @param data
  */
-export function useFlattenData(data: ItemDataType[], itemKeys: ItemKeys) {
+export function useFlattenData<T>(data: T[], itemKeys: ItemKeys) {
   const { childrenKey } = itemKeys;
-  const [flattenData, setFlattenData] = useState<ItemDataType[]>(
-    flattenTree(data, itemKeys.childrenKey)
-  );
+  const [flattenData, setFlattenData] = useState<T[]>(flattenTree(data, itemKeys.childrenKey));
 
   const addFlattenData = useCallback(
-    (children: ItemDataType[], parent: ItemDataType) => {
+    (children: T[], parent: T) => {
       const nodes = children.map(child => {
         return attachParent(child, parent);
       });

--- a/src/MultiCascader/utils.ts
+++ b/src/MultiCascader/utils.ts
@@ -61,14 +61,18 @@ export const isSomeChildChecked = <T extends Record<string, unknown>>(
   });
 };
 
+type MayHasParent<T extends Record<string, unknown>> = T & {
+  parent?: MayHasParent<T>;
+};
+
 /**
  * Check if the parent is selected.
  * @param node
  * @param value
  * @param itemKeys
  */
-export const isSomeParentChecked = (
-  node: ItemDataType,
+export const isSomeParentChecked = <T extends Record<string, unknown>>(
+  node: MayHasParent<T>,
   value: ValueType,
   itemKeys: Pick<ItemKeys, 'valueKey'>
 ) => {

--- a/src/MultiCascader/utils.ts
+++ b/src/MultiCascader/utils.ts
@@ -40,8 +40,8 @@ export const getParents = (node: ItemType) => {
  * @param value
  * @param itemKeys
  */
-export const isSomeChildChecked = (
-  node: ItemDataType,
+export const isSomeChildChecked = <T extends Record<string, unknown>>(
+  node: T,
   value: ValueType,
   itemKeys: Omit<ItemKeys, 'labelKey'>
 ) => {
@@ -50,11 +50,11 @@ export const isSomeChildChecked = (
     return false;
   }
 
-  return node[childrenKey].some((child: ItemDataType) => {
+  return (node[childrenKey] as T[]).some(child => {
     if (value.some(n => n === child[valueKey])) {
       return true;
     }
-    if (child[childrenKey]?.length) {
+    if ((child[childrenKey] as T[] | undefined)?.length) {
       return isSomeChildChecked(child, value, itemKeys);
     }
     return false;

--- a/src/MultiCascader/utils.ts
+++ b/src/MultiCascader/utils.ts
@@ -197,18 +197,16 @@ export function useFlattenData<T>(data: T[], itemKeys: ItemKeys) {
  * A hook for column data
  * @param flattenData
  */
-export function useColumnData(flattenData: ItemType[]) {
+export function useColumnData<T extends MayHasParent<Record<string, unknown>>>(flattenData: T[]) {
   // The columns displayed in the cascading panel.
-  const [columnData, setColumnData] = useState<ItemDataType[][]>([
-    flattenData.filter(item => !item.parent)
-  ]);
+  const [columnData, setColumnData] = useState<T[][]>([flattenData.filter(item => !item.parent)]);
 
   /**
    * Add a list of options to the cascading panel. Used for lazy loading options.
    * @param column
    * @param index The index of the current column.
    */
-  function addColumn(column: ItemDataType[], index: number) {
+  function addColumn(column: T[], index: number) {
     setColumnData([...slice(columnData, 0, index), column]);
   }
 
@@ -220,7 +218,7 @@ export function useColumnData(flattenData: ItemType[]) {
     setColumnData([...slice(columnData, 0, index)]);
   }
 
-  function enforceUpdateColumnData(nextData: ItemDataType[]) {
+  function enforceUpdateColumnData(nextData: T[]) {
     const nextFlattenData = flattenTree(nextData);
     setColumnData([nextFlattenData.filter(item => !item.parent)]);
   }

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -232,7 +232,7 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
     setDragOverNodeKey,
     setDragNode,
     setDropNodePosition
-  } = useTreeDrag();
+  } = useTreeDrag<ItemDataType>();
 
   const { treeNodesRefs, saveTreeNodeRef } = useTreeNodeRefs();
 

--- a/src/utils/test/treeUtilsSpec.ts
+++ b/src/utils/test/treeUtilsSpec.ts
@@ -1,4 +1,4 @@
-import { findNodeOfTree, filterNodesOfTree } from '../treeUtils';
+import { findNodeOfTree, filterNodesOfTree, toggleExpand } from '../treeUtils';
 
 describe('[utils] Tree utils', () => {
   it('Should find the valid node', () => {
@@ -97,5 +97,68 @@ describe('[utils] Tree utils', () => {
     assert.equal(nodes[0].value, 'vvv');
     assert.equal((nodes[0].children as any[]).length, 2);
     assert.equal((nodes[0].children as any)[1].value, 'vv-abcd');
+  });
+
+  describe('toggleExpand({ node, isExpand, expandItemValues, valueKey })', () => {
+    context('isExpand = true', () => {
+      it('Should add `node[valueKey]` if `expandItemValues` does not include it', () => {
+        const node = {
+          value: 2
+        };
+        const valueKey = 'value';
+        expect(
+          toggleExpand({
+            node,
+            valueKey,
+            expandItemValues: [1],
+            isExpand: true
+          })
+        ).to.eql([1, 2]);
+      });
+      it('Should return `expandItemValues` as is if it already includes `node[valueKey]`', () => {
+        const node = {
+          value: 2
+        };
+        const valueKey = 'value';
+        expect(
+          toggleExpand({
+            node,
+            valueKey,
+            expandItemValues: [1, 2],
+            isExpand: true
+          })
+        ).to.eql([1, 2]);
+      });
+    });
+    context('isExpand = false', () => {
+      it('Should remove `node[valueKey]` if `expandItemValues` includes it', () => {
+        const node = {
+          value: 2
+        };
+        const valueKey = 'value';
+        expect(
+          toggleExpand({
+            node,
+            valueKey,
+            expandItemValues: [1, 2],
+            isExpand: false
+          })
+        ).to.eql([1]);
+      });
+      it('Should return `expandItemValues` as is if it does not include `node[valueKey]`', () => {
+        const node = {
+          value: 2
+        };
+        const valueKey = 'value';
+        expect(
+          toggleExpand({
+            node,
+            valueKey,
+            expandItemValues: [1],
+            isExpand: false
+          })
+        ).to.eql([1]);
+      });
+    });
   });
 });

--- a/src/utils/test/treeUtilsSpec.ts
+++ b/src/utils/test/treeUtilsSpec.ts
@@ -63,8 +63,8 @@ describe('[utils] Tree utils', () => {
     assert.equal(items[2].children[0].value, 'vv-abc');
     assert.equal(nodes.length, 2);
     assert.equal(nodes[0].value, 'abcd');
-    assert.equal((nodes[1].children as any[]).length, 1);
-    assert.equal((nodes[1].children as any)[0].value, 'vv-abcd');
+    assert.equal((nodes[1] as any).children.length, 1);
+    assert.equal((nodes[1] as any).children[0].value, 'vv-abcd');
   });
 
   it('Should have a child', () => {

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -39,12 +39,12 @@ export function shouldShowNodeByParentExpanded(
  * @param {*} childrenKey
  * @param {*} executor
  */
-export function flattenTree(
-  tree: any[],
+export function flattenTree<TItem>(
+  tree: TItem[],
   childrenKey = 'children',
   executor?: (node: any, index: number) => any
-) {
-  const flattenData: any[] = [];
+): TItem[] {
+  const flattenData: TItem[] = [];
   const traverse = (data: any[], parent: any | null) => {
     if (!isArray(data)) {
       return;
@@ -124,8 +124,8 @@ export function compareArray(a: any[], b: any[]) {
   return isArray(a) && isArray(b) && !shallowEqualArray(a, b);
 }
 
-export function getDefaultExpandItemValues(
-  data: ItemDataType[],
+export function getDefaultExpandItemValues<TItem>(
+  data: TItem[],
   props: Required<
     Pick<
       TreePickerProps,
@@ -325,15 +325,15 @@ export function filterNodesOfTree<TItem extends HasChildren<Record<string, unkno
  * @param isSearching - component is in Searching
  * @returns
  */
-export const getFocusableItems = (
-  filteredData: ItemDataType[],
+export const getFocusableItems = <TItem extends ItemDataType>(
+  filteredData: TItem[],
   props: Required<
     Pick<PartialTreeProps, 'disabledItemValues' | 'valueKey' | 'childrenKey' | 'expandItemValues'>
   >,
   isSearching?: boolean
-) => {
+): TItem[] => {
   const { disabledItemValues, valueKey, childrenKey, expandItemValues } = props;
-  const items: TreeNodeType[] = [];
+  const items: TItem[] = [];
   const loop = (nodes: any[]) => {
     nodes.forEach((node: any) => {
       const disabled = disabledItemValues.some(disabledItem =>
@@ -558,15 +558,27 @@ export { getTreeActiveNode };
  * toggle tree node
  * @param param0
  */
-export function toggleExpand({ node, isExpand, expandItemValues, valueKey }: any) {
-  const newExpandItemValues = new Set(expandItemValues);
+export function toggleExpand<T>({
+  node,
+  isExpand,
+  expandItemValues,
+  valueKey
+}: ToggleExpandOptions<T>): T[] {
+  const newExpandItemValues = new Set<T>(expandItemValues);
   if (isExpand) {
-    newExpandItemValues.add(node[valueKey]);
+    newExpandItemValues.add(node[valueKey] as T);
   } else {
-    newExpandItemValues.delete(node[valueKey]);
+    newExpandItemValues.delete(node[valueKey] as T);
   }
-  return Array.from(newExpandItemValues) as ItemDataType[];
+  return Array.from(newExpandItemValues);
 }
+
+type ToggleExpandOptions<T> = {
+  node: Record<string, unknown>;
+  isExpand: boolean;
+  expandItemValues: T[];
+  valueKey: string;
+};
 
 export function getTreeNodeTitle(label: any) {
   if (typeof label === 'string') {

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -325,7 +325,7 @@ export function filterNodesOfTree<TItem extends HasChildren<Record<string, unkno
  * @param isSearching - component is in Searching
  * @returns
  */
-export const getFocusableItems = <TItem extends ItemDataType>(
+export const getFocusableItems = <TItem extends TreeNodeType>(
   filteredData: TItem[],
   props: Required<
     Pick<PartialTreeProps, 'disabledItemValues' | 'valueKey' | 'childrenKey' | 'expandItemValues'>
@@ -334,8 +334,8 @@ export const getFocusableItems = <TItem extends ItemDataType>(
 ): TItem[] => {
   const { disabledItemValues, valueKey, childrenKey, expandItemValues } = props;
   const items: TItem[] = [];
-  const loop = (nodes: any[]) => {
-    nodes.forEach((node: any) => {
+  const loop = (nodes: TItem[]) => {
+    nodes.forEach((node: TItem) => {
       const disabled = disabledItemValues.some(disabledItem =>
         shallowEqual(disabledItem, node[valueKey])
       );

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -285,12 +285,19 @@ export function findNodeOfTree(data, check) {
   return findNode(data);
 }
 
-export function filterNodesOfTree(data, check) {
-  const findNodes = (nodes: readonly TreeNodeType[] = []) => {
-    const nextNodes: TreeNodeType[] = [];
+type HasChildren<T extends Record<string, unknown>> = T & {
+  children?: readonly HasChildren<T>[];
+};
+
+export function filterNodesOfTree<TItem extends HasChildren<Record<string, unknown>>>(
+  data: readonly TItem[],
+  check: (item: TItem) => boolean
+): TItem[] {
+  const findNodes = (nodes: readonly TItem[] = []) => {
+    const nextNodes: TItem[] = [];
     for (let i = 0; i < nodes.length; i += 1) {
       if (isArray(nodes[i].children)) {
-        const nextChildren = findNodes(nodes[i].children);
+        const nextChildren = findNodes(nodes[i].children as TItem[]);
         if (nextChildren.length) {
           const item = clone(nodes[i]);
           item.children = nextChildren;

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -835,25 +835,25 @@ export function useTreeNodeRefs() {
   };
 }
 
-interface TreeSearchProps {
+interface TreeSearchProps<T> {
   labelKey: string;
   childrenKey: string;
   searchKeyword?: string;
-  data: ItemDataType[];
+  data: T[];
   searchBy?: (keyword, label, item) => boolean;
-  callback?: (keyword: string, data: ItemDataType[], event: React.SyntheticEvent) => void;
+  callback?: (keyword: string, data: T[], event: React.SyntheticEvent) => void;
 }
 
 /**
  * A hook that handles tree search filter options
  * @param props
  */
-export function useTreeSearch<T extends HTMLElement = HTMLInputElement>(props: TreeSearchProps) {
+export function useTreeSearch<T>(props: TreeSearchProps<T>) {
   const { labelKey, childrenKey, searchKeyword, data, searchBy, callback } = props;
 
   const filterVisibleData = useCallback(
-    (data: ItemDataType[], searchKeyword: string) => {
-      const setVisible = (nodes: ItemDataType[]) =>
+    (data: T[], searchKeyword: string) => {
+      const setVisible = (nodes: T[]) =>
         nodes.forEach((item: any) => {
           item.visible = searchBy
             ? searchBy(searchKeyword, item[labelKey], item)
@@ -881,13 +881,13 @@ export function useTreeSearch<T extends HTMLElement = HTMLInputElement>(props: T
   );
 
   const handleSetFilteredData = useCallback(
-    (data: ItemDataType[], searchKeyword: string) => {
+    (data: T[], searchKeyword: string) => {
       setFilteredData(filterVisibleData(data, searchKeyword));
     },
     [filterVisibleData]
   );
 
-  const handleSearch = (searchKeyword: string, event: React.ChangeEvent<T>) => {
+  const handleSearch = (searchKeyword: string, event: React.ChangeEvent) => {
     const filteredData = filterVisibleData(data, searchKeyword);
     setFilteredData(filteredData);
     setSearchKeyword(searchKeyword);
@@ -903,8 +903,8 @@ export function useTreeSearch<T extends HTMLElement = HTMLInputElement>(props: T
   };
 }
 
-export function useGetTreeNodeChildren(
-  treeData: ItemDataType[],
+export function useGetTreeNodeChildren<T extends Record<string, unknown>>(
+  treeData: T[],
   valueKey: string,
   childrenKey: string
 ) {

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -4,7 +4,6 @@ import shallowEqualArray from '../utils/shallowEqualArray';
 import { TreeNodeType, TreeNodesType, getNodeCheckState } from '../CheckTreePicker/utils';
 import { TREE_NODE_DROP_POSITION, shallowEqual } from '../utils';
 import { CheckTreePickerProps } from '../CheckTreePicker/CheckTreePicker';
-import { ItemDataType } from '../@types/common';
 import { TreePickerProps } from '../TreePicker/TreePicker';
 import { shouldDisplay } from '../Picker';
 import reactToString from './reactToString';
@@ -22,9 +21,9 @@ const TREE_NODE_GAP = 4;
  * @param {*} expandItemValues
  * @param {*} parentKeys
  */
-export function shouldShowNodeByParentExpanded(
-  expandItemValues: any[] = [],
-  parentKeys: any[] = []
+export function shouldShowNodeByParentExpanded<T>(
+  expandItemValues: T[] = [],
+  parentKeys: T[] = []
 ) {
   const intersectionKeys = intersection(expandItemValues, parentKeys);
   if (intersectionKeys.length === parentKeys.length) {
@@ -94,8 +93,8 @@ export function getNodeParents(node: any, parentKey = 'parent', valueKey?: strin
  * @param node
  * @param valueKey
  */
-export function getNodeParentKeys(nodes: TreeNodesType, node: TreeNodeType, valueKey: string) {
-  const parentKeys: TreeNodeType[] = [];
+export function getNodeParentKeys<T>(nodes: TreeNodesType, node: TreeNodeType, valueKey: string) {
+  const parentKeys: T[] = [];
   const traverse = (node: TreeNodeType) => {
     if (node?.parent?.refKey) {
       traverse(nodes[node.parent.refKey]);
@@ -604,15 +603,15 @@ export function getChildrenByFlattenNodes(nodes: TreeNodesType, parent: TreeNode
   );
 }
 
-export function useTreeDrag() {
+export function useTreeDrag<T>() {
   // current dragging node
-  const dragNode = useRef<ItemDataType | null>(null);
+  const dragNode = useRef<T | null>(null);
   const [dragOverNodeKey, setDragOverNodeKey] = useState(null);
   // drag node and it's children nodes key
   const [dragNodeKeys, setDragNodeKeys] = useState<(number | string)[]>([]);
   const [dropNodePosition, setDropNodePosition] = useState<TREE_NODE_DROP_POSITION | null>(null);
 
-  const setDragNode = (node: ItemDataType | null) => {
+  const setDragNode = (node: T | null) => {
     dragNode.current = node;
   };
   return {
@@ -755,7 +754,7 @@ export function useFlattenTreeData({
   const formatVirtualizedTreeData = (
     nodes: TreeNodesType,
     data: any[],
-    expandItemValues: ItemDataType[],
+    expandItemValues: unknown[],
     options: {
       cascade?: boolean;
       searchKeyword?: string;


### PR DESCRIPTION
The problem with `ItemDataType` is that the `{ label; value; children; }` structure can be inaccurate, respecting `labelKey`/`valueKey`/`childrenKey` arguments.
There is currently an abuse of `ItemDataType` across Picker components, making it hard to apply fixes and refactoring in those components. The first step of removing inappropriate usage of `ItemDataType` is to make picker utils generic - they are bound to `ItemDataType` and used all across picker components.