### PR TITLE
fix(Affix): fix misalignment due to DOM content updates

### DIFF
--- a/src/Affix/test/AffixSpec.tsx
+++ b/src/Affix/test/AffixSpec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, act } from '@testing-library/react';
 import sinon from 'sinon';
 import getOffset from 'dom-lib/getOffset';
 
@@ -31,8 +31,10 @@ describe('Affix', () => {
 
     const top = getOffset(buttonRef.current)?.top;
 
-    window.scrollTo({ top });
-    window.dispatchEvent(new UIEvent('scroll'));
+    act(() => {
+      window.scrollTo({ top });
+      window.dispatchEvent(new UIEvent('scroll'));
+    });
 
     expect(onChangeSpy).to.have.been.called;
 
@@ -73,8 +75,10 @@ describe('Affix', () => {
 
     const top = getOffset(buttonRef.current)?.top;
 
-    window.scrollTo({ top });
-    window.dispatchEvent(new UIEvent('scroll'));
+    act(() => {
+      window.scrollTo({ top });
+      window.dispatchEvent(new UIEvent('scroll'));
+    });
 
     await waitFor(() => {
       expect(onOffsetChangeSpy).to.have.been.called;

--- a/src/Affix/test/AffixSpec.tsx
+++ b/src/Affix/test/AffixSpec.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
-import { act } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
-import { getDOMNode } from '@test/testUtils';
 import getOffset from 'dom-lib/getOffset';
+
 import Affix from '../Affix';
 
 describe('Affix', () => {
   it('Should render a button', () => {
-    const instance = getDOMNode(
+    render(
       <Affix>
         <button>button</button>
       </Affix>
     );
 
-    expect(instance.children[0].children[0].tagName).to.equal('BUTTON');
+    expect(screen.getByRole('button')).to.exist;
   });
 
   it('Should call onChange callback', () => {
@@ -22,7 +22,7 @@ describe('Affix', () => {
 
     const onChangeSpy = sinon.spy();
 
-    getDOMNode(
+    render(
       <div style={{ height: 3000 }}>
         <div style={{ height: 100 }}>--</div>
         <Affix top={10} ref={affixRef} onChange={onChangeSpy}>
@@ -33,23 +33,53 @@ describe('Affix', () => {
 
     const top = getOffset(buttonRef.current)?.top;
 
-    act(() => {
-      window.scrollTo({ top });
-      window.dispatchEvent(new UIEvent('scroll'));
-    });
+    window.scrollTo({ top });
+    window.dispatchEvent(new UIEvent('scroll'));
 
     expect(onChangeSpy).to.have.been.called;
 
-    const affixDOM = getDOMNode(affixRef.current);
+    const affixDOM = affixRef.current as HTMLElement;
 
     expect(affixDOM.children[0].className).to.contain('rs-affix');
     expect((affixDOM.children[0] as HTMLElement).style.position).to.equal('fixed');
   });
 
   it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Affix style={{ fontSize }} />);
+    render(<Affix data-testid="affix" style={{ fontSize: 12 }} />);
 
-    expect(instance.style.fontSize).to.equal(fontSize);
+    expect(screen.getByTestId('affix')).to.have.style('font-size', '12px');
+  });
+
+  it('Should call onOffsetChange callback', async () => {
+    const buttonRef = React.createRef<HTMLButtonElement>();
+    const onOffsetChangeSpy = sinon.spy();
+
+    const App = () => {
+      const [height, setHeight] = React.useState(100);
+
+      return (
+        <div style={{ height: 3000 }}>
+          <div style={{ height }}>--</div>
+          <Affix top={10} onOffsetChange={onOffsetChangeSpy}>
+            <button ref={buttonRef} onClick={() => setHeight(200)}>
+              button
+            </button>
+          </Affix>
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.click(buttonRef.current as HTMLButtonElement);
+
+    const top = getOffset(buttonRef.current)?.top;
+
+    window.scrollTo({ top });
+    window.dispatchEvent(new UIEvent('scroll'));
+
+    await waitFor(() => {
+      expect(onOffsetChangeSpy).to.have.been.called;
+    });
   });
 });

--- a/src/Affix/test/AffixSpec.tsx
+++ b/src/Affix/test/AffixSpec.tsx
@@ -18,14 +18,12 @@ describe('Affix', () => {
 
   it('Should call onChange callback', () => {
     const buttonRef = React.createRef<HTMLButtonElement>();
-    const affixRef = React.createRef<HTMLDivElement>();
-
     const onChangeSpy = sinon.spy();
 
     render(
       <div style={{ height: 3000 }}>
         <div style={{ height: 100 }}>--</div>
-        <Affix top={10} ref={affixRef} onChange={onChangeSpy}>
+        <Affix top={10} data-testid="affix" onChange={onChangeSpy}>
           <button ref={buttonRef}>button</button>
         </Affix>
       </div>
@@ -38,10 +36,10 @@ describe('Affix', () => {
 
     expect(onChangeSpy).to.have.been.called;
 
-    const affixDOM = affixRef.current as HTMLElement;
+    const affix = screen.getByTestId('affix').firstChild as HTMLDivElement;
 
-    expect(affixDOM.children[0].className).to.contain('rs-affix');
-    expect((affixDOM.children[0] as HTMLElement).style.position).to.equal('fixed');
+    expect(affix.className).to.contain('rs-affix');
+    expect(affix.style.position).to.equal('fixed');
   });
 
   it('Should have a custom style', () => {


### PR DESCRIPTION
Since the ad slot is dynamically inserted, the position of the button changes. The top value of the button is not recalculated after the position change, resulting in the following bug.

https://user-images.githubusercontent.com/1203827/225947257-17aaf228-fede-43ce-8594-ef4db5e01269.mp4

