### PR TITLE
build(website): replace nextjs rewrites with redirects

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -188,11 +188,12 @@ module.exports = {
     pagesBufferLength: 3 // default 2
   },
   pageExtensions: ['tsx'],
-  rewrites() {
+  redirects() {
     return [
       {
         source: '/design/:theme(default|dark)',
-        destination: '/design/:theme/index.html'
+        destination: '/design/:theme/index.html',
+        permanent: true
       }
     ];
   }


### PR DESCRIPTION
Resolve 404 issue on `/design/:theme` paths

https://rsuite-nextjs-git-build-docs-nextjs-redirects-rsuite.vercel.app/design/default
https://rsuite-nextjs-git-build-docs-nextjs-redirects-rsuite.vercel.app/design/dark