### PR TITLE
Test: (Container)removing the getDOMNode and using the render

### DIFF
--- a/src/Container/test/ContainerSpec.tsx
+++ b/src/Container/test/ContainerSpec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getDOMNode } from '@test/testUtils';
+import { render } from '@testing-library/react';
 import { testStandardProps } from '@test/commonCases';
 import { waitFor } from '@testing-library/react';
 
@@ -10,33 +10,33 @@ describe('Container', () => {
   testStandardProps(<Container />);
 
   it('Should render a Container', () => {
-    const instance = getDOMNode(
+    const { container } = render(
       <Container>
         <span>test</span>
       </Container>
     );
 
-    expect(instance).to.have.class('rs-container');
-    expect(instance).to.have.text('test');
+    expect(container.firstChild).to.have.class('rs-container');
+    expect(container.firstChild).to.have.text('test');
   });
 
   it('Should render a Container when children is false', () => {
-    const instance = getDOMNode(<Container>{false}</Container>);
+    const { container } = render(<Container>{false}</Container>);
 
-    expect(instance).to.have.class('rs-container');
-    expect(instance).to.be.empty;
+    expect(container.firstChild).to.have.class('rs-container');
+    expect(container.firstChild).to.be.empty;
   });
 
   // TODO: This is a temporary solution and will be deleted after the component style is updated.
   it('Should have a `has-sidebar` className', async () => {
-    const instance = getDOMNode(
+    const { container } = render(
       <Container>
         <Sidebar />
       </Container>
     );
 
     await waitFor(() => {
-      expect(instance).to.have.class('rs-container-has-sidebar');
+      expect(container.firstChild).to.have.class('rs-container-has-sidebar');
     });
   });
 });


### PR DESCRIPTION
Why I am doing this: https://github.com/rsuite/rsuite/discussions/3200
What I did: removing the `getDOMNode` and using the `render` in `@testing-library/react`

This update involves 1 component change: `Container`