### PR TITLE
Feat/remove find dom node

### DIFF
--- a/src/DateRangePicker/test/CalendarSpec.tsx
+++ b/src/DateRangePicker/test/CalendarSpec.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import sinon from 'sinon';
-import { getDOMNode } from '@test/testUtils';
 import Calendar from '../Calendar';
 import { parseISO } from '../../utils/dateUtils';
+import { testStandardProps } from '@test/commonCases';
 
 describe('DateRangePicker - Calendar', () => {
+  testStandardProps(<Calendar index={0} onToggleMeridian={() => void 0} />);
   it('Should render a div with "rs-calendar" class', () => {
-    const instance = getDOMNode(
+    const { container } = render(
       <Calendar onChangeCalendarMonth={() => 1} index={0} onToggleMeridian={() => void 0} />
     );
-
-    expect(instance.nodeName).to.equal('DIV');
-    expect(instance).to.have.class('rs-calendar');
+    expect(container.firstChild).to.have.class('rs-calendar');
+    expect(container.firstChild).to.have.tagName('DIV');
   });
 
   it('Should output a date', () => {
@@ -31,7 +31,7 @@ describe('DateRangePicker - Calendar', () => {
 
   it('Should call `onChangeCalendarMonth` callback', () => {
     const onChangeCalendarMonthSpy = sinon.spy();
-    const instance = getDOMNode(
+    render(
       <Calendar
         calendarDate={[parseISO('2017-08'), parseISO('2017-09')]}
         index={0}
@@ -40,15 +40,13 @@ describe('DateRangePicker - Calendar', () => {
       />
     );
 
-    // eslint-disable-next-line testing-library/no-node-access
-    fireEvent.click(instance.querySelector('.rs-calendar-header-backward') as HTMLElement);
-
+    fireEvent.click(screen.getByRole('button', { name: 'Previous month' }));
     expect(onChangeCalendarMonthSpy).to.have.been.called;
   });
 
   it('Should call `onChangeCalendarMonth` callback', () => {
     const onChangeCalendarMonthSpy = sinon.spy();
-    const instance = getDOMNode(
+    render(
       <Calendar
         calendarDate={[parseISO('2017-08'), parseISO('2017-10')]}
         index={0}
@@ -57,14 +55,13 @@ describe('DateRangePicker - Calendar', () => {
       />
     );
     // eslint-disable-next-line testing-library/no-node-access
-    fireEvent.click(instance.querySelector('.rs-calendar-header-forward') as HTMLElement);
-
+    fireEvent.click(screen.getByRole('button', { name: 'Next month' }));
     expect(onChangeCalendarMonthSpy).to.have.been.called;
   });
 
   it('Should call `onChangeCalendarMonth` callback', () => {
     const onChangeCalendarMonthSpy = sinon.spy();
-    const instance = getDOMNode(
+    const { container } = render(
       <Calendar
         calendarDate={[parseISO('2017-08'), parseISO('2017-10')]}
         index={0}
@@ -73,19 +70,10 @@ describe('DateRangePicker - Calendar', () => {
       />
     );
 
-    // eslint-disable-next-line testing-library/no-node-access
-    fireEvent.click(instance.querySelector('.rs-calendar-header-title-date') as HTMLElement);
-    // eslint-disable-next-line testing-library/no-node-access
-    fireEvent.click(instance.querySelector('.rs-calendar-month-dropdown-cell') as HTMLElement);
+    fireEvent.click(screen.getByRole('button', { name: 'Select month' }));
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    fireEvent.click(container.querySelector('.rs-calendar-month-dropdown-cell') as HTMLElement);
 
     expect(onChangeCalendarMonthSpy).to.have.been.called;
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(
-      <Calendar classPrefix="custom-prefix" index={0} onToggleMeridian={() => void 0} />
-    );
-
-    expect(instance.className).to.contain('custom-prefix');
   });
 });

--- a/src/DateRangePicker/test/DateRangePickerSpec.tsx
+++ b/src/DateRangePicker/test/DateRangePickerSpec.tsx
@@ -1,8 +1,9 @@
-import { getDOMNode, getInstance } from '@test/testUtils';
 import React from 'react';
 import { render, act, fireEvent, waitFor, screen } from '@testing-library/react';
+import { getInstance } from '@test/testUtils';
 import sinon from 'sinon';
 import userEvent from '@testing-library/user-event';
+import { testStandardProps } from '@test/commonCases';
 import {
   addDays,
   endOfMonth,
@@ -37,28 +38,29 @@ afterEach(() => {
 });
 
 describe('DateRangePicker', () => {
+  testStandardProps(<DateRangePicker />);
   it('Should render a div with "rs-picker-daterange" class', () => {
-    const instance = getDOMNode(<DateRangePicker />);
+    const { container } = render(<DateRangePicker />);
 
-    assert.equal(instance.tagName, 'DIV');
-    assert.ok(instance.className.match(/\brs-picker-daterange\b/));
+    expect(container.firstChild).to.have.tagName('DIV');
+    expect(container.firstChild).to.have.class('rs-picker-daterange');
   });
 
   it('Should have "default" appearance by default', () => {
-    const instance = getDOMNode(<DateRangePicker />);
+    const { container } = render(<DateRangePicker />);
 
-    expect(instance).to.have.class('rs-picker-default');
+    expect(container.firstChild).to.have.class('rs-picker-default');
   });
 
   it('Should be cleanable by default', () => {
-    const instance = getDOMNode(<DateRangePicker value={[new Date(), new Date()]} />);
+    const { container } = render(<DateRangePicker value={[new Date(), new Date()]} />);
 
-    expect(instance).to.have.class('rs-picker-cleanable');
+    expect(container.firstChild).to.have.class('rs-picker-cleanable');
   });
 
   it('Should be disabled', () => {
-    const instance = getDOMNode(<DateRangePicker disabled />);
-    assert.ok(instance.className.match(/\bdisabled\b/));
+    const { container } = render(<DateRangePicker disabled />);
+    expect(container.firstChild).to.have.class('rs-picker-disabled');
   });
 
   it('Should output custom value', () => {
@@ -252,22 +254,10 @@ describe('DateRangePicker', () => {
     assert.ok(root.className.match(/\bblock\b/));
   });
 
-  it('Should have a custom className', () => {
-    const root = getInstance(<DateRangePicker className="custom" />).root;
-    assert.include(root.className, 'custom');
-  });
-
   it('Should have a menuClassName in Menu', () => {
     const menu = getInstance(<DateRangePicker menuClassName="custom" open />).overlay;
 
     assert.include(menu.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-
-    const root = getInstance(<DateRangePicker style={{ fontSize }} />).root;
-    assert.equal(root.style.fontSize, fontSize);
   });
 
   it('Should select a date range by clicking starting date and ending date', () => {
@@ -487,11 +477,6 @@ describe('DateRangePicker', () => {
     expect(onChangeSpy.callCount).to.equal(1);
     expect(isSameDay(startOfWeek(new Date()), onChangeSpy.firstCall.firstArg[0])).to.be.true;
     expect(isSameDay(endOfWeek(new Date()), onChangeSpy.firstCall.firstArg[1])).to.be.true;
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<DateRangePicker classPrefix="custom-prefix" />);
-    expect(instance.className).to.contain('custom-prefix');
   });
 
   it('Should show default calendar value', () => {

--- a/src/Divider/test/DividerSpec.tsx
+++ b/src/Divider/test/DividerSpec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getDOMNode } from '@test/testUtils';
+import { render } from '@testing-library/react';
 import { testStandardProps } from '@test/commonCases';
 import Divider from '../Divider';
 
@@ -7,23 +7,19 @@ describe('Divider', () => {
   testStandardProps(<Divider />);
 
   it('Should render a Divider', () => {
-    const instance = getDOMNode(<Divider />);
-    const classes = instance.className;
-
-    assert.include(classes, 'rs-divider');
-    assert.include(classes, 'rs-divider-horizontal');
+    const { container } = render(<Divider />);
+    expect(container.firstChild).to.have.class('rs-divider');
+    expect(container.firstChild).to.have.class('rs-divider-horizontal');
   });
 
   it('Should be vertical', () => {
-    const instance = getDOMNode(<Divider vertical />);
-    const classes = instance.className;
-    assert.include(classes, 'rs-divider-vertical');
-    assert.equal(instance.getAttribute('aria-orientation'), 'vertical');
+    const { container } = render(<Divider vertical />);
+    expect(container.firstChild).to.have.class('rs-divider-vertical');
+    expect(container.firstChild).to.have.attr('aria-orientation', 'vertical');
   });
 
   it('Should hava a children', () => {
-    const instance = getDOMNode(<Divider>abc</Divider>);
-    const classes = instance.className;
-    assert.include(classes, 'rs-divider-with-text');
+    const { container } = render(<Divider>abc</Divider>);
+    expect(container.firstChild).to.have.class('rs-divider-with-text');
   });
 });

--- a/src/Drawer/Drawer.tsx
+++ b/src/Drawer/Drawer.tsx
@@ -58,7 +58,6 @@ const Drawer: DrawerComponent = React.forwardRef((props: DrawerProps, ref) => {
   } = props;
   const { merge, prefix } = useClassNames(classPrefix);
   const classes = merge(className, prefix(placement));
-
   const animationProps = {
     placement
   };

--- a/src/Drawer/Drawer.tsx
+++ b/src/Drawer/Drawer.tsx
@@ -58,6 +58,7 @@ const Drawer: DrawerComponent = React.forwardRef((props: DrawerProps, ref) => {
   } = props;
   const { merge, prefix } = useClassNames(classPrefix);
   const classes = merge(className, prefix(placement));
+
   const animationProps = {
     placement
   };

--- a/src/Drawer/test/DrawerActionsSpec.tsx
+++ b/src/Drawer/test/DrawerActionsSpec.tsx
@@ -10,5 +10,6 @@ describe('Drawer.Actions', () => {
     const title = 'Test';
     const { container } = render(<Drawer.Actions>{title}</Drawer.Actions>);
     expect(container.firstChild).to.have.text(title);
+    expect(container.firstChild).to.have.class('rs-drawer-actions');
   });
 });

--- a/src/Drawer/test/DrawerActionsSpec.tsx
+++ b/src/Drawer/test/DrawerActionsSpec.tsx
@@ -1,29 +1,14 @@
 import React from 'react';
-import { getDOMNode } from '@test/testUtils';
-
+import { render } from '@testing-library/react';
 import Drawer from '../index';
+import { testStandardProps } from '@test/commonCases';
 
 describe('Drawer.Actions', () => {
+  testStandardProps(<Drawer.Actions />);
+
   it('Should render a drawer actions', () => {
     const title = 'Test';
-    const instance = getDOMNode(<Drawer.Actions>{title}</Drawer.Actions>);
-    assert.equal(instance.className, 'rs-drawer-actions');
-    assert.equal(instance.innerHTML, title);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Drawer.Actions className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Drawer.Actions style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Drawer.Actions classPrefix="custom-prefix" />);
-    assert.include(instance.className, 'custom-prefix');
+    const { container } = render(<Drawer.Actions>{title}</Drawer.Actions>);
+    expect(container.firstChild).to.have.text(title);
   });
 });

--- a/src/Drawer/test/DrawerBodySpec.tsx
+++ b/src/Drawer/test/DrawerBodySpec.tsx
@@ -1,31 +1,17 @@
 import React from 'react';
-import { getDOMNode } from '@test/testUtils';
 import { render } from '@testing-library/react';
+import { testStandardProps } from '@test/commonCases';
 
 import Drawer from '../index';
 
 describe('Drawer.Body', () => {
+  testStandardProps(<Drawer.Body />);
+
   it('Should render a drawer body', () => {
     const title = 'Test';
-    const instance = getDOMNode(<Drawer.Body>{title}</Drawer.Body>);
-    assert.equal(instance.className, 'rs-drawer-body');
-    assert.equal(instance.innerHTML, title);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Drawer.Body className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Drawer.Body style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Drawer.Body classPrefix="custom-prefix" />);
-    assert.include(instance.className, 'custom-prefix');
+    const { container } = render(<Drawer.Body>{title}</Drawer.Body>);
+    expect(container.firstChild).to.have.class('rs-drawer-body');
+    expect(container.firstChild).to.have.text(title);
   });
 
   context('Ref', () => {

--- a/src/Drawer/test/DrawerFooterSpec.tsx
+++ b/src/Drawer/test/DrawerFooterSpec.tsx
@@ -1,29 +1,15 @@
 import React from 'react';
-import { getDOMNode } from '@test/testUtils';
+import { render } from '@testing-library/react';
+import { testStandardProps } from '@test/commonCases';
 
 import Drawer from '../index';
 
 describe('Drawer.Footer', () => {
+  testStandardProps(<Drawer.Footer />);
   it('Should render a drawer footer', () => {
     const title = 'Test';
-    const instance = getDOMNode(<Drawer.Footer>{title}</Drawer.Footer>);
-    assert.equal(instance.className, 'rs-drawer-footer');
-    assert.equal(instance.innerHTML, title);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Drawer.Footer className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Drawer.Footer style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Drawer.Footer classPrefix="custom-prefix" />);
-    assert.include(instance.className, 'custom-prefix');
+    const { container } = render(<Drawer.Footer>{title}</Drawer.Footer>);
+    expect(container.firstChild).to.have.class('rs-drawer-footer');
+    expect(container.firstChild).to.have.text(title);
   });
 });

--- a/src/Drawer/test/DrawerHeaderSpec.tsx
+++ b/src/Drawer/test/DrawerHeaderSpec.tsx
@@ -1,44 +1,33 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import sinon from 'sinon';
-import { getDOMNode } from '@test/testUtils';
+import { render } from '@testing-library/react';
+import { testStandardProps } from '@test/commonCases';
 
 import Drawer from '../Drawer';
 
 describe('Drawer.Header', () => {
+  testStandardProps(<Drawer.Header />);
   it('Should render a drawer header', () => {
     const title = 'Test';
-    const instance = getDOMNode(<Drawer.Header>{title}</Drawer.Header>);
-    assert.equal(instance.className, 'rs-drawer-header');
-    assert.equal(instance.textContent, 'Test');
+    const { container } = render(<Drawer.Header>{title}</Drawer.Header>);
+    expect(container.firstChild).to.have.class('rs-drawer-header');
+    expect(container.firstChild).to.have.text(title);
   });
 
   it('Should hide close button', () => {
     const title = 'Test';
-    const instance = getDOMNode(<Drawer.Header closeButton={false}>{title}</Drawer.Header>);
-    assert.isNull(instance.querySelector('button'));
+    const { container } = render(<Drawer.Header closeButton={false}>{title}</Drawer.Header>);
+    expect(container.firstChild).to.not.have.class('button');
   });
 
   it('Should call onClose callback', () => {
     const onCloseSpy = sinon.spy();
-    const instance = getDOMNode(<Drawer.Header onClose={onCloseSpy} />);
-    ReactTestUtils.Simulate.click(instance.querySelector('.rs-drawer-header-close') as HTMLElement);
-    assert.isTrue(onCloseSpy.calledOnce);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Drawer.Header className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Drawer.Header style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Drawer.Header classPrefix="custom-prefix" />);
-    assert.include(instance.className, 'custom-prefix');
+    const { container } = render(<Drawer.Header onClose={onCloseSpy} />);
+    ReactTestUtils.Simulate.click(
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+      container.querySelector('.rs-drawer-header-close') as HTMLElement
+    );
+    expect(onCloseSpy).to.have.been.calledOnce;
   });
 });

--- a/src/Drawer/test/DrawerHeaderSpec.tsx
+++ b/src/Drawer/test/DrawerHeaderSpec.tsx
@@ -8,6 +8,7 @@ import Drawer from '../Drawer';
 
 describe('Drawer.Header', () => {
   testStandardProps(<Drawer.Header />);
+
   it('Should render a drawer header', () => {
     const title = 'Test';
     const { container } = render(<Drawer.Header>{title}</Drawer.Header>);
@@ -18,7 +19,8 @@ describe('Drawer.Header', () => {
   it('Should hide close button', () => {
     const title = 'Test';
     const { container } = render(<Drawer.Header closeButton={false}>{title}</Drawer.Header>);
-    expect(container.firstChild).to.not.have.class('button');
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelector('button')).to.not.exist;
   });
 
   it('Should call onClose callback', () => {

--- a/src/Drawer/test/DrawerSpec.tsx
+++ b/src/Drawer/test/DrawerSpec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 import sinon from 'sinon';
-import { getDOMNode } from '@test/testUtils';
 
 import Drawer from '../Drawer';
 
@@ -33,9 +32,8 @@ describe('Drawer', () => {
 
   it('Should have a custom style', () => {
     const fontSize = '12px';
-    const instance = getDOMNode(<Drawer style={{ fontSize }} open />);
-    // eslint-disable-next-line testing-library/no-node-access
-    assert.equal((instance.querySelector('.rs-drawer') as HTMLElement).style.fontSize, fontSize);
+    render(<Drawer style={{ fontSize }} open />);
+    expect(screen.getByRole('dialog')).to.have.style('font-size', fontSize);
   });
 
   it('Should have a custom className prefix', () => {

--- a/src/Drawer/test/DrawerTitleSpec.tsx
+++ b/src/Drawer/test/DrawerTitleSpec.tsx
@@ -6,6 +6,7 @@ import Drawer from '../index';
 
 describe('Drawer.Title', () => {
   testStandardProps(<Drawer.Title />);
+
   it('Should render a drawer title', () => {
     const title = 'Test';
     const { container } = render(<Drawer.Title>{title}</Drawer.Title>);

--- a/src/Drawer/test/DrawerTitleSpec.tsx
+++ b/src/Drawer/test/DrawerTitleSpec.tsx
@@ -1,29 +1,15 @@
 import React from 'react';
-import { getDOMNode } from '@test/testUtils';
+import { render } from '@testing-library/react';
+import { testStandardProps } from '@test/commonCases';
 
 import Drawer from '../index';
 
 describe('Drawer.Title', () => {
+  testStandardProps(<Drawer.Title />);
   it('Should render a drawer title', () => {
     const title = 'Test';
-    const instance = getDOMNode(<Drawer.Title>{title}</Drawer.Title>);
-    assert.equal(instance.className, 'rs-drawer-title');
-    assert.equal(instance.innerHTML, title);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Drawer.Title className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Drawer.Title style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Drawer.Title classPrefix="custom-prefix" />);
-    assert.include(instance.className, 'custom-prefix');
+    const { container } = render(<Drawer.Title>{title}</Drawer.Title>);
+    expect(container.firstChild).to.have.class('rs-drawer-title');
+    expect(container.firstChild).to.have.text(title);
   });
 });

--- a/src/Dropdown/test/DropdownMenuSpec.tsx
+++ b/src/Dropdown/test/DropdownMenuSpec.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import sinon from 'sinon';
-import { getDOMNode } from '@test/testUtils';
 import DropdownMenu from '../DropdownMenu';
 import DropdownItem from '../DropdownItem';
 import Dropdown from '../Dropdown';
 import userEvent from '@testing-library/user-event';
+import { testStandardProps } from '@test/commonCases';
 
 describe('<Dropdown.Menu>', () => {
+  testStandardProps(<DropdownMenu />);
   it('Should render a vertical ARIA menubar when used alone', () => {
     const { container } = render(
       <DropdownMenu>
@@ -53,13 +54,13 @@ describe('<Dropdown.Menu>', () => {
   // Ref: https://www.w3.org/TR/wai-aria-practices-1.2/#menu
   describe('Keyboard interaction & Focus management', () => {
     function renderMenubar(ui, focusAfterRender = true) {
-      const menubar = getDOMNode(ui);
+      const { container } = render(ui);
 
-      if (focusAfterRender) {
-        fireEvent.focus(menubar);
+      if (focusAfterRender && container.firstChild) {
+        fireEvent.focus(container.firstChild);
       }
 
-      return menubar;
+      return container.firstChild;
     }
 
     it('When a menubar receives focus, keyboard focus is placed on the first item.', () => {
@@ -68,8 +69,7 @@ describe('<Dropdown.Menu>', () => {
           <DropdownItem id="first-item">First item</DropdownItem>
         </DropdownMenu>
       );
-
-      expect(menubar.getAttribute('aria-activedescendant')).to.equal('first-item');
+      expect(menubar).to.have.attr('aria-activedescendant', 'first-item');
     });
 
     it('Clicking a menuitem moves focus onto the menuitem.', () => {
@@ -82,8 +82,7 @@ describe('<Dropdown.Menu>', () => {
       );
 
       fireEvent.mouseDown(screen.getByText('Second item'));
-
-      expect(menubar.getAttribute('aria-activedescendant')).to.equal('second-item');
+      expect(menubar).to.have.attr('aria-activedescendant', 'second-item');
     });
 
     describe('Down Arrow', () => {
@@ -94,10 +93,10 @@ describe('<Dropdown.Menu>', () => {
             <DropdownItem id="second-item">Second item</DropdownItem>
           </DropdownMenu>
         );
-
-        fireEvent.keyDown(menubar, { key: 'ArrowDown' });
-
-        expect(menubar.getAttribute('aria-activedescendant')).to.equal('second-item');
+        if (menubar) {
+          fireEvent.keyDown(menubar, { key: 'ArrowDown' });
+          expect(menubar).to.have.attr('aria-activedescendant', 'second-item');
+        }
       });
     });
 
@@ -109,12 +108,12 @@ describe('<Dropdown.Menu>', () => {
             <DropdownItem id="second-item">Second item</DropdownItem>
           </DropdownMenu>
         );
+        if (menubar) {
+          fireEvent.keyDown(menubar, { key: 'ArrowDown' });
 
-        fireEvent.keyDown(menubar, { key: 'ArrowDown' });
-
-        fireEvent.keyDown(menubar, { key: 'ArrowUp' });
-
-        expect(menubar.getAttribute('aria-activedescendant')).to.equal('first-item');
+          fireEvent.keyDown(menubar, { key: 'ArrowUp' });
+          expect(menubar).to.have.attr('aria-activedescendant', 'first-item');
+        }
       });
     });
 
@@ -127,10 +126,10 @@ describe('<Dropdown.Menu>', () => {
             <DropdownItem id="last-item">Third item</DropdownItem>
           </DropdownMenu>
         );
-
-        fireEvent.keyDown(menubar, { key: 'End' });
-
-        expect(menubar.getAttribute('aria-activedescendant')).to.equal('last-item');
+        if (menubar) {
+          fireEvent.keyDown(menubar, { key: 'End' });
+          expect(menubar).to.have.attr('aria-activedescendant', 'last-item');
+        }
       });
     });
 
@@ -143,12 +142,11 @@ describe('<Dropdown.Menu>', () => {
             <DropdownItem id="last-item">Third item</DropdownItem>
           </DropdownMenu>
         );
-
-        fireEvent.keyDown(menubar, { key: 'End' });
-
-        fireEvent.keyDown(menubar, { key: 'Home' });
-
-        expect(menubar.getAttribute('aria-activedescendant')).to.equal('first-item');
+        if (menubar) {
+          fireEvent.keyDown(menubar, { key: 'End' });
+          fireEvent.keyDown(menubar, { key: 'Home' });
+          expect(menubar).to.have.attr('aria-activedescendant', 'first-item');
+        }
       });
     });
 
@@ -164,11 +162,12 @@ describe('<Dropdown.Menu>', () => {
             </DropdownItem>
           </DropdownMenu>
         );
+        if (menubar) {
+          fireEvent.keyDown(menubar, { key: 'Enter' });
 
-        fireEvent.keyDown(menubar, { key: 'Enter' });
-
-        expect(onSelectItemSpy).to.have.been.called;
-        expect(onSelectSpy).to.have.been.calledWith('active-item');
+          expect(onSelectItemSpy).to.have.been.called;
+          expect(onSelectSpy).to.have.been.calledWith('active-item');
+        }
       });
     });
 
@@ -184,11 +183,11 @@ describe('<Dropdown.Menu>', () => {
             </DropdownItem>
           </DropdownMenu>
         );
-
-        fireEvent.keyDown(menubar, { key: ' ' });
-
-        expect(onSelectItemSpy).to.have.been.called;
-        expect(onSelectSpy).to.have.been.calledWith('active-item');
+        if (menubar) {
+          fireEvent.keyDown(menubar, { key: ' ' });
+          expect(onSelectItemSpy).to.have.been.called;
+          expect(onSelectSpy).to.have.been.calledWith('active-item');
+        }
       });
     });
   });
@@ -297,16 +296,5 @@ describe('<Dropdown.Menu>', () => {
     expect(screen.getByTestId('menu'))
       .to.have.class('custom')
       .and.to.have.class('rs-dropdown-menu');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<DropdownMenu style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<DropdownMenu classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 });

--- a/src/Dropdown/test/DropdownMenuSpec.tsx
+++ b/src/Dropdown/test/DropdownMenuSpec.tsx
@@ -9,6 +9,7 @@ import { testStandardProps } from '@test/commonCases';
 
 describe('<Dropdown.Menu>', () => {
   testStandardProps(<DropdownMenu />);
+
   it('Should render a vertical ARIA menubar when used alone', () => {
     const { container } = render(
       <DropdownMenu>
@@ -60,7 +61,7 @@ describe('<Dropdown.Menu>', () => {
         fireEvent.focus(container.firstChild);
       }
 
-      return container.firstChild;
+      return container.firstChild as HTMLElement;
     }
 
     it('When a menubar receives focus, keyboard focus is placed on the first item.', () => {
@@ -93,10 +94,8 @@ describe('<Dropdown.Menu>', () => {
             <DropdownItem id="second-item">Second item</DropdownItem>
           </DropdownMenu>
         );
-        if (menubar) {
-          fireEvent.keyDown(menubar, { key: 'ArrowDown' });
-          expect(menubar).to.have.attr('aria-activedescendant', 'second-item');
-        }
+        fireEvent.keyDown(menubar, { key: 'ArrowDown' });
+        expect(menubar).to.have.attr('aria-activedescendant', 'second-item');
       });
     });
 
@@ -108,12 +107,9 @@ describe('<Dropdown.Menu>', () => {
             <DropdownItem id="second-item">Second item</DropdownItem>
           </DropdownMenu>
         );
-        if (menubar) {
-          fireEvent.keyDown(menubar, { key: 'ArrowDown' });
-
-          fireEvent.keyDown(menubar, { key: 'ArrowUp' });
-          expect(menubar).to.have.attr('aria-activedescendant', 'first-item');
-        }
+        fireEvent.keyDown(menubar, { key: 'ArrowDown' });
+        fireEvent.keyDown(menubar, { key: 'ArrowUp' });
+        expect(menubar).to.have.attr('aria-activedescendant', 'first-item');
       });
     });
 
@@ -126,10 +122,8 @@ describe('<Dropdown.Menu>', () => {
             <DropdownItem id="last-item">Third item</DropdownItem>
           </DropdownMenu>
         );
-        if (menubar) {
-          fireEvent.keyDown(menubar, { key: 'End' });
-          expect(menubar).to.have.attr('aria-activedescendant', 'last-item');
-        }
+        fireEvent.keyDown(menubar, { key: 'End' });
+        expect(menubar).to.have.attr('aria-activedescendant', 'last-item');
       });
     });
 
@@ -142,11 +136,9 @@ describe('<Dropdown.Menu>', () => {
             <DropdownItem id="last-item">Third item</DropdownItem>
           </DropdownMenu>
         );
-        if (menubar) {
-          fireEvent.keyDown(menubar, { key: 'End' });
-          fireEvent.keyDown(menubar, { key: 'Home' });
-          expect(menubar).to.have.attr('aria-activedescendant', 'first-item');
-        }
+        fireEvent.keyDown(menubar, { key: 'End' });
+        fireEvent.keyDown(menubar, { key: 'Home' });
+        expect(menubar).to.have.attr('aria-activedescendant', 'first-item');
       });
     });
 
@@ -162,12 +154,10 @@ describe('<Dropdown.Menu>', () => {
             </DropdownItem>
           </DropdownMenu>
         );
-        if (menubar) {
-          fireEvent.keyDown(menubar, { key: 'Enter' });
 
-          expect(onSelectItemSpy).to.have.been.called;
-          expect(onSelectSpy).to.have.been.calledWith('active-item');
-        }
+        fireEvent.keyDown(menubar, { key: 'Enter' });
+        expect(onSelectItemSpy).to.have.been.called;
+        expect(onSelectSpy).to.have.been.calledWith('active-item');
       });
     });
 
@@ -183,11 +173,9 @@ describe('<Dropdown.Menu>', () => {
             </DropdownItem>
           </DropdownMenu>
         );
-        if (menubar) {
-          fireEvent.keyDown(menubar, { key: ' ' });
-          expect(onSelectItemSpy).to.have.been.called;
-          expect(onSelectSpy).to.have.been.calledWith('active-item');
-        }
+        fireEvent.keyDown(menubar, { key: ' ' });
+        expect(onSelectItemSpy).to.have.been.called;
+        expect(onSelectSpy).to.have.been.calledWith('active-item');
       });
     });
   });

--- a/src/Dropdown/test/DropdownSpec.tsx
+++ b/src/Dropdown/test/DropdownSpec.tsx
@@ -1,13 +1,14 @@
 import React, { Ref, useState } from 'react';
 import { fireEvent, render, act, screen } from '@testing-library/react';
 import sinon from 'sinon';
-import { getDOMNode } from '@test/testUtils';
+
 import Dropdown from '../Dropdown';
 import Button from '../../Button';
 import Nav from '../../Nav';
 import { KEY_VALUES } from '../../utils';
 import * as utils from '../../utils';
 import userEvent from '@testing-library/user-event';
+import { testStandardProps } from '@test/commonCases';
 
 afterEach(() => {
   sinon.restore();
@@ -31,6 +32,7 @@ function renderDropdown(ui) {
 }
 
 describe('<Dropdown>', () => {
+  testStandardProps(<Dropdown />);
   it('Should render a button that controls a popup menu', () => {
     render(
       <Dropdown title="Menu">
@@ -119,13 +121,13 @@ describe('<Dropdown>', () => {
   });
 
   it('Should be disabled given `disabled=true`', () => {
-    const instance = getDOMNode(
+    const { container } = render(
       <Dropdown disabled>
         <Dropdown.Item>1</Dropdown.Item>
         <Dropdown.Item>2</Dropdown.Item>
       </Dropdown>
     );
-    assert.include(instance.className, 'rs-dropdown-disabled');
+    expect(container.firstChild).to.have.class('rs-dropdown-disabled');
   });
 
   it('Should have a custom className in toggle', () => {
@@ -139,13 +141,13 @@ describe('<Dropdown>', () => {
   });
 
   it('Should have a className for placement', () => {
-    const instance = getDOMNode(
+    const { container } = render(
       <Dropdown placement="topStart">
         <Dropdown.Item>1</Dropdown.Item>
         <Dropdown.Item>2</Dropdown.Item>
       </Dropdown>
     );
-    assert.include(instance.className, 'rs-dropdown-placement-top-start');
+    expect(container.firstChild).to.have.class('rs-dropdown-placement-top-start');
   });
 
   it('Should have a title', () => {
@@ -176,9 +178,9 @@ describe('<Dropdown>', () => {
   });
 
   it('Should not show caret', () => {
-    const instance = getDOMNode(<Dropdown noCaret />);
-    // eslint-disable-next-line testing-library/no-node-access
-    assert.ok(!instance.querySelector('.rs-dropdown-toggle-caret'));
+    const { container } = render(<Dropdown noCaret />);
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    expect(container.querySelector('.rs-dropdown-toggle-caret')).not.to.exist;
   });
 
   it('Should call onSelect callback with correct eventKey when clicking an item', () => {
@@ -306,22 +308,6 @@ describe('<Dropdown>', () => {
     const fontSize = '12px';
     render(<Dropdown defaultOpen menuStyle={{ fontSize }} />);
     expect(screen.getByRole('menu')).to.have.style('font-size', fontSize);
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<Dropdown className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Dropdown style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Dropdown classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   describe('Keyboard interaction & Focus management', () => {

--- a/src/Dropdown/test/DropdownToggleSpec.tsx
+++ b/src/Dropdown/test/DropdownToggleSpec.tsx
@@ -1,37 +1,42 @@
 import React from 'react';
-import { getDOMNode } from '@test/testUtils';
 import DropdownToggle from '../DropdownToggle';
 import User from '@rsuite/icons/legacy/User';
+import { render } from '@testing-library/react';
+import { testStandardProps } from '@test/commonCases';
 
 describe('DropdownToggle', () => {
+  testStandardProps(<DropdownToggle />);
   it('Should render a toggle', () => {
     const title = 'Test';
-    const instance = getDOMNode(<DropdownToggle>{title}</DropdownToggle>);
+    const { container } = render(<DropdownToggle>{title}</DropdownToggle>);
+    expect(container.firstChild).to.have.class('rs-dropdown-toggle');
 
-    assert.include(instance.className, 'dropdown-toggle');
-    assert.ok(instance.querySelector('.rs-dropdown-toggle-caret'));
-    assert.equal(instance.textContent, title);
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelector('.rs-dropdown-toggle-caret')).to.exist;
+    expect(container.firstChild).to.have.text(title);
   });
 
   it('Should have a title', () => {
     const title = 'Test';
-    const instance = getDOMNode(<DropdownToggle>{title}</DropdownToggle>);
-    assert.equal(instance.textContent, title);
+    const { container } = render(<DropdownToggle>{title}</DropdownToggle>);
+    expect(container.firstChild).to.have.text(title);
   });
 
   it('Should have an icon', () => {
-    const instance = getDOMNode(<DropdownToggle icon={<User />}>abc</DropdownToggle>);
-    assert.ok(instance.querySelector('.rs-dropdown-toggle-icon.rs-icon'));
+    const { container } = render(<DropdownToggle icon={<User />}>abc</DropdownToggle>);
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelector('.rs-dropdown-toggle-icon.rs-icon')).to.exist;
   });
 
   it('Should render custom component', () => {
-    const instance = getDOMNode(<DropdownToggle as={'div'}>abc</DropdownToggle>);
-    assert.equal(instance.tagName, 'DIV');
+    const { container } = render(<DropdownToggle as={'div'}>abc</DropdownToggle>);
+    expect(container.firstChild).to.have.tagName('DIV');
   });
 
   it('Should not show caret', () => {
-    const instance = getDOMNode(<DropdownToggle noCaret>abc</DropdownToggle>);
-    assert.ok(!instance.querySelector('.rs-dropdown-toggle-caret'));
+    const { container } = render(<DropdownToggle noCaret>abc</DropdownToggle>);
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelector('.rs-dropdown-toggle-caret')).to.not.exist;
   });
 
   it('Should render a custom toggle', () => {
@@ -42,23 +47,7 @@ describe('DropdownToggle', () => {
         </button>
       );
     };
-    const instance = getDOMNode(<DropdownToggle renderToggle={renderToggle}>abc</DropdownToggle>);
-    assert.equal(instance.textContent, 'new');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<DropdownToggle className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<DropdownToggle style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<DropdownToggle classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
+    const { container } = render(<DropdownToggle renderToggle={renderToggle}>abc</DropdownToggle>);
+    expect(container.firstChild).to.have.text('new');
   });
 });

--- a/src/FlexboxGrid/test/FlexboxGridItemSpec.tsx
+++ b/src/FlexboxGrid/test/FlexboxGridItemSpec.tsx
@@ -1,30 +1,30 @@
 import React from 'react';
-import { getDOMNode } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import FlexboxGridItem from '../FlexboxGridItem';
 import Col from '../../Col';
+import { render } from '@testing-library/react';
 
 describe('FlexboxGridItem', () => {
   testStandardProps(<FlexboxGridItem />);
 
   it('Should render a FlexboxGridItem', () => {
-    const instance = getDOMNode(<FlexboxGridItem>Test</FlexboxGridItem>);
-    assert.include(instance.className, 'rs-flex-box-grid-item');
+    const { container } = render(<FlexboxGridItem>Test</FlexboxGridItem>);
+    expect(container.firstChild).to.have.class('rs-flex-box-grid-item');
   });
 
   it('Should be colspan', () => {
-    const instance = getDOMNode(<FlexboxGridItem colspan={1} />);
-    assert.include(instance.className, 'rs-flex-box-grid-item-1');
+    const { container } = render(<FlexboxGridItem colspan={1} />);
+    expect(container.firstChild).to.have.class('rs-flex-box-grid-item-1');
   });
 
   it('Should be order', () => {
-    const instance = getDOMNode(<FlexboxGridItem order={1} />);
-    assert.include(instance.className, 'rs-flex-box-grid-item-order-1');
+    const { container } = render(<FlexboxGridItem order={1} />);
+    expect(container.firstChild).to.have.class('rs-flex-box-grid-item-order-1');
   });
 
   it('Should render a col', () => {
-    const instance = getDOMNode(<FlexboxGridItem as={Col} md={1} />);
-    assert.include(instance.className, 'rs-col');
-    assert.include(instance.className, 'rs-col-md-1');
+    const { container } = render(<FlexboxGridItem as={Col} md={1} />);
+    expect(container.firstChild).to.have.class('rs-col');
+    expect(container.firstChild).to.have.class('rs-col-md-1');
   });
 });

--- a/src/FlexboxGrid/test/FlexboxGridSpec.tsx
+++ b/src/FlexboxGrid/test/FlexboxGridSpec.tsx
@@ -1,23 +1,23 @@
 import React from 'react';
-import { getDOMNode } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import FlexboxGrid from '../FlexboxGrid';
+import { render } from '@testing-library/react';
 
 describe('FlexboxGrid', () => {
   testStandardProps(<FlexboxGrid />);
 
   it('Should render a FlexboxGrid', () => {
-    const instance = getDOMNode(<FlexboxGrid>Test</FlexboxGrid>);
-    assert.include(instance.className, 'rs-flex-box-grid');
+    const { container } = render(<FlexboxGrid>Test</FlexboxGrid>);
+    expect(container.firstChild).to.have.class('rs-flex-box-grid');
   });
 
   it('Should be aligned on the top', () => {
-    const instance = getDOMNode(<FlexboxGrid align="top" />);
-    assert.include(instance.className, 'rs-flex-box-grid-top');
+    const { container } = render(<FlexboxGrid align="top" />);
+    expect(container.firstChild).to.have.class('rs-flex-box-grid-top');
   });
 
   it('Should be justify content on the center', () => {
-    const instance = getDOMNode(<FlexboxGrid justify="center" />);
-    assert.include(instance.className, 'rs-flex-box-grid-center');
+    const { container } = render(<FlexboxGrid justify="center" />);
+    expect(container.firstChild).to.have.class('rs-flex-box-grid-center');
   });
 });

--- a/src/FlexboxGrid/test/FlexboxStylesSpec.tsx
+++ b/src/FlexboxGrid/test/FlexboxStylesSpec.tsx
@@ -1,26 +1,19 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Flexbox from '../index';
-import { getDOMNode, getStyle, inChrome } from '@test/testUtils';
+import { inChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Flexbox styles', () => {
   it('Should render the correct styles', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    render(<Flexbox ref={instanceRef} />);
-    assert.equal(getStyle(getDOMNode(instanceRef.current), 'display'), 'flex', 'Flexbox display');
-    inChrome &&
-      assert.equal(
-        getStyle(getDOMNode(instanceRef.current), 'flexFlow'),
-        'row wrap',
-        'Flexbox flex-flow'
-      );
+    const { container } = render(<Flexbox />);
+    expect(container.firstChild).to.have.style('display', 'flex');
+    inChrome && expect(container.firstChild).to.have.style('flex-flow', 'row wrap');
   });
 
   it('Should render the correct aligned', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    render(<Flexbox ref={instanceRef} align="top" />);
-    assert.equal(getStyle(getDOMNode(instanceRef.current), 'alignItems'), 'flex-start');
+    const { container } = render(<Flexbox align="top" />);
+    expect(container.firstChild).to.have.style('align-items', 'flex-start');
   });
 });

--- a/src/Footer/test/FooterSpec.tsx
+++ b/src/Footer/test/FooterSpec.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
-import { getDOMNode } from '@test/testUtils';
+
 import { testStandardProps } from '@test/commonCases';
 import Footer from '../Footer';
+import { render } from '@testing-library/react';
 
 describe('Footer', () => {
   testStandardProps(<Footer />);
 
   it('Should render a Footer', () => {
     const title = 'Test';
-    const instance = getDOMNode(<Footer>{title}</Footer>);
-    assert.include(instance.className, 'rs-footer');
-    assert.equal(instance.textContent, title);
+    const { container } = render(<Footer>{title}</Footer>);
+    expect(container.firstChild).to.have.class('rs-footer');
+    expect(container.firstChild).to.have.text(title);
   });
 });

--- a/src/Footer/test/FooterStylesSpec.tsx
+++ b/src/Footer/test/FooterStylesSpec.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Footer from '../index';
-import { getDOMNode, getStyle, itChrome } from '@test/testUtils';
+import { itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Footer styles', () => {
   itChrome('Should render the correct styles', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    render(<Footer ref={instanceRef} />);
-    assert.equal(getStyle(getDOMNode(instanceRef.current), 'flex'), '0 0 auto');
+    const { container } = render(<Footer />);
+    expect(container.firstChild).to.have.style('flex', '0 0 auto');
   });
 });

--- a/src/Form/test/FormSpec.tsx
+++ b/src/Form/test/FormSpec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent, act, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
-import { getDOMNode, getInstance } from '@test/testUtils';
+import { getInstance } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 
 import Form, { FormInstance } from '../Form';
@@ -40,21 +40,19 @@ describe('Form', () => {
 
   it('Should render a Form', () => {
     const title = 'Test';
-    const instance = getDOMNode(<Form>{title}</Form>);
-    assert.equal(instance.tagName, 'FORM');
-    assert.equal(instance.innerHTML, title);
+    const { container } = render(<Form>{title}</Form>);
+    expect(container.firstChild).to.have.tagName('FORM');
+    expect(container.firstChild).to.have.text(title);
   });
 
   it('Should be horizontal', () => {
-    const instance = getDOMNode(<Form layout="horizontal" />);
-
-    assert.include(instance.className, 'rs-form-horizontal');
+    const { container } = render(<Form layout="horizontal" />);
+    expect(container.firstChild).to.have.class('rs-form-horizontal');
   });
 
   it('Should be inline', () => {
-    const instance = getDOMNode(<Form layout="inline" />);
-
-    assert.include(instance.className, 'rs-form-inline');
+    const { container } = render(<Form layout="inline" />);
+    expect(container.firstChild).to.have.class('rs-form-inline');
   });
 
   it('Should have a value', () => {

--- a/src/Nav/test/NavItemSpec.tsx
+++ b/src/Nav/test/NavItemSpec.tsx
@@ -8,7 +8,11 @@ import Navbar from '../../Navbar';
 import Sidenav from '../../Sidenav';
 
 describe('<Nav.Item>', () => {
-  testStandardProps(<Nav.Item />, { renderOptions: { wrapper: Nav } });
+  testStandardProps(<Nav.Item />, {
+    renderOptions: { wrapper: Nav },
+    // eslint-disable-next-line testing-library/prefer-screen-queries
+    getRootElement: view => view.getByTestId('element')
+  });
 
   it('Should render a <a>', () => {
     render(<Nav.Item data-testid="item">Test</Nav.Item>, {

--- a/src/Sidenav/test/SidenavToggleSpec.tsx
+++ b/src/Sidenav/test/SidenavToggleSpec.tsx
@@ -9,7 +9,9 @@ describe('Sidenav.Toggle', () => {
   testStandardProps(<SidenavToggle />, {
     renderOptions: {
       wrapper: Sidenav
-    }
+    },
+    // eslint-disable-next-line testing-library/prefer-screen-queries
+    getRootElement: view => view.getByTestId('element')
   });
 
   it('Should have rs-sidenav-toggle className', () => {

--- a/test/commonCases.js
+++ b/test/commonCases.js
@@ -12,37 +12,50 @@ export function testTestIdProp(element, renderOptions) {
   });
 }
 
-export function testClassNameProp(element, customClassName = 'custom-class', renderOptions) {
+export function testClassNameProp(
+  element,
+  customClassName = 'custom-class',
+  renderOptions,
+  getRootElement = view => view.container.firstChild
+) {
   it('Should accept custom className', () => {
-    const { getByTestId } = render(
+    const view = render(
       React.cloneElement(element, { 'data-testid': 'element', className: customClassName }),
       renderOptions
     );
 
-    expect(getByTestId('element')).to.have.class(customClassName);
+    expect(getRootElement(view)).to.have.class(customClassName);
   });
 }
 
-export function testClassPrefixProp(element, renderOptions) {
+export function testClassPrefixProp(
+  element,
+  renderOptions,
+  getRootElement = view => view.container.firstChild
+) {
   it('Should accept custom className prefix', () => {
     const customClassPrefix = 'custom-prefix';
-    const { getByTestId } = render(
+    const view = render(
       React.cloneElement(element, { 'data-testid': 'element', classPrefix: customClassPrefix }),
       renderOptions
     );
-    expect(getByTestId('element')).to.have.class(new RegExp('^rs-' + customClassPrefix));
+    expect(getRootElement(view)).to.have.class(new RegExp('^rs-' + customClassPrefix));
   });
 }
 
-export function testStyleProp(element, renderOptions) {
+export function testStyleProp(
+  element,
+  renderOptions,
+  getRootElement = view => view.container.firstChild
+) {
   it('Should accept custom style', () => {
     const fontSize = '12px';
-    const { getByTestId } = render(
+    const view = render(
       React.cloneElement(element, { 'data-testid': 'element', style: { fontSize } }),
       renderOptions
     );
 
-    expect(getByTestId('element')).to.have.style('font-size', fontSize);
+    expect(getRootElement(view)).to.have.style('font-size', fontSize);
   });
 }
 
@@ -50,9 +63,14 @@ export function testStandardProps(element, options) {
   describe('Standard props', () => {
     testTestIdProp(element, options?.renderOptions);
     if (options?.customClassName !== false) {
-      testClassNameProp(element, options?.customClassName, options?.renderOptions);
+      testClassNameProp(
+        element,
+        options?.customClassName,
+        options?.renderOptions,
+        options?.getRootElement
+      );
     }
-    testClassPrefixProp(element, options?.renderOptions);
-    testStyleProp(element, options?.renderOptions);
+    testClassPrefixProp(element, options?.renderOptions, options?.getRootElement);
+    testStyleProp(element, options?.renderOptions, options?.getRootElement);
   });
 }


### PR DESCRIPTION
Drop usage of getDOMNode() util function which uses [the deprecated findDOMNode API](https://beta.reactjs.org/reference/react-dom/findDOMNode) under the hood

I received the task from discussion https://github.com/rsuite/rsuite/discussions/3200

I have completed these components (DateRangePicker,Divider,Drawer,Dropdown,FlexboxGrid,Footer,Form)

Thank you for reviewing my work

