### PR TITLE
fix(InputPicker): add missing top padding of listbox

### DIFF
--- a/src/InputPicker/InputPicker.tsx
+++ b/src/InputPicker/InputPicker.tsx
@@ -659,7 +659,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
     const renderDropdownMenu = (positionProps: PositionChildProps, speakerRef) => {
       const { left, top, className } = positionProps;
       const menuClassPrefix = multi ? 'picker-check-menu' : 'picker-select-menu';
-      const classes = merge(className, menuClassName, prefix(menuClassPrefix));
+      const classes = merge(className, menuClassName, prefix(multi ? 'check-menu' : 'select-menu'));
       const styles = { ...menuStyle, left, top };
 
       let items: ItemDataType[] = filterNodesOfTree(getAllData(), checkShouldDisplay);


### PR DESCRIPTION
Expected

<img width="299" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/faffb351-54a1-4f9a-af44-57e3eb26b129">

Actual (before fix)

<img width="258" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/9a0014e7-3f01-4c4f-b2f8-31859feca115">

Fixed

<img width="251" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/17eaa499-308e-4064-8ddd-f370a5237810">
