### PR TITLE
fix(SelectPicker): wrong padding for grouped options

### DIFF
--- a/src/SelectPicker/styles/index.less
+++ b/src/SelectPicker/styles/index.less
@@ -11,6 +11,10 @@
   .picker-menu-group-common(picker);
   .picker-menu-group-title(picker);
   .picker-menu-group-closed(picker);
+
+  .rs-picker-menu-group ~ [role='option'] > .rs-picker-select-menu-item {
+    padding-left: 26px;
+  }
 }
 
 // Menu item (the option)


### PR DESCRIPTION
Before fix
<img width="275" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/f6d7485e-496f-4de8-931f-0ee1979df666">

After fix
<img width="303" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/1d098d6d-03f3-4375-92cd-08c736658cb1">

Design
<img width="373" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/c06a397c-5be4-4442-a61e-8a64d53d2d28">
