### PR TITLE
feat(Calendar): add support for `onMonthChange` on `<Calendar>`

### DIFF
--- a/src/Calendar/Calendar.tsx
+++ b/src/Calendar/Calendar.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
+import isSameMonth from 'date-fns/isSameMonth';
 import Calendar from './CalendarContainer';
 import { CalendarLocale } from '../locales';
 import Button from '../Button';
@@ -30,6 +31,9 @@ export interface CalendarProps extends WithAsProps {
   /**  Callback fired before the value changed  */
   onChange?: (date: Date) => void;
 
+  /** Callback fired before the month changed */
+  onMonthChange?: (date: Date) => void;
+
   /** Callback fired before the date selected */
   onSelect?: (date: Date) => void;
 
@@ -49,6 +53,7 @@ const CalendarPanel: RsRefForwardingComponent<typeof Calendar, CalendarProps> = 
       isoWeek,
       locale: overrideLocale,
       onChange,
+      onMonthChange,
       onSelect,
       renderCell,
       value,
@@ -76,6 +81,17 @@ const CalendarPanel: RsRefForwardingComponent<typeof Calendar, CalendarProps> = 
         handleChange(nextValue);
       },
       [handleChange, onSelect]
+    );
+
+    // Trigger onMonthChange when the month changes
+    const handleMonthChange = useCallback(
+      (nextValue: Date) => {
+        if (!isSameMonth(nextValue, calendarDate)) {
+          handleChange(nextValue);
+          onMonthChange?.(nextValue);
+        }
+      },
+      [calendarDate, handleChange, onMonthChange]
     );
 
     const { prefix, merge, withClassPrefix } = useClassNames(classPrefix);
@@ -109,9 +125,9 @@ const CalendarPanel: RsRefForwardingComponent<typeof Calendar, CalendarProps> = 
         )}
         renderToolbar={renderToolbar}
         renderCell={customRenderCell}
-        onMoveForward={handleChange}
-        onMoveBackward={handleChange}
-        onChangeMonth={handleChange}
+        onMoveForward={handleMonthChange}
+        onMoveBackward={handleMonthChange}
+        onChangeMonth={handleMonthChange}
         onSelect={handleSelect}
       />
     );

--- a/src/Calendar/CalendarHeader.tsx
+++ b/src/Calendar/CalendarHeader.tsx
@@ -105,15 +105,23 @@ const CalendarHeader: RsRefForwardingComponent<'div', CalendarHeaderPrivateProps
       <div className={prefix('month-toolbar')}>
         <IconButton
           {...btnProps}
+          // TODO: aria-label should be translated by i18n
+          aria-label="Previous month"
           className={backwardClass}
           onClick={disabledBackward ? undefined : onMoveBackward}
           icon={<AngleLeftIcon />}
         />
-        <Button {...btnProps} className={dateTitleClasses} onClick={onToggleMonthDropdown}>
+        <Button
+          {...btnProps}
+          aria-label="Select month"
+          className={dateTitleClasses}
+          onClick={onToggleMonthDropdown}
+        >
           {renderTitle()}
         </Button>
         <IconButton
           {...btnProps}
+          aria-label="Next month"
           className={forwardClass}
           onClick={disabledForward ? undefined : onMoveForward}
           icon={<AngleRightIcon />}

--- a/src/Calendar/test/CalendarContainerSpec.tsx
+++ b/src/Calendar/test/CalendarContainerSpec.tsx
@@ -57,7 +57,7 @@ describe('CalendarContainer', () => {
     );
     expect(container.querySelector('.rs-calendar-btn-close')).to.be.null;
 
-    fireEvent.click(getByRole('button', { name: '2022-09' }));
+    fireEvent.click(getByRole('button', { name: 'Select month' }));
 
     expect(getByRole('button', { name: 'Collapse month view' })).to.have.class(
       'rs-calendar-btn-close'

--- a/src/Calendar/test/CalendarSpec.tsx
+++ b/src/Calendar/test/CalendarSpec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import sinon from 'sinon';
 import { parseISO } from '../../utils/dateUtils';
 import { testStandardProps } from '@test/commonCases';
@@ -93,5 +93,26 @@ describe('Calendar', () => {
     await waitFor(() => {
       expect(calendar.querySelector('.rs-calendar-header-title')).text('Jul 2021');
     });
+  });
+
+  it('Should call `onMonthChange` callback', () => {
+    const onMonthChangeSpy = sinon.spy();
+
+    render(<Calendar defaultValue={new Date('2023-01-01')} onMonthChange={onMonthChangeSpy} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next month' }));
+    expect(onMonthChangeSpy).to.have.been.calledOnce;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous month' }));
+    expect(onMonthChangeSpy).to.have.been.calledTwice;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select month' }));
+
+    fireEvent.click(
+      screen.getByRole('menu').querySelector('.rs-calendar-month-dropdown-cell-active')
+        ?.nextElementSibling as HTMLElement
+    );
+
+    expect(onMonthChangeSpy).to.have.been.calledThrice;
   });
 });

--- a/src/Calendar/test/CalendarSpec.tsx
+++ b/src/Calendar/test/CalendarSpec.tsx
@@ -115,4 +115,27 @@ describe('Calendar', () => {
 
     expect(onMonthChangeSpy).to.have.been.calledThrice;
   });
+
+  it('Should  not call `onMonthChange` callback when same month is clicked', () => {
+    const onMonthChangeSpy = sinon.spy();
+    const onToggleMonthDropdownSpy = sinon.spy();
+
+    render(
+      <Calendar
+        defaultValue={new Date('2023-01-01')}
+        onMonthChange={onMonthChangeSpy}
+        onToggleMonthDropdown={onToggleMonthDropdownSpy}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select month' }));
+    fireEvent.click(
+      screen
+        .getByRole('menu')
+        .querySelector('.rs-calendar-month-dropdown-cell-active') as HTMLElement
+    );
+
+    expect(onMonthChangeSpy).to.have.been.not.called;
+    expect(onToggleMonthDropdownSpy).to.have.been.called;
+  });
 });


### PR DESCRIPTION
When clicking on the previous month or next month or directly selecting the month, the onMonthChange event will be triggered and the Date object of the current month will be returned.

```tsx
<Calendar
  onMonthChange={(date: Date) => {
    console.log(Date);
  }}
/>;
```