### PR TITLE
fix(Modal): fix close button alignment and color

### DIFF
--- a/src/Modal/styles/index.less
+++ b/src/Modal/styles/index.less
@@ -3,6 +3,7 @@
 
 //
 // Modals
+// Figma: https://www.figma.com/file/uEq9QBplcKUYZrcWWA3RK2/NXT-UI?node-id=0%3A1348&t=H5h3Dd3AnJVgbAbz-4
 // --------------------------------------------------
 
 // Modal background
@@ -100,17 +101,16 @@
   padding-right: @line-height-computed;
 
   .rs-modal-header-close {
-    // button width the same to height
-    @padding-right: 4px;
-
     position: absolute;
     right: @modal-content-padding;
     top: @modal-content-padding;
     font-size: @modal-close-btn-size;
-    line-height: @modal-close-btn-line-height;
     color: @modal-close-btn-color;
-    width: @line-height-computed;
-    padding: 0 @padding-right;
+    padding: 0;
+
+    &:hover {
+      color: @modal-close-btn-hover-color;
+    }
   }
 }
 

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -520,7 +520,8 @@
 
 @modal-close-btn-size:          @font-size-small;
 @modal-close-btn-line-height:   @line-height-small;
-@modal-close-btn-color:         var(--rs-text-primary);
+@modal-close-btn-color:         var(--rs-text-secondary);
+@modal-close-btn-hover-color:   var(--rs-text-primary);
 
 // Modal sizes
 @modal-lg: 968px;
@@ -540,7 +541,7 @@
 
 @drawer-close-btn-size:         @font-size-small;
 @drawer-close-btn-line-height:  @line-height-small;
-@drawer-close-btn-color:        @modal-close-btn-color;
+@drawer-close-btn-color:        var(--rs-text-primary);
 
 // Drawer sizes
 @drawer-horizontal-lg: @modal-lg;


### PR DESCRIPTION
1. The close button should have been aligned with the title by their top edges, according to [design materials](https://www.figma.com/file/uEq9QBplcKUYZrcWWA3RK2/NXT-UI?node-id=0%3A1348&t=H5h3Dd3AnJVgbAbz-4).

<img width="741" alt="image" src="https://user-images.githubusercontent.com/8225666/206678674-3c25e445-861f-4fbd-9f64-857791c50d45.png">

2. Add a hover color 