### PR TITLE
fix(Uploader): correct type for status argument of onError callback

### DIFF
--- a/src/Uploader/Uploader.tsx
+++ b/src/Uploader/Uploader.tsx
@@ -7,6 +7,7 @@ import { ajaxUpload, useClassNames, useCustom, guid, useWillUnmount } from '../u
 import { WithAsProps } from '../@types/common';
 import Plaintext from '../Plaintext';
 import { UploaderLocale } from '../locales';
+import type { ErrorStatus } from '../utils/ajaxUpload';
 
 export interface FileType {
   /** File Name */
@@ -136,8 +137,13 @@ export interface UploaderProps
   /** In the file list, click the callback function for the uploaded file */
   onPreview?: (file: FileType, event: React.SyntheticEvent) => void;
 
-  /** Upload callback function with erro */
-  onError?: (status: any, file: FileType, event: ProgressEvent, xhr: XMLHttpRequest) => void;
+  /** Upload callback function with error */
+  onError?: (
+    status: ErrorStatus,
+    file: FileType,
+    event: ProgressEvent,
+    xhr: XMLHttpRequest
+  ) => void;
 
   /** callback function after successful upload */
   onSuccess?: (response: any, file: FileType, event: ProgressEvent, xhr: XMLHttpRequest) => void;
@@ -349,7 +355,7 @@ const Uploader = React.forwardRef((props: UploaderProps, ref) => {
    * @param xhr
    */
   const handleAjaxUploadError = useCallback(
-    (file: FileType, status: any, event: ProgressEvent, xhr: XMLHttpRequest) => {
+    (file: FileType, status: ErrorStatus, event: ProgressEvent, xhr: XMLHttpRequest) => {
       const nextFile: FileType = {
         ...file,
         status: 'error'

--- a/src/Uploader/test/Uploader.test.tsx
+++ b/src/Uploader/test/Uploader.test.tsx
@@ -1,8 +1,16 @@
 import React from 'react';
 import Uploader from '../Uploader';
+import { expectType } from 'ts-expect';
 
 <Uploader appearance="primary" action="#" />;
 
 <Uploader appearance="primary" color="orange" action="#" />;
 
 <Uploader size="lg" action="#" />;
+
+<Uploader
+  action="#"
+  onError={status => {
+    expectType<'timeout' | 'server_error' | 'xhr_error'>(status.type);
+  }}
+/>;

--- a/src/utils/ajaxUpload.ts
+++ b/src/utils/ajaxUpload.ts
@@ -1,4 +1,4 @@
-interface ErrorStatus {
+export interface ErrorStatus {
   type: 'timeout' | 'server_error' | 'xhr_error';
   response?: any;
 }


### PR DESCRIPTION
`status` was typed `any` which prevents user from reading its properties with correct type declaration

<img width="317" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/7adce4ba-ecdf-4ba6-8feb-922a21c42eca">
