### PR TITLE
build(deps): bump schema-typed from 2.0.3 to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "prop-types": "^15.8.1",
         "react-window": "^1.8.8",
         "rsuite-table": "^5.9.0",
-        "schema-typed": "^2.0.3"
+        "schema-typed": "^2.1.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.7.0",
@@ -17940,12 +17940,9 @@
       }
     },
     "node_modules/schema-typed": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.0.3.tgz",
-      "integrity": "sha512-4KckVnJjTtVugYpSAoQrcH4quE4yIVTvI/nHEqtwdceBr/ZCuH2LfV8/gaZFrYU7cwwyufLKaswt28aqQ1T9ww==",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.1.0.tgz",
+      "integrity": "sha512-qKe33FDv1fckflGD97BrTjU9s2mvclTHM+f720DTOGhiloUMP5QfzuQi/U92KfahWZQUCsEJHmyzXVATTU3oVA=="
     },
     "node_modules/schema-utils": {
       "version": "2.7.1",
@@ -35624,12 +35621,9 @@
       }
     },
     "schema-typed": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.0.3.tgz",
-      "integrity": "sha512-4KckVnJjTtVugYpSAoQrcH4quE4yIVTvI/nHEqtwdceBr/ZCuH2LfV8/gaZFrYU7cwwyufLKaswt28aqQ1T9ww==",
-      "requires": {
-        "@babel/runtime": "^7.16.0"
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.1.0.tgz",
+      "integrity": "sha512-qKe33FDv1fckflGD97BrTjU9s2mvclTHM+f720DTOGhiloUMP5QfzuQi/U92KfahWZQUCsEJHmyzXVATTU3oVA=="
     },
     "schema-utils": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "prop-types": "^15.8.1",
     "react-window": "^1.8.8",
     "rsuite-table": "^5.9.0",
-    "schema-typed": "^2.0.3"
+    "schema-typed": "^2.1.0"
   },
   "peerDependencies": {
     "react": ">=16.8.0",


### PR DESCRIPTION
# [2.1.0](https://github.com/rsuite/schema-typed/compare/2.0.4...2.1.0) (2023-03-02)


### Features

* addAsyncRule to allow sync and async rules to run ([#63](https://github.com/rsuite/schema-typed/issues/63)) ([574f9ad](https://github.com/rsuite/schema-typed/commit/574f9ad973af97b8c1bae44c3fcfa3dad608c4d6))



## [2.0.4](https://github.com/rsuite/schema-typed/compare/2.0.3...2.0.4) (2023-03-01)


### Bug Fixes

* promises where not allowed by type ([#61](https://github.com/rsuite/schema-typed/issues/61)) ([9cc665c](https://github.com/rsuite/schema-typed/commit/9cc665c4f72b5a22942d351c961263c179888a7a))

