### PR TITLE
Fix Cascader: onSelect not trigger when press Enter

### DIFF
--- a/src/Cascader/Cascader.tsx
+++ b/src/Cascader/Cascader.tsx
@@ -339,6 +339,7 @@ const Cascader = React.forwardRef(<T extends number | string>(props: CascaderPro
         }
 
         if (!shallowEqual(value, focusItemValue)) {
+          onSelect?.(focusItem as ItemDataType<T>, pathTowardsActiveItem, event);
           onChange?.(focusItemValue ?? null, event);
         }
         handleClose();
@@ -354,7 +355,8 @@ const Cascader = React.forwardRef(<T extends number | string>(props: CascaderPro
       setLayer,
       setValue,
       value,
-      valueKey
+      valueKey,
+      onSelect
     ]
   );
 

--- a/src/Cascader/test/CascaderSpec.tsx
+++ b/src/Cascader/test/CascaderSpec.tsx
@@ -610,6 +610,22 @@ describe('Cascader', () => {
     );
   });
 
+  it('Should trigger onChange callback & onSelect callback when press Enter', () => {
+    const onChangeSpy = sinon.spy();
+    const onSelectSpy = sinon.spy();
+
+    const instance = getInstance(
+      <Cascader data={items} onChange={onChangeSpy} onSelect={onSelectSpy} defaultOpen />
+    );
+
+    fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
+
+    fireEvent.keyDown(instance.target, { key: 'Enter' });
+
+    expect(onChangeSpy).to.have.been.calledOnce;
+    expect(onSelectSpy).to.have.been.calledOnce;
+  });
+
   describe('Focus item', () => {
     it('Should update scroll position when the focus is not within the viewport', () => {
       const instance = getInstance(<Cascader defaultOpen data={items} menuHeight={72} />);


### PR DESCRIPTION
## ISSUE

close #3242

## CHANGES

add `onSelect` call in `handleMenuPressEnter`