### PR TITLE
fix(Tree): fix Tree drag preview style error

### DIFF
--- a/src/Tree/test/TreeSpec.tsx
+++ b/src/Tree/test/TreeSpec.tsx
@@ -93,6 +93,15 @@ describe('Tree', () => {
     assert.equal(onDragEndSpy.firstCall.firstArg.value, 'Master');
   });
 
+  it('Should display drag Preview when dragging, and remove after drop', () => {
+    const { getByText } = render(<Tree data={data} draggable />);
+    const treeNode = getByText('tester1') as HTMLElement;
+    fireEvent.dragStart(treeNode);
+    assert.equal(document.querySelector('.rs-tree-drag-preview')?.textContent, 'tester1');
+    fireEvent.drop(treeNode);
+    assert.equal(document.querySelector('.rs-tree-drag-preview'), null);
+  });
+
   it('Should call `onDrop` callback without exception', () => {
     expect(() => {
       const onDropSpy = sinon.spy();

--- a/src/Tree/test/TreeSpec.tsx
+++ b/src/Tree/test/TreeSpec.tsx
@@ -97,9 +97,9 @@ describe('Tree', () => {
     const { getByText } = render(<Tree data={data} draggable />);
     const treeNode = getByText('tester1') as HTMLElement;
     fireEvent.dragStart(treeNode);
-    assert.equal(document.querySelector('.rs-tree-drag-preview')?.textContent, 'tester1');
+    expect(document.querySelector('.rs-tree-drag-preview')?.textContent).to.equal('tester1');
     fireEvent.drop(treeNode);
-    assert.equal(document.querySelector('.rs-tree-drag-preview'), null);
+    expect(document.querySelector('.rs-tree-drag-preview')).to.be.a('null');
   });
 
   it('Should call `onDrop` callback without exception', () => {

--- a/src/TreePicker/TreeNode.tsx
+++ b/src/TreePicker/TreeNode.tsx
@@ -3,16 +3,15 @@ import PropTypes from 'prop-types';
 import hasClass from 'dom-lib/hasClass';
 import ArrowDown from '@rsuite/icons/legacy/ArrowDown';
 import Spinner from '@rsuite/icons/legacy/Spinner';
-import reactToString from '../utils/reactToString';
 import { useClassNames } from '../utils';
-import { getTreeNodeIndent } from '../utils/treeUtils';
-import { WithAsProps, RsRefForwardingComponent } from '../@types/common';
+import { getTreeNodeIndent, stringifyTreeNodeLabel } from '../utils/treeUtils';
+import { WithAsProps, RsRefForwardingComponent, ItemDataType } from '../@types/common';
 
 export interface TreeNodeProps extends WithAsProps {
   rtl?: boolean;
   layer: number;
-  value?: any;
-  label?: any;
+  value?: ItemDataType['value'];
+  label?: ItemDataType['label'];
   focus?: boolean;
   loading?: boolean;
   expand?: boolean;
@@ -82,15 +81,6 @@ const TreeNode: RsRefForwardingComponent<'div', TreeNodeProps> = forwardRef<
     ref
   ) => {
     const { prefix, merge, withClassPrefix } = useClassNames(classPrefix);
-
-    const getTitle = useCallback(() => {
-      if (typeof label === 'string') {
-        return label;
-      } else if (React.isValidElement(label)) {
-        const nodes = reactToString(label);
-        return nodes.join('');
-      }
-    }, [label]);
 
     const handleExpand = useCallback(
       (event: React.SyntheticEvent) => {
@@ -214,7 +204,7 @@ const TreeNode: RsRefForwardingComponent<'div', TreeNodeProps> = forwardRef<
       return (
         <span
           className={prefix('label')}
-          title={getTitle()}
+          title={stringifyTreeNodeLabel(label)}
           data-layer={layer}
           data-key={nodeData?.refKey || ''}
           role="button"

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { pick, omit, isUndefined, isNil, isFunction } from 'lodash';
 import { List, AutoSizer, ListHandle, ListChildComponentProps } from '../Windowing';
 import TreeNode from './TreeNode';
-import { getTreeNodeIndent } from '../utils/treeUtils';
+import { createDragPreview, getTreeNodeIndent, removeDragPreview } from '../utils/treeUtils';
 import { PickerLocale } from '../locales';
 import {
   createChainedFunction,
@@ -410,12 +410,24 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
   const handleDragStart = useCallback(
     (nodeData: any, event: React.DragEvent) => {
       if (draggable) {
+        const dragMoverNode = createDragPreview(nodeData[labelKey], treePrefix('drag-preview'));
+        event.dataTransfer?.setDragImage(dragMoverNode, 0, 0);
         setDragNodeKeys(getDragNodeKeys(nodeData, childrenKey, valueKey));
         setDragNode(flattenNodes[nodeData.refKey]);
         onDragStart?.(nodeData, event);
       }
     },
-    [draggable, childrenKey, flattenNodes, onDragStart, setDragNodeKeys, setDragNode, valueKey]
+    [
+      draggable,
+      labelKey,
+      treePrefix,
+      setDragNodeKeys,
+      childrenKey,
+      valueKey,
+      setDragNode,
+      flattenNodes,
+      onDragStart
+    ]
   );
 
   const handleDragEnter = useCallback(
@@ -444,6 +456,7 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
   const handleDragOver = useCallback(
     (nodeData: any, event: React.DragEvent) => {
       if (dragNodeKeys.some(d => shallowEqual(d, nodeData[valueKey]))) {
+        event.dataTransfer.dropEffect = 'none';
         return;
       }
 
@@ -477,6 +490,7 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
 
   const handleDragEnd = useCallback(
     (nodeData: any, event: React.DragEvent) => {
+      removeDragPreview();
       setDragNode(null);
       setDragNodeKeys([]);
       setDragOverNodeKey(null);
@@ -493,6 +507,7 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
         const dropData = getDropData(nodeData) as DropData<Record<string, any>>;
         onDrop?.(dropData, event);
       }
+      removeDragPreview();
       setDragNode(null);
       setDragNodeKeys([]);
       setDragOverNodeKey(null);

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -3,7 +3,12 @@ import PropTypes from 'prop-types';
 import { pick, omit, isUndefined, isNil, isFunction } from 'lodash';
 import { List, AutoSizer, ListHandle, ListChildComponentProps } from '../Windowing';
 import TreeNode from './TreeNode';
-import { createDragPreview, getTreeNodeIndent, removeDragPreview } from '../utils/treeUtils';
+import {
+  createDragPreview,
+  getTreeNodeIndent,
+  removeDragPreview,
+  stringifyTreeNodeLabel
+} from '../utils/treeUtils';
 import { PickerLocale } from '../locales';
 import {
   createChainedFunction,
@@ -410,7 +415,10 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
   const handleDragStart = useCallback(
     (nodeData: any, event: React.DragEvent) => {
       if (draggable) {
-        const dragMoverNode = createDragPreview(nodeData[labelKey], treePrefix('drag-preview'));
+        const dragMoverNode = createDragPreview(
+          stringifyTreeNodeLabel(nodeData[labelKey]),
+          treePrefix('drag-preview')
+        );
         event.dataTransfer?.setDragImage(dragMoverNode, 0, 0);
         setDragNodeKeys(getDragNodeKeys(nodeData, childrenKey, valueKey));
         setDragNode(flattenNodes[nodeData.refKey]);

--- a/src/TreePicker/styles/index.less
+++ b/src/TreePicker/styles/index.less
@@ -16,6 +16,19 @@
   &.rs-tree-virtualized {
     overflow: hidden;
   }
+
+  &-drag-preview {
+    position: absolute;
+    top: 0px;
+    color: var(--rs-text-primary);
+    background-color: var(--rs-bg-overlay);
+    display: inline-block;
+    margin: 0;
+    padding: @picker-tree-node-padding-vertical @picker-tree-node-padding-horizontal;
+    border-radius: 6px;
+    box-shadow: 0 1px 8px rgba(0, 0, 0, 0.12);
+    z-index: -1;
+  }
 }
 
 .rs-tree-node {

--- a/src/TreePicker/styles/index.less
+++ b/src/TreePicker/styles/index.less
@@ -19,7 +19,7 @@
 
   &-drag-preview {
     position: absolute;
-    top: 0px;
+    top: 0;
     color: var(--rs-text-primary);
     background-color: var(--rs-bg-overlay);
     display: inline-block;

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -1008,3 +1008,26 @@ export function getTreeNodeIndent(rtl, layer, absolute = false) {
 export function getNodeFormattedRefKey(value: string | number) {
   return `${typeof value === 'number' ? 'Number_' : 'String_'}${value}`;
 }
+
+/**
+ * create drag preview when tree node start drag
+ * @param name
+ * @param className
+ * @returns
+ */
+export function createDragPreview(name: string, className: string) {
+  const dragPreview = document.createElement('div');
+  dragPreview.id = 'drag-preview';
+  dragPreview.innerHTML = name;
+  dragPreview.classList.add(className);
+  document.body.appendChild(dragPreview);
+  return dragPreview;
+}
+
+/**
+ * remove drag preview when tree node drop
+ */
+export function removeDragPreview() {
+  const dragPreview = document.getElementById('drag-preview');
+  dragPreview?.parentNode?.removeChild?.(dragPreview);
+}

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -1017,7 +1017,7 @@ export function getNodeFormattedRefKey(value: string | number) {
  */
 export function createDragPreview(name: string, className: string) {
   const dragPreview = document.createElement('div');
-  dragPreview.id = 'drag-preview';
+  dragPreview.id = 'rs-tree-drag-preview';
   dragPreview.innerHTML = name;
   dragPreview.classList.add(className);
   document.body.appendChild(dragPreview);
@@ -1028,6 +1028,16 @@ export function createDragPreview(name: string, className: string) {
  * remove drag preview when tree node drop
  */
 export function removeDragPreview() {
-  const dragPreview = document.getElementById('drag-preview');
+  const dragPreview = document.getElementById('rs-tree-drag-preview');
   dragPreview?.parentNode?.removeChild?.(dragPreview);
+}
+
+export function stringifyTreeNodeLabel(label: string | React.ReactNode) {
+  if (typeof label === 'string') {
+    return label;
+  } else if (React.isValidElement(label)) {
+    const nodes = reactToString(label);
+    return nodes.join('');
+  }
+  return '';
 }


### PR DESCRIPTION
This PR fixes an issue where the Tree drag style is not expected as designed.

**Problem:**
![image](https://user-images.githubusercontent.com/12592949/210953877-73e73fe7-52e0-4c3c-8d16-d1d28d6c0334.png)

**Design:**

![image](https://user-images.githubusercontent.com/12592949/210953805-81f5fdeb-263f-494b-b9d6-d35fde09f638.png)


 The issue was caused by https://github.com/rsuite/rsuite/pull/2237.

To avoid the drag preview appearing on the page, I add the style `z-index:-1` for the preview node, to ensure that it does not affect the page display. And the test case has been added.

With this fix, the Tree component should be able to function correctly and have a more aesthetically pleasing appearance when dragging.

Preview Link: https://rsuite-nextjs-git-fix-tree-drag-preview-rsuite.vercel.app/components/tree/#draggable