### PR TITLE
fix(build): fix broken lodash currying in CDN bundles

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,9 @@ const __DEV__ = process.env.NODE_ENV === 'development';
 const filename = __DEV__ ? '[name].js' : '[name].min.js';
 
 const plugins = [
-  new LodashModuleReplacementPlugin(),
+  new LodashModuleReplacementPlugin({
+    currying: true
+  }),
   new webpack.SourceMapDevToolPlugin({
     filename: `${filename}.map`
   })


### PR DESCRIPTION
Fix #3143

`lodash-webpack-plugin` requires proper configuration if currying features are used (used in `utils/prefix.ts`.

Ref: https://github.com/lodash/lodash-webpack-plugin#feature-sets