### PR TITLE
feat(common): add autoComplete for FormControlBaseProps

### DIFF
--- a/src/AutoComplete/AutoComplete.tsx
+++ b/src/AutoComplete/AutoComplete.tsx
@@ -61,6 +61,9 @@ export interface AutoCompleteProps<T = ValueType>
   /** The width of the menu will automatically follow the width of the input box */
   menuAutoWidth?: boolean;
 
+  /** AutoComplete Content */
+  autoComplete?: string;
+
   /** Custom filter function to determine whether the item will be displayed */
   filterBy?: (value: string, item: ItemDataType) => boolean;
 

--- a/src/AutoComplete/test/AutoCompleteSpec.tsx
+++ b/src/AutoComplete/test/AutoCompleteSpec.tsx
@@ -262,6 +262,13 @@ describe('AutoComplete', () => {
     expect((listbox.parentNode as HTMLElement).style.minWidth).to.equal('100px');
   });
 
+  it('Should be autoComplete', () => {
+    const { getByTestId } = render(
+      <AutoComplete data={data} autoComplete="on" style={{ width: 100 }} data-testid="test" />
+    );
+    expect(getByTestId('test').querySelector('input')).to.have.attribute('autocomplete', 'on');
+  });
+
   it('Should not throw an error', () => {
     const callback = sinon.spy();
     expect(() => {


### PR DESCRIPTION
Can I add `autoComplete` to FormControlBaseProps?
I have noticed that many components use FormControlBaseProps, but I think this will not affect, coz all are `Input`

Link #3105 