### PR TITLE
fix(docs): fix syntax error in date range picker docs

### DIFF
--- a/docs/pages/components/date-range-picker/en-US/index.md
+++ b/docs/pages/components/date-range-picker/en-US/index.md
@@ -197,7 +197,7 @@ Learn more in [Accessibility](/guide/accessibility).
 | placeholder          | string                                                                           | Setting placeholders                                                                             |
 | placement            | [Placement](#code-ts-placement-code) `('bottomStart')`                           | The placement of component                                                                       |
 | preventOverflow      | boolean                                                                          | Prevent floating element overflow                                                                |
-| ranges               | [Range[]](#code-ts-range-code) ([Ranges](#code-ts-ranges-code))                  | Set predefined date ranges the user can select from. Defeult: `Today`,`Yesterday`，`Last 7 days` |
+| ranges               | [Range[]](#code-ts-range-code) ([Ranges](#code-ts-ranges-code))                  | Set predefined date ranges the user can select from. Default: `Today`,`Yesterday`，`Last 7 days` |
 | renderTitle          | (date: Date) => ReactNode                                                        | Custom render for month's title                                                                  |
 | renderValue          | (value: [ValueType](#code-ts-value-type-code), format: string) => ReactNode      | Custom render selected date range                                                                |
 | showMeridian         | boolean                                                                          | Display hours in 12 format                                                                       |


### PR DESCRIPTION
Hi there! I've just fixed the syntax error, please check it out