### PR TITLE
feat: Picker's onOpen & onClose should decouple with onEnter & onExit

### DIFF
--- a/src/Overlay/OverlayTrigger.tsx
+++ b/src/Overlay/OverlayTrigger.tsx
@@ -197,6 +197,7 @@ const OverlayTrigger = React.forwardRef(
       onContextMenu,
       onFocus,
       onBlur,
+      onOpen,
       onClose,
       onExited,
       ...rest
@@ -245,8 +246,9 @@ const OverlayTrigger = React.forwardRef(
         }
 
         setOpen(true);
+        onOpen?.();
       },
-      [delayOpen, setOpen]
+      [delayOpen, setOpen, onOpen]
     );
 
     const handleClose = useCallback(

--- a/src/Picker/PickerToggleTrigger.tsx
+++ b/src/Picker/PickerToggleTrigger.tsx
@@ -13,7 +13,7 @@ export type { OverlayTriggerHandle, PositionChildProps };
 
 export interface PickerToggleTriggerProps
   extends Omit<AnimationEventProps, 'onEntering' | 'onExiting'>,
-    Pick<OverlayTriggerProps, 'speaker' | 'onClose'> {
+    Pick<OverlayTriggerProps, 'speaker' | 'onOpen' | 'onClose'> {
   placement?: TypeAttributes.Placement;
   pickerProps: any;
   open?: boolean;
@@ -29,7 +29,9 @@ export const omitTriggerPropKeys = [
   'onExit',
   'onExiting',
   'open',
+  'onOpen',
   'defaultOpen',
+  'onClose',
   'onHide',
   'container',
   'containerPadding',


### PR DESCRIPTION
## Question

In the current picker, users cannot control the `open` prop with `onOpen` and `onClose` because these props are bound to the animation. As a result, they cannot be triggered before the animation.

## Changes

in this PR, `onOpen` and `onClose` will be separate from animation, these callback bound to inner open state change. allow user to control picker with `open` props

```tsx
```