### PR TITLE
Export ja_JP.

### DIFF
--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -20,6 +20,7 @@ export { default as zhCN } from './zh_CN';
 export { default as zhTW } from './zh_TW';
 export { default as faIR } from './fa_IR';
 export { default as frFR } from './fr_FR';
+export { default as jaJP } from './ja_JP';
 
 type PickKeys<T> = {
   [keys in keyof T]?: T[keys];


### PR DESCRIPTION
I exported ja_JP as following:

` export { default as jaJP } from './ja_JP';`

