### PR TITLE
build(deps-dev): update prettier-plugin-sort-markdown-table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,7 @@
         "postcss-custom-properties": "^10.0.0",
         "postcss-less": "^6.0.0",
         "prettier": "^2.8.8",
-        "prettier-plugin-sort-markdown-table": "^1.0.2",
+        "prettier-plugin-sort-markdown-table": "^1.0.3",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-test-renderer": "^17.0.2",
@@ -17116,12 +17116,12 @@
       }
     },
     "node_modules/prettier-plugin-sort-markdown-table": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-sort-markdown-table/-/prettier-plugin-sort-markdown-table-1.0.2.tgz",
-      "integrity": "sha512-MAcnejamJM8oM7zZBW3CXurVEOWKSWLzXkyEq16kzx9bbk83PXTWif5/yB8npr0kPyRiSTa0F49cuxYDC73t8Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-sort-markdown-table/-/prettier-plugin-sort-markdown-table-1.0.3.tgz",
+      "integrity": "sha512-A8m86YWeUClKTp7yw/F6gAOtZ+tc9P/ddnJsX9noo+IIvBkon+StFfSHfVRBdMDonqU2ufSX/17mUSyjCcziuA==",
       "dev": true,
       "peerDependencies": {
-        "prettier": "2.5.1"
+        "prettier": "^2.5.1"
       }
     },
     "node_modules/pretty-format": {
@@ -35155,9 +35155,9 @@
       "dev": true
     },
     "prettier-plugin-sort-markdown-table": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-sort-markdown-table/-/prettier-plugin-sort-markdown-table-1.0.2.tgz",
-      "integrity": "sha512-MAcnejamJM8oM7zZBW3CXurVEOWKSWLzXkyEq16kzx9bbk83PXTWif5/yB8npr0kPyRiSTa0F49cuxYDC73t8Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-sort-markdown-table/-/prettier-plugin-sort-markdown-table-1.0.3.tgz",
+      "integrity": "sha512-A8m86YWeUClKTp7yw/F6gAOtZ+tc9P/ddnJsX9noo+IIvBkon+StFfSHfVRBdMDonqU2ufSX/17mUSyjCcziuA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "postcss-custom-properties": "^10.0.0",
     "postcss-less": "^6.0.0",
     "prettier": "^2.8.8",
-    "prettier-plugin-sort-markdown-table": "^1.0.2",
+    "prettier-plugin-sort-markdown-table": "^1.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-test-renderer": "^17.0.2",


### PR DESCRIPTION
Resolve peer dependency conflict with prettier 2.8.8