### PR TITLE
Test: (CustomProvider & Content)removing the getDOMNode and using the render

### DIFF
--- a/src/Content/test/ContentSpec.tsx
+++ b/src/Content/test/ContentSpec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getDOMNode } from '@test/testUtils';
+import { render } from '@testing-library/react';
 import { testStandardProps } from '@test/commonCases';
 import Content from '../Content';
 
@@ -8,9 +8,9 @@ describe('Content', () => {
 
   it('Should render a Content', () => {
     const title = 'Test';
-    const instance = getDOMNode(<Content>{title}</Content>);
+    const { container } = render(<Content>{title}</Content>);
 
-    assert.equal(instance.className, 'rs-content');
-    assert.equal(instance.textContent, title);
+    expect(container.firstChild).to.have.class('rs-content');
+    expect(container.firstChild).to.have.text(title);
   });
 });

--- a/src/CustomProvider/test/CustomProviderSpec.tsx
+++ b/src/CustomProvider/test/CustomProviderSpec.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import CustomProvider from '../CustomProvider';
 import Pagination from '../../Pagination';
 import Calendar from '../../Calendar';
-import { getDOMNode } from '@test/testUtils';
+// import { getDOMNode } from '@test/testUtils';
 import zhCN from '../../locales/zh_CN';
 import ruRU from '../../locales/ru_RU';
 import TreePicker from '../../TreePicker';
@@ -50,7 +50,7 @@ describe('CustomProvider', () => {
 
   // TODO: This is a side-effect test, which will affect the style check test.
   it('Should be rendered as a dark theme', () => {
-    getDOMNode(
+    render(
       <div>
         <CustomProvider theme="dark">
           <div />

--- a/src/CustomProvider/test/CustomProviderSpec.tsx
+++ b/src/CustomProvider/test/CustomProviderSpec.tsx
@@ -3,7 +3,6 @@ import { render, screen } from '@testing-library/react';
 import CustomProvider from '../CustomProvider';
 import Pagination from '../../Pagination';
 import Calendar from '../../Calendar';
-// import { getDOMNode } from '@test/testUtils';
 import zhCN from '../../locales/zh_CN';
 import ruRU from '../../locales/ru_RU';
 import TreePicker from '../../TreePicker';

--- a/src/CustomProvider/test/FormattedDateSpec.tsx
+++ b/src/CustomProvider/test/FormattedDateSpec.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import ru from 'date-fns/locale/ru';
 import CustomProvider from '../CustomProvider';
+import { render } from '@testing-library/react';
 import FormattedDate from '../FormattedDate';
-import { getDOMNode } from '@test/testUtils';
 import { format } from '../../utils/dateUtils';
 import ruRU from '../../locales/ru_RU';
 
@@ -14,7 +14,7 @@ function formatDate(date, formatStr) {
 
 describe('FormattedDate', () => {
   it('Should render formatted date ', () => {
-    const domNode = getDOMNode(
+    const { container } = render(
       <div>
         <CustomProvider locale={ruRU}>
           <div>
@@ -23,11 +23,12 @@ describe('FormattedDate', () => {
         </CustomProvider>
       </div>
     );
-    assert.equal(domNode.textContent, 'янв. 01, 2020');
+
+    expect(container.firstChild).to.have.text('янв. 01, 2020');
   });
 
   it('Should render formatted date by formatDate', () => {
-    const domNode = getDOMNode(
+    const { container } = render(
       <div>
         <CustomProvider formatDate={formatDate}>
           <div>
@@ -36,15 +37,17 @@ describe('FormattedDate', () => {
         </CustomProvider>
       </div>
     );
-    assert.equal(domNode.textContent, 'янв. 01, 2020');
+
+    expect(container.firstChild).to.have.text('янв. 01, 2020');
   });
 
   it('Should render default formatted date', () => {
-    const domNode = getDOMNode(
+    const { container } = render(
       <div>
         <FormattedDate date={new Date('2020-01-01')} formatStr="MMM dd, yyyy" />
       </div>
     );
-    assert.equal(domNode.textContent, 'Jan 01, 2020');
+
+    expect(container.firstChild).to.have.text('Jan 01, 2020');
   });
 });


### PR DESCRIPTION
Why I am doing this: https://github.com/rsuite/rsuite/discussions/3200
What I did: removing the `getDOMNode` and using the `render` in `@testing-library/react`

This update involves 2 component changes: `Container` and `Content`