### PR TITLE
test: replace `done` callback with async assertions

### DIFF
--- a/src/Breadcrumb/test/BreadcrumbItemSpec.tsx
+++ b/src/Breadcrumb/test/BreadcrumbItemSpec.tsx
@@ -4,6 +4,8 @@ import { getDOMNode, getInstance } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import Breadcrumb from '../Breadcrumb';
 import BreadcrumbItem from '../BreadcrumbItem';
+import Sinon from 'sinon';
+import { act } from '@testing-library/react';
 
 describe('Breadcrumb.Item', () => {
   testStandardProps(<BreadcrumbItem />);
@@ -33,18 +35,20 @@ describe('Breadcrumb.Item', () => {
     assert.notOk(instance.hasAttribute('href'));
   });
 
-  it('Should spread additional props onto inner element', done => {
-    const handleClick = () => {
-      done();
-    };
+  it('Should spread additional props onto inner element', () => {
+    const onClick = Sinon.spy();
 
     const instance = getDOMNode(
-      <Breadcrumb.Item href="#" onClick={handleClick}>
+      <Breadcrumb.Item href="#" onClick={onClick}>
         Crumb
       </Breadcrumb.Item>
     );
 
-    ReactTestUtils.Simulate.click(instance);
+    act(() => {
+      ReactTestUtils.Simulate.click(instance);
+    });
+
+    expect(onClick).to.have.been.calledOnce;
   });
 
   it('Should apply id onto the anchor', () => {

--- a/src/Breadcrumb/test/BreadcrumbSpec.tsx
+++ b/src/Breadcrumb/test/BreadcrumbSpec.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { getDOMNode, getInstance } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import sinon from 'sinon';
 import Breadcrumb from '../Breadcrumb';
+import Sinon from 'sinon';
 
 afterEach(() => {
   sinon.restore();
@@ -41,13 +42,10 @@ describe('Breadcrumb', () => {
     assert.equal(instance.querySelectorAll('.rs-breadcrumb-item')[1].textContent, '...');
   });
 
-  it('Should call onExpand callback', done => {
+  it('Should call onExpand callback', () => {
+    const onExpand = Sinon.spy();
     const instance = getDOMNode(
-      <Breadcrumb
-        onExpand={() => {
-          done();
-        }}
-      >
+      <Breadcrumb onExpand={onExpand}>
         <Breadcrumb.Item>1</Breadcrumb.Item>
         <Breadcrumb.Item>2</Breadcrumb.Item>
         <Breadcrumb.Item>3</Breadcrumb.Item>
@@ -57,7 +55,11 @@ describe('Breadcrumb', () => {
       </Breadcrumb>
     );
 
-    ReactTestUtils.Simulate.click(instance.querySelectorAll('.rs-breadcrumb-item')[1]);
+    act(() => {
+      ReactTestUtils.Simulate.click(instance.querySelectorAll('.rs-breadcrumb-item')[1]);
+    });
+
+    expect(onExpand).to.have.been.calledOnce;
   });
 
   it('Should have a default separator', () => {

--- a/src/Breadcrumb/test/BreadcrumbSpec.tsx
+++ b/src/Breadcrumb/test/BreadcrumbSpec.tsx
@@ -5,7 +5,6 @@ import { getDOMNode, getInstance } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import sinon from 'sinon';
 import Breadcrumb from '../Breadcrumb';
-import Sinon from 'sinon';
 
 afterEach(() => {
   sinon.restore();
@@ -43,7 +42,7 @@ describe('Breadcrumb', () => {
   });
 
   it('Should call onExpand callback', () => {
-    const onExpand = Sinon.spy();
+    const onExpand = sinon.spy();
     const instance = getDOMNode(
       <Breadcrumb onExpand={onExpand}>
         <Breadcrumb.Item>1</Breadcrumb.Item>

--- a/src/Button/test/ButtonSpec.tsx
+++ b/src/Button/test/ButtonSpec.tsx
@@ -5,7 +5,6 @@ import sinon from 'sinon';
 import { getDOMNode, getInstance } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import Button from '../Button';
-import Sinon from 'sinon';
 
 describe('Button', () => {
   testStandardProps(<Button />);
@@ -35,7 +34,7 @@ describe('Button', () => {
   });
 
   it('Should call onClick callback', () => {
-    const onClick = Sinon.spy();
+    const onClick = sinon.spy();
     const instance = getDOMNode(<Button onClick={onClick}>Title</Button>);
     ReactTestUtils.Simulate.click(instance);
 

--- a/src/Button/test/ButtonSpec.tsx
+++ b/src/Button/test/ButtonSpec.tsx
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import { getDOMNode, getInstance } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import Button from '../Button';
+import Sinon from 'sinon';
 
 describe('Button', () => {
   testStandardProps(<Button />);
@@ -33,12 +34,12 @@ describe('Button', () => {
     assert.equal(instance.getAttribute('href'), href);
   });
 
-  it('Should call onClick callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<Button onClick={doneOp}>Title</Button>);
+  it('Should call onClick callback', () => {
+    const onClick = Sinon.spy();
+    const instance = getDOMNode(<Button onClick={onClick}>Title</Button>);
     ReactTestUtils.Simulate.click(instance);
+
+    expect(onClick).to.have.been.calledOnce;
   });
 
   it('Should be disabled', () => {

--- a/src/Calendar/test/CalendarHeaderSpec.tsx
+++ b/src/Calendar/test/CalendarHeaderSpec.tsx
@@ -5,6 +5,7 @@ import { getDOMNode } from '@test/testUtils';
 
 import Header from '../CalendarHeader';
 import CalendarContext from '../CalendarContext';
+import Sinon from 'sinon';
 
 describe('Calendar-Header', () => {
   it('Should render a div with "calendar-header" class', () => {
@@ -14,58 +15,56 @@ describe('Calendar-Header', () => {
     assert.ok(instance.className.match(/\bcalendar-header\b/));
   });
 
-  it('Should call `onMoveForward` callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call `onMoveForward` callback', () => {
+    const onMoveForward = Sinon.spy();
 
-    const instance = getDOMNode(<Header showMonth onMoveForward={doneOp} />);
+    const instance = getDOMNode(<Header showMonth onMoveForward={onMoveForward} />);
 
     ReactTestUtils.Simulate.click(
       instance.querySelector('.rs-calendar-header-forward') as HTMLElement
     );
+
+    expect(onMoveForward).to.have.been.calledOnce;
   });
 
-  it('Should call `onMoveBackward` callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<Header showMonth onMoveBackward={doneOp} />);
+  it('Should call `onMoveBackward` callback', () => {
+    const onMoveBackward = Sinon.spy();
+
+    const instance = getDOMNode(<Header showMonth onMoveBackward={onMoveBackward} />);
 
     ReactTestUtils.Simulate.click(
       instance.querySelector('.rs-calendar-header-backward') as HTMLElement
     );
+    expect(onMoveBackward).to.have.been.calledOnce;
   });
 
-  it('Should call `onToggleMonthDropdown` callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call `onToggleMonthDropdown` callback', () => {
+    const onToggleMonthDropdown = Sinon.spy();
 
-    const instance = getDOMNode(<Header showMonth onToggleMonthDropdown={doneOp} />);
+    const instance = getDOMNode(<Header showMonth onToggleMonthDropdown={onToggleMonthDropdown} />);
 
     ReactTestUtils.Simulate.click(
       instance.querySelector('.rs-calendar-header-title-date') as HTMLElement
     );
+    expect(onToggleMonthDropdown).to.have.been.calledOnce;
   });
 
-  it('Should call `onToggleTimeDropdown` callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call `onToggleTimeDropdown` callback', () => {
+    const onToggleTimeDropdown = Sinon.spy();
     const ref = React.createRef<HTMLDivElement>();
 
     render(
       <CalendarContext.Provider
         value={{ date: new Date(), format: 'HH:mm:ss', locale: {}, isoWeek: false }}
       >
-        <Header showTime onToggleTimeDropdown={doneOp} ref={ref} />
+        <Header showTime onToggleTimeDropdown={onToggleTimeDropdown} ref={ref} />
       </CalendarContext.Provider>
     );
 
     ReactTestUtils.Simulate.click(
       (ref.current as HTMLDivElement).querySelector('.rs-calendar-header-title-time') as HTMLElement
     );
+    expect(onToggleTimeDropdown).to.have.been.calledOnce;
   });
 
   it('Should have a custom className', () => {

--- a/src/Calendar/test/CalendarMonthDropdownItemSpec.tsx
+++ b/src/Calendar/test/CalendarMonthDropdownItemSpec.tsx
@@ -5,6 +5,7 @@ import { getDOMNode } from '@test/testUtils';
 import MonthDropdownItem from '../MonthDropdownItem';
 import { format } from '../../utils/dateUtils';
 import CalendarContext from '../CalendarContext';
+import Sinon from 'sinon';
 
 describe('Calendar-MonthDropdownItem', () => {
   it('Should output a  `1` ', () => {
@@ -14,15 +15,9 @@ describe('Calendar-MonthDropdownItem', () => {
     assert.equal(instance.textContent, '1');
   });
 
-  it('Should call `onSelect` callback with correct date', done => {
-    const onChangeMonth = date => {
-      try {
-        assert.equal(format(date, 'yyyy-MM'), '2017-01');
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should call `onSelect` callback with correct date', () => {
+    const onChangeMonth = Sinon.spy();
+
     const ref = React.createRef<HTMLDivElement>();
     render(
       <CalendarContext.Provider
@@ -33,6 +28,9 @@ describe('Calendar-MonthDropdownItem', () => {
     );
 
     ReactTestUtils.Simulate.click(ref.current as HTMLDivElement);
+
+    expect(onChangeMonth).to.have.been.calledOnce;
+    expect(format(onChangeMonth.firstCall.args[0], 'yyyy-MM')).to.equal('2017-01');
   });
 
   it('Should have a custom className', () => {

--- a/src/Calendar/test/CalendarTableRowSpec.tsx
+++ b/src/Calendar/test/CalendarTableRowSpec.tsx
@@ -5,6 +5,7 @@ import { getDOMNode } from '@test/testUtils';
 import TableRow from '../TableRow';
 import { getDate, format } from '../../utils/dateUtils';
 import CalendarContext from '../CalendarContext';
+import Sinon from 'sinon';
 
 describe('Calendar-TableRow', () => {
   it('Should render a div with `table-row` class', () => {
@@ -22,14 +23,12 @@ describe('Calendar-TableRow', () => {
     );
   });
 
-  it('Should call `onSelect` callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call `onSelect` callback', () => {
+    const onSelect = Sinon.spy();
     const ref = React.createRef<HTMLDivElement>();
     render(
       <CalendarContext.Provider
-        value={{ onSelect: doneOp, date: new Date(2022, 10, 2), locale: {}, isoWeek: false }}
+        value={{ onSelect, date: new Date(2022, 10, 2), locale: {}, isoWeek: false }}
       >
         <TableRow ref={ref} />
       </CalendarContext.Provider>
@@ -39,6 +38,8 @@ describe('Calendar-TableRow', () => {
         '.rs-calendar-table-cell .rs-calendar-table-cell-content'
       ) as HTMLElement
     );
+
+    expect(onSelect).to.have.been.calledOnce;
   });
 
   it('Should have a custom className', () => {

--- a/src/Calendar/test/CalendarTimeDropdownSpec.tsx
+++ b/src/Calendar/test/CalendarTimeDropdownSpec.tsx
@@ -4,6 +4,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import TimeDropdown from '../TimeDropdown';
 import CalendarContext from '../CalendarContext';
+import Sinon from 'sinon';
 
 describe('Calendar - TimeDropdown', () => {
   it('Should render a div with `time-dropdown` class', () => {
@@ -61,10 +62,8 @@ describe('Calendar - TimeDropdown', () => {
     );
   });
 
-  it('Should call `onSelect` callback', done => {
-    const onChangeTime = () => {
-      done();
-    };
+  it('Should call `onChangeTime` callback', () => {
+    const onChangeTime = Sinon.spy();
     const ref = React.createRef<HTMLDivElement>();
     render(
       <CalendarContext.Provider
@@ -77,6 +76,8 @@ describe('Calendar - TimeDropdown', () => {
     ReactTestUtils.Simulate.click(
       (ref.current as HTMLDivElement).querySelector('[data-key="hours-1"]') as HTMLElement
     );
+
+    expect(onChangeTime).to.have.been.calledOnce;
   });
 
   it('Should be disabled', () => {

--- a/src/Cascader/test/CascaderSpec.tsx
+++ b/src/Cascader/test/CascaderSpec.tsx
@@ -6,6 +6,7 @@ import Button from '../../Button';
 import { getDOMNode, getInstance } from '@test/testUtils';
 import { PickerHandle } from '../../Picker';
 import '../styles/index.less';
+import Sinon from 'sinon';
 
 const items = [
   {
@@ -143,72 +144,63 @@ describe('Cascader', () => {
     );
   });
 
-  it('Should call onSelect callback with correct node value', done => {
-    const doneOp = node => {
-      try {
-        assert.equal(node.value, '2');
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
-    const instance = getInstance(<Cascader data={items} defaultOpen onSelect={doneOp} />);
+  it('Should call onSelect callback with correct node value', () => {
+    const onSelect = Sinon.spy();
+    const instance = getInstance(<Cascader data={items} defaultOpen onSelect={onSelect} />);
     fireEvent.click(instance.overlay.querySelectorAll('.rs-picker-cascader-menu-item')[1]);
+
+    expect(onSelect).to.have.been.calledWith(sinon.match({ value: '2' }));
   });
 
-  it('Should call onChange callback with correct value', done => {
-    const doneOp = value => {
-      try {
-        assert.equal(value, '2');
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should call onChange callback with correct value', () => {
+    const onChange = sinon.spy();
 
-    const instance = getInstance(<Cascader data={items} defaultOpen onChange={doneOp} />);
+    const instance = getInstance(<Cascader data={items} defaultOpen onChange={onChange} />);
     fireEvent.click(instance.overlay.querySelectorAll('.rs-picker-cascader-menu-item')[1]);
+
+    expect(onChange).to.have.been.calledWith('2');
   });
 
-  it('Should call onChange callback by `parentSelectable`', done => {
-    const doneOp = value => {
-      try {
-        assert.equal(value, '3');
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should call onChange callback by `parentSelectable`', () => {
+    const onChange = sinon.spy();
 
     const instance = getInstance(
-      <Cascader data={items} defaultOpen parentSelectable onChange={doneOp} />
+      <Cascader data={items} defaultOpen parentSelectable onChange={onChange} />
     );
     fireEvent.click(instance.overlay.querySelectorAll('.rs-picker-cascader-menu-item')[2]);
+    expect(onChange).to.have.been.calledWith('3');
   });
 
-  it('Should call onClean callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<Cascader data={items} defaultValue={'3-1'} onClean={doneOp} />);
+  it('Should call onClean callback', () => {
+    const onClean = sinon.spy();
+    const instance = getDOMNode(<Cascader data={items} defaultValue={'3-1'} onClean={onClean} />);
 
     fireEvent.click(instance.querySelector('.rs-picker-toggle-clean') as HTMLElement);
+
+    expect(onClean).to.have.been.calledOnce;
   });
 
-  it('Should call `onOpen` callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const picker = getInstance(<Cascader onOpen={doneOp} data={items} />);
-    picker.open();
+  it('Should call `onOpen` callback', async () => {
+    const onOpen = sinon.spy();
+    const picker = getInstance(<Cascader onOpen={onOpen} data={items} />);
+    act(() => {
+      picker.open();
+    });
+
+    await waitFor(() => {
+      expect(onOpen).to.have.been.calledOnce;
+    });
   });
 
-  it('Should call `onClose` callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const picker = getInstance(<Cascader defaultOpen onClose={doneOp} data={items} />);
-    picker.close();
+  it('Should call `onClose` callback', async () => {
+    const onClose = sinon.spy();
+    const picker = getInstance(<Cascader defaultOpen onClose={onClose} data={items} />);
+    act(() => {
+      picker.close();
+    });
+    await waitFor(() => {
+      expect(onClose).to.have.been.calledOnce;
+    });
   });
 
   it('Should clean selected default value', () => {

--- a/src/Cascader/test/CascaderSpec.tsx
+++ b/src/Cascader/test/CascaderSpec.tsx
@@ -6,7 +6,6 @@ import Button from '../../Button';
 import { getDOMNode, getInstance } from '@test/testUtils';
 import { PickerHandle } from '../../Picker';
 import '../styles/index.less';
-import Sinon from 'sinon';
 
 const items = [
   {
@@ -145,7 +144,7 @@ describe('Cascader', () => {
   });
 
   it('Should call onSelect callback with correct node value', () => {
-    const onSelect = Sinon.spy();
+    const onSelect = sinon.spy();
     const instance = getInstance(<Cascader data={items} defaultOpen onSelect={onSelect} />);
     fireEvent.click(instance.overlay.querySelectorAll('.rs-picker-cascader-menu-item')[1]);
 

--- a/src/Cascader/test/DropdownMenuSpec.tsx
+++ b/src/Cascader/test/DropdownMenuSpec.tsx
@@ -93,19 +93,13 @@ describe('Cascader -  DropdownMenu', () => {
     expect(instance.overlay.querySelectorAll('li')).to.length(3);
   });
 
-  it('Should call onSelect callback node value', done => {
-    const doneOp = node => {
-      try {
-        assert.equal(node.value, 'abcd');
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
-
-    const instance = getInstance(<Dropdown defaultOpen data={items} onSelect={doneOp} />);
+  it('Should call onSelect callback node value', () => {
+    const onSelect = sinon.spy();
+    const instance = getInstance(<Dropdown defaultOpen data={items} onSelect={onSelect} />);
 
     fireEvent.click(instance.overlay.querySelectorAll('.rs-picker-cascader-menu-item')[1]);
+
+    expect(onSelect).to.have.been.calledWith(sinon.match({ value: 'abcd' }));
   });
 
   it('Should call onSelect callback 2 count', () => {

--- a/src/CheckPicker/test/CheckPickerSpec.tsx
+++ b/src/CheckPicker/test/CheckPickerSpec.tsx
@@ -457,14 +457,24 @@ describe('CheckPicker', () => {
     expect(onCleanSpy).to.not.have.been.called;
   });
 
-  it('Should call onClose callback by key="Escape"', done => {
-    const instance = getInstance(<CheckPicker data={data} onClose={done} defaultOpen />);
+  it('Should call onClose callback by key="Escape"', async () => {
+    const onClose = sinon.spy();
+    const instance = getInstance(<CheckPicker data={data} onClose={onClose} defaultOpen />);
     fireEvent.keyDown(instance.target, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(onClose).to.have.been.calledOnce;
+    });
   });
 
-  it('Should call onClose callback by key="Tab"', done => {
-    const instance = getInstance(<CheckPicker data={data} onClose={done} defaultOpen />);
+  it('Should call onClose callback by key="Tab"', async () => {
+    const onClose = sinon.spy();
+    const instance = getInstance(<CheckPicker data={data} onClose={onClose} defaultOpen />);
     fireEvent.keyDown(instance.target, { key: 'Tab' });
+
+    await waitFor(() => {
+      expect(onClose).to.have.been.calledOnce;
+    });
   });
 
   describe('With a label', () => {

--- a/src/Checkbox/test/CheckboxSpec.tsx
+++ b/src/Checkbox/test/CheckboxSpec.tsx
@@ -90,28 +90,28 @@ describe('Checkbox', () => {
     expect(onChange).to.have.been.calledWith('Test', false);
   });
 
-  it('Should call onClick callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<Checkbox onClick={doneOp}>Title</Checkbox>);
+  it('Should call onClick callback', () => {
+    const onClick = sinon.spy();
+    const instance = getDOMNode(<Checkbox onClick={onClick}>Title</Checkbox>);
     ReactTestUtils.Simulate.click(instance.querySelector('label') as HTMLLabelElement);
+
+    expect(onClick).to.have.been.calledOnce;
   });
 
-  it('Should call onBlur callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<Checkbox onBlur={doneOp} />);
+  it('Should call onBlur callback', () => {
+    const onBlur = sinon.spy();
+    const instance = getDOMNode(<Checkbox onBlur={onBlur} />);
     ReactTestUtils.Simulate.blur(instance.querySelector('input') as HTMLInputElement);
+
+    expect(onBlur).to.have.been.calledOnce;
   });
 
-  it('Should call onFocus callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<Checkbox onFocus={doneOp} />);
+  it('Should call onFocus callback', () => {
+    const onFocus = sinon.spy();
+    const instance = getDOMNode(<Checkbox onFocus={onFocus} />);
     ReactTestUtils.Simulate.focus(instance.querySelector('input') as HTMLInputElement);
+
+    expect(onFocus).to.have.been.calledOnce;
   });
 
   describe('Plain text', () => {

--- a/src/CheckboxGroup/test/CheckboxGroupSpec.tsx
+++ b/src/CheckboxGroup/test/CheckboxGroupSpec.tsx
@@ -137,21 +137,15 @@ describe('CheckboxGroup', () => {
     expect(onChange).to.have.been.calledWith([3]);
   });
 
-  it('Should call onChange callback', done => {
-    let count = 0;
-
-    function onDone() {
-      count++;
-      if (count === 2) {
-        done();
-      }
-    }
+  it('Should call onChange callback', () => {
+    const onChange = sinon.spy();
+    const onGroupChange = sinon.spy();
 
     const instance = getDOMNode(
-      <CheckboxGroup onChange={onDone}>
+      <CheckboxGroup onChange={onGroupChange}>
         <Checkbox value={1}>Test1</Checkbox>
         <Checkbox value={2}>Test2</Checkbox>
-        <Checkbox value={3} onChange={onDone}>
+        <Checkbox value={3} onChange={onChange}>
           Test2
         </Checkbox>
         <Checkbox value={4}>Test2</Checkbox>
@@ -160,6 +154,9 @@ describe('CheckboxGroup', () => {
 
     const checkboxs = instance.querySelectorAll(`.${globalKey}checkbox`);
     ReactTestUtils.Simulate.change(checkboxs[2].querySelector('input') as HTMLInputElement);
+
+    expect(onChange).to.have.been.calledOnce;
+    expect(onGroupChange).to.have.been.calledOnce;
   });
 
   describe('Plain text', () => {

--- a/src/DatePicker/test/DatePickerSpec.tsx
+++ b/src/DatePicker/test/DatePickerSpec.tsx
@@ -351,43 +351,49 @@ describe('DatePicker', () => {
     assert.equal(instance.style.fontSize, fontSize);
   });
 
-  it('Should call `onChangeCalendarDate` callback when click backward', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call `onChangeCalendarDate` callback when click backward', () => {
+    const onChangeCalendarDate = sinon.spy();
 
-    const instance = getInstance(<DatePicker onChangeCalendarDate={doneOp} defaultOpen />);
+    const instance = getInstance(
+      <DatePicker onChangeCalendarDate={onChangeCalendarDate} defaultOpen />
+    );
 
     ReactTestUtils.Simulate.click(instance.overlay.querySelector('.rs-calendar-header-backward'));
+
+    expect(onChangeCalendarDate).to.have.been.calledOnce;
   });
 
-  it('Should call `onChangeCalendarDate` callback when click forward', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call `onChangeCalendarDate` callback when click forward', () => {
+    const onChangeCalendarDate = sinon.spy();
 
-    const instance = getInstance(<DatePicker onChangeCalendarDate={doneOp} defaultOpen />);
+    const instance = getInstance(
+      <DatePicker onChangeCalendarDate={onChangeCalendarDate} defaultOpen />
+    );
     ReactTestUtils.Simulate.click(instance.overlay.querySelector('.rs-calendar-header-forward'));
+
+    expect(onChangeCalendarDate).to.have.been.calledOnce;
   });
 
-  it('Should call `onChangeCalendarDate` callback when click today ', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call `onChangeCalendarDate` callback when click today ', () => {
+    const onChangeCalendarDate = sinon.spy();
 
-    const instance = getInstance(<DatePicker onChangeCalendarDate={doneOp} defaultOpen />);
+    const instance = getInstance(
+      <DatePicker onChangeCalendarDate={onChangeCalendarDate} defaultOpen />
+    );
     const today = instance.overlay.querySelector(
       '.rs-calendar-table-cell-is-today .rs-calendar-table-cell-content'
     );
     ReactTestUtils.Simulate.click(today);
+
+    expect(onChangeCalendarDate).to.have.been.calledOnce;
   });
 
-  it('Should call `onChangeCalendarDate` callback when click month ', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call `onChangeCalendarDate` callback when click month ', () => {
+    const onChangeCalendarDate = sinon.spy();
 
-    const instance = getInstance(<DatePicker onChangeCalendarDate={doneOp} defaultOpen />);
+    const instance = getInstance(
+      <DatePicker onChangeCalendarDate={onChangeCalendarDate} defaultOpen />
+    );
 
     act(() => {
       const title = instance.overlay.querySelector('.rs-calendar-header-title-date');
@@ -398,6 +404,8 @@ describe('DatePicker', () => {
       const month = instance.overlay.querySelector('.rs-calendar-month-dropdown-cell');
       ReactTestUtils.Simulate.click(month);
     });
+
+    expect(onChangeCalendarDate).to.have.been.calledOnce;
   });
 
   it('Should be consistent whether a month can be selected and whether OK button is enabled when that month is selected', () => {
@@ -425,24 +433,27 @@ describe('DatePicker', () => {
     expect(screen.getByRole('button', { name: 'OK' })).to.have.property('disabled', false);
   });
 
-  it('Should call `onOpen` callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call `onOpen` callback', async () => {
+    const onOpen = sinon.spy();
 
-    const instance = getDOMNode(<DatePicker onOpen={doneOp} />);
+    const instance = getDOMNode(<DatePicker onOpen={onOpen} />);
     ReactTestUtils.Simulate.click(instance.querySelector('[role="combobox"]') as HTMLElement);
+
+    await waitFor(() => {
+      expect(onOpen).to.have.been.calledOnce;
+    });
   });
 
-  it('Should call `onClose` callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call `onClose` callback', async () => {
+    const onClose = sinon.spy();
 
-    const instance = getInstance(<DatePicker onClose={doneOp} defaultOpen />);
+    const instance = getInstance(<DatePicker onClose={onClose} defaultOpen />);
     ReactTestUtils.Simulate.click(
       instance.overlay.querySelector('.rs-picker-toolbar-right .rs-btn')
     );
+    await waitFor(() => {
+      expect(onClose).to.have.been.calledOnce;
+    });
   });
 
   it('Should reset unsaved selected date after closing calendar panel', async () => {
@@ -492,21 +503,11 @@ describe('DatePicker', () => {
     );
   });
 
-  it('Should not change for the value  when it is controlled', done => {
-    const doneOp = () => {
-      try {
-        assert.equal(
-          instance.target.querySelector('.rs-picker-toggle-value').textContent,
-          '2018-01-05'
-        );
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should not change for the value  when it is controlled', () => {
+    const onChange = sinon.spy();
 
     const instance = getInstance(
-      <DatePicker value={parseISO('2018-01-05')} onChange={doneOp} defaultOpen />
+      <DatePicker value={parseISO('2018-01-05')} onChange={onChange} defaultOpen />
     );
 
     const allCells = instance.overlay.querySelectorAll(
@@ -515,6 +516,9 @@ describe('DatePicker', () => {
 
     fireEvent.click(allCells[allCells.length - 1]);
     fireEvent.click(instance.overlay.querySelector('.rs-picker-toolbar-right .rs-btn'));
+
+    expect(onChange).to.have.been.calledOnce;
+    expect(instance.target.querySelector('.rs-picker-toggle-value')).to.have.text('2018-01-05');
   });
 
   it('Should call onBlur callback', async () => {

--- a/src/DateRangePicker/test/DateRangePickerSpec.tsx
+++ b/src/DateRangePicker/test/DateRangePickerSpec.tsx
@@ -279,12 +279,17 @@ describe('DateRangePicker', () => {
     });
   });
 
-  it('Should call `onClose` callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const picker = getInstance(<DateRangePicker defaultOpen onClose={doneOp} />);
-    picker.close();
+  it('Should call `onClose` callback', async () => {
+    const onClose = sinon.spy();
+    const picker = getInstance(<DateRangePicker defaultOpen onClose={onClose} />);
+
+    act(() => {
+      picker.close();
+    });
+
+    await waitFor(() => {
+      expect(onClose).to.have.been.calledOnce;
+    });
   });
 
   it('Should output a button', () => {

--- a/src/Dropdown/test/DropdownSpec.tsx
+++ b/src/Dropdown/test/DropdownSpec.tsx
@@ -178,22 +178,17 @@ describe('<Dropdown>', () => {
     assert.ok(!instance.querySelector('.rs-dropdown-toggle-caret'));
   });
 
-  it('Should call onSelect callback with correct eventKey when clicking an item', done => {
-    const doneOp = eventKey => {
-      try {
-        assert.equal(eventKey, 2);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should call onSelect callback with correct eventKey when clicking an item', () => {
+    const onSelect = sinon.spy();
     const instance = getDOMNode(
-      <Dropdown onSelect={doneOp}>
+      <Dropdown onSelect={onSelect}>
         <Dropdown.Item eventKey={1}>1</Dropdown.Item>
         <Dropdown.Item eventKey={2}>2</Dropdown.Item>
       </Dropdown>
     );
     fireEvent.click(instance.querySelectorAll('.rs-dropdown-menu [role="menuitem"]')[1]);
+
+    expect(onSelect).to.have.been.calledWith(2);
   });
 
   it('Should close menu after clicking an item without submenu', () => {
@@ -240,38 +235,36 @@ describe('<Dropdown>', () => {
     expect(menu.hidden, 'Menu is closed').to.be.true;
   });
 
-  it('Should call onToggle callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onToggle callback', () => {
+    const onToggle = sinon.spy();
     const instance = getDOMNode(
-      <Dropdown onToggle={doneOp}>
+      <Dropdown onToggle={onToggle}>
         <Dropdown.Item eventKey={1}>1</Dropdown.Item>
         <Dropdown.Item eventKey={2}>2</Dropdown.Item>
       </Dropdown>
     );
     fireEvent.click(instance.querySelector('.rs-dropdown-toggle') as HTMLElement);
+
+    expect(onToggle).to.have.been.calledOnce;
   });
 
-  it('Should call onOpen callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onOpen callback', () => {
+    const onOpen = sinon.spy();
     const instance = getDOMNode(
-      <Dropdown onOpen={doneOp}>
+      <Dropdown onOpen={onOpen}>
         <Dropdown.Item eventKey={1}>1</Dropdown.Item>
         <Dropdown.Item eventKey={2}>2</Dropdown.Item>
       </Dropdown>
     );
     fireEvent.click(instance.querySelector('.rs-dropdown-toggle') as HTMLElement);
+
+    expect(onOpen).to.have.been.calledOnce;
   });
 
-  it('Should call onClose callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onClose callback', () => {
+    const onClose = sinon.spy();
     const instance = getDOMNode(
-      <Dropdown onClose={doneOp}>
+      <Dropdown onClose={onClose}>
         <Dropdown.Item eventKey={1}>1</Dropdown.Item>
         <Dropdown.Item eventKey={2}>2</Dropdown.Item>
       </Dropdown>
@@ -279,6 +272,8 @@ describe('<Dropdown>', () => {
     const btn = instance.querySelector('.rs-dropdown-toggle') as HTMLElement;
     fireEvent.click(btn);
     fireEvent.click(btn);
+
+    expect(onClose).to.have.been.calledOnce;
   });
 
   it('Should not call onToggle callback when set disabled', () => {

--- a/src/FormControl/test/FormControlSpec.tsx
+++ b/src/FormControl/test/FormControlSpec.tsx
@@ -29,17 +29,16 @@ describe('FormControl', () => {
     assert.ok(instance.querySelector('textarea'));
   });
 
-  it('Should call onChange callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onChange callback', () => {
+    const onChange = sinon.spy();
     const instance = getDOMNode(
       <Form>
-        <FormControl name="username" onChange={doneOp} />
+        <FormControl name="username" onChange={onChange} />
       </Form>
     );
 
     ReactTestUtils.Simulate.change(instance.querySelector('input') as HTMLInputElement);
+    expect(onChange).to.have.been.calledOnce;
   });
 
   it('Should be readOnly', () => {
@@ -52,32 +51,28 @@ describe('FormControl', () => {
     assert.ok(instance.querySelector('input[readonly]'));
   });
 
-  it('Should be readOnly on accepter', done => {
-    function Input(props) {
-      // eslint-disable-next-line react/prop-types
-      if (props && props.readOnly) {
-        done();
-      }
-      return <input {...props} />;
-    }
+  it('Should be readOnly on accepter', () => {
+    const Input = sinon.spy(props => <input {...props} />);
     getDOMNode(
       <Form readOnly>
         <FormControl name="username" accepter={Input} />
       </Form>
     );
+
+    expect(Input).to.have.been.calledWithMatch({ readOnly: true });
   });
 
-  it('Should call onBlur callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onBlur callback', () => {
+    const onBlur = sinon.spy();
     const instance = getDOMNode(
       <Form>
-        <FormControl name="username" onBlur={doneOp} />
+        <FormControl name="username" onBlur={onBlur} />
       </Form>
     );
 
     ReactTestUtils.Simulate.blur(instance.querySelector('input') as HTMLInputElement);
+
+    expect(onBlur).to.have.been.calledOnce;
   });
 
   it('Should apply custom className to accepter component', () => {

--- a/src/Input/test/InputSpec.tsx
+++ b/src/Input/test/InputSpec.tsx
@@ -5,6 +5,7 @@ import { getDOMNode } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 
 import Input from '../Input';
+import Sinon from 'sinon';
 
 describe('Input', () => {
   testStandardProps(<Input />);
@@ -19,28 +20,28 @@ describe('Input', () => {
     assert.ok(domNode.disabled);
   });
 
-  it('Should call onChange callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<Input onChange={doneOp} />);
+  it('Should call onChange callback', () => {
+    const onChange = Sinon.spy();
+    const instance = getDOMNode(<Input onChange={onChange} />);
     ReactTestUtils.Simulate.change(instance);
+
+    expect(onChange).to.have.been.calledOnce;
   });
 
-  it('Should call onKeyDown callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<Input onKeyDown={doneOp} />);
+  it('Should call onKeyDown callback', () => {
+    const onKeyDown = Sinon.spy();
+    const instance = getDOMNode(<Input onKeyDown={onKeyDown} />);
     ReactTestUtils.Simulate.keyDown(instance);
+
+    expect(onKeyDown).to.have.been.calledOnce;
   });
 
-  it('Should call onPressEnter callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<Input onPressEnter={doneOp} />);
+  it('Should call onPressEnter callback', () => {
+    const onPressEnter = Sinon.spy();
+    const instance = getDOMNode(<Input onPressEnter={onPressEnter} />);
     ReactTestUtils.Simulate.keyDown(instance, { key: 'Enter' });
+
+    expect(onPressEnter).to.have.been.calledOnce;
   });
 
   it('Should set size', () => {

--- a/src/InputPicker/test/InputAutosizeSpec.tsx
+++ b/src/InputPicker/test/InputAutosizeSpec.tsx
@@ -3,6 +3,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 
 import { getDOMNode } from '@test/testUtils';
 import InputAutosize from '../InputAutosize';
+import Sinon from 'sinon';
 
 describe('InputPicker - InputAutosize', () => {
   it('Should have a custom className', () => {
@@ -16,12 +17,12 @@ describe('InputPicker - InputAutosize', () => {
     assert.equal(instance.style.fontSize, fontSize);
   });
 
-  it('Should call onChange callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<InputAutosize onChange={doneOp} />);
+  it('Should call onChange callback', () => {
+    const onChange = Sinon.spy();
+    const instance = getDOMNode(<InputAutosize onChange={onChange} />);
     ReactTestUtils.Simulate.change(instance.querySelector('input') as HTMLInputElement);
+
+    expect(onChange).to.have.been.calledOnce;
   });
 
   it('Should have a placeholder', () => {

--- a/src/InputPicker/test/InputSearchSpec.tsx
+++ b/src/InputPicker/test/InputSearchSpec.tsx
@@ -4,6 +4,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import InputAutosize from '../InputAutosize';
 import InputSearch from '../InputSearch';
+import Sinon from 'sinon';
 
 describe('InputPicker - InputSearch', () => {
   it('Should render a div with `rs-picker-search` class', () => {
@@ -35,12 +36,12 @@ describe('InputPicker - InputSearch', () => {
     expect(instance.querySelector('.rs-picker-search-input input')).to.exist;
   });
 
-  it('Should call onChange callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<InputSearch onChange={doneOp} />);
+  it('Should call onChange callback', () => {
+    const onChange = Sinon.spy();
+    const instance = getDOMNode(<InputSearch onChange={onChange} />);
     ReactTestUtils.Simulate.change(instance.querySelector('input') as HTMLInputElement);
+
+    expect(onChange).to.have.been.calledOnce;
   });
 
   it('Should have a custom className prefix', () => {

--- a/src/List/test/ListSpec.tsx
+++ b/src/List/test/ListSpec.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import List from '../List';
+import Sinon from 'sinon';
 
 describe('List', () => {
   testStandardProps(<List />);
@@ -55,21 +56,25 @@ describe('List', () => {
     assert.include((domNodeLarge.firstChild as HTMLElement).className, 'rs-list-item-lg');
   });
 
-  it('should call onSortStart', done => {
-    const callback = () => done();
+  it('should call onSortStart', async () => {
+    const onSortStart = Sinon.spy();
     const ref = React.createRef<HTMLDivElement>();
     render(
-      <List ref={ref} sortable onSortStart={callback}>
+      <List ref={ref} sortable onSortStart={onSortStart}>
         <List.Item index={1}>item1</List.Item>
         <List.Item index={2}>item2</List.Item>
       </List>
     );
 
     ReactTestUtils.Simulate.mouseDown((ref.current as HTMLDivElement).firstChild as HTMLElement);
+
+    await waitFor(() => {
+      expect(onSortStart).to.have.been.calledOnce;
+    });
   });
 
-  it('should call onSortMove', done => {
-    const callback = () => done();
+  it('should call onSortMove', async () => {
+    const onSortMove = Sinon.spy();
     const mousemoveEvent = new Event('mousemove', { bubbles: true });
     const ref = React.createRef<HTMLDivElement>();
     render(
@@ -77,7 +82,7 @@ describe('List', () => {
         sortable
         ref={ref}
         onSortStart={() => window.dispatchEvent(mousemoveEvent)}
-        onSortMove={callback}
+        onSortMove={onSortMove}
       >
         <List.Item index={1}>item1</List.Item>
         <List.Item index={2}>item2</List.Item>
@@ -85,11 +90,14 @@ describe('List', () => {
     );
 
     ReactTestUtils.Simulate.mouseDown((ref.current as HTMLDivElement).firstChild as HTMLElement);
+    await waitFor(() => {
+      expect(onSortMove).to.have.been.calledOnce;
+    });
   });
 
-  it('should call onSortEnd & onSort', done => {
-    let count = 0;
-    const callback = () => ++count > 1 && done();
+  it('should call onSortEnd & onSort', async () => {
+    const onSort = Sinon.spy();
+    const onSortEnd = Sinon.spy();
     const mouseupEvent = new Event('mouseup', { bubbles: true });
     const ref = React.createRef<HTMLDivElement>();
     render(
@@ -97,8 +105,8 @@ describe('List', () => {
         sortable
         ref={ref}
         onSortStart={() => window.dispatchEvent(mouseupEvent)}
-        onSortEnd={callback}
-        onSort={callback}
+        onSortEnd={onSortEnd}
+        onSort={onSort}
       >
         <List.Item index={1}>item1</List.Item>
         <List.Item index={2}>item2</List.Item>
@@ -106,5 +114,11 @@ describe('List', () => {
     );
 
     ReactTestUtils.Simulate.mouseDown((ref.current as HTMLDivElement).firstChild as HTMLElement);
+    await waitFor(() => {
+      expect(onSort).to.have.been.calledOnce;
+    });
+    await waitFor(() => {
+      expect(onSortEnd).to.have.been.calledOnce;
+    });
   });
 });

--- a/src/Modal/test/ModalHeaderSpec.tsx
+++ b/src/Modal/test/ModalHeaderSpec.tsx
@@ -3,6 +3,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 
 import ModalHeader from '../ModalHeader';
+import Sinon from 'sinon';
 
 describe('ModalHeader', () => {
   it('Should render a modal header', () => {
@@ -18,12 +19,12 @@ describe('ModalHeader', () => {
     assert.ok(!instance.querySelector('button'));
   });
 
-  it('Should call onClose callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<ModalHeader onClose={doneOp} />);
+  it('Should call onClose callback', () => {
+    const onClose = Sinon.spy();
+    const instance = getDOMNode(<ModalHeader onClose={onClose} />);
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-modal-header-close') as HTMLElement);
+
+    expect(onClose).to.have.been.calledOnce;
   });
 
   it('Should have a custom className', () => {

--- a/src/MultiCascader/test/DropdownMenuSpec.tsx
+++ b/src/MultiCascader/test/DropdownMenuSpec.tsx
@@ -100,19 +100,14 @@ describe('MultiCascader -  DropdownMenu', () => {
     assert.equal(instance.overlay.querySelectorAll('li').length, 3);
   });
 
-  it('Should call onSelect callback with correct node value', done => {
-    const doneOp = node => {
-      try {
-        assert.equal(node.value, 'abcd');
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should call onSelect callback with correct node value', () => {
+    const onSelect = sinon.spy();
 
-    const instance = getInstance(<MultiCascader defaultOpen data={items} onSelect={doneOp} />);
+    const instance = getInstance(<MultiCascader defaultOpen data={items} onSelect={onSelect} />);
 
     fireEvent.click(instance.overlay.querySelectorAll('.rs-checkbox')[1]);
+
+    expect(onSelect).to.have.been.calledWithMatch({ value: 'abcd' });
   });
 
   it('Should call onSelect callback 2 count', () => {

--- a/src/Notification/test/NotificationSpec.tsx
+++ b/src/Notification/test/NotificationSpec.tsx
@@ -3,6 +3,8 @@ import { getDOMNode } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import ReactTestUtils from 'react-dom/test-utils';
 import Notification from '../Notification';
+import Sinon from 'sinon';
+import { waitFor } from '@testing-library/react';
 
 describe('Notification', () => {
   testStandardProps(<Notification />);
@@ -37,18 +39,20 @@ describe('Notification', () => {
     );
   });
 
-  it('Should call onClose callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<Notification closable onClose={doneOp} />);
+  it('Should call onClose callback', () => {
+    const onClose = Sinon.spy();
+    const instance = getDOMNode(<Notification closable onClose={onClose} />);
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-btn-close') as HTMLElement);
+
+    expect(onClose).to.have.been.calledOnce;
   });
 
-  it('Should call onClose callback by duration', done => {
-    const doneOp = () => {
-      done();
-    };
-    getDOMNode(<Notification closable onClose={doneOp} duration={1} />);
+  it('Should call onClose callback by duration', async () => {
+    const onClose = Sinon.spy();
+    getDOMNode(<Notification closable onClose={onClose} duration={1} />);
+
+    await waitFor(() => {
+      expect(onClose).to.have.been.calledOnce;
+    });
   });
 });

--- a/src/Overlay/test/OverlayTriggerSpec.tsx
+++ b/src/Overlay/test/OverlayTriggerSpec.tsx
@@ -88,74 +88,70 @@ describe('OverlayTrigger', () => {
     assert.equal(document.getElementsByClassName('test-whisper_active').length, 1);
   });
 
-  it('Should call onClick callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onClick callback', () => {
+    const onClick = sinon.spy();
 
     const whisper = getDOMNode(
-      <OverlayTrigger onClick={doneOp} trigger="click" speaker={<Tooltip />}>
+      <OverlayTrigger onClick={onClick} trigger="click" speaker={<Tooltip />}>
         <button>button</button>
       </OverlayTrigger>
     );
 
     fireEvent.click(whisper);
+
+    expect(onClick).to.have.been.calledOnce;
   });
 
-  it('Should call onContextMenu callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onContextMenu callback', () => {
+    const onContextMenu = sinon.spy();
 
     const whisper = getDOMNode(
-      <OverlayTrigger onContextMenu={doneOp} trigger="contextMenu" speaker={<Tooltip />}>
+      <OverlayTrigger onContextMenu={onContextMenu} trigger="contextMenu" speaker={<Tooltip />}>
         <button>button</button>
       </OverlayTrigger>
     );
 
     fireEvent.contextMenu(whisper);
+    expect(onContextMenu).to.have.been.calledOnce;
   });
 
-  it('Should call onFocus callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onFocus callback', () => {
+    const onFocus = sinon.spy();
 
     const whisper = getDOMNode(
-      <OverlayTrigger onFocus={doneOp} trigger="focus" speaker={<Tooltip />}>
+      <OverlayTrigger onFocus={onFocus} trigger="focus" speaker={<Tooltip />}>
         <button>button</button>
       </OverlayTrigger>
     );
 
     fireEvent.focus(whisper);
+    expect(onFocus).to.have.been.calledOnce;
   });
 
-  it('Should call onMouseOver callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onMouseOver callback', () => {
+    const onMouseOver = sinon.spy();
 
     const whisper = getDOMNode(
-      <OverlayTrigger onMouseOver={doneOp} trigger="hover" speaker={<Tooltip />}>
+      <OverlayTrigger onMouseOver={onMouseOver} trigger="hover" speaker={<Tooltip />}>
         <button>button</button>
       </OverlayTrigger>
     );
 
     fireEvent.mouseOver(whisper);
+    expect(onMouseOver).to.have.been.calledOnce;
   });
 
-  it('Should call onMouseOut callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onMouseOut callback', () => {
+    const onMouseOut = sinon.spy();
 
     const whisper = getDOMNode(
-      <OverlayTrigger onMouseOut={doneOp} trigger="hover" speaker={<Tooltip />}>
+      <OverlayTrigger onMouseOut={onMouseOut} trigger="hover" speaker={<Tooltip />}>
         <button>button</button>
       </OverlayTrigger>
     );
 
     fireEvent.mouseOut(whisper);
+    expect(onMouseOut).to.have.been.calledOnce;
   });
 
   it('Should call onMouseMove callback', () => {

--- a/src/Pagination/test/PaginationButtonSpec.tsx
+++ b/src/Pagination/test/PaginationButtonSpec.tsx
@@ -3,6 +3,7 @@ import React, { Ref } from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import PaginationButton, { PaginationButtonProps } from '../PaginationButton';
+import Sinon from 'sinon';
 
 describe('PaginationButton', () => {
   it('Should render a <button>', () => {
@@ -22,25 +23,20 @@ describe('PaginationButton', () => {
     assert.ok(instance.className.match(/\bactive\b/));
   });
 
-  it('Should call onSelect callback with correct eventKey', done => {
-    const doneOp = eventKey => {
-      try {
-        assert.equal(eventKey, 10);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
-    const instance = getDOMNode(<PaginationButton onSelect={doneOp} eventKey={10} />);
+  it('Should call onSelect callback with correct eventKey', () => {
+    const onSelect = Sinon.spy();
+    const instance = getDOMNode(<PaginationButton onSelect={onSelect} eventKey={10} />);
     ReactTestUtils.Simulate.click(instance);
+
+    expect(onSelect).to.have.been.calledWith(10);
   });
 
-  it('Should call onClick callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<PaginationButton onClick={doneOp} eventKey={10} />);
+  it('Should call onClick callback', () => {
+    const onClick = Sinon.spy();
+    const instance = getDOMNode(<PaginationButton onClick={onClick} eventKey={10} />);
     ReactTestUtils.Simulate.click(instance);
+
+    expect(onClick).to.have.been.calledOnce;
   });
 
   it('Custom elements can get the active prop', () => {

--- a/src/Pagination/test/PaginationGroupSpec.tsx
+++ b/src/Pagination/test/PaginationGroupSpec.tsx
@@ -3,6 +3,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 
 import PaginationGroup from '../PaginationGroup';
 import { getDOMNode, getInstance } from '@test/testUtils';
+import Sinon from 'sinon';
 
 describe('Pagination Group', () => {
   it('Should output a PaginationGroup', () => {
@@ -88,10 +89,8 @@ describe('Pagination Group', () => {
     );
   });
 
-  it('Should call onChangePage callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onChangePage callback', () => {
+    const onChangePage = Sinon.spy();
     const instance = getDOMNode(
       <PaginationGroup
         last={false}
@@ -99,10 +98,12 @@ describe('Pagination Group', () => {
         prev={false}
         first={false}
         total={100}
-        onChangePage={doneOp}
+        onChangePage={onChangePage}
       />
     );
     ReactTestUtils.Simulate.click(instance.querySelectorAll('.rs-pagination-btn')[1]);
+
+    expect(onChangePage).to.have.been.calledOnce;
   });
 
   it('Should render a limit picker', () => {

--- a/src/Pagination/test/PaginationSpec.tsx
+++ b/src/Pagination/test/PaginationSpec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import Pagination from '../Pagination';
+import Sinon from 'sinon';
 
 describe('Pagination', () => {
   it('Should render a <div>', () => {
@@ -94,19 +95,13 @@ describe('Pagination', () => {
     );
   });
 
-  it('Should call onSelect callback with correct eventKey', done => {
-    const doneOp = eventKey => {
-      try {
-        assert.equal(eventKey, 2);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
-
-    const instance = getDOMNode(<Pagination pages={20} onSelect={doneOp} />);
+  it('Should call onSelect callback with correct eventKey', () => {
+    const onSelect = Sinon.spy();
+    const instance = getDOMNode(<Pagination pages={20} onSelect={onSelect} />);
 
     ReactTestUtils.Simulate.click(instance.querySelectorAll('button')[1]);
+
+    expect(onSelect).to.have.been.calledWith(2);
   });
 
   it('Should apply size class', () => {

--- a/src/PanelGroup/test/PanelGroupSpec.tsx
+++ b/src/PanelGroup/test/PanelGroupSpec.tsx
@@ -30,17 +30,10 @@ describe('PanelGroup', () => {
     assert.equal(instance.querySelectorAll('.rs-panel').length, 2);
   });
 
-  it('Should call onSelect callback', done => {
-    const doneOp = eventKey => {
-      try {
-        assert.equal(eventKey, 2);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should call onSelect callback', () => {
+    const onSelect = sinon.spy();
     const instance = getDOMNode(
-      <PanelGroup accordion onSelect={doneOp}>
+      <PanelGroup accordion onSelect={onSelect}>
         <Panel eventKey={1} header="Click me">
           111
         </Panel>
@@ -50,6 +43,8 @@ describe('PanelGroup', () => {
       </PanelGroup>
     );
     ReactTestUtils.Simulate.click(instance.querySelectorAll('.rs-panel-header')[1]);
+
+    expect(onSelect).to.have.been.calledWith(2);
   });
 
   it('Should call `onSelect` with undefined when click on Panel without eventKey', () => {

--- a/src/Picker/test/DropdownMenuCheckItemSpec.tsx
+++ b/src/Picker/test/DropdownMenuCheckItemSpec.tsx
@@ -37,22 +37,20 @@ describe('picker - DropdownMenuCheckItem', () => {
     assert.include((instance.querySelector('.rs-checkbox') as HTMLElement).className, 'item-focus');
   });
 
-  it('Should call onSelect callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<DropdownMenuItem title="title" onSelect={doneOp} />);
+  it('Should call onSelect callback', () => {
+    const onSelect = sinon.spy();
+    const instance = getDOMNode(<DropdownMenuItem title="title" onSelect={onSelect} />);
 
     ReactTestUtils.Simulate.change(instance.querySelector('input') as HTMLInputElement);
+    expect(onSelect).to.have.been.calledOnce;
   });
 
-  it('Should call onKeyDown callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<DropdownMenuItem title="title" onKeyDown={doneOp} />);
+  it('Should call onKeyDown callback', () => {
+    const onKeyDown = sinon.spy();
+    const instance = getDOMNode(<DropdownMenuItem title="title" onKeyDown={onKeyDown} />);
 
     ReactTestUtils.Simulate.keyDown(instance.querySelector('input') as HTMLInputElement);
+    expect(onKeyDown).to.have.been.calledOnce;
   });
 
   it('Should call onCheck callback', () => {
@@ -69,13 +67,12 @@ describe('picker - DropdownMenuCheckItem', () => {
     assert.ok(onSelectSpy.calledOnce);
   });
 
-  it('Should call onSelectItem callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<DropdownMenuItem title="title" onSelectItem={doneOp} />);
+  it('Should call onSelectItem callback', () => {
+    const onSelectItem = sinon.spy();
+    const instance = getDOMNode(<DropdownMenuItem title="title" onSelectItem={onSelectItem} />);
 
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-checkbox') as HTMLElement);
+    expect(onSelectItem).to.have.been.calledOnce;
   });
 
   it('Should have a role', () => {

--- a/src/Picker/test/DropdownMenuItemSpec.tsx
+++ b/src/Picker/test/DropdownMenuItemSpec.tsx
@@ -3,6 +3,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 
 import { getDOMNode } from '@test/testUtils';
 import DropdownMenuItem from '../DropdownMenuItem';
+import Sinon from 'sinon';
 
 describe('picker - DropdownMenuItem', () => {
   it('Should output a item', () => {
@@ -31,24 +32,23 @@ describe('picker - DropdownMenuItem', () => {
     assert.include((instance.querySelector('.rs-item') as HTMLElement).className, 'item-focus');
   });
 
-  it('Should call onSelect callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<DropdownMenuItem title="title" onSelect={doneOp} />);
+  it('Should call onSelect callback', () => {
+    const onSelect = Sinon.spy();
+    const instance = getDOMNode(<DropdownMenuItem title="title" onSelect={onSelect} />);
 
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-dropdown-menu-item') as HTMLElement);
+
+    expect(onSelect).to.have.been.calledOnce;
   });
 
-  it('Should call onKeyDown callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<DropdownMenuItem title="title" onKeyDown={doneOp} />);
+  it('Should call onKeyDown callback', () => {
+    const onKeyDown = Sinon.spy();
+    const instance = getDOMNode(<DropdownMenuItem title="title" onKeyDown={onKeyDown} />);
 
     ReactTestUtils.Simulate.keyDown(
       instance.querySelector('.rs-dropdown-menu-item') as HTMLElement
     );
+    expect(onKeyDown).to.have.been.calledOnce;
   });
 
   it('Should have a role', () => {

--- a/src/Picker/test/DropdownMenuSpec.tsx
+++ b/src/Picker/test/DropdownMenuSpec.tsx
@@ -5,6 +5,7 @@ import { getDOMNode } from '@test/testUtils';
 import DropdownMenu from '../DropdownMenu';
 import DropdownMenuItem from '../DropdownMenuItem';
 import getDataGroupBy from '../../utils/getDataGroupBy';
+import Sinon from 'sinon';
 
 const classPrefix = 'dropdown-menu';
 
@@ -113,44 +114,38 @@ describe('picker -  DropdownMenu', () => {
     assert.equal(instance.querySelectorAll('.rs-dropdown-menu-item').length, 3);
   });
 
-  it('Should call onSelect callback with correct value', done => {
-    const doneOp = value => {
-      try {
-        assert.equal(value, 'b');
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should call onSelect callback with correct value', () => {
+    const onSelect = Sinon.spy();
 
     const instance = getDOMNode(
       <DropdownMenu
         data={items}
         group
-        onSelect={doneOp}
+        onSelect={onSelect}
         classPrefix={classPrefix}
         dropdownMenuItemAs={DropdownMenuItem}
       />
     );
 
     ReactTestUtils.Simulate.click(instance.querySelectorAll('.rs-dropdown-menu-item')[1]);
+    expect(onSelect).to.have.been.calledWith('b');
   });
 
-  it('Should call onGroupTitleClick callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onGroupTitleClick callback', () => {
+    const onGroupTitleClick = Sinon.spy();
+
     const instance = getDOMNode(
       <DropdownMenu
         group
         data={getDataGroupBy(items, 'groupKey')}
-        onGroupTitleClick={doneOp}
+        onGroupTitleClick={onGroupTitleClick}
         classPrefix={classPrefix}
         dropdownMenuItemAs={DropdownMenuItem}
       />
     );
 
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-picker-menu-group') as HTMLElement);
+    expect(onGroupTitleClick).to.have.been.calledOnce;
   });
 
   it('Should render custom item', () => {

--- a/src/Picker/test/PickerOverlaySpec.tsx
+++ b/src/Picker/test/PickerOverlaySpec.tsx
@@ -12,8 +12,9 @@ describe('PickerOverlay', () => {
     sinon.restore();
   });
 
-  it('Should update the position after the size is changed', done => {
+  it('Should update the position after the size is changed', () => {
     sinon.stub(utils, 'useElementResize').callsFake(useElementResize);
+    const updatePosition = sinon.spy();
     type AppInstance = {
       changeOverlaySize: () => void;
     };
@@ -34,9 +35,7 @@ describe('PickerOverlay', () => {
           () =>
             ({
               root: targetRef.current as HTMLButtonElement,
-              updatePosition: () => {
-                done();
-              }
+              updatePosition
             } as any)
         );
         return <button ref={targetRef} {...props} />;
@@ -65,9 +64,11 @@ describe('PickerOverlay', () => {
     render(<App ref={instanceRef} />);
 
     (instanceRef.current as AppInstance).changeOverlaySize();
+
+    expect(updatePosition).to.have.been.calledOnce;
   });
 
-  it('Should go to change the width according to the target', done => {
+  it('Should go to change the width according to the target', () => {
     const instanceRef = React.createRef<HTMLDivElement>();
 
     const Button = React.forwardRef(
@@ -83,10 +84,7 @@ describe('PickerOverlay', () => {
           ref,
           () =>
             ({
-              root: targetRef.current as HTMLButtonElement,
-              updatePosition: () => {
-                done();
-              }
+              root: targetRef.current as HTMLButtonElement
             } as any)
         );
         return <button ref={targetRef} {...props} />;
@@ -116,12 +114,10 @@ describe('PickerOverlay', () => {
     });
 
     render(<App ref={instanceRef} />);
-    if (
+    expect(
       getWidth(
         (instanceRef.current as HTMLDivElement).querySelector('.rs-picker-menu') as HTMLElement
-      ) === 200
-    ) {
-      done();
-    }
+      )
+    ).to.equal(200);
   });
 });

--- a/src/Picker/test/PickerToggleSpec.tsx
+++ b/src/Picker/test/PickerToggleSpec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 
@@ -70,21 +70,27 @@ describe('<PickerToggle>', () => {
     });
   });
 
-  it('Should call onBlur callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<Toggle onBlur={doneOp} />);
-    ReactTestUtils.Simulate.blur(instance);
+  it('Should call onBlur callback', async () => {
+    const onBlur = sinon.spy();
+    const instance = getDOMNode(<Toggle onBlur={onBlur} />);
+    act(() => {
+      ReactTestUtils.Simulate.blur(instance);
+    });
+
+    await waitFor(() => {
+      expect(onBlur).to.have.been.calledOnce;
+    });
   });
 
-  it('Should call onFocus callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<Toggle onFocus={doneOp} />);
+  it('Should call onFocus callback', async () => {
+    const onFocus = sinon.spy();
+    const instance = getDOMNode(<Toggle onFocus={onFocus} />);
 
     ReactTestUtils.Simulate.focus(instance);
+
+    await waitFor(() => {
+      expect(onFocus).to.have.been.calledOnce;
+    });
   });
 
   it('Should have a custom className', () => {

--- a/src/Picker/test/SearchBarSpec.tsx
+++ b/src/Picker/test/SearchBarSpec.tsx
@@ -3,6 +3,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 
 import SearchBar from '../SearchBar';
 import { getDOMNode } from '@test/testUtils';
+import Sinon from 'sinon';
 
 const searchInputClassName = '.rs-picker-search-bar-input';
 
@@ -13,12 +14,12 @@ describe('SearchBar', () => {
     assert.ok(instance.className.match(/\bpicker-search-bar\b/));
   });
 
-  it('Should call `onChange` callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<SearchBar onChange={doneOp} />);
+  it('Should call `onChange` callback', () => {
+    const onChange = Sinon.spy();
+    const instance = getDOMNode(<SearchBar onChange={onChange} />);
     ReactTestUtils.Simulate.change(instance.querySelector(searchInputClassName) as HTMLElement);
+
+    expect(onChange).to.have.been.calledOnce;
   });
 
   it('Should have a custom className', () => {

--- a/src/Radio/test/RadioSpec.tsx
+++ b/src/Radio/test/RadioSpec.tsx
@@ -3,6 +3,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import Radio from '../Radio';
+import Sinon from 'sinon';
 
 describe('Radio', () => {
   testStandardProps(<Radio />);
@@ -54,66 +55,54 @@ describe('Radio', () => {
     assert.ok(input);
   });
 
-  it('Should call onClick callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onClick callback', () => {
+    const onClick = Sinon.spy();
 
-    const instance = getDOMNode(<Radio onClick={doneOp}>Title</Radio>);
+    const instance = getDOMNode(<Radio onClick={onClick}>Title</Radio>);
     ReactTestUtils.Simulate.click(instance.querySelector('label') as HTMLLabelElement);
+
+    expect(onClick).to.have.been.calledOnce;
   });
 
-  it('Should call onChange callback with correct value', done => {
+  it('Should call onChange callback with correct value', () => {
     const value = 'Test';
-    const doneOp = data => {
-      try {
-        assert.equal(data, value);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+    const onChange = Sinon.spy();
 
     const instance = getDOMNode(
-      <Radio onChange={doneOp} value={value}>
+      <Radio onChange={onChange} value={value}>
         Title
       </Radio>
     );
     ReactTestUtils.Simulate.change(instance.querySelector('input') as HTMLInputElement);
+
+    expect(onChange).to.have.been.calledWith(value);
   });
 
-  it('Should call onBlur callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<Radio onBlur={doneOp} />);
+  it('Should call onBlur callback', () => {
+    const onBlur = Sinon.spy();
+    const instance = getDOMNode(<Radio onBlur={onBlur} />);
     ReactTestUtils.Simulate.blur(instance.querySelector('input') as HTMLInputElement);
+
+    expect(onBlur).to.have.been.calledOnce;
   });
 
-  it('Should call onFocus callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<Radio onFocus={doneOp} />);
+  it('Should call onFocus callback', () => {
+    const onFocus = Sinon.spy();
+    const instance = getDOMNode(<Radio onFocus={onFocus} />);
     ReactTestUtils.Simulate.focus(instance.querySelector('input') as HTMLInputElement);
+
+    expect(onFocus).to.have.been.calledOnce;
   });
 
-  it('Should be checked with change', done => {
-    const doneOp = checked => {
-      try {
-        assert.equal(checked, '100');
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
-
+  it('Should be checked with change', () => {
+    const onChange = Sinon.spy();
     const instance = getDOMNode(
-      <Radio onChange={doneOp} value="100">
+      <Radio onChange={onChange} value="100">
         Title
       </Radio>
     );
 
     ReactTestUtils.Simulate.change(instance.querySelector('input') as HTMLInputElement);
+    expect(onChange).to.have.been.calledWith('100');
   });
 });

--- a/src/RadioGroup/test/RadioGroupSpec.tsx
+++ b/src/RadioGroup/test/RadioGroupSpec.tsx
@@ -5,6 +5,7 @@ import { getDOMNode } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import RadioGroup from '../RadioGroup';
 import Radio from '../../Radio';
+import Sinon from 'sinon';
 
 describe('RadioGroup', () => {
   testStandardProps(<RadioGroup />);
@@ -78,18 +79,10 @@ describe('RadioGroup', () => {
     assert.ok(radios[1].className.match(/\bradio-checked\b/));
   });
 
-  it('Should call onChange callback with correct value', done => {
+  it('Should call onChange callback with correct value', () => {
+    const onChange = Sinon.spy();
     const instance = getDOMNode(
-      <RadioGroup
-        onChange={value => {
-          try {
-            assert.equal(value, 3);
-            done();
-          } catch (err) {
-            done(err);
-          }
-        }}
-      >
+      <RadioGroup onChange={onChange}>
         <Radio value={1}>Test1</Radio>
         <Radio value={2}>Test2</Radio>
         <Radio value={3}>Test2</Radio>
@@ -99,23 +92,19 @@ describe('RadioGroup', () => {
 
     const radios = instance.querySelectorAll('.rs-radio');
     ReactTestUtils.Simulate.change(radios[2].querySelector('input') as HTMLInputElement);
+
+    expect(onChange).to.have.been.calledWith(3);
   });
 
-  it('Should call onChange callback', done => {
-    let count = 0;
-
-    function onDone() {
-      count++;
-      if (count === 2) {
-        done();
-      }
-    }
+  it('Should call onChange callback', () => {
+    const onChange = Sinon.spy();
+    const onGroupChange = Sinon.spy();
 
     const instance = getDOMNode(
-      <RadioGroup onChange={onDone}>
+      <RadioGroup onChange={onGroupChange}>
         <Radio value={1}>Test1</Radio>
         <Radio value={2}>Test2</Radio>
-        <Radio value={3} onChange={onDone}>
+        <Radio value={3} onChange={onChange}>
           Test2
         </Radio>
         <Radio value={4}>Test2</Radio>
@@ -124,21 +113,15 @@ describe('RadioGroup', () => {
 
     const radios = instance.querySelectorAll('.rs-radio');
     ReactTestUtils.Simulate.change(radios[2].querySelector('input') as HTMLInputElement);
+
+    expect(onChange).to.have.been.calledOnce;
+    expect(onGroupChange).to.have.been.calledOnce;
   });
 
-  it('Should call onChange callback with correct event target', done => {
+  it('Should call onChange callback with correct event target', () => {
+    const onChange = Sinon.spy();
     const instance = getDOMNode(
-      <RadioGroup
-        name="test"
-        onChange={(_value, event) => {
-          try {
-            assert.equal((event.target as HTMLInputElement).name, 'test');
-            done();
-          } catch (err) {
-            done(err);
-          }
-        }}
-      >
+      <RadioGroup name="test" onChange={onChange}>
         <Radio value={1}>Test1</Radio>
         <Radio value={2}>Test2</Radio>
         <Radio value={3}>Test2</Radio>
@@ -148,6 +131,15 @@ describe('RadioGroup', () => {
 
     const radios = instance.querySelectorAll('.rs-radio');
     ReactTestUtils.Simulate.change(radios[2].querySelector('input') as HTMLInputElement);
+
+    expect(onChange).to.have.been.calledWith(
+      3,
+      Sinon.match({
+        target: {
+          name: 'test'
+        }
+      })
+    );
   });
 
   it('Should be selected as false', () => {

--- a/src/RangeSlider/test/RangeSliderSpec.tsx
+++ b/src/RangeSlider/test/RangeSliderSpec.tsx
@@ -120,22 +120,28 @@ describe('RangeSlider', () => {
     assert.equal(input.value, '100');
   });
 
-  it('Should call `onChangeCommitted` callback', done => {
+  it('Should call `onChangeCommitted` callback', async () => {
+    const onChangeCommitted = sinon.spy();
     const mousemoveEvent = new MouseEvent('mousemove', { bubbles: true });
     const mouseupEvent = new MouseEvent('mouseup', { bubbles: true });
-    const instance = getDOMNode(<RangeSlider onChangeCommitted={() => done()} />);
+    const instance = getDOMNode(<RangeSlider onChangeCommitted={onChangeCommitted} />);
 
     const handle = instance.querySelector('.rs-slider-handle') as HTMLElement;
     fireEvent.mouseDown(handle);
     handle.dispatchEvent(mousemoveEvent);
-    handle.dispatchEvent(mouseupEvent);
 
     assert.include(handle.className, 'active');
+
+    handle.dispatchEvent(mouseupEvent);
+    expect(onChangeCommitted).to.have.been.calledOnce;
   });
 
-  it('Should call `onChange` callback', done => {
-    const instance = getDOMNode(<RangeSlider onChange={() => done()} />);
+  it('Should call `onChange` callback', () => {
+    const onChange = sinon.spy();
+    const instance = getDOMNode(<RangeSlider onChange={onChange} />);
     fireEvent.click(instance.querySelector('.rs-slider-bar') as HTMLElement);
+
+    expect(onChange).to.have.been.calledOnce;
   });
 
   it('Should output an `input` stored value', () => {

--- a/src/Rate/test/RateSpec.tsx
+++ b/src/Rate/test/RateSpec.tsx
@@ -6,6 +6,7 @@ import { testStandardProps } from '@test/commonCases';
 import CameraRetro from '@rsuite/icons/legacy/CameraRetro';
 import Star from '@rsuite/icons/legacy/Star';
 import Rate from '../Rate';
+import Sinon from 'sinon';
 
 describe('Rate', () => {
   testStandardProps(<Rate />);
@@ -118,18 +119,11 @@ describe('Rate', () => {
     assert.include(instance.className, 'rs-rate-lg');
   });
 
-  it('Should call onChange callback with correct value', done => {
-    const doneOp = value => {
-      try {
-        assert.equal(value, 3);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should call onChange callback with correct value', () => {
+    const onChange = Sinon.spy();
 
     const ref = React.createRef<HTMLUListElement>();
-    render(<Rate ref={ref} defaultValue={1} onChange={doneOp} />);
+    render(<Rate ref={ref} defaultValue={1} onChange={onChange} />);
 
     act(() => {
       ReactTestUtils.Simulate.mouseMove(
@@ -142,21 +136,16 @@ describe('Rate', () => {
         (ref.current as HTMLElement).querySelectorAll('.rs-rate-character')[2]
       );
     });
+
+    expect(onChange).to.have.been.calledWith(3);
   });
 
-  it('Should call onChange callback by KeyDown event', done => {
-    const doneOp = value => {
-      try {
-        assert.equal(value, 3);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should call onChange callback by KeyDown event', () => {
+    const onChange = Sinon.spy();
 
     const ref = React.createRef<HTMLUListElement>();
 
-    render(<Rate ref={ref} defaultValue={1} onChange={doneOp} />);
+    render(<Rate ref={ref} defaultValue={1} onChange={onChange} />);
 
     act(() => {
       ReactTestUtils.Simulate.keyDown(
@@ -184,6 +173,8 @@ describe('Rate', () => {
         }
       );
     });
+
+    expect(onChange).to.have.been.calledWith(3);
   });
 
   it('Should be vertical', () => {

--- a/src/Ripple/test/RippleSpec.tsx
+++ b/src/Ripple/test/RippleSpec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, act } from '@testing-library/react';
 import { getDOMNode } from '@test/testUtils';
 import Ripple from '../Ripple';
+import Sinon from 'sinon';
 
 describe('Ripple', () => {
   it('Should render a Ripple', () => {
@@ -9,14 +10,12 @@ describe('Ripple', () => {
     assert.include(instance.className, 'rs-ripple');
   });
 
-  it('Should call onMouseDown callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onMouseDown callback', () => {
+    const onMouseDown = Sinon.spy();
     const ref = React.createRef<HTMLDivElement>();
     render(
       <div ref={ref} style={{ width: 100, height: 100 }}>
-        <Ripple onMouseDown={doneOp} />
+        <Ripple onMouseDown={onMouseDown} />
       </div>
     );
 
@@ -24,6 +23,8 @@ describe('Ripple', () => {
       const event = new Event('mousedown');
       (ref.current as HTMLElement).dispatchEvent(event);
     });
+
+    expect(onMouseDown).to.have.been.calledOnce;
   });
 
   it('Should have a custom className prefix', () => {

--- a/src/SafeAnchor/test/SafeAnchorSpec.tsx
+++ b/src/SafeAnchor/test/SafeAnchorSpec.tsx
@@ -13,20 +13,20 @@ describe('SafeAnchor', () => {
     assert.equal(instance.innerHTML, 'Title');
   });
 
-  it('Should call onClick callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<SafeAnchor onClick={doneOp} />);
+  it('Should call onClick callback', () => {
+    const onClick = sinon.spy();
+    const instance = getDOMNode(<SafeAnchor onClick={onClick} />);
     ReactTestUtils.Simulate.click(instance);
+
+    expect(onClick).to.have.been.calledOnce;
   });
 
-  it('Should call onClick callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<SafeAnchor onClick={doneOp} href="http://a.com" />);
+  it('Should call onClick callback', () => {
+    const onClick = sinon.spy();
+    const instance = getDOMNode(<SafeAnchor onClick={onClick} href="http://a.com" />);
     ReactTestUtils.Simulate.click(instance);
+
+    expect(onClick).to.have.been.calledOnce;
   });
 
   it('Should not prevent the default value when href is provided', () => {

--- a/src/Sidenav/test/SidenavSpec.tsx
+++ b/src/Sidenav/test/SidenavSpec.tsx
@@ -93,12 +93,10 @@ describe('<Sidenav>', () => {
     });
   });
 
-  it('Should call onOpenChange callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onOpenChange callback', () => {
+    const onOpenChange = sinon.spy();
     const instance = getDOMNode(
-      <Sidenav onOpenChange={doneOp}>
+      <Sidenav onOpenChange={onOpenChange}>
         <Nav>
           <Nav.Item eventKey="1">a</Nav.Item>
           <Nav.Item eventKey="2">b</Nav.Item>
@@ -111,6 +109,8 @@ describe('<Sidenav>', () => {
     );
 
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-dropdown-toggle') as HTMLElement);
+
+    expect(onOpenChange).to.have.been.calledOnce;
   });
 
   it('Should open the default menu', () => {

--- a/src/Slider/test/SliderSpec.tsx
+++ b/src/Slider/test/SliderSpec.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from '@testing-library/react';
 import { getDOMNode } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import Slider from '../Slider';
+import Sinon from 'sinon';
 
 describe('Slider', () => {
   testStandardProps(<Slider />);
@@ -90,22 +91,28 @@ describe('Slider', () => {
     assert.equal(input.value, '100');
   });
 
-  it('Should call `onChangeCommitted` callback', done => {
+  it('Should call `onChangeCommitted` callback', () => {
+    const onChangeCommitted = Sinon.spy();
     const mousemoveEvent = new MouseEvent('mousemove', { bubbles: true });
     const mouseupEvent = new MouseEvent('mouseup', { bubbles: true });
-    const instance = getDOMNode(<Slider onChangeCommitted={() => done()} />);
+    const instance = getDOMNode(<Slider onChangeCommitted={onChangeCommitted} />);
 
     const handle = instance.querySelector('.rs-slider-handle') as HTMLElement;
     fireEvent.mouseDown(handle);
     handle.dispatchEvent(mousemoveEvent);
-    handle.dispatchEvent(mouseupEvent);
 
     assert.include(handle.className, 'active');
+    handle.dispatchEvent(mouseupEvent);
+
+    expect(onChangeCommitted).to.have.been.calledOnce;
   });
 
-  it('Should call `onChange` callback', done => {
-    const instance = getDOMNode(<Slider onChange={() => done()} />);
+  it('Should call `onChange` callback', () => {
+    const onChange = Sinon.spy();
+    const instance = getDOMNode(<Slider onChange={onChange} />);
     fireEvent.click(instance.querySelector('.rs-slider-bar') as HTMLElement);
+
+    expect(onChange).to.have.been.calledOnce;
   });
 
   it('Should output an `input` stored value', () => {

--- a/src/Tag/test/TagSpec.tsx
+++ b/src/Tag/test/TagSpec.tsx
@@ -3,6 +3,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import { getDOMNode } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import Tag from '../Tag';
+import Sinon from 'sinon';
 
 describe('Tag', () => {
   testStandardProps(<Tag />);
@@ -11,15 +12,15 @@ describe('Tag', () => {
     assert.equal(instance.className, 'rs-tag rs-tag-md rs-tag-default');
   });
 
-  it('Should call onClose callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onClose callback', () => {
+    const onClose = Sinon.spy();
     const instance = getDOMNode(
-      <Tag closable onClose={doneOp}>
+      <Tag closable onClose={onClose}>
         tag
       </Tag>
     );
     ReactTestUtils.Simulate.click(instance.querySelector('.rs-tag-icon-close') as HTMLElement);
+
+    expect(onClose).to.have.been.calledOnce;
   });
 });

--- a/src/TagPicker/test/TagPickerSpec.tsx
+++ b/src/TagPicker/test/TagPickerSpec.tsx
@@ -185,32 +185,31 @@ describe('TagPicker', () => {
     expect(onChangeSpy).to.calledOnce;
   });
 
-  it('Should call `onClean` callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call `onClean` callback', () => {
+    const onClean = sinon.spy();
     const instance = getDOMNode(
-      <TagPicker data={data} defaultValue={['Kariane']} onClean={doneOp} />
+      <TagPicker data={data} defaultValue={['Kariane']} onClean={onClean} />
     );
     fireEvent.click(instance.querySelector('.rs-picker-toggle-clean') as HTMLElement);
+
+    expect(onClean).to.have.been.calledOnce;
   });
 
-  it('Should call `onSelect` with correct args by key=Enter ', done => {
-    const doneOp = (value, item) => {
-      try {
-        assert.deepEqual(value, ['Kariane', 'Louisa']);
-        assert.equal(item.value, 'Louisa');
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should call `onSelect` with correct args by key=Enter ', () => {
+    const onSelect = sinon.spy();
     const instance = getDOMNode(
-      <TagPicker defaultOpen data={data} onSelect={doneOp} defaultValue={['Kariane']} />
+      <TagPicker defaultOpen data={data} onSelect={onSelect} defaultValue={['Kariane']} />
     );
 
     fireEvent.keyDown(instance, { key: 'ArrowDown' });
     fireEvent.keyDown(instance, { key: 'Enter' });
+
+    expect(onSelect).to.have.been.calledWith(
+      ['Kariane', 'Louisa'],
+      sinon.match({
+        value: 'Louisa'
+      })
+    );
   });
 
   it('Should output a clean button', () => {
@@ -218,19 +217,14 @@ describe('TagPicker', () => {
     assert.ok(instance.root.querySelector('.rs-picker-toggle-clean'));
   });
 
-  it('Should call `onSearch` callback with correct search keyword', done => {
-    const doneOp = key => {
-      try {
-        assert.equal(key, 'a');
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
-    const instance = getDOMNode(<TagPicker data={[]} defaultOpen onSearch={doneOp} />);
+  it('Should call `onSearch` callback with correct search keyword', () => {
+    const onSearch = sinon.spy();
+    const instance = getDOMNode(<TagPicker data={[]} defaultOpen onSearch={onSearch} />);
     const input = instance.querySelector('.rs-picker-search-input input') as HTMLElement;
 
     fireEvent.change(input, { target: { value: 'a' } });
+
+    expect(onSearch).to.have.been.calledWith('a');
   });
 
   it('Should focus item by key=ArrowDown ', () => {
@@ -245,47 +239,47 @@ describe('TagPicker', () => {
     assert.equal(instance.overlay.querySelector('.rs-check-item-focus').textContent, 'Eugenia');
   });
 
-  it('Should call `onChange` by key=Enter ', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call `onChange` by key=Enter ', () => {
+    const onChange = sinon.spy();
     const instance = getDOMNode(
-      <TagPicker defaultOpen data={data} onChange={doneOp} defaultValue={['Kariane']} />
+      <TagPicker defaultOpen data={data} onChange={onChange} defaultValue={['Kariane']} />
     );
 
     fireEvent.keyDown(instance, { key: 'Enter' });
+
+    expect(onChange).to.have.been.calledOnce;
   });
 
-  it('Should call `onChange` by remove last item ', done => {
-    const doneOp = value => {
-      try {
-        assert.deepEqual(value, ['Kariane']);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should call `onChange` by remove last item ', () => {
+    const onChange = sinon.spy();
     const instance = getDOMNode(
-      <TagPicker defaultOpen data={data} onChange={doneOp} defaultValue={['Kariane', 'Eugenia']} />
+      <TagPicker
+        defaultOpen
+        data={data}
+        onChange={onChange}
+        defaultValue={['Kariane', 'Eugenia']}
+      />
     );
     assert.equal(instance.querySelectorAll('.rs-tag').length, 2);
     fireEvent.keyDown(instance.querySelector('input') as HTMLElement, { key: 'Backspace' });
+
+    expect(onChange).to.have.been.calledWith(['Kariane']);
   });
 
-  it('Should call `onChange` by removeTag ', done => {
-    const doneOp = value => {
-      try {
-        assert.deepEqual(value, ['Eugenia']);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should call `onChange` by removeTag ', () => {
+    const onChange = sinon.spy();
     const instance = getDOMNode(
-      <TagPicker defaultOpen data={data} onChange={doneOp} defaultValue={['Kariane', 'Eugenia']} />
+      <TagPicker
+        defaultOpen
+        data={data}
+        onChange={onChange}
+        defaultValue={['Kariane', 'Eugenia']}
+      />
     );
     assert.equal(instance.querySelectorAll('.rs-tag').length, 2);
     fireEvent.click(instance.querySelector('.rs-tag-icon-close') as HTMLElement);
+
+    expect(onChange).to.have.been.calledWith(['Eugenia']);
   });
 
   it('Should have a custom className', () => {
@@ -309,22 +303,22 @@ describe('TagPicker', () => {
     assert.ok(instance.querySelector('.rs-btn'));
   });
 
-  it('Should call `tagProps.onClose` ', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call `tagProps.onClose` ', () => {
+    const onClose = sinon.spy();
     const instance = getDOMNode(
       <TagPicker
         defaultOpen
         data={data}
         defaultValue={['Kariane', 'Eugenia']}
         tagProps={{
-          onClose: doneOp
+          onClose
         }}
       />
     );
     assert.equal(instance.querySelectorAll('.rs-tag').length, 2);
     fireEvent.click(instance.querySelector('.rs-tag-icon-close') as HTMLElement);
+
+    expect(onClose).to.have.been.calledOnce;
   });
 
   it('Should not render tag close icon', () => {
@@ -405,20 +399,13 @@ describe('TagPicker', () => {
     );
   });
 
-  it('Should call `onCreate` with correct value', done => {
-    const doneOp = value => {
-      try {
-        assert.deepEqual(value, ['abc']);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should call `onCreate` with correct value', () => {
+    const onCreate = sinon.spy();
 
     const inputRef = React.createRef<PickerHandle>();
 
     act(() => {
-      render(<TagPicker ref={inputRef} data={[]} onCreate={doneOp} creatable />);
+      render(<TagPicker ref={inputRef} data={[]} onCreate={onCreate} creatable />);
     });
 
     const picker = (inputRef.current as PickerHandle).root as HTMLElement;
@@ -427,22 +414,17 @@ describe('TagPicker', () => {
     fireEvent.click(picker);
     fireEvent.change(input, { target: { value: 'abc' } });
     fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onCreate).to.have.been.calledWith(['abc']);
   });
 
-  it('Should create a tag by tirgger="Space" ', done => {
-    const doneOp = value => {
-      try {
-        assert.deepEqual(value, ['abc']);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should create a tag by tirgger="Space" ', () => {
+    const onCreate = sinon.spy();
 
     const inputRef = React.createRef<PickerHandle>();
 
     act(() => {
-      render(<TagPicker ref={inputRef} data={[]} onCreate={doneOp} creatable trigger="Space" />);
+      render(<TagPicker ref={inputRef} data={[]} onCreate={onCreate} creatable trigger="Space" />);
     });
 
     const picker = (inputRef.current as PickerHandle).root as HTMLElement;
@@ -451,22 +433,17 @@ describe('TagPicker', () => {
     fireEvent.click(picker);
     fireEvent.change(input, { target: { value: 'abc' } });
     fireEvent.keyDown(input, { key: ' ' });
+
+    expect(onCreate).to.have.been.calledWith(['abc']);
   });
 
-  it('Should create a tag by tirgger="Comma" ', done => {
-    const doneOp = value => {
-      try {
-        assert.deepEqual(value, ['abc']);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    };
+  it('Should create a tag by tirgger="Comma" ', () => {
+    const onCreate = sinon.spy();
 
     const inputRef = React.createRef<PickerHandle>();
 
     act(() => {
-      render(<TagPicker ref={inputRef} data={[]} onCreate={doneOp} creatable trigger="Comma" />);
+      render(<TagPicker ref={inputRef} data={[]} onCreate={onCreate} creatable trigger="Comma" />);
     });
 
     const picker = (inputRef.current as PickerHandle).root as HTMLElement;
@@ -475,6 +452,8 @@ describe('TagPicker', () => {
     fireEvent.click(picker);
     fireEvent.change(input, { target: { value: 'abc' } });
     fireEvent.keyDown(input, { key: ',' });
+
+    expect(onCreate).to.have.been.calledWith(['abc']);
   });
 
   it('Should be plaintext', () => {

--- a/src/Uploader/test/UploadTriggerSpec.tsx
+++ b/src/Uploader/test/UploadTriggerSpec.tsx
@@ -31,12 +31,12 @@ describe('UploadTrigger', () => {
     assert.equal((instance.querySelector('.rs-uploader-trigger-btn') as HTMLElement).tagName, 'A');
   });
 
-  it('Should call onChange callback', done => {
-    const doneOp = () => {
-      done();
-    };
-    const instance = getDOMNode(<UploadTrigger onChange={doneOp} />);
+  it('Should call onChange callback', () => {
+    const onChange = sinon.spy();
+    const instance = getDOMNode(<UploadTrigger onChange={onChange} />);
     ReactTestUtils.Simulate.change(instance.querySelector('input') as HTMLElement);
+
+    expect(onChange).to.have.been.calledOnce;
   });
 
   it('Should have a name', () => {

--- a/src/Whisper/test/WhisperSpec.tsx
+++ b/src/Whisper/test/WhisperSpec.tsx
@@ -39,103 +39,93 @@ describe('Whisper', () => {
     expect(document.getElementsByClassName('test-whisper')).to.length(1);
   });
 
-  it('Should call onClick callback', done => {
-    const doneOp = () => {
-      done();
-    };
-
+  it('Should call onClick callback', () => {
+    const onClick = sinon.spy();
     const whisper = getDOMNode(
-      <Whisper onClick={doneOp} trigger="click" speaker={<Tooltip />}>
+      <Whisper onClick={onClick} trigger="click" speaker={<Tooltip />}>
         <button>button</button>
       </Whisper>
     );
 
     fireEvent.click(whisper);
+
+    expect(onClick).to.have.been.calledOnce;
   });
 
-  it('Should call onOpen callback', done => {
-    const doneOp = () => {
-      done();
-    };
-
+  it('Should call onOpen callback', async () => {
+    const onOpen = sinon.spy();
     const whisper = getDOMNode(
-      <Whisper onOpen={doneOp} trigger="click" speaker={<Tooltip />}>
+      <Whisper onOpen={onOpen} trigger="click" speaker={<Tooltip />}>
         <button>button</button>
       </Whisper>
     );
 
     fireEvent.click(whisper);
+
+    await waitFor(() => {
+      expect(onOpen).to.have.been.calledOnce;
+    });
   });
 
-  it('Should call onOpen callback by open()', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onOpen callback by open()', async () => {
+    const onOpen = sinon.spy();
     const instance = getInstance(
-      <Whisper onOpen={doneOp} trigger="none" speaker={<Tooltip />}>
+      <Whisper onOpen={onOpen} trigger="none" speaker={<Tooltip />}>
         <button>button</button>
       </Whisper>
     );
 
     instance.open();
+    await waitFor(() => {
+      expect(onOpen).to.have.been.calledOnce;
+    });
   });
 
-  it('Should call onOpen callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onEntered callback', async () => {
+    const onEntered = sinon.spy();
 
     const whisper = getDOMNode(
-      <Whisper onOpen={doneOp} trigger="click" speaker={<Tooltip />}>
+      <Whisper onEntered={onEntered} trigger="click" speaker={<Tooltip />}>
         <button>button</button>
       </Whisper>
     );
 
     fireEvent.click(whisper);
+    await waitFor(() => {
+      expect(onEntered).to.have.been.calledOnce;
+    });
   });
 
-  it('Should call onEntered callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onClose callback', async () => {
+    const onClose = sinon.spy();
 
     const whisper = getDOMNode(
-      <Whisper onEntered={doneOp} trigger="click" speaker={<Tooltip />}>
-        <button>button</button>
-      </Whisper>
-    );
-
-    fireEvent.click(whisper);
-  });
-
-  it('Should call onClose callback', done => {
-    const doneOp = () => {
-      done();
-    };
-
-    const whisper = getDOMNode(
-      <Whisper onClose={doneOp} trigger="click" speaker={<Tooltip />}>
+      <Whisper onClose={onClose} trigger="click" speaker={<Tooltip />}>
         <button>button</button>
       </Whisper>
     );
 
     fireEvent.click(whisper);
     fireEvent.click(whisper);
+    await waitFor(() => {
+      expect(onClose).to.have.been.calledOnce;
+    });
   });
 
-  it('Should call onExited callback', done => {
-    const doneOp = () => {
-      done();
-    };
+  it('Should call onExited callback', async () => {
+    const onExited = sinon.spy();
 
     const whisper = getDOMNode(
-      <Whisper onExited={doneOp} trigger="click" speaker={<Tooltip />}>
+      <Whisper onExited={onExited} trigger="click" speaker={<Tooltip />}>
         <button>button</button>
       </Whisper>
     );
 
     fireEvent.click(whisper);
     fireEvent.click(whisper);
+    await waitFor(() => {
+      expect(onExited).to.have.been.calledOnce;
+    });
   });
 
   it('Should pass transition callbacks to Transition', async () => {

--- a/src/utils/test/ajaxUploadSpec.ts
+++ b/src/utils/test/ajaxUploadSpec.ts
@@ -45,8 +45,9 @@ describe('[utils] ajaxUpload', () => {
     assert.ok(xhr.withCredentials);
   });
 
-  it('Should time out', done => {
+  it('Should time out', () => {
     sinon.useFakeXMLHttpRequest();
+    const onError = sinon.spy();
     const clock = sinon.useFakeTimers();
     const file = new File(['foo'], 'foo.txt');
     ajaxUpload({
@@ -54,15 +55,10 @@ describe('[utils] ajaxUpload', () => {
       file,
       url: '',
       timeout: 1,
-      onError: e => {
-        try {
-          assert.equal(e.type, 'timeout');
-          done();
-        } catch (err) {
-          done(err);
-        }
-      }
+      onError
     });
     clock.tick(1000);
+
+    expect(onError).to.have.been.calledWithMatch({ type: 'timeout' });
   });
 });

--- a/src/utils/test/previewFileSpec.ts
+++ b/src/utils/test/previewFileSpec.ts
@@ -1,30 +1,31 @@
+import { waitFor } from '@testing-library/react';
+import Sinon from 'sinon';
 import previewFile from '../previewFile';
 
 describe('[utils] previewFile', () => {
-  it('Should output image base64 string', done => {
+  it('Should output image base64 string', async () => {
     const file = new File(['10'], 'image.png', {
       type: 'image/png'
     });
 
-    previewFile(file, result => {
-      if (result === 'data:image/png;base64,MTA=') {
-        done();
-      }
+    const callback = Sinon.spy();
+
+    previewFile(file, callback);
+
+    await waitFor(() => {
+      expect(callback).to.have.been.calledWith('data:image/png;base64,MTA=');
     });
   });
 
-  it('Should output null if file is not an image', done => {
+  it('Should output null if file is not an image', () => {
     const file = new File(['10'], 'image.png', {
       type: 'text/plain'
     });
 
-    previewFile(file, result => {
-      try {
-        assert.isNull(result);
-        done();
-      } catch (err) {
-        done(err);
-      }
-    });
+    const callback = Sinon.spy();
+
+    previewFile(file, callback);
+
+    expect(callback).to.have.been.calledWith(null);
   });
 });

--- a/src/utils/test/useElementResizeSpec.ts
+++ b/src/utils/test/useElementResizeSpec.ts
@@ -1,43 +1,46 @@
 import sinon from 'sinon';
 import { renderHook } from '@test/testUtils';
 import useElementResize from '../useElementResize';
+import { act, waitFor } from '@testing-library/react';
 
 describe('[utils] useElementResize', () => {
   it('should be defined', () => {
     expect(useElementResize).to.be.exist;
   });
 
-  it('should be called after a change in size', done => {
+  it('should be called after a change in size', async () => {
     const target = document.createElement('div');
     const callbackSpy = sinon.spy();
-
-    target.style.width = '100px';
-    target.style.height = '100px';
 
     document.body.appendChild(target);
 
     renderHook(() => useElementResize(target, callbackSpy));
 
-    setTimeout(() => {
+    act(() => {
+      target.style.width = '100px';
+      target.style.height = '100px';
+    });
+
+    await waitFor(() => {
       // ResizeObserver first fires a resize event
       const { width, height } = callbackSpy.firstCall.args[0][0].contentRect;
 
       assert.equal(callbackSpy.callCount, 1);
       assert.equal(width, 100);
       assert.equal(height, 100);
+    });
 
+    act(() => {
       target.style.width = '200px';
-    }, 100);
+    });
 
-    setTimeout(() => {
+    await waitFor(() => {
       // ResizeObserver second fires a resize event
       const { width, height } = callbackSpy.secondCall.args[0][0].contentRect;
 
       assert.equal(callbackSpy.callCount, 2);
       assert.equal(width, 200);
       assert.equal(height, 100);
-
-      done();
-    }, 200);
+    });
   });
 });


### PR DESCRIPTION
Replace `done` callback style async test cases with `waitFor` util function.
