### PR TITLE
test(Tag/TagGroup): drop use of getDOMNode util

### DIFF
--- a/src/Tag/test/TagSpec.tsx
+++ b/src/Tag/test/TagSpec.tsx
@@ -1,26 +1,28 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-import { getDOMNode } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import Tag from '../Tag';
 import Sinon from 'sinon';
+import { render } from '@testing-library/react';
 
 describe('Tag', () => {
   testStandardProps(<Tag />);
   it('Should output a Tag', () => {
-    const instance = getDOMNode(<Tag />);
-    assert.equal(instance.className, 'rs-tag rs-tag-md rs-tag-default');
+    const { container } = render(<Tag />);
+    expect(container.firstChild).to.have.class('rs-tag');
   });
 
   it('Should call onClose callback', () => {
     const onClose = Sinon.spy();
-    const instance = getDOMNode(
+    const { container } = render(
       <Tag closable onClose={onClose}>
         tag
       </Tag>
     );
-    ReactTestUtils.Simulate.click(instance.querySelector('.rs-tag-icon-close') as HTMLElement);
-
+    ReactTestUtils.Simulate.click(
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+      container.querySelector('.rs-tag-icon-close') as HTMLElement
+    );
     expect(onClose).to.have.been.calledOnce;
   });
 });

--- a/src/Tag/test/TagSpec.tsx
+++ b/src/Tag/test/TagSpec.tsx
@@ -7,6 +7,7 @@ import { render } from '@testing-library/react';
 
 describe('Tag', () => {
   testStandardProps(<Tag />);
+
   it('Should output a Tag', () => {
     const { container } = render(<Tag />);
     expect(container.firstChild).to.have.class('rs-tag');
@@ -19,10 +20,12 @@ describe('Tag', () => {
         tag
       </Tag>
     );
+
     ReactTestUtils.Simulate.click(
       // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
       container.querySelector('.rs-tag-icon-close') as HTMLElement
     );
+
     expect(onClose).to.have.been.calledOnce;
   });
 });

--- a/src/Tag/test/TagSpec.tsx
+++ b/src/Tag/test/TagSpec.tsx
@@ -10,7 +10,10 @@ describe('Tag', () => {
 
   it('Should output a Tag', () => {
     const { container } = render(<Tag />);
+
     expect(container.firstChild).to.have.class('rs-tag');
+    expect(container.firstChild).to.have.class('rs-tag-md');
+    expect(container.firstChild).to.have.class('rs-tag-default');
   });
 
   it('Should call onClose callback', () => {

--- a/src/Tag/test/TagStylesSpec.tsx
+++ b/src/Tag/test/TagStylesSpec.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Tag from '../index';
-import { getDOMNode, getStyle, toRGB, inChrome } from '@test/testUtils';
+import { toRGB } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Tag styles', () => {
   it('Should render the correct styles', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    render(<Tag ref={instanceRef}>Text</Tag>);
-    const dom = getDOMNode(instanceRef.current);
-    assert.equal(getStyle(dom, 'backgroundColor'), toRGB('#f7f7fa'), 'Tag background-color');
-    inChrome && assert.equal(getStyle(dom, 'padding'), '2px 8px', 'Tag padding');
-    assert.equal(getStyle(dom, 'fontSize'), '12px', 'Tag font-size');
-    assert.equal(getStyle(dom, 'height'), '24px', 'Tag height');
+    const { container } = render(<Tag>Text</Tag>);
+
+    expect(container.firstChild).to.have.style('background-color', toRGB('#f7f7fa'));
+    expect(container.firstChild).to.have.style('padding', '2px 8px');
+    expect(container.firstChild).to.have.style('font-size', '12px');
+    expect(container.firstChild).to.have.style('height', '24px');
   });
 });

--- a/src/TagGroup/test/TagGroupSpec.tsx
+++ b/src/TagGroup/test/TagGroupSpec.tsx
@@ -11,7 +11,7 @@ describe('TagGroup', () => {
 
     render(<TagGroup ref={instanceRef} />);
 
-    expect(instanceRef.current).to.have.tagName('DIV');
+    expect(instanceRef.current).to.have.property('tagName', 'DIV');
     expect(instanceRef.current).to.have.class('rs-tag-group');
   });
 });

--- a/src/TagGroup/test/TagGroupSpec.tsx
+++ b/src/TagGroup/test/TagGroupSpec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@test/testUtils';
+import { render } from '@testing-library/react';
 import { testStandardProps } from '@test/commonCases';
 import TagGroup from '../TagGroup';
 

--- a/src/TagGroup/test/TagGroupSpec.tsx
+++ b/src/TagGroup/test/TagGroupSpec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getDOMNode } from '@test/testUtils';
+import { render } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import TagGroup from '../TagGroup';
 
@@ -7,7 +7,11 @@ describe('TagGroup', () => {
   testStandardProps(<TagGroup />);
 
   it('Should output a TagGroup', () => {
-    const instance = getDOMNode(<TagGroup />);
-    assert.equal(instance.className, 'rs-tag-group');
+    const instanceRef = React.createRef<HTMLDivElement>();
+
+    render(<TagGroup ref={instanceRef} />);
+
+    expect(instanceRef.current).to.have.tagName('DIV');
+    expect(instanceRef.current).to.have.class('rs-tag-group');
   });
 });

--- a/src/TagGroup/test/TagGroupStylesSpec.tsx
+++ b/src/TagGroup/test/TagGroupStylesSpec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { getStyle, itChrome } from '@test/testUtils';
+import { itChrome } from '@test/testUtils';
 import TagGroup from '../TagGroup';
 
 import '../../Tag/styles/index.less';
@@ -10,10 +10,7 @@ describe('TagGroup styles', () => {
     const instanceRef = React.createRef<HTMLDivElement>();
 
     render(<TagGroup ref={instanceRef} />);
-    assert.equal(
-      getStyle(instanceRef.current as HTMLElement, 'margin'),
-      '-10px 0px 0px -10px',
-      'TagGroup margin'
-    );
+
+    expect(instanceRef.current).to.have.style('margin', '-10px 0px 0px -10px');
   });
 });


### PR DESCRIPTION
drop use of getDOMNode util

This update involves changes to two components: Tag and TagGroup.