### PR TITLE
refactor(pickers): adjust the position of the clear button

### DIFF
--- a/src/Picker/PickerToggle.tsx
+++ b/src/Picker/PickerToggle.tsx
@@ -277,7 +277,7 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
               onClick={handleClean}
             />
           )}
-          {caret && <Caret className={prefix`caret`} />}
+          {caret && !showCleanButton && <Caret className={prefix`caret`} />}
         </Stack>
       </Component>
     );

--- a/src/Picker/styles/index.less
+++ b/src/Picker/styles/index.less
@@ -233,14 +233,6 @@
 
   .rs-picker-cleanable.rs-picker-has-value & {
     padding-right: (@dropdown-toggle-padding-right + @picker-toggle-clean-width);
-
-    .rs-@{date-picker-prefix}&,
-    .rs-@{date-range-picker-prefix}& {
-      padding-right: (
-        @dropdown-toggle-padding-right + @picker-toggle-clean-width +
-          @picker-item-content-padding-vertical
-      );
-    }
   }
 }
 
@@ -259,6 +251,11 @@
 
   &:hover {
     color: var(--rs-state-error);
+  }
+
+  &:hover svg path {
+    stroke: var(--rs-state-error);
+    stroke-width: 1;
   }
 
   .rs-@{date-picker-prefix} &,

--- a/src/Picker/styles/mixin.less
+++ b/src/Picker/styles/mixin.less
@@ -99,27 +99,17 @@
   }
 
   .rs-picker-has-value.rs-picker-cleanable & {
-    padding-right: (
-      @padding-horizontal + @dropdown-caret-width + @dropdown-caret-padding + @clean-btn-width +
-        @clean-btn-margin
-    );
+    padding-right: (@padding-horizontal + @dropdown-caret-width + @dropdown-caret-padding);
   }
 
   .rs-picker-toggle-caret,
   .rs-picker-toggle-clean {
     top: @padding-vertical;
+    right: @padding-horizontal;
 
     .rs-picker-default & {
       top: @padding-vertical - @picker-default-toggle-border-width;
     }
-  }
-
-  .rs-picker-toggle-caret {
-    right: @padding-horizontal;
-  }
-
-  .rs-picker-toggle-clean {
-    right: (@dropdown-caret-width + @padding-horizontal + @clean-btn-width - @clean-btn-margin);
   }
 }
 
@@ -156,18 +146,11 @@
   .rs-picker-toggle-clean,
   .rs-picker-toggle-caret {
     top: @top;
+    right: @padding-horizontal;
 
     .rs-picker-subtle & {
       top: @top - @picker-default-toggle-border-width;
     }
-  }
-
-  .rs-picker-toggle-caret {
-    right: @padding-horizontal;
-  }
-
-  .rs-picker-toggle-clean {
-    right: (@padding-horizontal + @toggle-clean-padding + @calendar-caret-width);
   }
 }
 

--- a/src/Picker/test/PickerToggleSpec.tsx
+++ b/src/Picker/test/PickerToggleSpec.tsx
@@ -135,4 +135,11 @@ describe('<PickerToggle>', () => {
 
     expect(getByTestId('caret')).to.have.class('rs-picker-toggle-caret');
   });
+
+  it('Should not show caret icon when it has value', () => {
+    render(<Toggle hasValue cleanable />);
+
+    expect(screen.getByRole('combobox').querySelector('.rs-picker-toggle-clean')).to.exist;
+    expect(screen.getByRole('combobox').querySelector('.rs-picker-toggle-caret')).to.not.exist;
+  });
 });


### PR DESCRIPTION
Talking with designer @LeightonYao, it was decided to move the clear button on the picker to the right and hide the arrow icon.

### Before

![image](https://user-images.githubusercontent.com/1203827/212819049-e2e1c87b-845d-4c8e-99ff-b27b298f0528.png)


### After 
![image](https://user-images.githubusercontent.com/1203827/212818972-af76b26e-2a0d-49d8-b85c-d604719b00a1.png)


### Affected components

- Cascader
- CheckPicker
- CheckTreePicker
- DatePicker
- DateRangePicker
- InputPicker
- MultiCascader
- SelectPicker
- TagPicker
- TagInput
- TreePicker

