### PR TITLE
build: pin aria-query 5.1.3

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Setup kernel, increase watchers
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
+      - name: Use Node.js LTS
+        uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: 'lts/*'
       - name: Cache Node.js modules
         uses: actions/cache@v1
         with:

--- a/package.json
+++ b/package.json
@@ -184,6 +184,9 @@
     "webpack-bundle-analyzer": "^4.3.0",
     "webpack-cli": "^4.2.0"
   },
+  "overrides": {
+    "aria-query@>5.1.3": "5.1.3"
+  },
   "browserslist": [
     "> 1%",
     "last 2 versions",


### PR DESCRIPTION
React Testing Library's dependency `aria-query` released an update with breaking change, leading to the broken tests in our CI checks https://github.com/rsuite/rsuite/pull/3246#pullrequestreview-1480904847.

`@testing-library/dom` has published [a fixed release](https://github.com/testing-library/dom-testing-library/releases/tag/v9.3.1) with `aria-query` pinned to a working version 5.1.3, but `@testing-library/react` hasn't released a fix so far. To address this issue in our CI checks, explicitly pin `aria-query` to 5.1.3 with [`overrides` property in `package.json`](https://docs.npmjs.com/cli/v8/configuring-npm/package-json?v=true#overrides). This feature is supported since npm 8 so also update the Node.js version in CI workflow.

Related issues
- https://github.com/testing-library/dom-testing-library/issues/1235
- https://github.com/A11yance/aria-query/issues/512