### PR TITLE
build(deps): bump schema-typed from 2.1.0 to 2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "prop-types": "^15.8.1",
         "react-window": "^1.8.8",
         "rsuite-table": "^5.9.0",
-        "schema-typed": "^2.1.0"
+        "schema-typed": "^2.1.2"
       },
       "devDependencies": {
         "@babel/cli": "^7.7.0",
@@ -17943,9 +17943,9 @@
       }
     },
     "node_modules/schema-typed": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.1.0.tgz",
-      "integrity": "sha512-qKe33FDv1fckflGD97BrTjU9s2mvclTHM+f720DTOGhiloUMP5QfzuQi/U92KfahWZQUCsEJHmyzXVATTU3oVA=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.1.2.tgz",
+      "integrity": "sha512-5BCduF1qt9ch2kEqc3/4Jj0mZfUzh+E8iIto5AViOwgReCho2yiT1LlQJ/5KQ1MTkthD8EDokLA/BlhbYow7Bw=="
     },
     "node_modules/schema-utils": {
       "version": "2.7.1",
@@ -35601,9 +35601,9 @@
       }
     },
     "schema-typed": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.1.0.tgz",
-      "integrity": "sha512-qKe33FDv1fckflGD97BrTjU9s2mvclTHM+f720DTOGhiloUMP5QfzuQi/U92KfahWZQUCsEJHmyzXVATTU3oVA=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.1.2.tgz",
+      "integrity": "sha512-5BCduF1qt9ch2kEqc3/4Jj0mZfUzh+E8iIto5AViOwgReCho2yiT1LlQJ/5KQ1MTkthD8EDokLA/BlhbYow7Bw=="
     },
     "schema-utils": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "prop-types": "^15.8.1",
     "react-window": "^1.8.8",
     "rsuite-table": "^5.9.0",
-    "schema-typed": "^2.1.0"
+    "schema-typed": "^2.1.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0",


### PR DESCRIPTION
## [2.1.2](https://github.com/rsuite/schema-typed/compare/2.1.1...2.1.2) (2023-03-10)


### Bug Fixes

* **build:** fix unpublished source code ([#67](https://github.com/rsuite/schema-typed/issues/67)) ([c21ae0a](https://github.com/rsuite/schema-typed/commit/c21ae0a94578907e3fdd0467e5d1a1e3ec7c4d85))



## [2.1.1](https://github.com/rsuite/schema-typed/compare/2.1.0...2.1.1) (2023-03-08)

- chore: change the compilation target of TypeScript from esnext to es2019