### PR TITLE
fix(toaster): fix style when message at the left

### DIFF
--- a/src/toaster/styles/index.less
+++ b/src/toaster/styles/index.less
@@ -63,7 +63,6 @@
     left: @toast-spacing;
 
     .rs-toast-fade-entered {
-      margin-left: auto;
       animation-name: notificationMoveInLeft;
     }
   }


### PR DESCRIPTION
Before:
![message before](https://user-images.githubusercontent.com/50652358/228755152-c7cb7156-6fcb-4adc-8dac-2bb5e6e70733.png)

After:
![message after](https://user-images.githubusercontent.com/50652358/228755202-1d6c0f5e-7b24-47f0-bd6d-4e8188448204.png)
