### PR TITLE
docs(Whisper): support defaultOpen and open on `<Whisper>`

### DIFF
--- a/docs/pages/components/whisper/en-US/props.md
+++ b/docs/pages/components/whisper/en-US/props.md
@@ -4,6 +4,7 @@
 | --------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
 | container       | HTMLElement &#124; (() => HTMLElement)                 | Sets the rendering container                                                                                 |
 | controlId       | string                                                 | Set the `id` on `<Overlay>` and `aria-describedby` on `<Whisper>`                                            |
+| defaultOpen     | boolean                                                | Whether to open the overlay by default                                                                       |
 | delay           | number                                                 | Delay time (ms) Time                                                                                         |
 | delayClose      | number                                                 | Delay close time (ms) Time                                                                                   |
 | delayOpen       | number                                                 | Delay open time (ms) Time                                                                                    |
@@ -21,6 +22,7 @@
 | onExiting       | () => void                                             | Callback fired as the overlay begins to transition out                                                       |
 | onFocus         | () => void                                             | Callback function to get focus                                                                               |
 | onOpen          | () => void                                             | Callback fired when open component                                                                           |
+| open            | boolean                                                | Whether to open the overlay                                                                                  |
 | placement       | [Placement](#code-ts-placement-code) `('right')`       | Dispaly placement                                                                                            |
 | preventOverflow | boolean                                                | Prevent floating element overflow                                                                            |
 | speaker \*      | Tooltip &#124; Popover &#124; ReactElement             | Displayed component                                                                                          |

--- a/docs/pages/components/whisper/zh-CN/props.md
+++ b/docs/pages/components/whisper/zh-CN/props.md
@@ -4,6 +4,7 @@
 | --------------- | ------------------------------------------------------ | ------------------------------------------------------------------------- |
 | container       | HTMLElement &#124; (() => HTMLElement)                 | 设置渲染的容器                                                            |
 | controlId       | string                                                 | 设置 `id` 到 `<Overlay>`上，并且设置 `aria-describedby` 到 `<Whisper>` 上 |
+| defaultOpen     | boolean                                                | 默认是否显示                                                              |
 | delay           | number                                                 | 延迟时间 (ms)                                                             |
 | delayClose      | number                                                 | 延迟关闭时间 (ms)                                                         |
 | delayOpen       | number                                                 | 延迟打开时间 (ms)                                                         |
@@ -21,6 +22,7 @@
 | onExiting       | () => void                                             | 退出中动画过渡的回调函数                                                  |
 | onFocus         | () => void                                             | 获取焦点的回调函数                                                        |
 | onOpen          | () => void                                             | 打开回调函数                                                              |
+| open            | boolean                                                | 手动控制是否显示                                                          |
 | placement       | [Placement](#code-ts-placement-code) `('right')`       | 显示位置                                                                  |
 | preventOverflow | boolean                                                | 防止浮动元素溢出                                                          |
 | speaker \*      | Tooltip &#124; Popover &#124; ReactElement             | 展示的元素                                                                |

--- a/src/Overlay/test/OverlayTriggerSpec.tsx
+++ b/src/Overlay/test/OverlayTriggerSpec.tsx
@@ -1,9 +1,9 @@
 import React, { Ref } from 'react';
 import { Simulate } from 'react-dom/test-utils';
-import { act, fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
 import { getDOMNode } from '@test/testUtils';
-import OverlayTrigger from '../OverlayTrigger';
+import OverlayTrigger, { OverlayTriggerHandle } from '../OverlayTrigger';
 import Tooltip from '../../Tooltip';
 
 describe('OverlayTrigger', () => {
@@ -252,5 +252,40 @@ describe('OverlayTrigger', () => {
     }).toHaveError(
       '[rsuite] The OverlayTrigger component does not accept strings or Fragments as child.'
     );
+  });
+
+  it('Should open the Overlay', () => {
+    render(
+      <OverlayTrigger speaker={<Tooltip>tooltip</Tooltip>} open>
+        <button>button</button>
+      </OverlayTrigger>
+    );
+
+    expect(screen.getByRole('tooltip')).to.exist;
+  });
+
+  it('Should open the Overlay by default', async () => {
+    const onCloseSpy = sinon.spy();
+    const ref = React.createRef<OverlayTriggerHandle>();
+
+    render(
+      <OverlayTrigger
+        speaker={<Tooltip>tooltip</Tooltip>}
+        defaultOpen
+        onExited={onCloseSpy}
+        ref={ref}
+      >
+        <button>button</button>
+      </OverlayTrigger>
+    );
+
+    expect(screen.getByRole('tooltip')).to.exist;
+
+    ref.current?.close();
+
+    await waitFor(() => {
+      expect(onCloseSpy).to.have.been.calledOnce;
+      expect(screen.queryByRole('tooltip')).to.not.exist;
+    });
   });
 });


### PR DESCRIPTION
close: https://github.com/rsuite/rsuite/issues/3062

```tsx
<Whisper
  open={open}  // Controlled Whisper
  speaker={<Popover>...</Popover>}
>
  Content
</Whisper>
```