### PR TITLE
feat(InputPicker): add shouldDisplayCreateOption prop

### DIFF
--- a/docs/pages/components/input-picker/en-US/index.md
+++ b/docs/pages/components/input-picker/en-US/index.md
@@ -52,56 +52,59 @@ Learn more in [Accessibility](/guide/accessibility).
 
 ### `<InputPicker>`
 
-| Property           | Type `(Default)`                                                                  | Description                                                 |
-| ------------------ | --------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| block              | boolean                                                                           | Blocking an entire row                                      |
-| classPrefix        | string `('picker')`                                                               | The prefix of the component CSS class                       |
-| cleanable          | boolean `(true)`                                                                  | Whether the option can be emptied.                          |
-| container          | HTMLElement &#124; (() => HTMLElement)                                            | Sets the rendering container                                |
-| creatable          | boolean                                                                           | Settings can create new options                             |
-| data \*            | [ItemDataType][item][]                                                            | Selectable data                                             |
-| defaultValue       | string                                                                            | Default value                                               |
-| disabled           | boolean                                                                           | Whether or not component is disabled                        |
-| disabledItemValues | string[]                                                                          | Disable optional                                            |
-| groupBy            | string                                                                            | Set grouping criteria 'key' in 'data'                       |
-| labelKey           | string `('label')`                                                                | Set options to display the 'key' in 'data'                  |
-| listProps          | [ListProps][listprops]                                                            | Properties of virtualized lists.                            |
-| locale             | [PickerLocaleType](/guide/i18n/#pickers)                                          | Locale text                                                 |
-| menuMaxHeight      | number `(320)`                                                                    | Set the max height of the Dropdown                          |
-| menuClassName      | string                                                                            | A css class to apply to the Menu DOM node.                  |
-| menuStyle          | CSSProperties                                                                     | A style to apply to the Menu DOM node.                      |
-| onChange           | (value:string, event) => void                                                     | callback function when value changes                        |
-| onClean            | (event) => void                                                                   | Callback fired when value clean                             |
-| onClose            | () => void                                                                        | Close callback functions                                    |
-| onCreate           | (value: string, item: [ItemDataType][item], event) => void                        | Callback fired when a new option is created                 |
-| onEnter            | () => void                                                                        | Callback fired before the overlay transitions in            |
-| onEntered          | () => void                                                                        | Callback fired after the overlay finishes transitioning in  |
-| onEntering         | () => void                                                                        | Callback fired as the overlay begins to transition in       |
-| onExit             | () => void                                                                        | Callback fired right before the overlay transitions out     |
-| onExited           | () => void                                                                        | Callback fired after the overlay finishes transitioning out |
-| onExiting          | () => void                                                                        | Callback fired as the overlay begins to transition out      |
-| onGroupTitleClick  | (event) => void                                                                   | Click the callback function for the group header            |
-| onOpen             | () => void                                                                        | Open callback function                                      |
-| onSearch           | (searchKeyword:string, event) => void                                             | callback function for Search                                |
-| onSelect           | (value:string, item: [ItemDataType][item] , event) => void                        | option is clicked after the selected callback function      |
-| open               | boolean                                                                           | Whether open the component                                  |
-| placeholder        | ReactNode `('Select')`                                                            | Setting placeholders                                        |
-| placement          | [Placement](#code-ts-placement-code)`('bottomStart')`                             | The placement of component                                  |
-| preventOverflow    | boolean                                                                           | Prevent floating element overflow                           |
-| renderExtraFooter  | () => ReactNode                                                                   | custom render extra footer                                  |
-| renderMenu         | (menu: ReactNode) => ReactNode                                                    | Customizing the Rendering Menu list                         |
-| renderMenuGroup    | (groupTitle: ReactNode, item: [ItemDataType][item]) => ReactNode                  | Custom Render Options Group                                 |
-| renderMenuItem     | (label: ReactNode, item: [ItemDataType][item]) => ReactNode                       | Custom Render Options                                       |
-| renderValue        | (value:string, item: [ItemDataType][item],selectedElement:ReactNode) => ReactNode | Custom Render selected options                              |
-| searchBy           | (keyword: string, label: ReactNode, item: [ItemDataType][item]) => boolean        | Custom search rules                                         |
-| searchable         | boolean `(true)`                                                                  | Whether you can search for options.                         |
-| size               | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')`                                 | A picker can have different sizes                           |
-| sort               | (isGroup: boolean) => (a: any, b: any) => number                                  | Sort options                                                |
-| toggleAs           | ElementType `('a')`                                                               | You can use a custom element for this component             |
-| value              | string                                                                            | Value (Controlled)                                          |
-| valueKey           | string `('value')`                                                                | Set option value 'key' in 'data'                            |
-| virtualized        | boolean                                                                           | Whether using Virtualized List                              |
-| caretAs            | ElementType                                                                       | Custom component for the caret icon                         |
+<!-- prettier-sort-markdown-table -->
+
+| Property                  | Type `(Default)`                                                                  | Description                                                                  |
+| ------------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| block                     | boolean                                                                           | Blocking an entire row                                                       |
+| caretAs                   | ElementType                                                                       | Custom component for the caret icon                                          |
+| classPrefix               | string `('picker')`                                                               | The prefix of the component CSS class                                        |
+| cleanable                 | boolean `(true)`                                                                  | Whether the option can be emptied.                                           |
+| container                 | HTMLElement &#124; (() => HTMLElement)                                            | Sets the rendering container                                                 |
+| creatable                 | boolean                                                                           | Settings can create new options                                              |
+| data \*                   | [ItemDataType][item][]                                                            | Selectable data                                                              |
+| defaultValue              | string                                                                            | Default value                                                                |
+| disabled                  | boolean                                                                           | Whether or not component is disabled                                         |
+| disabledItemValues        | string[]                                                                          | Disable optional                                                             |
+| groupBy                   | string                                                                            | Set grouping criteria 'key' in 'data'                                        |
+| labelKey                  | string `('label')`                                                                | Set options to display the 'key' in 'data'                                   |
+| listProps                 | [ListProps][listprops]                                                            | Properties of virtualized lists.                                             |
+| locale                    | [PickerLocaleType](/guide/i18n/#pickers)                                          | Locale text                                                                  |
+| menuClassName             | string                                                                            | A css class to apply to the Menu DOM node.                                   |
+| menuMaxHeight             | number `(320)`                                                                    | Set the max height of the Dropdown                                           |
+| menuStyle                 | CSSProperties                                                                     | A style to apply to the Menu DOM node.                                       |
+| onChange                  | (value:string, event) => void                                                     | callback function when value changes                                         |
+| onClean                   | (event) => void                                                                   | Callback fired when value clean                                              |
+| onClose                   | () => void                                                                        | Close callback functions                                                     |
+| onCreate                  | (value: string, item: [ItemDataType][item], event) => void                        | Callback fired when a new option is created                                  |
+| onEnter                   | () => void                                                                        | Callback fired before the overlay transitions in                             |
+| onEntered                 | () => void                                                                        | Callback fired after the overlay finishes transitioning in                   |
+| onEntering                | () => void                                                                        | Callback fired as the overlay begins to transition in                        |
+| onExit                    | () => void                                                                        | Callback fired right before the overlay transitions out                      |
+| onExited                  | () => void                                                                        | Callback fired after the overlay finishes transitioning out                  |
+| onExiting                 | () => void                                                                        | Callback fired as the overlay begins to transition out                       |
+| onGroupTitleClick         | (event) => void                                                                   | Click the callback function for the group header                             |
+| onOpen                    | () => void                                                                        | Open callback function                                                       |
+| onSearch                  | (searchKeyword:string, event) => void                                             | callback function for Search                                                 |
+| onSelect                  | (value:string, item: [ItemDataType][item] , event) => void                        | option is clicked after the selected callback function                       |
+| open                      | boolean                                                                           | Whether open the component                                                   |
+| placeholder               | ReactNode `('Select')`                                                            | Setting placeholders                                                         |
+| placement                 | [Placement](#code-ts-placement-code)`('bottomStart')`                             | The placement of component                                                   |
+| preventOverflow           | boolean                                                                           | Prevent floating element overflow                                            |
+| renderExtraFooter         | () => ReactNode                                                                   | custom render extra footer                                                   |
+| renderMenu                | (menu: ReactNode) => ReactNode                                                    | Customizing the Rendering Menu list                                          |
+| renderMenuGroup           | (groupTitle: ReactNode, item: [ItemDataType][item]) => ReactNode                  | Custom Render Options Group                                                  |
+| renderMenuItem            | (label: ReactNode, item: [ItemDataType][item]) => ReactNode                       | Custom Render Options                                                        |
+| renderValue               | (value:string, item: [ItemDataType][item],selectedElement:ReactNode) => ReactNode | Custom Render selected options                                               |
+| searchable                | boolean `(true)`                                                                  | Whether you can search for options.                                          |
+| searchBy                  | (keyword: string, label: ReactNode, item: [ItemDataType][item]) => boolean        | Custom search rules                                                          |
+| shouldDisplayCreateOption | (searchKeyword: string, filteredData: InputItemDataType[]) => boolean             | Customize whether to display "Create option" action with given textbox value |
+| size                      | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')`                                 | A picker can have different sizes                                            |
+| sort                      | (isGroup: boolean) => (a: any, b: any) => number                                  | Sort options                                                                 |
+| toggleAs                  | ElementType `('a')`                                                               | You can use a custom element for this component                              |
+| value                     | string                                                                            | Value (Controlled)                                                           |
+| valueKey                  | string `('value')`                                                                | Set option value 'key' in 'data'                                             |
+| virtualized               | boolean                                                                           | Whether using Virtualized List                                               |
 
 <!--{include:(_common/types/item-data-type.md)}-->
 <!--{include:(_common/types/placement.md)}-->

--- a/docs/pages/components/input-picker/zh-CN/index.md
+++ b/docs/pages/components/input-picker/zh-CN/index.md
@@ -55,56 +55,59 @@
 
 ### `<InputPicker>`
 
-| 属性名称           | 类型`(默认值)`                                                                    | 描述                                       |
-| ------------------ | --------------------------------------------------------------------------------- | ------------------------------------------ |
-| block              | boolean                                                                           | 堵塞整行                                   |
-| classPrefix        | string `('picker')`                                                               | 组件 CSS 类的前缀                          |
-| cleanable          | boolean `(true)`                                                                  | 可以清除                                   |
-| container          | HTMLElement &#124; (() => HTMLElement)                                            | 设置渲染的容器                             |
-| creatable          | boolean                                                                           | 设置可以新建选项                           |
-| data \*            | [ItemDataType][item][]                                                            | 组件数据                                   |
-| defaultValue       | string                                                                            | 设置默认值 `非受控`                        |
-| disabled           | boolean                                                                           | 禁用组件                                   |
-| disabledItemValues | string[]                                                                          | 禁用选项                                   |
-| groupBy            | string                                                                            | 设置分组条件在 `data` 中的 `key`           |
-| labelKey           | string `('label')`                                                                | 设置选项显示内容在 `data` 中的 `key`       |
-| listProps          | [ListProps][listprops]                                                            | 虚拟化长列表的相关属性                     |
-| locale             | [PickerLocaleType](/zh/guide/i18n/#pickers)                                       | 本地化的文本                               |
-| menuMaxHeight      | number `(320)`                                                                    | 设置 Dropdown 的最大高度                   |
-| menuClassName      | string                                                                            | 应用于菜单 DOM 节点的 css class            |
-| menuStyle          | CSSProperties                                                                     | 应用于菜单 DOM 节点的 style                |
-| onChange           | (value:string, event) => void                                                     | `value` 发生改变时的回调函数               |
-| onClean            | (event:SyntheticEvent) => void                                                    | 值清理时触发回调                           |
-| onClose            | () => void                                                                        | 关闭回调函数                               |
-| onCreate           | (value: string, item: [ItemDataType][item], event) => void                        | 在设置 `creatable`，创建新选项后的回调函数 |
-| onEnter            | () => void                                                                        | 显示前动画过渡的回调函数                   |
-| onEntered          | () => void                                                                        | 显示后动画过渡的回调函数                   |
-| onEntering         | () => void                                                                        | 显示中动画过渡的回调函数                   |
-| onExit             | () => void                                                                        | 退出前动画过渡的回调函数                   |
-| onExited           | () => void                                                                        | 退出后动画过渡的回调函数                   |
-| onExiting          | () => void                                                                        | 退出中动画过渡的回调函数                   |
-| onGroupTitleClick  | (event) => void                                                                   | 点击分组标题的回调函数                     |
-| onOpen             | () => void                                                                        | 打开回调函数                               |
-| onSearch           | (searchKeyword:string, event) => void                                             | 搜索的回调函数                             |
-| onSelect           | (value:string, item: [ItemDataType][item] , event) => void                        | 选项被点击选择后的回调函数                 |
-| open               | boolean                                                                           | 是否打开                                   |
-| placeholder        | ReactNode `('Select')`                                                            | 占位符                                     |
-| placement          | [Placement](#code-ts-placement-code)`('bottomStart')`                             | 位置                                       |
-| preventOverflow    | boolean                                                                           | 防止浮动元素溢出                           |
-| renderExtraFooter  | () => ReactNode                                                                   | 自定义页脚内容                             |
-| renderMenu         | (menu:ReactNode) => ReactNode                                                     | 自定义渲染菜单列表                         |
-| renderMenuGroup    | (groupTitle:ReactNode, item: [ItemDataType][item]) => ReactNode                   | 自定义渲染选项组                           |
-| renderMenuItem     | (label:ReactNode, item: [ItemDataType][item]) => ReactNode                        | 自定义渲染选项                             |
-| renderValue        | (value:string, item: [ItemDataType][item],selectedElement:ReactNode) => ReactNode | 自定义渲染被选中的选项                     |
-| searchBy           | (keyword: string, label: ReactNode, item: [ItemDataType][item]) => boolean        | 自定义搜索规则                             |
-| searchable         | boolean `(true)`                                                                  | 可以搜索                                   |
-| size               | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')`                                 | 设置组件尺寸                               |
-| sort               | (isGroup: boolean) => (a: any, b: any) => number                                  | 对选项排序                                 |
-| toggleAs           | ElementType `('a')`                                                               | 为组件自定义元素类型                       |
-| value              | string                                                                            | 设置值 `受控`,                             |
-| valueKey           | string `('value')`                                                                | 设置选项值在 `data` 中的 `key`             |
-| virtualized        | boolean                                                                           | 是否开启虚拟列表                           |
-| caretAs            | ElementType                                                                       | 自定义右侧箭头图标的组件                   |
+<!-- prettier-sort-markdown-table -->
+
+| 属性名称                  | 类型`(默认值)`                                                                    | 描述                                       |
+| ------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------ |
+| block                     | boolean                                                                           | 堵塞整行                                   |
+| caretAs                   | ElementType                                                                       | 自定义右侧箭头图标的组件                   |
+| classPrefix               | string `('picker')`                                                               | 组件 CSS 类的前缀                          |
+| cleanable                 | boolean `(true)`                                                                  | 可以清除                                   |
+| container                 | HTMLElement &#124; (() => HTMLElement)                                            | 设置渲染的容器                             |
+| creatable                 | boolean                                                                           | 设置可以新建选项                           |
+| data \*                   | [ItemDataType][item][]                                                            | 组件数据                                   |
+| defaultValue              | string                                                                            | 设置默认值 `非受控`                        |
+| disabled                  | boolean                                                                           | 禁用组件                                   |
+| disabledItemValues        | string[]                                                                          | 禁用选项                                   |
+| groupBy                   | string                                                                            | 设置分组条件在 `data` 中的 `key`           |
+| labelKey                  | string `('label')`                                                                | 设置选项显示内容在 `data` 中的 `key`       |
+| listProps                 | [ListProps][listprops]                                                            | 虚拟化长列表的相关属性                     |
+| locale                    | [PickerLocaleType](/zh/guide/i18n/#pickers)                                       | 本地化的文本                               |
+| menuClassName             | string                                                                            | 应用于菜单 DOM 节点的 css class            |
+| menuMaxHeight             | number `(320)`                                                                    | 设置 Dropdown 的最大高度                   |
+| menuStyle                 | CSSProperties                                                                     | 应用于菜单 DOM 节点的 style                |
+| onChange                  | (value:string, event) => void                                                     | `value` 发生改变时的回调函数               |
+| onClean                   | (event:SyntheticEvent) => void                                                    | 值清理时触发回调                           |
+| onClose                   | () => void                                                                        | 关闭回调函数                               |
+| onCreate                  | (value: string, item: [ItemDataType][item], event) => void                        | 在设置 `creatable`，创建新选项后的回调函数 |
+| onEnter                   | () => void                                                                        | 显示前动画过渡的回调函数                   |
+| onEntered                 | () => void                                                                        | 显示后动画过渡的回调函数                   |
+| onEntering                | () => void                                                                        | 显示中动画过渡的回调函数                   |
+| onExit                    | () => void                                                                        | 退出前动画过渡的回调函数                   |
+| onExited                  | () => void                                                                        | 退出后动画过渡的回调函数                   |
+| onExiting                 | () => void                                                                        | 退出中动画过渡的回调函数                   |
+| onGroupTitleClick         | (event) => void                                                                   | 点击分组标题的回调函数                     |
+| onOpen                    | () => void                                                                        | 打开回调函数                               |
+| onSearch                  | (searchKeyword:string, event) => void                                             | 搜索的回调函数                             |
+| onSelect                  | (value:string, item: [ItemDataType][item] , event) => void                        | 选项被点击选择后的回调函数                 |
+| open                      | boolean                                                                           | 是否打开                                   |
+| placeholder               | ReactNode `('Select')`                                                            | 占位符                                     |
+| placement                 | [Placement](#code-ts-placement-code)`('bottomStart')`                             | 位置                                       |
+| preventOverflow           | boolean                                                                           | 防止浮动元素溢出                           |
+| renderExtraFooter         | () => ReactNode                                                                   | 自定义页脚内容                             |
+| renderMenu                | (menu:ReactNode) => ReactNode                                                     | 自定义渲染菜单列表                         |
+| renderMenuGroup           | (groupTitle:ReactNode, item: [ItemDataType][item]) => ReactNode                   | 自定义渲染选项组                           |
+| renderMenuItem            | (label:ReactNode, item: [ItemDataType][item]) => ReactNode                        | 自定义渲染选项                             |
+| renderValue               | (value:string, item: [ItemDataType][item],selectedElement:ReactNode) => ReactNode | 自定义渲染被选中的选项                     |
+| searchable                | boolean `(true)`                                                                  | 可以搜索                                   |
+| searchBy                  | (keyword: string, label: ReactNode, item: [ItemDataType][item]) => boolean        | 自定义搜索规则                             |
+| shouldDisplayCreateOption | (searchKeyword: string, filteredData: InputItemDataType[]) => boolean             | 自定义何时显示/隐藏“新建选项”操作          |
+| size                      | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')`                                 | 设置组件尺寸                               |
+| sort                      | (isGroup: boolean) => (a: any, b: any) => number                                  | 对选项排序                                 |
+| toggleAs                  | ElementType `('a')`                                                               | 为组件自定义元素类型                       |
+| value                     | string                                                                            | 设置值 `受控`,                             |
+| valueKey                  | string `('value')`                                                                | 设置选项值在 `data` 中的 `key`             |
+| virtualized               | boolean                                                                           | 是否开启虚拟列表                           |
 
 <!--{include:(_common/types/item-data-type.md)}-->
 <!--{include:(_common/types/placement.md)}-->

--- a/src/InputPicker/InputPicker.tsx
+++ b/src/InputPicker/InputPicker.tsx
@@ -103,6 +103,20 @@ export interface InputPickerProps<T = ValueType>
 
   /** Called when the option is created */
   onCreate?: (value: ValueType, item: ItemDataType, event: React.SyntheticEvent) => void;
+
+  /**
+   * Customize whether to display "Create option" action with given textbox value
+   *
+   * By default, InputPicker hides "Create option" action when textbox value matches any filtered item's [valueKey] property
+   *
+   * @param searchKeyword Value of the textbox
+   * @param filteredData The items filtered by the searchKeyword
+   */
+  shouldDisplayCreateOption?: (
+    searchKeyword: string,
+    // FIXME-Doma Use generic type
+    filteredData: InputItemDataType[]
+  ) => boolean;
 }
 
 const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
@@ -132,6 +146,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
       menuAutoWidth = true,
       menuMaxHeight = 320,
       creatable,
+      shouldDisplayCreateOption,
       value: valueProp,
       valueKey = 'value',
       virtualized,
@@ -668,7 +683,12 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
 
       let items: ItemDataType[] = filterNodesOfTree(getAllData(), checkShouldDisplay);
 
-      if (creatable && searchKeyword && !items.find(item => item[valueKey] === searchKeyword)) {
+      if (
+        creatable &&
+        (typeof shouldDisplayCreateOption === 'function'
+          ? shouldDisplayCreateOption(searchKeyword, items)
+          : searchKeyword && !items.find(item => item[valueKey] === searchKeyword))
+      ) {
         items = [...items, createOption(searchKeyword)];
       }
 

--- a/src/InputPicker/test/InputPickerSpec.tsx
+++ b/src/InputPicker/test/InputPickerSpec.tsx
@@ -385,6 +385,33 @@ describe('InputPicker', () => {
     expect(onCreateSpy).to.calledWith('abc');
   });
 
+  it('Should hide "Create option" action if `shouldDisplayCreateOption` returns false', () => {
+    const data = [
+      { label: 'Alice', value: 1 },
+      { label: 'Bob', value: 2 }
+    ];
+
+    // Display "Create option" action only when no item's `label` matches searchKeyword
+    const shouldDisplayCreateOption = sinon.spy((searchKeyword, filteredData) =>
+      filteredData.every(item => item.label !== searchKeyword)
+    );
+    render(
+      <InputPicker
+        defaultOpen
+        data={data}
+        creatable
+        shouldDisplayCreateOption={shouldDisplayCreateOption}
+      />
+    );
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Alice' } });
+
+    expect(shouldDisplayCreateOption).to.have.been.calledWith('Alice', [
+      { label: 'Alice', value: 1 }
+    ]);
+    expect(screen.queryByText(/^Create option/)).to.not.exist;
+  });
+
   describe('ref testing', () => {
     it('Should get public objects and methods', () => {
       const instance = getInstance(<InputPicker data={data} open virtualized />);


### PR DESCRIPTION
## New `shouldDisplayCreateOption` prop of InputPicker component

Specify when to display/hide "Create option" action with given search keyword in a creatable InputPicker.

Example: A creatable InputPicker, but only display "Create option" action when no item's `name` matches searchKeyword

```jsx
<InputPicker
  data={data}
  creatable
  shouldDisplayCreateOption={(searchKeyword, filteredData) =>
    filteredData.every(item => item.name !== searchKeyword)
  )}
/>
```

### Signature

The `shouldDisplayCreateOption` function takes two arguments and returns a boolean value

```typescript
type InputPickerProps = {
  /**
   * @param searchKeyword  Value of the textbox
   * @param filteredData   The items filtered by the searchKeyword
   *
   * @returns Whether to display "Create option" action
   */
  shouldDisplayCreateOption?: (
    searchKeyword: string,
    filteredData: InputItemDataType[]
  ) => boolean;
}
```

---

Close #3267 