### PR TITLE
fix(OverlayTrigger): fix handleClose will trigger twice

### DIFF
--- a/src/Overlay/OverlayTrigger.tsx
+++ b/src/Overlay/OverlayTrigger.tsx
@@ -327,7 +327,7 @@ const OverlayTrigger = React.forwardRef(
 
     const handleDelayedClose = useCallback(() => {
       if (!enterable) {
-        handleClose();
+        return handleClose();
       }
 
       isOnTrigger.current = false;


### PR DESCRIPTION
https://github.com/rsuite/rsuite/assets/53305259/850ce8a5-7884-4a9a-bb60-fe11fe48302a




Sometimes Chrome will trigger `mouseover`  => `mouseout`  =>  `mouseover`, Because there's a hidden bug in `OverlayTrigger `,  and then it will cause strange problems similar to the one mentioned above.


