### PR TITLE
fix(Form.Control): fix not able to override checked prop

### DIFF
--- a/src/FormControl/FormControl.tsx
+++ b/src/FormControl/FormControl.tsx
@@ -208,8 +208,8 @@ const FormControl: FormControlComponent = React.forwardRef((props: FormControlPr
         aria-describedby={ariaDescribedby}
         aria-invalid={fieldHasError || undefined}
         aria-errormessage={ariaErrormessage}
-        {...rest}
         {...accepterProps}
+        {...rest}
         readOnly={readOnly}
         plaintext={plaintext}
         disabled={disabled}

--- a/src/FormControl/test/FormControlSpec.tsx
+++ b/src/FormControl/test/FormControlSpec.tsx
@@ -381,17 +381,33 @@ describe('FormControl', () => {
     });
   });
 
-  it('Should be to initialize the state of Toggle through the form value', () => {
-    const formValue = {
-      toggle: true
-    };
+  describe('Use `checked` instead of `value` with Toggle', () => {
+    it('Should be to initialize the state of Toggle through the form value', () => {
+      const formValue = {
+        toggle: true
+      };
 
-    render(
-      <Form formValue={formValue}>
-        <FormControl name="toggle" accepter={Toggle} />
-      </Form>
-    );
+      render(
+        <Form formValue={formValue}>
+          <FormControl name="toggle" accepter={Toggle} />
+        </Form>
+      );
 
-    expect(screen.getByRole('switch')).to.be.checked;
+      expect(screen.getByRole('switch')).to.be.checked;
+    });
+
+    it('Should be possible to override `checked` value', () => {
+      const formValue = {
+        toggle: true
+      };
+
+      render(
+        <Form formValue={formValue}>
+          <FormControl name="toggle" accepter={Toggle} checked={false} />
+        </Form>
+      );
+
+      expect(screen.getByRole('switch')).not.to.be.checked;
+    });
   });
 });


### PR DESCRIPTION
Overriding `checked` prop of Toggle as a Form.Control accepter was broken since #3048

```jsx
<Form.Control
  name="…"
  accepter={Toggle}
  checked={myValue} // not working
/>
```

See https://github.com/rsuite/rsuite/pull/3048#issuecomment-1469181356