### PR TITLE
fix(Button): fix Button content not center-aligned

### DIFF
--- a/src/Button/styles/index.less
+++ b/src/Button/styles/index.less
@@ -10,6 +10,7 @@
 .rs-btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   margin-bottom: 0; // For input.btn
   font-weight: @btn-font-weight;
   text-align: center;


### PR DESCRIPTION
Button content alignment was broken since `display` is updated to `inline-flex` in #3067. This affects Buttons with explicitly specified width. 

A repro can be found in Sidenav example on docs site https://rsuitejs.com/components/sidenav/#appearance

![企业微信截图_40a92946-1758-4601-ac74-304d617283db](https://user-images.githubusercontent.com/8225666/221749266-c928866b-7bb7-463d-ba48-f95664d86d96.png)
