### PR TITLE
refactor(useSearch): improve state flow

### DIFF
--- a/src/CheckPicker/CheckPicker.tsx
+++ b/src/CheckPicker/CheckPicker.tsx
@@ -149,10 +149,9 @@ const CheckPicker = React.forwardRef(
     );
 
     // Use search keywords to filter options.
-    const { searchKeyword, filteredData, setSearchKeyword, handleSearch, checkShouldDisplay } =
-      useSearch({
+    const { searchKeyword, filteredData, handleSearch, resetSearch, checkShouldDisplay } =
+      useSearch(data, {
         labelKey,
-        data,
         searchBy,
         callback: handleSearchCallback
       });
@@ -267,11 +266,11 @@ const CheckPicker = React.forwardRef(
     }, [onOpen]);
 
     const handleExited = useCallback(() => {
-      setSearchKeyword('');
+      resetSearch();
       setFocusItemValue(null);
       setActive(false);
       onClose?.();
-    }, [onClose, setFocusItemValue, setSearchKeyword]);
+    }, [onClose, setFocusItemValue, resetSearch]);
 
     usePublicMethods(ref, { triggerRef, overlayRef, targetRef, listRef });
 

--- a/src/InputPicker/InputPicker.tsx
+++ b/src/InputPicker/InputPicker.tsx
@@ -240,12 +240,14 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
     );
 
     // Use search keywords to filter options.
-    const { searchKeyword, setSearchKeyword, checkShouldDisplay, handleSearch } = useSearch({
-      labelKey,
-      data: getAllData(),
-      searchBy,
-      callback: handleSearchCallback
-    });
+    const { searchKeyword, resetSearch, checkShouldDisplay, handleSearch } = useSearch(
+      getAllData(),
+      {
+        labelKey,
+        searchBy,
+        callback: handleSearchCallback
+      }
+    );
 
     // Update the state when the data in props changes
     useEffect(() => {
@@ -356,7 +358,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
     const handleSelectItem = (value: string, item: InputItemDataType, event: React.MouseEvent) => {
       setValue(value);
       setFocusItemValue(value);
-      setSearchKeyword('');
+      resetSearch();
       handleSelect(value, item, event);
       handleChange(value, event);
       handleClose();
@@ -383,7 +385,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
       }
 
       setValue(val);
-      setSearchKeyword('');
+      resetSearch();
       setFocusItemValue(nextItemValue);
       handleSelect(val, item, event);
       handleChange(val, event);
@@ -421,7 +423,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
         }
 
         setValue(val);
-        setSearchKeyword('');
+        resetSearch();
         handleSelect(val, focusItem, event);
         handleChange(val, event);
       },
@@ -432,7 +434,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
         disabledItemValues,
         disabledOptions,
         setValue,
-        setSearchKeyword,
+        resetSearch,
         handleSelect,
         handleChange,
         valueKey,
@@ -460,7 +462,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
           focusItem = createOption(searchKeyword);
         }
         setValue(focusItemValue);
-        setSearchKeyword('');
+        resetSearch();
 
         if (focusItem) {
           handleSelect(focusItemValue, focusItem, event);
@@ -476,7 +478,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
         valueKey,
         searchKeyword,
         handleClose,
-        setSearchKeyword,
+        resetSearch,
         createOption,
         getAllData,
         handleChange,
@@ -515,7 +517,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
         }
         setValue(null);
         setFocusItemValue(null);
-        setSearchKeyword('');
+        resetSearch();
         if (multi) {
           handleChange([], event);
         } else {
@@ -528,7 +530,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
         searchKeyword,
         setValue,
         setFocusItemValue,
-        setSearchKeyword,
+        resetSearch,
         multi,
         onClean,
         handleChange
@@ -581,9 +583,9 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
 
     const handleExited = useCallback(() => {
       setFocusItemValue(multi ? value?.[0] : value);
-      setSearchKeyword('');
+      resetSearch();
       onClose?.();
-    }, [setFocusItemValue, setSearchKeyword, onClose, value, multi]);
+    }, [setFocusItemValue, resetSearch, onClose, value, multi]);
 
     const handleFocus = useCallback(() => {
       if (!readOnly) {

--- a/src/Picker/test/useSearchSpec.ts
+++ b/src/Picker/test/useSearchSpec.ts
@@ -1,0 +1,97 @@
+import { act } from '@testing-library/react';
+import { renderHook } from '@test/testUtils';
+import { useSearch } from '../utils';
+import Sinon from 'sinon';
+
+describe('useSearch(data, opts)', () => {
+  const data = ['wanted', 'other'];
+
+  it('Should set empty string as default search keyword', () => {
+    const { result } = renderHook(() => useSearch(data, { labelKey: '' }));
+
+    expect(result.current.searchKeyword).to.equal('');
+  });
+
+  it('Should return data as is initially', () => {
+    const { result } = renderHook(() => useSearch(data, { labelKey: '' }));
+
+    expect(result.current.filteredData).to.deep.equal(data);
+  });
+
+  it('Should update search keyword to new value specified by handleSearch', () => {
+    const { result } = renderHook(() => useSearch(data, { labelKey: '' }));
+
+    act(() => {
+      result.current.handleSearch('test', void 0 as any);
+    });
+
+    expect(result.current.searchKeyword).to.equal('test');
+  });
+
+  it('Should return filtered data when search keyword is updated', () => {
+    const { result } = renderHook(() => useSearch(data, { labelKey: '' }));
+
+    act(() => {
+      result.current.handleSearch('wanted', void 0 as any);
+    });
+
+    expect(result.current.filteredData).to.deep.equal(['wanted']);
+  });
+
+  it('Should filter data based on labelKey when data items are objects', () => {
+    const { result } = renderHook(() =>
+      useSearch(
+        [
+          { label: 'wanted', value: 'other' },
+          { label: 'other', value: 'wanted' }
+        ],
+        { labelKey: 'label' }
+      )
+    );
+
+    act(() => {
+      result.current.handleSearch('wanted', void 0 as any);
+    });
+
+    expect(result.current.filteredData).to.deep.equal([{ label: 'wanted', value: 'other' }]);
+  });
+
+  it('Should filter data based on opts.searchBy function when specified', () => {
+    const searchBy = Sinon.spy((_keyword, _label, item: string) => item === 'other');
+
+    const { result } = renderHook(() => useSearch(data, { labelKey: '', searchBy }));
+
+    act(() => {
+      result.current.handleSearch('wanted', void 0 as any);
+    });
+
+    expect(searchBy).to.have.been.calledWith('wanted', 'wanted', 'wanted');
+    expect(result.current.filteredData).to.deep.equal(['other']);
+  });
+
+  it('Should call opts.callback when keyword is updated', () => {
+    const callback = Sinon.spy();
+
+    const { result } = renderHook(() => useSearch(data, { labelKey: '', callback }));
+
+    act(() => {
+      result.current.handleSearch('wanted', void 0 as any);
+    });
+
+    expect(callback).to.have.been.calledWith('wanted', ['wanted'], void 0);
+  });
+
+  it('Should reset search keyword to empty string when calling resetSearch', () => {
+    const { result } = renderHook(() => useSearch(data, { labelKey: '' }));
+
+    act(() => {
+      result.current.handleSearch('test', void 0 as any);
+    });
+
+    act(() => {
+      result.current.resetSearch();
+    });
+
+    expect(result.current.searchKeyword).to.equal('');
+  });
+});

--- a/src/SelectPicker/SelectPicker.tsx
+++ b/src/SelectPicker/SelectPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useCallback, useEffect, Ref } from 'react';
+import React, { useRef, useState, useCallback, Ref } from 'react';
 import PropTypes from 'prop-types';
 import pick from 'lodash/pick';
 import isUndefined from 'lodash/isUndefined';
@@ -202,25 +202,19 @@ const SelectPicker = React.forwardRef(
     });
 
     // Use search keywords to filter options.
-    const { searchKeyword, filteredData, updateFilteredData, setSearchKeyword, handleSearch } =
-      useSearch({
-        labelKey,
-        data,
-        searchBy,
-        callback: (
-          searchKeyword: string,
-          filteredData: ItemDataType[],
-          event: React.SyntheticEvent
-        ) => {
-          // The first option after filtering is the focus.
-          setFocusItemValue(filteredData?.[0]?.[valueKey]);
-          onSearch?.(searchKeyword, event);
-        }
-      });
-
-    useEffect(() => {
-      updateFilteredData(data);
-    }, [data, updateFilteredData]);
+    const { searchKeyword, filteredData, resetSearch, handleSearch } = useSearch(data, {
+      labelKey,
+      searchBy,
+      callback: (
+        searchKeyword: string,
+        filteredData: ItemDataType[],
+        event: React.SyntheticEvent
+      ) => {
+        // The first option after filtering is the focus.
+        setFocusItemValue(filteredData?.[0]?.[valueKey]);
+        onSearch?.(searchKeyword, event);
+      }
+    });
 
     // Use component active state to support keyboard events.
     const [active, setActive] = useState(false);
@@ -304,11 +298,11 @@ const SelectPicker = React.forwardRef(
     });
 
     const handleExited = useCallback(() => {
-      setSearchKeyword('');
+      resetSearch();
       setActive(false);
       onSearch?.('');
       onClose?.();
-    }, [onClose, setSearchKeyword, onSearch]);
+    }, [onClose, resetSearch, onSearch]);
 
     const handleEntered = useCallback(() => {
       setActive(true);


### PR DESCRIPTION
- Update `useSearch` to not only work with object arrays
- Remove `updateFilteredData` call from outside of `useSearch` and remove `updateFilteredData` method from return value
- Remove `setSearchKeyword` method from return value and replaced with `resetSearch` method, as it's always called with `''`.
- Add tests for `useSearch`
