### PR TITLE
fix(Picker): fix async container update cause offset error

### DIFF
--- a/src/Overlay/Modal.tsx
+++ b/src/Overlay/Modal.tsx
@@ -2,7 +2,6 @@ import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react'
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import contains from 'dom-lib/contains';
-import getContainer from 'dom-lib/getContainer';
 import on from 'dom-lib/on';
 import ModalManager, { ModalInstance } from './ModalManager';
 import Fade from '../Animation/Fade';
@@ -138,7 +137,7 @@ const Modal: RsRefForwardingComponent<'div', BaseModalProps> = React.forwardRef<
   } = props;
 
   const [exited, setExited] = useState(!open);
-  const { Portal } = usePortal({ container });
+  const { Portal, target: containerElement } = usePortal({ container });
   const modal = useModalManager();
 
   if (open) {
@@ -192,11 +191,9 @@ const Modal: RsRefForwardingComponent<'div', BaseModalProps> = React.forwardRef<
   const documentFocusListener = useRef<{ off: () => void } | null>();
 
   const handleOpen = useEventCallback(() => {
-    const containerElement = getContainer(
-      container as Element | (() => Element),
-      document.body
-    ) as HTMLElement;
-    modal.add(containerElement, containerClassName);
+    if (containerElement) {
+      modal.add(containerElement, containerClassName);
+    }
 
     if (!documentKeyDownListener.current) {
       documentKeyDownListener.current = on(document, 'keydown', handleDocumentKeyDown);

--- a/src/Overlay/OverlayTrigger.tsx
+++ b/src/Overlay/OverlayTrigger.tsx
@@ -202,7 +202,7 @@ const OverlayTrigger = React.forwardRef(
       ...rest
     } = props;
 
-    const { Portal } = usePortal({ container });
+    const { Portal, target: containerElement } = usePortal({ container });
     const triggerRef = useRef();
     const overlayRef = useRef<PositionInstance>();
     const [open, setOpen] = useControlled(openProp, defaultOpen);
@@ -470,7 +470,7 @@ const OverlayTrigger = React.forwardRef(
             : undefined,
         onExited: createChainedFunction(followCursor ? handleExited : undefined, onExited),
         placement,
-        container,
+        container: containerElement,
         open
       };
 

--- a/src/Overlay/test/OverlayTriggerSpec.tsx
+++ b/src/Overlay/test/OverlayTriggerSpec.tsx
@@ -288,4 +288,40 @@ describe('OverlayTrigger', () => {
       expect(screen.queryByRole('tooltip')).to.not.exist;
     });
   });
+
+  it('Should open in new container', () => {
+    const newContainer = document.createElement('div');
+
+    newContainer.style.position = 'relative';
+    newContainer.style.marginTop = '100px';
+    newContainer.style.marginLeft = '100px';
+
+    document.body.appendChild(newContainer);
+
+    const { rerender } = render(
+      <OverlayTrigger
+        speaker={<Tooltip>tooltip</Tooltip>}
+        defaultOpen
+        container={() => document.body}
+      >
+        <button>button</button>
+      </OverlayTrigger>
+    );
+
+    expect(newContainer.compareDocumentPosition(screen.getByRole('tooltip'))).to.equal(4);
+
+    rerender(
+      <OverlayTrigger
+        speaker={<Tooltip>tooltip</Tooltip>}
+        defaultOpen
+        container={() => newContainer}
+      >
+        <button>button</button>
+      </OverlayTrigger>
+    );
+
+    expect(newContainer.compareDocumentPosition(screen.getByRole('tooltip'))).to.equal(20);
+
+    document.body.removeChild(newContainer);
+  });
 });

--- a/src/Overlay/test/OverlayTriggerSpec.tsx
+++ b/src/Overlay/test/OverlayTriggerSpec.tsx
@@ -298,27 +298,17 @@ describe('OverlayTrigger', () => {
 
     document.body.appendChild(newContainer);
 
-    const { rerender } = render(
-      <OverlayTrigger
-        speaker={<Tooltip>tooltip</Tooltip>}
-        defaultOpen
-        container={() => document.body}
-      >
+    const App = ({ container }) => (
+      <OverlayTrigger speaker={<Tooltip>tooltip</Tooltip>} defaultOpen container={container}>
         <button>button</button>
       </OverlayTrigger>
     );
+
+    const { rerender } = render(<App container={() => document.body} />);
 
     expect(newContainer.compareDocumentPosition(screen.getByRole('tooltip'))).to.equal(4);
 
-    rerender(
-      <OverlayTrigger
-        speaker={<Tooltip>tooltip</Tooltip>}
-        defaultOpen
-        container={() => newContainer}
-      >
-        <button>button</button>
-      </OverlayTrigger>
-    );
+    rerender(<App container={() => newContainer} />);
 
     expect(newContainer.compareDocumentPosition(screen.getByRole('tooltip'))).to.equal(20);
 

--- a/src/utils/usePortal.tsx
+++ b/src/utils/usePortal.tsx
@@ -26,17 +26,16 @@ function usePortal(props: PortalProps = {}) {
   const { container, waitMount = false } = props;
   const rootElemRef = useRef<HTMLElement | null>(canUseDOM ? document.body : null);
 
+  const containerElement = typeof container === 'function' ? container() : container;
   /**
    * useMemo can be updated before the Portal is called.
    */
   useMemo(() => {
-    const containerElement = typeof container === 'function' ? container() : container;
-
     // Parent is either a new root or the existing dom element
     const parentElement = containerElement || document.body;
 
     rootElemRef.current = parentElement as HTMLElement;
-  }, [rootElemRef, container]);
+  }, [rootElemRef, containerElement]);
 
   const Portal = useCallback(({ children }: { children: React.ReactNode }) => {
     return rootElemRef.current != null ? createPortal(children, rootElemRef.current) : null;

--- a/src/utils/usePortal.tsx
+++ b/src/utils/usePortal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState, useCallback } from 'react';
+import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import canUseDOM from 'dom-lib/canUseDOM';
 
@@ -26,7 +26,10 @@ function usePortal(props: PortalProps = {}) {
   const { container, waitMount = false } = props;
   const rootElemRef = useRef<HTMLElement | null>(canUseDOM ? document.body : null);
 
-  useEffect(() => {
+  /**
+   * useMemo can be updated before the Portal is called.
+   */
+  useMemo(() => {
     const containerElement = typeof container === 'function' ? container() : container;
 
     // Parent is either a new root or the existing dom element

--- a/src/utils/usePortal.tsx
+++ b/src/utils/usePortal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import canUseDOM from 'dom-lib/canUseDOM';
 
@@ -24,30 +24,26 @@ const MountedPortal = React.memo(
 
 function usePortal(props: PortalProps = {}) {
   const { container, waitMount = false } = props;
-  const rootElemRef = useRef<HTMLElement | null>(canUseDOM ? document.body : null);
-
   const containerElement = typeof container === 'function' ? container() : container;
-  /**
-   * useMemo can be updated before the Portal is called.
-   */
-  useMemo(() => {
-    // Parent is either a new root or the existing dom element
-    const parentElement = containerElement || document.body;
+  const rootElement = useMemo(
+    () => (canUseDOM ? containerElement || document.body : null),
+    [containerElement]
+  );
 
-    rootElemRef.current = parentElement as HTMLElement;
-  }, [rootElemRef, containerElement]);
-
-  const Portal = useCallback(({ children }: { children: React.ReactNode }) => {
-    return rootElemRef.current != null ? createPortal(children, rootElemRef.current) : null;
-  }, []);
+  const Portal = useCallback(
+    ({ children }: { children: React.ReactNode }) => {
+      return rootElement != null ? createPortal(children, rootElement) : null;
+    },
+    [rootElement]
+  );
 
   const WaitMountPortal = useCallback(
-    props => <MountedPortal container={rootElemRef.current} {...props} />,
-    []
+    props => <MountedPortal container={rootElement} {...props} />,
+    [rootElement]
   );
 
   return {
-    target: rootElemRef.current,
+    target: rootElement,
     Portal: waitMount ? WaitMountPortal : Portal
   };
 }


### PR DESCRIPTION
## CHANGES
- Picker: use `useMemo` to update container before Portal recreate

## ISSUES
#3125 