### PR TITLE
fix(Sidenav): fix Sidenav multilevel Nav.Menu arrow icon exception

### DIFF
--- a/src/Sidenav/ExpandedSidenavDropdownMenu.tsx
+++ b/src/Sidenav/ExpandedSidenavDropdownMenu.tsx
@@ -106,6 +106,11 @@ const ExpandedSidenavDropdownMenu: RsRefForwardingComponent<'li', SidenavDropdow
               disabled
             })
           );
+          const iconClasses = merge(
+            className,
+            prefix('toggle-icon'),
+            prefix(`${open ? 'expand' : 'collapse'}-icon`)
+          );
           return (
             <Component
               ref={ref}
@@ -125,7 +130,7 @@ const ExpandedSidenavDropdownMenu: RsRefForwardingComponent<'li', SidenavDropdow
                     >
                       {icon && React.cloneElement(icon, { className: prefix('menu-icon') })}
                       {title}
-                      <Icon className={prefix`toggle-icon`} />
+                      <Icon className={iconClasses} />
                       <Ripple />
                     </button>
                   );

--- a/src/Sidenav/styles/index.less
+++ b/src/Sidenav/styles/index.less
@@ -76,13 +76,18 @@
         top: @sidenav-children-padding-vertical;
         // width: auto;
         // height: @sidenav-dropdown-toggle-caret-width;
-        transform: rotate(90deg);
+        // transform: rotate(90deg);
       }
     }
 
     // Expanded submenu toggle icon
-    .rs-dropdown-item-expand .rs-dropdown-item-toggle-icon {
+    .rs-dropdown-item-expand-icon {
       transform: rotate(270deg);
+    }
+
+    // Collapse submenu toggle icon
+    .rs-dropdown-item-collapse-icon {
+      transform: rotate(90deg);
     }
   }
 

--- a/src/Sidenav/test/SidenavSpec.tsx
+++ b/src/Sidenav/test/SidenavSpec.tsx
@@ -348,4 +348,34 @@ describe('<Sidenav>', () => {
       });
     });
   });
+
+  describe('Expanded', () => {
+    it('Should add collapsed or expanded className on multilevel <Nav.Menu> when click on it', async () => {
+      const { getByText } = render(
+        <Sidenav defaultOpenKeys={['1', '1-1']}>
+          <Sidenav.Body>
+            <Nav>
+              <Nav.Menu eventKey="1" title="menu1">
+                <Nav.Menu eventKey="1-1" title="menu2">
+                  <Nav.Menu eventKey="1-1-1" title="menu3" />
+                </Nav.Menu>
+              </Nav.Menu>
+            </Nav>
+          </Sidenav.Body>
+        </Sidenav>
+      );
+
+      const menu = getByText('menu3');
+      expect(menu.querySelector('.rs-dropdown-item-toggle-icon')).to.have.class(
+        'rs-dropdown-item-collapse-icon'
+      );
+
+      // opens the menu
+      fireEvent.click(menu);
+
+      expect(menu.querySelector('.rs-dropdown-item-toggle-icon')).to.have.class(
+        'rs-dropdown-item-expand-icon'
+      );
+    });
+  });
 });


### PR DESCRIPTION
## 示例代码
~~~jsx
<Sidenav defaultOpenKeys={['1', '1-1' ]}>
    <Sidenav.Body>
        <Nav>
            <Nav.Menu eventKey="1" title="menu1">
                <Nav.Menu eventKey="1-1" title="menu2">
                    <Nav.Menu eventKey="1-1-1" title="menu3" />
                </Nav.Menu>
            </Nav.Menu>
        </Nav>
    </Sidenav.Body>
</Sidenav>
~~~
## 问题描述
### 问题1
当 `Sidenav` 中的 `<Nav.Menu>` 嵌套至第三层或更多层时，从第三层开始，其箭头图标的方向不会随着其内部内容的折叠或展开状态而改变。
### 问题2
当  `<Nav.Menu>`  第三层的内部内容的状态为展开且对第二层进行折叠时，第三层的箭头图标会随着第二层的箭头图标进行更改。
## 前后对比
### 解决前

https://user-images.githubusercontent.com/112228030/209444808-8d867122-bec1-47b9-99c8-a13aee04b6f1.mov

### 解决后

https://user-images.githubusercontent.com/112228030/209445105-006bd62f-22c4-46a9-9e35-a8609a64af7f.mov

## 问题来源
close #2985 
