### PR TITLE
feat(Button): add startIcon and endIcon props

### DIFF
--- a/docs/pages/components/button/en-US/index.md
+++ b/docs/pages/components/button/en-US/index.md
@@ -117,9 +117,11 @@ function App() {
 | classPrefix | string `('btn')`                                     | The prefix of the component CSS class                          |
 | color       | [Color](#code-ts-color-code)                         | A button can have different colors                             |
 | disabled    | boolean                                              | A button can show it is currently unable to be interacted with |
+| endIcon     | ReactNode                                            | Display an icon after buttont text                             |
 | href        | string                                               | Providing a `href` will render an `a` element                  |
 | loading     | boolean                                              | A button can show a loading indicator                          |
 | size        | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')`    | A button can have different sizes                              |
+| startIcon   | ReactNode                                            | Display an icon before buttont text                            |
 
 ### `<IconButton>`
 

--- a/docs/pages/components/button/fragments/custom.md
+++ b/docs/pages/components/button/fragments/custom.md
@@ -11,23 +11,23 @@ import WeiboIcon from '@rsuite/icons/legacy/Weibo';
 
 const App = () => (
   <ButtonToolbar>
-    <Button color="blue" appearance="primary">
-      <FacebookOfficialIcon /> Facebook
+    <Button color="blue" appearance="primary" startIcon={<FacebookOfficialIcon />}>
+      Facebook
     </Button>
-    <Button color="red" appearance="primary">
-      <GooglePlusCircleIcon /> Google Plus
+    <Button color="red" appearance="primary" startIcon={<GooglePlusCircleIcon />}>
+      Google Plus
     </Button>
-    <Button color="cyan" appearance="primary">
-      <TwitterIcon /> Twitter
+    <Button color="cyan" appearance="primary" startIcon={<TwitterIcon />}>
+      Twitter
     </Button>
-    <Button color="blue" appearance="primary">
-      <LinkedinIcon /> LinkedIn
+    <Button color="blue" appearance="primary" endIcon={<LinkedinIcon />}>
+      LinkedIn
     </Button>
-    <Button color="green" appearance="primary">
-      <WechatIcon /> WeChat
+    <Button color="green" appearance="primary" endIcon={<WechatIcon />}>
+      WeChat
     </Button>
-    <Button color="yellow" appearance="primary">
-      <WeiboIcon /> WeiBo
+    <Button color="yellow" appearance="primary" endIcon={<WeiboIcon />}>
+      WeiBo
     </Button>
   </ButtonToolbar>
 );

--- a/docs/pages/components/button/zh-CN/index.md
+++ b/docs/pages/components/button/zh-CN/index.md
@@ -107,19 +107,21 @@ function App() {
 
 ### `<Button>`
 
-| 属性名称    | 类型 `(默认值)`                                      | 描述                   |
-| ----------- | ---------------------------------------------------- | ---------------------- |
-| active      | boolean                                              | 激活状态               |
-| appearance  | [Appearance](#code-ts-appearance-code) `('default')` | 设置外观               |
-| as          | ElementType `('button')`                             | 为组件自定义元素类型   |
-| block       | boolean                                              | 显示为块级元素         |
-| children \* | ReactNode                                            | 组件的内容             |
-| classPrefix | string `('btn')`                                     | 组件 CSS 类的前缀      |
-| color       | [Color](#code-ts-color-code)                         | 设置颜色               |
-| disabled    | boolean                                              | 禁用                   |
-| href        | string                                               | 按钮跳转链接           |
-| loading     | boolean                                              | 按钮可以显示加载指示器 |
-| size        | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')`    | 设置按钮尺寸           |
+| 属性名称    | 类型 `(默认值)`                                      | 描述                       |
+| ----------- | ---------------------------------------------------- | -------------------------- | --- |
+| active      | boolean                                              | 激活状态                   |
+| appearance  | [Appearance](#code-ts-appearance-code) `('default')` | 设置外观                   |
+| as          | ElementType `('button')`                             | 为组件自定义元素类型       |
+| block       | boolean                                              | 显示为块级元素             |
+| children \* | ReactNode                                            | 组件的内容                 |
+| classPrefix | string `('btn')`                                     | 组件 CSS 类的前缀          |
+| color       | [Color](#code-ts-color-code)                         | 设置颜色                   |
+| disabled    | boolean                                              | 禁用                       |
+| endIcon     | ReactNode                                            | 在按钮文字之后显示一个图标 |
+| href        | string                                               | 按钮跳转链接               |
+| loading     | boolean                                              | 按钮可以显示加载指示器     |
+| size        | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')`    | 设置按钮尺寸               |
+| startIcon   | ReactNode                                            | 在按钮文字之前显示一个图标 |     |
 
 ### `<IconButton>`
 

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { ButtonGroupContext } from '../ButtonGroup';
 import SafeAnchor from '../SafeAnchor';
@@ -37,6 +37,12 @@ export interface ButtonProps extends WithAsProps, React.HTMLAttributes<HTMLEleme
   /** Ripple after button click */
   ripple?: boolean;
 
+  /** The icon element placed _before_ the button text */
+  startIcon?: React.ReactNode;
+
+  /** The icon element placed _after_ the button text */
+  endIcon?: React.ReactNode;
+
   /** Defines HTML button type attribute */
   type?: 'button' | 'reset' | 'submit';
 }
@@ -56,6 +62,8 @@ const Button: RsRefForwardingComponent<'button', ButtonProps> = React.forwardRef
       loading,
       ripple = true,
       size: sizeProp,
+      startIcon,
+      endIcon,
       type: typeProp,
       ...rest
     } = props;
@@ -70,8 +78,20 @@ const Button: RsRefForwardingComponent<'button', ButtonProps> = React.forwardRef
       withClassPrefix(appearance, color, size, { active, disabled, loading, block })
     );
 
-    const rippleElement = ripple && !isOneOf(appearance, ['link', 'ghost']) ? <Ripple /> : null;
-    const spin = <span className={prefix`spin`} />;
+    const renderButtonContent = useCallback(() => {
+      const spin = <span className={prefix`spin`} />;
+      const rippleElement = ripple && !isOneOf(appearance, ['link', 'ghost']) ? <Ripple /> : null;
+
+      return (
+        <>
+          {loading && spin}
+          {startIcon ? <span className={prefix`start-icon`}>{startIcon}</span> : null}
+          {children}
+          {endIcon ? <span className={prefix`end-icon`}>{endIcon}</span> : null}
+          {rippleElement}
+        </>
+      );
+    }, [appearance, children, endIcon, loading, prefix, ripple, startIcon]);
 
     if (rest.href) {
       return (
@@ -83,9 +103,7 @@ const Button: RsRefForwardingComponent<'button', ButtonProps> = React.forwardRef
           disabled={disabled}
           className={classes}
         >
-          {loading && spin}
-          {children}
-          {rippleElement}
+          {renderButtonContent()}
         </SafeAnchor>
       );
     }
@@ -104,9 +122,7 @@ const Button: RsRefForwardingComponent<'button', ButtonProps> = React.forwardRef
         aria-disabled={disabled}
         className={classes}
       >
-        {loading && spin}
-        {children}
-        {rippleElement}
+        {renderButtonContent()}
       </Component>
     );
   }

--- a/src/Button/styles/index.less
+++ b/src/Button/styles/index.less
@@ -8,7 +8,8 @@
 
 // Default Button
 .rs-btn {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   margin-bottom: 0; // For input.btn
   font-weight: @btn-font-weight;
   text-align: center;
@@ -50,6 +51,16 @@
   });
 
   .with-ripple();
+}
+
+.rs-btn-start-icon {
+  line-height: 0; // Eliminate whitespace
+  margin-right: @btn-icon-gap;
+}
+
+.rs-btn-end-icon {
+  line-height: 0; // Eliminate whitespace
+  margin-left: @btn-icon-gap;
 }
 
 // Appearance variants

--- a/src/Button/test/ButtonSpec.tsx
+++ b/src/Button/test/ButtonSpec.tsx
@@ -116,21 +116,13 @@ describe('Button', () => {
   });
 
   it('Should render `startIcon` before text', () => {
-    render(
-      <Button startIcon={<i>Icon</i>} data-testid="button">
-        Text
-      </Button>
-    );
+    render(<Button startIcon={<i>Icon</i>}>Text</Button>);
 
-    expect(screen.getByTestId('button')).to.have.text('IconText');
+    expect(screen.getByRole('button')).to.have.text('IconText');
   });
   it('Should render `endIcon` after text', () => {
-    render(
-      <Button endIcon={<i>Icon</i>} data-testid="button">
-        Text
-      </Button>
-    );
+    render(<Button endIcon={<i>Icon</i>}>Text</Button>);
 
-    expect(screen.getByTestId('button')).to.have.text('TextIcon');
+    expect(screen.getByRole('button')).to.have.text('TextIcon');
   });
 });

--- a/src/Button/test/ButtonSpec.tsx
+++ b/src/Button/test/ButtonSpec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import sinon from 'sinon';
 import { getDOMNode, getInstance } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
@@ -113,5 +113,24 @@ describe('Button', () => {
     render(<Button ref={buttonRef}>Text</Button>);
 
     expect(buttonRef.current).to.have.tagName('button');
+  });
+
+  it('Should render `startIcon` before text', () => {
+    render(
+      <Button startIcon={<i>Icon</i>} data-testid="button">
+        Text
+      </Button>
+    );
+
+    expect(screen.getByTestId('button')).to.have.text('IconText');
+  });
+  it('Should render `endIcon` after text', () => {
+    render(
+      <Button endIcon={<i>Icon</i>} data-testid="button">
+        Text
+      </Button>
+    );
+
+    expect(screen.getByTestId('button')).to.have.text('TextIcon');
   });
 });

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -247,6 +247,9 @@
 // Ghost Button
 @btn-ghost-border-width:    1px;
 
+// Button with icons (not IconButton)
+@btn-icon-gap:              5px;
+
 // Button Loading
 @btn-loading-spin-default-diameter: 18px;
 @btn-loading-spin-xs-diameter:      16px;


### PR DESCRIPTION
## Feature

Add `startIcon` and `endIcon` props to specify an icon element placed before/after text content in a Button.

<img width="669" alt="image" src="https://user-images.githubusercontent.com/8225666/218407245-733344d9-a680-46ad-a371-e00c3008823c.png">

Design material: https://www.figma.com/file/uEq9QBplcKUYZrcWWA3RK2/NXT-UI?node-id=0%3A2050&t=V95uYVLyuHWmOIYM-4

### How's it different from directly adding icon element in `children`?

You have to handle alignment if putting icon element as `children`, otherwise you get misaligned icons as shown below.

<img width="665" alt="image" src="https://user-images.githubusercontent.com/8225666/218407429-e42a6a23-b752-42cb-bb7e-6581e4f733e1.png">

(This is an example from rsuitejs.com)

<img width="451" alt="image" src="https://user-images.githubusercontent.com/8225666/218407844-02f0eb7e-0c78-4822-9856-51468ddb64b9.png">

### Why `start/end` rather than `left/right`?

`start/end` indicates whether the icon is placed _before_/_after_ the text, which is not bound to be left/right if taking RTL situations into account.