### PR TITLE
Test: (DatePicker)removing the getDOMNode and using the render

### DIFF
--- a/src/DatePicker/test/DatePickerSpec.tsx
+++ b/src/DatePicker/test/DatePickerSpec.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import { testStandardProps } from '@test/commonCases';
 import { render, fireEvent, act, waitFor, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 import enGB from 'date-fns/locale/en-GB';
 import ReactTestUtils from 'react-dom/test-utils';
 import { format, isSameDay, parseISO, addMonths, isBefore } from '../../utils/dateUtils';
-import { getDOMNode, getInstance } from '@test/testUtils';
+import { getInstance } from '@test/testUtils';
 import DatePicker from '../DatePicker';
 import { DateUtils } from '../../utils';
 
@@ -17,27 +18,31 @@ afterEach(() => {
 });
 
 describe('DatePicker', () => {
+  testStandardProps(<DatePicker />);
+
   it('Should render a div with "rs-picker-date" class', () => {
-    const instance = getDOMNode(<DatePicker />);
-    assert.equal(instance.nodeName, 'DIV');
-    assert.ok(instance.className.match(/\brs-picker-date\b/));
+    const { container } = render(<DatePicker />);
+
+    expect(container.firstChild).to.have.tagName('DIV');
+    expect(container.firstChild).to.have.class('rs-picker-date');
   });
 
   it('Should have "default" appearance by default', () => {
-    const instance = getDOMNode(<DatePicker />);
+    const { container } = render(<DatePicker />);
 
-    expect(instance).to.have.class('rs-picker-default');
+    expect(container.firstChild).to.have.class('rs-picker-default');
   });
 
   it('Should be cleanable by default', () => {
-    const instance = getDOMNode(<DatePicker value={new Date()} />);
+    const { container } = render(<DatePicker value={new Date()} />);
 
-    expect(instance).to.have.class('rs-picker-cleanable');
+    expect(container.firstChild).to.have.class('rs-picker-cleanable');
   });
 
   it('Should be disabled', () => {
-    const instance = getDOMNode(<DatePicker disabled />);
-    assert.ok(instance.className.match(/\bdisabled\b/));
+    const { container } = render(<DatePicker disabled />);
+
+    expect(container.firstChild).to.have.class('rs-picker-disabled');
   });
 
   it('Should be not cleanable', () => {
@@ -53,9 +58,9 @@ describe('DatePicker', () => {
   });
 
   it('Should be block', () => {
-    const instance = getDOMNode(<DatePicker block />);
+    const { container } = render(<DatePicker block />);
 
-    assert.ok(instance.className.match(/\bblock\b/));
+    expect(container.firstChild).to.have.class('rs-picker-block');
   });
 
   it('Should output a date', () => {
@@ -116,8 +121,9 @@ describe('DatePicker', () => {
   });
 
   it('Should get panel container ref', function () {
-    const instance = getDOMNode(<DatePicker defaultOpen />);
-    assert.equal(instance.tagName, 'DIV');
+    const { container } = render(<DatePicker defaultOpen />);
+
+    expect(container.firstChild).to.have.tagName('DIV');
   });
 
   it('Should call `onChange` callback', () => {
@@ -468,17 +474,6 @@ describe('DatePicker', () => {
     expect(onToggleTimeDropdownSpy).to.calledTwice;
   });
 
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<DatePicker className="custom" />);
-    assert.ok(instance.className.match(/\bcustom\b/));
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<DatePicker style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
   it('Should call `onChangeCalendarDate` callback when click backward', () => {
     const onChangeCalendarDate = sinon.spy();
 
@@ -676,11 +671,6 @@ describe('DatePicker', () => {
 
     expect(onFocusSpy).to.have.been.calledOnce;
     expect(screen.getByRole('combobox')).to.have.class('rs-picker-toggle-active');
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<DatePicker classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
   });
 
   it('Should call onChange after setting oneTap and clicking date', () => {

--- a/src/DatePicker/test/ToolbarSpec.tsx
+++ b/src/DatePicker/test/ToolbarSpec.tsx
@@ -2,16 +2,27 @@ import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { render, screen } from '@testing-library/react';
 import sinon from 'sinon';
-import { getDOMNode } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 
 import Toolbar from '../Toolbar';
 
 describe('DatePicker - Toolbar', () => {
-  it('Should render a div with `rs-picker-toolbar` class', () => {
-    const instance = getDOMNode(<Toolbar calendarDate={new Date(2021, 11, 24)} locale={{}} />);
+  const fontSize = '12px';
+  testStandardProps(
+    <Toolbar
+      calendarDate={new Date(2021, 11, 24)}
+      className="custom"
+      classPrefix="custom-prefix"
+      style={{ fontSize }}
+      locale={{}}
+    />
+  );
 
-    assert.equal(instance.nodeName, 'DIV');
-    assert.include(instance.className, 'rs-picker-toolbar');
+  it('Should render a div with `rs-picker-toolbar` class', () => {
+    const { container } = render(<Toolbar calendarDate={new Date(2021, 11, 24)} locale={{}} />);
+
+    expect(container.firstChild).to.have.tagName('DIV');
+    expect(container.firstChild).to.have.class('rs-picker-toolbar');
   });
 
   it('Should render a custom option', () => {
@@ -58,39 +69,19 @@ describe('DatePicker - Toolbar', () => {
     assert.isTrue(onClickShortcutSpy.calledOnce);
   });
 
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(
-      <Toolbar calendarDate={new Date(2021, 11, 24)} className="custom" locale={{}} />
-    );
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(
-      <Toolbar calendarDate={new Date(2021, 11, 24)} style={{ fontSize }} locale={{}} />
-    );
-    assert.equal(instance.style.fontSize, fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(
-      <Toolbar calendarDate={new Date(2021, 11, 24)} classPrefix="custom-prefix" locale={{}} />
-    );
-    assert.include(instance.className, 'custom-prefix');
-  });
-
   it('Should not render the ok button', () => {
     render(<Toolbar calendarDate={new Date(2021, 11, 24)} hideOkBtn locale={{ ok: 'OK' }} />);
 
     expect(screen.queryByRole('button', { name: 'OK' })).to.not.exist;
   });
 
-  it('Should not render any elements', () => {
-    const instance = getDOMNode(
+  it('Should not render any elements xxx', () => {
+    const { container } = render(
       <Toolbar calendarDate={new Date(2021, 11, 24)} hideOkBtn ranges={[]} locale={{}} />
     );
-    assert.isNull(instance);
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelector('button')).to.not.exist;
   });
 
   it('Should be wrap in ranges', () => {

--- a/src/DatePicker/test/ToolbarSpec.tsx
+++ b/src/DatePicker/test/ToolbarSpec.tsx
@@ -7,13 +7,11 @@ import { testStandardProps } from '@test/commonCases';
 import Toolbar from '../Toolbar';
 
 describe('DatePicker - Toolbar', () => {
-  const fontSize = '12px';
   testStandardProps(
     <Toolbar
       calendarDate={new Date(2021, 11, 24)}
       className="custom"
       classPrefix="custom-prefix"
-      style={{ fontSize }}
       locale={{}}
     />
   );
@@ -75,7 +73,7 @@ describe('DatePicker - Toolbar', () => {
     expect(screen.queryByRole('button', { name: 'OK' })).to.not.exist;
   });
 
-  it('Should not render any elements xxx', () => {
+  it('Should not render any elements', () => {
     const { container } = render(
       <Toolbar calendarDate={new Date(2021, 11, 24)} hideOkBtn ranges={[]} locale={{}} />
     );


### PR DESCRIPTION
Why I am doing this: https://github.com/rsuite/rsuite/discussions/3200
What I did: removing the `getDOMNode` and using the `render` in `@testing-library/react`

This update involves 1 component change: `DatePicker`