### PR TITLE
build(deps): bump rsuite-table from 5.10.3 to 5.10.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "prop-types": "^15.8.1",
         "react-use-set": "^1.0.0",
         "react-window": "^1.8.8",
-        "rsuite-table": "^5.10.3",
+        "rsuite-table": "^5.10.4",
         "schema-typed": "^2.1.2"
       },
       "devDependencies": {
@@ -17834,9 +17834,9 @@
       }
     },
     "node_modules/rsuite-table": {
-      "version": "5.10.3",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.10.3.tgz",
-      "integrity": "sha512-GNOnjDp2vBHcPliVxC1kpAlUaXRSIbk1qtPt9FYCAU9Wq5aRAIktJPDvE0qWitzaaGUuiV2a4amZj9ui6Sd4NA==",
+      "version": "5.10.4",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.10.4.tgz",
+      "integrity": "sha512-hUJTSxKYEywjvyCg4V0xsmkbhxDhSj6lxjn9AO0FMB7rxNbjM2W/NWKMGYHcnV3Bk0z7FiPnqPrpZtnIeoXWrw==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",
@@ -35532,9 +35532,9 @@
       }
     },
     "rsuite-table": {
-      "version": "5.10.3",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.10.3.tgz",
-      "integrity": "sha512-GNOnjDp2vBHcPliVxC1kpAlUaXRSIbk1qtPt9FYCAU9Wq5aRAIktJPDvE0qWitzaaGUuiV2a4amZj9ui6Sd4NA==",
+      "version": "5.10.4",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.10.4.tgz",
+      "integrity": "sha512-hUJTSxKYEywjvyCg4V0xsmkbhxDhSj6lxjn9AO0FMB7rxNbjM2W/NWKMGYHcnV3Bk0z7FiPnqPrpZtnIeoXWrw==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "prop-types": "^15.8.1",
     "react-use-set": "^1.0.0",
     "react-window": "^1.8.8",
-    "rsuite-table": "^5.10.3",
+    "rsuite-table": "^5.10.4",
     "schema-typed": "^2.1.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
## What's Changed
* fix(ColumnGroup): fix `renderSortIcon` is not working in grouped columns by @simonguo in https://github.com/rsuite/rsuite-table/pull/426

> https://github.com/rsuite/rsuite-table/releases/tag/5.10.4