### PR TITLE
feat(Dropdown): add Dropdown.Separator component

### DIFF
--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -17,6 +17,7 @@ import { initialState, reducer } from './DropdownState';
 import Button from '../Button';
 import warnOnce from '../utils/warnOnce';
 import Nav from '../Nav';
+import DropdownSeparator from './DropdownSeparator';
 
 export type DropdownTrigger = 'click' | 'hover' | 'contextMenu';
 export interface DropdownProps<T = any>
@@ -97,6 +98,7 @@ export interface DropdownComponent extends RsRefForwardingComponent<'div', Dropd
 
   Item: typeof DropdownItem;
   Menu: typeof DropdownMenu;
+  Separator: typeof DropdownSeparator;
 }
 
 /**
@@ -245,6 +247,7 @@ const Dropdown: DropdownComponent = React.forwardRef<HTMLElement>((props: Dropdo
 
 Dropdown.Item = DropdownItem;
 Dropdown.Menu = DropdownMenu;
+Dropdown.Separator = DropdownSeparator;
 
 Dropdown.displayName = 'Dropdown';
 Dropdown.propTypes = {

--- a/src/Dropdown/DropdownItem.tsx
+++ b/src/Dropdown/DropdownItem.tsx
@@ -2,7 +2,7 @@ import { RsRefForwardingComponent, WithAsProps } from '../@types/common';
 import React, { useCallback, useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { IconProps } from '@rsuite/icons/lib/Icon';
-import deprecatePropType from '../utils/deprecatePropType';
+import deprecatePropType, { deprecatePropTypeNew } from '../utils/deprecatePropType';
 import MenuItem from '../Menu/MenuItem';
 import DropdownContext from './DropdownContext';
 import isNil from 'lodash/isNil';
@@ -13,6 +13,8 @@ import { DropdownActionType } from './DropdownState';
 import { useRenderDropdownItem } from './useRenderDropdownItem';
 import warnOnce from '../utils/warnOnce';
 import Nav from '../Nav';
+import DropdownSeparator, { DropdownSeparatorProps } from './DropdownSeparator';
+import _ from 'lodash';
 
 export interface DropdownMenuItemProps<T = any>
   extends WithAsProps,
@@ -26,7 +28,11 @@ export interface DropdownMenuItemProps<T = any>
   /** You can use a custom element for this component */
   as?: React.ElementType;
 
-  /** Whether to display the divider */
+  /**
+   * Whether to display the divider
+   *
+   * @deprecated Use dedicated <Dropdown.Separator> component instead
+   */
   divider?: boolean;
 
   /** Disable the current option */
@@ -138,12 +144,7 @@ const DropdownItem: RsRefForwardingComponent<'li', DropdownMenuItemProps> = Reac
     }
 
     if (divider) {
-      return renderDropdownItem({
-        ref,
-        role: 'separator',
-        className: merge(prefix('divider'), className),
-        ...restProps
-      });
+      return <DropdownSeparator {...(_.pick(props, ['data-testid']) as DropdownSeparatorProps)} />;
     }
 
     if (panel) {
@@ -200,7 +201,7 @@ const DropdownItem: RsRefForwardingComponent<'li', DropdownMenuItemProps> = Reac
 DropdownItem.displayName = 'Dropdown.Item';
 DropdownItem.propTypes = {
   as: PropTypes.elementType,
-  divider: PropTypes.bool,
+  divider: deprecatePropTypeNew(PropTypes.bool, 'Use Dropdown.Separator component instead.'),
   panel: PropTypes.bool,
   trigger: PropTypes.oneOfType([PropTypes.array, PropTypes.oneOf(['click', 'hover'])]),
   open: deprecatePropType(PropTypes.bool),

--- a/src/Dropdown/DropdownSeparator.tsx
+++ b/src/Dropdown/DropdownSeparator.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { RsRefForwardingComponent, WithAsProps } from '../@types/common';
+import { useClassNames } from '../utils';
+
+export interface DropdownSeparatorProps extends WithAsProps, React.HTMLAttributes<HTMLElement> {
+  /** You can use a custom element for this component */
+  as?: React.ElementType;
+}
+
+/**
+ * The <Dropdown.Separator> API
+ *
+ * Renders a non-focusable and non-interactive `separator`
+ * Per ARIA APG https://www.w3.org/WAI/ARIA/apg/patterns/menu/
+ */
+const DropdownSeparator: RsRefForwardingComponent<'li', DropdownSeparatorProps> = React.forwardRef(
+  (props: DropdownSeparatorProps, ref: React.Ref<any>) => {
+    const {
+      classPrefix = 'dropdown-item-divider',
+      className,
+      as: Component = 'li',
+      ...restProps
+    } = props;
+
+    const { merge, withClassPrefix } = useClassNames(classPrefix);
+
+    return (
+      <Component
+        ref={ref}
+        role="separator"
+        className={merge(withClassPrefix(), className)}
+        {...restProps}
+      />
+    );
+  }
+);
+
+DropdownSeparator.displayName = 'Dropdown.Separator';
+DropdownSeparator.propTypes = {
+  as: PropTypes.elementType
+};
+
+export default DropdownSeparator;

--- a/src/Dropdown/test/DropdownItemSpec.tsx
+++ b/src/Dropdown/test/DropdownItemSpec.tsx
@@ -34,7 +34,8 @@ describe('<Dropdown.Item>', () => {
     expect(element.parentElement).to.have.tagName('LI');
   });
 
-  it('Should render a divider', () => {
+  it('[Deprecated] Should render a divider with deprecation message', () => {
+    const warn = sinon.spy(console, 'warn');
     const { getByTestId } = render(
       <Dropdown>
         <DropdownItem divider data-testid="item" />
@@ -42,6 +43,9 @@ describe('<Dropdown.Item>', () => {
     );
 
     expect(getByTestId('item')).to.have.class('rs-dropdown-item-divider');
+    expect(warn).to.have.been.calledWith(
+      '[rsuite] "divider" property of Dropdown.Item component has been deprecated.\nUse Dropdown.Separator component instead.'
+    );
   });
 
   it('Should render a panel with given content', () => {

--- a/src/Dropdown/test/DropdownSeparatorSpec.tsx
+++ b/src/Dropdown/test/DropdownSeparatorSpec.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Dropdown from '../Dropdown';
+import DropdownSeparator from '../DropdownSeparator';
+
+describe('<Dropdown.Separator>', () => {
+  it('[Deprecated] Should render a divider', () => {
+    render(
+      <Dropdown>
+        <DropdownSeparator data-testid="separator" />
+      </Dropdown>
+    );
+
+    expect(screen.getByTestId('separator')).to.have.class('rs-dropdown-item-divider');
+    expect(screen.getByTestId('separator')).to.have.attribute('role', 'separator');
+  });
+});

--- a/src/Dropdown/test/DropdownSpec.tsx
+++ b/src/Dropdown/test/DropdownSpec.tsx
@@ -969,3 +969,9 @@ describe('<Dropdown>', () => {
     });
   });
 });
+
+describe('Member components', () => {
+  it('Should have <Dropdown.Separator> component', () => {
+    expect(() => render(<Dropdown.Separator />)).not.to.throw();
+  });
+});

--- a/src/utils/deprecatePropType.ts
+++ b/src/utils/deprecatePropType.ts
@@ -2,6 +2,11 @@
 import * as PropTypes from 'prop-types';
 import warnOnce from './warnOnce';
 
+/**
+ * Prints deprecation message when user uses a deprecated prop
+ *
+ * @deprecated Use {@link deprecatePropTypeNew} which prints clearer messages.
+ */
 export default function deprecatePropType<T extends PropTypes.Validator<any>>(
   propType: T,
   explanation?: string
@@ -10,6 +15,24 @@ export default function deprecatePropType<T extends PropTypes.Validator<any>>(
     // Note ...rest here
     if (props[propName] != null) {
       const message = `"${propName}" property of "${componentName}" has been deprecated.\n${explanation}`;
+      warnOnce(message);
+    }
+
+    return propType(props, propName, componentName, ...rest); // and here
+  } as T;
+}
+
+/**
+ * Prints deprecation message when user uses a deprecated prop
+ */
+export function deprecatePropTypeNew<T extends PropTypes.Validator<any>>(
+  propType: T,
+  explanation?: string
+): typeof propType {
+  return function validate(props, propName, componentName, ...rest) {
+    // Note ...rest here
+    if (props[propName] != null) {
+      const message = `[rsuite] "${propName}" property of ${componentName} component has been deprecated.\n${explanation}`;
       warnOnce(message);
     }
 


### PR DESCRIPTION
Deprecate `divider` prop of Dropdown.Item component in favor of a dedicated Dropdown.Separator component.

Before

```jsx
<Dropdown>
  <Dropdown.Item divider />
</Dropdown>
```

After

```jsx
<Dropdown>
  <Dropdown.Separator />
</Dropdown>
```
## Why

- It's difficult to separate unused props passed to Dropdown.Item when `divider` flag is set, thus a dedicated component is needed
- The naming of "divider" is changed to "separator", respecting [ARIA APG menu pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menu)

## Documentation

Documentation will be updated in a separate PR after this change is released, in order to avoid breaking the production build.