### PR TITLE
fix(Message,Notification): duration property migrated to `toaster.push` option

### DIFF
--- a/docs/pages/components/message/fragments/with-toaster.md
+++ b/docs/pages/components/message/fragments/with-toaster.md
@@ -9,7 +9,7 @@ const App = () => {
   const toaster = useToaster();
 
   const message = (
-    <Message showIcon type={type}>
+    <Message showIcon type={type} closable>
       {type}: The message appears on the {placement}.
     </Message>
   );
@@ -45,7 +45,7 @@ const App = () => {
           onChange={setPlacement}
           style={{ width: 200 }}
         />
-        <Button onClick={() => toaster.push(message, { placement })}>Push</Button>
+        <Button onClick={() => toaster.push(message, { placement, duration: 5000 })}>Push</Button>
         <Button onClick={() => toaster.remove()}>Remove</Button>
         <Button onClick={() => toaster.clear()}>Clear</Button>
       </ButtonToolbar>

--- a/docs/pages/components/notification/en-US/toaster.md
+++ b/docs/pages/components/notification/en-US/toaster.md
@@ -25,6 +25,9 @@ interface ToastContainerProps{
 
   /** Set the message to appear in the specified container */
   container?: HTMLElement | (() => HTMLElement);
+
+  /** The number of milliseconds to wait before automatically closing a message */
+  duration?: number;
 }
 
 toaster.push(message: ReactNode, options?: ToastContainerProps): string;
@@ -33,10 +36,15 @@ toaster.push(message: ReactNode, options?: ToastContainerProps): string;
 e.g:
 
 ```js
-// Message
+// Push a message
 toaster.push(<Message>message</Message>);
 
-// Notification
+// Push a message and set the duration
+toaster.push(<Message>message</Message>, {
+  duration: 1000
+});
+
+// Push notification and set placement
 toaster.push(<Notification>message</Notification>, {
   placement: 'topEnd'
 });

--- a/docs/pages/components/notification/zh-CN/toaster.md
+++ b/docs/pages/components/notification/zh-CN/toaster.md
@@ -20,11 +20,14 @@ return () => {
 type PlacementType = 'topCenter' | 'bottomCenter' | 'topStart' | 'topEnd' | 'bottomStart' | 'bottomEnd';
 
 interface ToastContainerProps{
-  /** The placement of the message box */
+  /** 消息框的位置 */
   placement?: PlacementType;
 
-  /** Set the message to appear in the specified container */
+  /** 设置消息出现在指定的容器中 */
   container?: HTMLElement | (() => HTMLElement);
+
+  /** 自动关闭消息前等待的毫秒数 */
+  duration?: number;
 }
 
 toaster.push(message: ReactNode, options?: ToastContainerProps): string;
@@ -33,10 +36,15 @@ toaster.push(message: ReactNode, options?: ToastContainerProps): string;
 e.g:
 
 ```js
-// Message
+// 弹出一个消息
 toaster.push(<Message>message</Message>);
 
-// Notification
+// 弹出一个消息，并设置自动关闭的时间
+toaster.push(<Message>message</Message>, {
+  duration: 1000
+});
+
+// 弹出一个通知, 并设置位置
 toaster.push(<Notification>message</Notification>, {
   placement: 'topEnd'
 });

--- a/src/Message/Message.tsx
+++ b/src/Message/Message.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useClassNames, useTimeout, MESSAGE_STATUS_ICONS, STATUS, useIsMounted } from '../utils';
 import { WithAsProps, TypeAttributes, RsRefForwardingComponent } from '../@types/common';
 import CloseButton from '../CloseButton';
+import ToastContext from '../toaster/ToastContext';
 
 export interface MessageProps extends WithAsProps {
   /** The type of the message box. */
@@ -15,6 +16,10 @@ export interface MessageProps extends WithAsProps {
    * Delay automatic removal of messages.
    * When set to 0, the message is not automatically removed.
    * (Unit: milliseconds)
+   *
+   * @default 2000
+   * @deprecated Use `toaster.push(<Message />, { duration: 2000 })` instead.
+   *
    */
   duration?: number;
 
@@ -53,9 +58,10 @@ const Message: RsRefForwardingComponent<'div', MessageProps> = React.forwardRef(
     const [display, setDisplay] = useState<DisplayType>('show');
     const { withClassPrefix, merge, prefix } = useClassNames(classPrefix);
     const isMounted = useIsMounted();
+    const { usedToaster } = useContext(ToastContext);
 
     // Timed close message
-    const { clear } = useTimeout(onClose, duration, duration > 0);
+    const { clear } = useTimeout(onClose, duration, usedToaster && duration > 0);
 
     const handleClose = useCallback(
       (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/Message/test/MessageSpec.tsx
+++ b/src/Message/test/MessageSpec.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
 import { testStandardProps } from '@test/commonCases';
 import Message from '../Message';
+import ToastContext from '../../toaster/ToastContext';
 
 describe('Message', () => {
   testStandardProps(<Message />);
@@ -58,5 +59,18 @@ describe('Message', () => {
     fireEvent.click(closeButton);
 
     expect(onCloseSpy).to.have.been.calledOnce;
+  });
+
+  it('Should call onClose callback by usedToaster', async () => {
+    const onCloseSpy = sinon.spy();
+    render(
+      <ToastContext.Provider value={{ usedToaster: true }}>
+        <Message duration={1} onClose={onCloseSpy} />
+      </ToastContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(onCloseSpy).to.have.been.calledOnce;
+    });
   });
 });

--- a/src/Notification/Notification.tsx
+++ b/src/Notification/Notification.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useClassNames, useTimeout, MESSAGE_STATUS_ICONS, useIsMounted } from '../utils';
 import { WithAsProps, RsRefForwardingComponent } from '../@types/common';
 import CloseButton from '../CloseButton';
+import ToastContext from '../toaster/ToastContext';
 
 export type MessageType = 'info' | 'success' | 'warning' | 'error';
 
@@ -16,6 +17,9 @@ export interface NotificationProps extends WithAsProps {
    * Delay automatic removal of messages.
    * When set to 0, the message is not automatically removed.
    * (Unit: milliseconds)
+   *
+   * @default 4500
+   * @deprecated Use `toaster.push(<Notification />, { duration: 4500 })` instead.
    */
   duration?: number;
 
@@ -48,9 +52,10 @@ const Notification: RsRefForwardingComponent<'div', NotificationProps> = React.f
     const [display, setDisplay] = useState<DisplayType>('show');
     const { withClassPrefix, merge, prefix } = useClassNames(classPrefix);
     const isMounted = useIsMounted();
+    const { usedToaster } = useContext(ToastContext);
 
     // Timed close message
-    const { clear } = useTimeout(onClose, duration, duration > 0);
+    const { clear } = useTimeout(onClose, duration, usedToaster && duration > 0);
 
     // Click to trigger to close the message
     const handleClose = useCallback(

--- a/src/Notification/test/NotificationSpec.tsx
+++ b/src/Notification/test/NotificationSpec.tsx
@@ -1,58 +1,68 @@
 import React from 'react';
-import { getDOMNode } from '@test/testUtils';
+import sinon from 'sinon';
 import { testStandardProps } from '@test/commonCases';
-import ReactTestUtils from 'react-dom/test-utils';
 import Notification from '../Notification';
 import Sinon from 'sinon';
-import { waitFor } from '@testing-library/react';
+import { waitFor, render, fireEvent, screen } from '@testing-library/react';
+import ToastContext from '../../toaster/ToastContext';
 
 describe('Notification', () => {
   testStandardProps(<Notification />);
 
   it('Should output a notification', () => {
-    const instance = getDOMNode(<Notification />);
-    assert.ok(instance.className.match(/\brs-notification\b/));
+    render(<Notification />);
+
+    expect(screen.getByRole('alert')).to.have.class('rs-notification');
   });
 
   it('Should render content', () => {
-    const instance = getDOMNode(<Notification>text</Notification>);
-    assert.equal(instance.textContent, 'text');
+    render(<Notification>text</Notification>);
+
+    expect(screen.getByRole('alert')).to.have.text('text');
   });
 
   it('Should be closable', () => {
-    const instance = getDOMNode(<Notification closable />);
+    render(<Notification closable />);
 
-    assert.ok(instance.querySelector('.rs-btn-close'));
+    expect(screen.getByRole('alert').querySelector('.rs-btn-close')).to.be.exist;
   });
 
   it('Should have a type', () => {
-    const instance = getDOMNode(<Notification type="info" header="info" />);
-    assert.include(instance.className, 'rs-notification-info');
-    assert.ok(instance.querySelector('[aria-label="info"]'));
+    render(<Notification type="info" header="info" />);
+
+    expect(screen.getByRole('alert')).to.have.class('rs-notification-info');
+    expect(screen.getByRole('alert').querySelector('.rs-icon')).to.have.attribute(
+      'aria-label',
+      'info'
+    );
   });
 
   it('Should have a header', () => {
-    const instance = getDOMNode(<Notification header="header" />);
-    assert.equal(
-      (instance.querySelector('.rs-notification-title') as HTMLElement).textContent,
+    render(<Notification header="header" />);
+
+    expect(screen.getByRole('alert').querySelector('.rs-notification-title')).to.have.text(
       'header'
     );
   });
 
   it('Should call onClose callback', () => {
     const onClose = Sinon.spy();
-    const instance = getDOMNode(<Notification closable onClose={onClose} />);
-    ReactTestUtils.Simulate.click(instance.querySelector('.rs-btn-close') as HTMLElement);
+    render(<Notification closable onClose={onClose} />);
+    fireEvent.click(screen.getByRole('alert').querySelector('.rs-btn-close') as HTMLElement);
 
     expect(onClose).to.have.been.calledOnce;
   });
 
-  it('Should call onClose callback by duration', async () => {
-    const onClose = Sinon.spy();
-    getDOMNode(<Notification closable onClose={onClose} duration={1} />);
+  it('Should call onClose callback by usedToaster', async () => {
+    const onCloseSpy = sinon.spy();
+    render(
+      <ToastContext.Provider value={{ usedToaster: true }}>
+        <Notification duration={1} onClose={onCloseSpy} />
+      </ToastContext.Provider>
+    );
 
     await waitFor(() => {
-      expect(onClose).to.have.been.calledOnce;
+      expect(onCloseSpy).to.have.been.calledOnce;
     });
   });
 });

--- a/src/toaster/ToastContext.ts
+++ b/src/toaster/ToastContext.ts
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export interface ToastContextProps {
+  usedToaster?: boolean;
+}
+
+const ToastContext = React.createContext<ToastContextProps>({ usedToaster: false });
+
+ToastContext.displayName = 'ToastContext';
+
+export default ToastContext;

--- a/src/toaster/test/useToasterSpec.tsx
+++ b/src/toaster/test/useToasterSpec.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { screen, render, act, fireEvent } from '@testing-library/react';
+import { screen, render, act, fireEvent, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
 import useToaster from '../useToaster';
 import CustomProvider from '../../CustomProvider';
 import Uploader from '../../Uploader';
 import zhCN from '../../locales/zh_CN';
 import { renderHook } from '@test/testUtils';
+import Message from '../../Message';
 
 afterEach(() => {
   sinon.restore();
@@ -114,5 +115,38 @@ describe('useToaster', () => {
     });
 
     expect(getByText('上传')).to.exist;
+  });
+
+  it('Should pass duration to Message', () => {
+    const toaster = renderHook(() => useToaster(), { wrapper: CustomProvider }).result.current;
+
+    const Message = React.forwardRef<HTMLDivElement, any>((props, ref) => {
+      const { duration } = props;
+      return (
+        <div data-testid="msg-1" ref={ref}>
+          {duration}
+        </div>
+      );
+    });
+
+    toaster.push(<Message>message</Message>, { duration: 10 });
+
+    expect(screen.getByTestId('msg-1')).to.have.text('10');
+  });
+
+  it('Should call onClose callback with duration', async () => {
+    const onCloseSpy = sinon.spy();
+    const toaster = renderHook(() => useToaster(), { wrapper: CustomProvider }).result.current;
+
+    toaster.push(
+      <Message data-testid="msg-1" onClose={onCloseSpy}>
+        message
+      </Message>,
+      { duration: 10 }
+    );
+
+    await waitFor(() => {
+      expect(onCloseSpy).to.have.been.calledOnce;
+    });
   });
 });

--- a/src/toaster/test/useToasterSpec.tsx
+++ b/src/toaster/test/useToasterSpec.tsx
@@ -117,7 +117,7 @@ describe('useToaster', () => {
     expect(getByText('上传')).to.exist;
   });
 
-  it('Should pass duration to Message', () => {
+  it('Should pass duration to Message', async () => {
     const toaster = renderHook(() => useToaster(), { wrapper: CustomProvider }).result.current;
 
     const Message = React.forwardRef<HTMLDivElement, any>((props, ref) => {
@@ -131,7 +131,9 @@ describe('useToaster', () => {
 
     toaster.push(<Message>message</Message>, { duration: 10 });
 
-    expect(screen.getByTestId('msg-1')).to.have.text('10');
+    await waitFor(() => {
+      expect(screen.getByTestId('msg-1')).to.have.text('10');
+    });
   });
 
   it('Should call onClose callback with duration', async () => {

--- a/src/toaster/toaster.tsx
+++ b/src/toaster/toaster.tsx
@@ -54,15 +54,15 @@ function getContainer(containerId?: string) {
 const toaster: Toaster = (message: React.ReactNode) => toaster.push(message);
 
 toaster.push = (message: React.ReactNode, options: ToastContainerProps = {}) => {
-  const containerId = options?.placement;
+  const { placement: containerId, ...restOptions } = options;
   const container = getContainer(containerId);
 
   if (container?.current) {
-    return container.current.push(message);
+    return container.current.push(message, restOptions);
   }
 
   return createContainer(containerId ?? '', options).then(ref => {
-    return ref.current?.push(message);
+    return ref.current?.push(message, restOptions);
   });
 };
 

--- a/src/toaster/useToaster.ts
+++ b/src/toaster/useToaster.ts
@@ -14,7 +14,7 @@ const useToaster = () => {
     push: (message: React.ReactNode, options?: ToastContainerProps) => {
       const customToaster = toasters?.current?.get(options?.placement || 'topCenter');
 
-      return customToaster ? customToaster.push(message) : toaster.push(message, options);
+      return customToaster ? customToaster.push(message, options) : toaster.push(message, options);
     },
     remove: (key: string) => {
       toasters


### PR DESCRIPTION
fix: https://github.com/rsuite/rsuite/issues/3056

### Before
```tsx
toaster.push(<Message duration={2000}>message</Message>);
```

### After

```tsx
toaster.push(<Message>message</Message>, {
  duration: 2000
});
```

