### PR TITLE
fix(Modal): fixed default size in modal component

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -76,7 +76,7 @@ const Modal: ModalComponent = React.forwardRef((props: ModalProps, ref) => {
     dialogStyle,
     animation = Bounce,
     open,
-    size = 'sm',
+    size = 'md',
     full,
     dialogAs: Dialog = ModalDialog,
     animationProps,

--- a/src/Modal/test/ModalSpec.tsx
+++ b/src/Modal/test/ModalSpec.tsx
@@ -255,6 +255,12 @@ describe('Modal', () => {
         '"full" property of "Modal" has been deprecated.\nUse size="full" instead.'
       );
     });
+
+    it('Should have a default size equal to "md"', () => {
+      render(<Modal open></Modal>);
+
+      expect(screen.getByRole('dialog')).to.have.class('rs-modal-md');
+    });
   });
 
   describe('a11y', () => {


### PR DESCRIPTION
**Changes**

- Changed modal default size prop to `md`

**Issue**
#3250 