### PR TITLE
build(deps): bump rsuite-table from 5.9.0 to 5.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "lodash": "^4.17.11",
         "prop-types": "^15.8.1",
         "react-window": "^1.8.8",
-        "rsuite-table": "^5.9.0",
+        "rsuite-table": "^5.10.0",
         "schema-typed": "^2.1.0"
       },
       "devDependencies": {
@@ -17815,9 +17815,9 @@
       }
     },
     "node_modules/rsuite-table": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.9.0.tgz",
-      "integrity": "sha512-1zA7o9e2vEFbz1Z/2Ud5bGK73ixHE/A2BYA/WYxODc+QyzxiOxJvve1vw70Q7V7iDl7paQ0aIutUhOHKw1KcKw==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.10.0.tgz",
+      "integrity": "sha512-fdU63wbFrSLNCshNRSKhEO7aCwBFzCQjRc+5FhGWMwsn/ToS9jLV5jEO/IZrmAWC1m2JTglCjzh3x6HRVGHvMg==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",
@@ -35500,9 +35500,9 @@
       }
     },
     "rsuite-table": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.9.0.tgz",
-      "integrity": "sha512-1zA7o9e2vEFbz1Z/2Ud5bGK73ixHE/A2BYA/WYxODc+QyzxiOxJvve1vw70Q7V7iDl7paQ0aIutUhOHKw1KcKw==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.10.0.tgz",
+      "integrity": "sha512-fdU63wbFrSLNCshNRSKhEO7aCwBFzCQjRc+5FhGWMwsn/ToS9jLV5jEO/IZrmAWC1m2JTglCjzh3x6HRVGHvMg==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "lodash": "^4.17.11",
         "prop-types": "^15.8.1",
         "react-window": "^1.8.8",
-        "rsuite-table": "^5.10.0",
+        "rsuite-table": "^5.10.1",
         "schema-typed": "^2.1.0"
       },
       "devDependencies": {
@@ -17815,9 +17815,9 @@
       }
     },
     "node_modules/rsuite-table": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.10.0.tgz",
-      "integrity": "sha512-fdU63wbFrSLNCshNRSKhEO7aCwBFzCQjRc+5FhGWMwsn/ToS9jLV5jEO/IZrmAWC1m2JTglCjzh3x6HRVGHvMg==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.10.1.tgz",
+      "integrity": "sha512-95vB4mPhxPKkq+EfYgQFVJ3BWDbRIVUs59hMwnYXZhiLKY1fY/cJd+ETeB725Qqcj7/AN3tDySo+CIKWLp1FAA==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",
@@ -35500,9 +35500,9 @@
       }
     },
     "rsuite-table": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.10.0.tgz",
-      "integrity": "sha512-fdU63wbFrSLNCshNRSKhEO7aCwBFzCQjRc+5FhGWMwsn/ToS9jLV5jEO/IZrmAWC1m2JTglCjzh3x6HRVGHvMg==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.10.1.tgz",
+      "integrity": "sha512-95vB4mPhxPKkq+EfYgQFVJ3BWDbRIVUs59hMwnYXZhiLKY1fY/cJd+ETeB725Qqcj7/AN3tDySo+CIKWLp1FAA==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lodash": "^4.17.11",
     "prop-types": "^15.8.1",
     "react-window": "^1.8.8",
-    "rsuite-table": "^5.10.0",
+    "rsuite-table": "^5.10.1",
     "schema-typed": "^2.1.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lodash": "^4.17.11",
     "prop-types": "^15.8.1",
     "react-window": "^1.8.8",
-    "rsuite-table": "^5.9.0",
+    "rsuite-table": "^5.10.0",
     "schema-typed": "^2.1.0"
   },
   "peerDependencies": {

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -8,12 +8,12 @@ import {
   TableProps,
   RowDataType,
   TableInstance,
-  CellProps as RsuiteCellProps
+  CellProps as TableCellProps
 } from 'rsuite-table';
 
 import { useCustom } from '../utils';
 
-export interface CellProps<T = any> extends Omit<RsuiteCellProps, 'rowData' | 'dataKey'> {
+export interface CellProps<T = any> extends Omit<TableCellProps, 'rowData' | 'dataKey'> {
   /** Data binding key, but also a sort of key */
   dataKey?: string | keyof T;
 

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -1,44 +1,38 @@
 import React from 'react';
-import { Table as RsTable, Column, Cell, HeaderCell, ColumnGroup, TableProps } from 'rsuite-table';
-import { StandardProps, RsRefForwardingComponent } from '../@types/common';
+import {
+  Table,
+  Column,
+  Cell,
+  HeaderCell,
+  ColumnGroup,
+  TableProps,
+  RowDataType,
+  TableInstance,
+  CellProps as RsuiteCellProps
+} from 'rsuite-table';
+
 import { useCustom } from '../utils';
 
-export interface TableInstance extends React.Component<TableProps> {
-  scrollTop: (top: number) => void;
-  scrollLeft: (left: number) => void;
-}
-
-export interface CellProps<T = any> extends StandardProps {
+export interface CellProps<T = any> extends Omit<RsuiteCellProps, 'rowData' | 'dataKey'> {
   /** Data binding key, but also a sort of key */
   dataKey?: string | keyof T;
-
-  /** Row Number */
-  rowIndex?: number;
 
   /** Row Data */
   rowData?: T;
 }
 
-interface TableComponent
-  extends RsRefForwardingComponent<'div', TableProps & { ref?: React.Ref<TableInstance> }> {
-  Column: typeof Column;
-  Cell: typeof Cell;
-  HeaderCell: typeof HeaderCell;
-  ColumnGroup: typeof ColumnGroup;
-}
-
-const Table: TableComponent = React.forwardRef<any, TableProps>((props, ref) => {
+const CustomTable = React.forwardRef((props, ref) => {
   const { locale: localeProp, loadAnimation = true, ...rest } = props;
   const { locale, rtl } = useCustom('Table', localeProp);
 
-  return <RsTable {...rest} rtl={rtl} ref={ref} locale={locale} loadAnimation={loadAnimation} />;
-}) as unknown as TableComponent;
+  return <Table {...rest} rtl={rtl} ref={ref} locale={locale} loadAnimation={loadAnimation} />;
+}) as <Row extends RowDataType, Key>(
+  props: TableProps<Row, Key> & React.RefAttributes<TableInstance<Row, Key>>
+) => React.ReactElement;
 
-Table.Cell = Cell;
-Table.Column = Column;
-Table.HeaderCell = HeaderCell;
-Table.ColumnGroup = ColumnGroup;
-
-Table.displayName = 'Table';
-
-export default Table;
+export default Object.assign(CustomTable, {
+  Cell,
+  Column,
+  HeaderCell,
+  ColumnGroup
+});

--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -1,5 +1,16 @@
 import Table from './Table';
-export type { TableProps, ColumnProps, ColumnGroupProps, TableLocaleType } from 'rsuite-table';
-export type { TableInstance, CellProps } from './Table';
+export type {
+  TableProps,
+  ColumnProps,
+  ColumnGroupProps,
+  HeaderCellProps,
+  CellProps,
+  SortType,
+  RowDataType,
+  RowKeyType,
+  TableLocaleType,
+  TableSizeChangeEventName,
+  TableInstance
+} from 'rsuite-table';
 
 export default Table;

--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -4,7 +4,6 @@ export type {
   ColumnProps,
   ColumnGroupProps,
   HeaderCellProps,
-  CellProps,
   SortType,
   RowDataType,
   RowKeyType,
@@ -12,5 +11,7 @@ export type {
   TableSizeChangeEventName,
   TableInstance
 } from 'rsuite-table';
+
+export type { CellProps } from './Table';
 
 export default Table;

--- a/src/Table/test/Table.test.tsx
+++ b/src/Table/test/Table.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { expectType } from 'ts-expect';
+import Table, { TableInstance } from '../';
+
+type Row = {
+  id: number;
+  name: string;
+};
+
+const data: Row[] = [
+  {
+    id: 1,
+    name: 'First'
+  },
+  {
+    id: 2,
+    name: 'Second'
+  }
+];
+
+const ref = React.createRef<TableInstance<Row, string>>();
+
+<Table
+  ref={ref}
+  data={data}
+  onRowClick={row => {
+    expectType<Row>(row);
+  }}
+>
+  <Table.Column width={100}>
+    <Table.HeaderCell>Name</Table.HeaderCell>
+    <Table.Cell dataKey="name" />
+  </Table.Column>
+</Table>;
+
+// It should be possible to call instance methods via ref
+
+ref.current?.body;
+ref.current?.root;
+ref.current?.scrollLeft(100);
+ref.current?.scrollTop(100);


### PR DESCRIPTION
## [5.10.1](https://github.com/rsuite/rsuite-table/compare/5.10.0...5.10.1) (2023-03-16)


### Bug Fixes

* **Table:** fix missing `ref` in type definition ([#411](https://github.com/rsuite/rsuite-table/issues/411)) ([28338ee](https://github.com/rsuite/rsuite-table/commit/28338ee30ad3a75d0c95fc216aab67116c5bd9c6))



# [5.10.0](https://github.com/rsuite/rsuite-table/compare/5.9.0...5.10.0) (2023-03-16)


### Bug Fixes

* **Table:** fix column misalignment after data update ([#409](https://github.com/rsuite/rsuite-table/issues/409)) ([e3bdb00](https://github.com/rsuite/rsuite-table/commit/e3bdb00a8a237139c5eb955c4acc13fc1a72a4f6))


### Features

* **Table:** support generic props ([#410](https://github.com/rsuite/rsuite-table/issues/410)) ([d774c74](https://github.com/rsuite/rsuite-table/commit/d774c74d7b40d29693f0086a3fe592ada51a4b4c))

