### PR TITLE
fix(RadioGroup): fix style in picker appearance

### DIFF
--- a/docs/pages/components/radio/fragments/radio-group-inline-picker.md
+++ b/docs/pages/components/radio/fragments/radio-group-inline-picker.md
@@ -5,7 +5,7 @@ import { Radio, RadioGroup, Form } from 'rsuite';
 
 const styles = {
   radioGroupLabel: {
-    padding: '8px 2px 8px 10px',
+    padding: '7px 2px 7px 12px',
     display: 'inline-block',
     verticalAlign: 'middle'
   }

--- a/src/RadioGroup/styles/index.less
+++ b/src/RadioGroup/styles/index.less
@@ -1,5 +1,3 @@
-@import (reference) '../../Button/styles/index';
-
 .rs-radio-group {
   display: flex;
   flex-direction: column;
@@ -15,21 +13,33 @@
 
 // Radio Group - picker appearance
 .rs-radio-group-picker {
+  @radio-group-padding-start: 12px;
+  @radio-group-padding-end: 12px;
+  @radio-group-border-width: 1px;
+  @radio-padding-x: 10px;
+  @radio-active-underline-width: 2px;
+
   display: inline-flex;
   color: var(--rs-text-primary);
-  border: 1px solid var(--rs-border-primary);
+  border: @radio-group-border-width solid var(--rs-border-primary);
   border-radius: @border-radius;
-  margin-left: 0;
 
   .rs-radio-inline {
-    margin-left: 0;
+    padding: 0 @radio-padding-x;
+    margin: 0;
+
+    &:first-child {
+      padding-left: @radio-group-padding-start;
+    }
+
+    &:last-child {
+      padding-right: @radio-group-padding-end;
+    }
   }
 
   .rs-radio-checker {
     padding: 0;
     min-height: auto;
-    border-bottom: 1px solid transparent;
-    margin: 0 10px;
   }
 
   // Picker Radio group hidden radio.
@@ -38,14 +48,16 @@
   }
 
   .rs-radio-checker > label {
-    // TODO: Should not inherit Button styles
-    .rs-btn();
-    .rs-btn-subtle();
-
+    display: inline-block;
+    font-size: @font-size-base;
+    line-height: @line-height-base;
+    border-radius: 0;
     color: var(--rs-text-secondary);
     background: none;
     transition: color 0.3s linear;
-    padding: (@padding-y - 1px) 0;
+    padding: (@padding-y - @radio-group-border-width) 0
+      (@padding-y - @radio-group-border-width - @radio-active-underline-width);
+    border-bottom: @radio-active-underline-width solid transparent;
 
     .high-contrast-mode({
       transition: none;
@@ -59,10 +71,9 @@
   }
 
   .rs-radio-checked .rs-radio-checker {
-    border-bottom: 2px solid var(--rs-text-active);
-
     > label {
       color: var(--rs-text-active);
+      border-color: var(--rs-text-active);
     }
   }
 


### PR DESCRIPTION
### Fix 3 styling issues

- Horizontal spacing between radios was 30px, which should have been 20px - this issue was introduced in [v5.34.1](https://github.com/rsuite/rsuite/releases/tag/v5.34.1) by [#3215](https://github.com/rsuite/rsuite/pull/3215)
- Total height of the RadioGroup was 38px, which should have been 36px - this also led to vertical mis-alignment of the radio text
- Leading/trailing padding of the RadioGroup was 10px, which should have been 12px

### Preview

https://rsuite-nextjs-git-fix-radiogroup-picker-style-rsuite.vercel.app/components/radio/#radio-group-picker

### Screenshots

Before

<img width="310" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/f8e9de87-a975-434f-9c85-85e3bc1b9658">

After

<img width="284" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/089ee36b-2d26-4153-a3c9-0bd09e9941e0">

Design

<img width="519" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/09324b6e-4310-44f1-91a6-371ada583973">
