### PR TITLE
fix(SelectPicker): prevent error when listProps.itemSize is a number

### DIFF
--- a/src/SelectPicker/test/SelectPickerSpec.tsx
+++ b/src/SelectPicker/test/SelectPickerSpec.tsx
@@ -491,4 +491,19 @@ describe('SelectPicker', () => {
       expect(instance.list).to.exist;
     });
   });
+
+  describe('Troubleshooting', () => {
+    it('Should not throw when `listProps.itemSize` is a number', () => {
+      expect(() => {
+        render(
+          <SelectPicker
+            data={[{ label: 'Master', value: 'Master' }]}
+            virtualized
+            listProps={{ itemSize: 66 }}
+            open
+          />
+        );
+      }).to.not.throw();
+    });
+  });
 });

--- a/src/Windowing/List.tsx
+++ b/src/Windowing/List.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useImperativeHandle, useCallback } from 'react';
+import React, { useRef, useImperativeHandle, useCallback, useMemo } from 'react';
 import {
   VariableSizeList,
   Align,
@@ -56,7 +56,7 @@ export interface ListHandle extends Partial<VariableSizeList> {
 }
 
 const List: RsRefForwardingComponent<'div', ListProps> = React.forwardRef((props, ref) => {
-  const { rowHeight, as: Component = VariableSizeList, ...rest } = props;
+  const { rowHeight, as: Component = VariableSizeList, itemSize: itemSizeProp, ...rest } = props;
   const listRef = useRef<VariableSizeList>(null);
   const { rtl } = useCustom();
 
@@ -82,7 +82,13 @@ const List: RsRefForwardingComponent<'div', ListProps> = React.forwardRef((props
     [rowHeight]
   );
 
-  const compatibleProps = { ...rest } as any;
+  const itemSize = useMemo(() => {
+    if (typeof itemSizeProp === 'function') return itemSizeProp;
+
+    return () => itemSizeProp;
+  }, [itemSizeProp]);
+
+  const compatibleProps = { itemSize, ...rest } as any;
 
   if (rowHeight) {
     compatibleProps.itemSize = Component === VariableSizeList ? setRowHeight : rowHeight;

--- a/src/Windowing/test/ListSpec.tsx
+++ b/src/Windowing/test/ListSpec.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import List from '../List';
+
+describe('List', () => {
+  it('Should not throw when `itemSize` is a number', () => {
+    expect(() => {
+      render(
+        // FIXME-Doma `itemCount` and `height` props are not declared in List's props,
+        //            but they're actually required by react-window List
+        <List itemSize={66} {...{ itemCount: 1, height: 400 }}>
+          {() => null}
+        </List>
+      );
+    }).to.not.throw();
+  });
+});


### PR DESCRIPTION
SelectPicker with `virtualized={true}` throws when opening the menu, if `listProps.itemSize` is a number

<img width="787" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/c21d14e2-7ab7-4315-a408-35e3cbdc3d17">

https://codesandbox.io/s/rsuite-selectpicker-listprops-itemsize-cqk09c?file=/index.js