### PR TITLE
Test: (Tree, Treepicker, Uploader, Whisper): Removing the getDOMNode and using render

### DIFF
--- a/src/Tree/test/TreeSpec.tsx
+++ b/src/Tree/test/TreeSpec.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { getDOMNode } from '@test/testUtils';
 import { fireEvent, render, screen } from '@testing-library/react';
 import sinon from 'sinon';
 import Tree from '../Tree';
@@ -36,10 +35,10 @@ const data = [
 
 describe('Tree', () => {
   it('Should render a tree', () => {
-    const instance = getDOMNode(<Tree data={data} />);
+    const { container } = render(<Tree data={data} />);
 
-    assert.include(instance.className, 'rs-tree');
-    assert.equal(instance.getAttribute('role'), 'tree');
+    expect(container.firstChild).to.have.class('rs-tree');
+    expect(container.firstChild).to.have.attr('role', 'tree');
   });
 
   it('Should call `onSelectItem` callback with the selected item and the full path', () => {
@@ -173,13 +172,13 @@ describe('Tree', () => {
   });
 
   it('Should show indent line', () => {
-    const instance = getDOMNode(<Tree data={data} showIndentLine />);
+    const { container } = render(<Tree data={data} showIndentLine />);
 
-    // eslint-disable-next-line testing-library/no-node-access
-    const lines = instance.querySelectorAll('.rs-tree-indent-line');
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    const lines = container.querySelectorAll('.rs-tree-indent-line');
 
-    // eslint-disable-next-line testing-library/no-node-access
-    assert.isNotNull(instance.querySelector('.rs-tree-indent-line'));
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    assert.isNotNull(container.querySelector('.rs-tree-indent-line'));
     assert.equal(lines.length, 2);
     assert.equal((lines[0] as HTMLElement).style.left, '44px');
     assert.equal((lines[1] as HTMLElement).style.left, '28px');

--- a/src/TreePicker/test/TreeNodeSpec.tsx
+++ b/src/TreePicker/test/TreeNodeSpec.tsx
@@ -1,24 +1,25 @@
 import React from 'react';
 import { Simulate } from 'react-dom/test-utils';
 import sinon from 'sinon';
-import { getDOMNode } from '@test/testUtils';
 import TreeNode from '../TreeNode';
+import { render } from '@testing-library/react';
 
 describe('TreePicker - TreeNode', () => {
   it('Should render tree node', () => {
-    const instance = getDOMNode(<TreeNode layer={0} visible nodeData={{}} />);
+    const { container } = render(<TreeNode layer={0} visible nodeData={{}} />);
 
-    assert.include(instance.className, 'rs-tree-node');
-    assert.include(instance.getAttribute('role'), 'treeitem');
+    expect(container.firstChild).to.have.class('rs-tree-node');
+    expect(container.firstChild).to.have.attr('role', 'treeitem');
   });
 
   it('Should call `onDragStart` callback', () => {
     const onDragStartSpy = sinon.spy();
-    const instance = getDOMNode(
+    const { container } = render(
       <TreeNode layer={0} onDragStart={onDragStartSpy} nodeData={1} visible />
     );
-
-    Simulate.dragStart(instance);
+    //eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const div = container.querySelector('div') as HTMLElement;
+    Simulate.dragStart(div); //Not working
 
     assert.isTrue(onDragStartSpy.calledOnce);
     assert.equal(onDragStartSpy.firstCall.firstArg, 1);
@@ -26,11 +27,13 @@ describe('TreePicker - TreeNode', () => {
 
   it('Should call `onDragEnter` callback', () => {
     const onDragEnterSpy = sinon.spy();
-    const instance = getDOMNode(
+    const { container } = render(
       <TreeNode layer={0} onDragEnter={onDragEnterSpy} nodeData={1} visible />
     );
+    //eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const div = container.querySelector('div') as HTMLElement;
 
-    Simulate.dragEnter(instance);
+    Simulate.dragEnter(div);
 
     assert.isTrue(onDragEnterSpy.calledOnce);
     assert.equal(onDragEnterSpy.firstCall.firstArg, 1);
@@ -38,11 +41,12 @@ describe('TreePicker - TreeNode', () => {
 
   it('Should call `onDragOver` callback', () => {
     const onDragOverSpy = sinon.spy();
-    const instance = getDOMNode(
+    const { container } = render(
       <TreeNode layer={0} onDragOver={onDragOverSpy} nodeData={1} visible />
     );
-
-    Simulate.dragOver(instance);
+    //eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const div = container.querySelector('div') as HTMLElement;
+    Simulate.dragOver(div);
 
     assert.isTrue(onDragOverSpy.calledOnce);
     assert.equal(onDragOverSpy.firstCall.firstArg, 1);
@@ -50,11 +54,13 @@ describe('TreePicker - TreeNode', () => {
 
   it('Should call `onDragEnd` callback', () => {
     const onDragEndSpy = sinon.spy();
-    const instance = getDOMNode(
+    const { container } = render(
       <TreeNode layer={0} onDragEnd={onDragEndSpy} nodeData={1} visible />
     );
+    //eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    const div = container.querySelector('div') as HTMLElement;
 
-    Simulate.dragEnd(instance);
+    Simulate.dragEnd(div);
 
     assert.isTrue(onDragEndSpy.calledOnce);
     assert.equal(onDragEndSpy.firstCall.firstArg, 1);

--- a/src/TreePicker/test/TreeNodeSpec.tsx
+++ b/src/TreePicker/test/TreeNodeSpec.tsx
@@ -30,9 +30,8 @@ describe('TreePicker - TreeNode', () => {
     const { container } = render(
       <TreeNode layer={0} onDragEnter={onDragEnterSpy} nodeData={1} visible />
     );
-    //eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const div = container.querySelector('div') as HTMLElement;
 
+    const div = container.firstChild as HTMLElement;
     Simulate.dragEnter(div);
 
     assert.isTrue(onDragEnterSpy.calledOnce);
@@ -44,8 +43,8 @@ describe('TreePicker - TreeNode', () => {
     const { container } = render(
       <TreeNode layer={0} onDragOver={onDragOverSpy} nodeData={1} visible />
     );
-    //eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const div = container.querySelector('div') as HTMLElement;
+
+    const div = container.firstChild as HTMLElement;
     Simulate.dragOver(div);
 
     assert.isTrue(onDragOverSpy.calledOnce);
@@ -57,9 +56,8 @@ describe('TreePicker - TreeNode', () => {
     const { container } = render(
       <TreeNode layer={0} onDragEnd={onDragEndSpy} nodeData={1} visible />
     );
-    //eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const div = container.querySelector('div') as HTMLElement;
 
+    const div = container.firstChild as HTMLElement;
     Simulate.dragEnd(div);
 
     assert.isTrue(onDragEndSpy.calledOnce);

--- a/src/TreePicker/test/TreeNodeSpec.tsx
+++ b/src/TreePicker/test/TreeNodeSpec.tsx
@@ -17,9 +17,9 @@ describe('TreePicker - TreeNode', () => {
     const { container } = render(
       <TreeNode layer={0} onDragStart={onDragStartSpy} nodeData={1} visible />
     );
-    //eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const div = container.querySelector('div') as HTMLElement;
-    Simulate.dragStart(div); //Not working
+
+    const div = container.firstChild as HTMLElement;
+    Simulate.dragStart(div);
 
     assert.isTrue(onDragStartSpy.calledOnce);
     assert.equal(onDragStartSpy.firstCall.firstArg, 1);

--- a/src/TreePicker/test/TreePickerSpec.tsx
+++ b/src/TreePicker/test/TreePickerSpec.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { act, fireEvent, render, waitFor, screen } from '@testing-library/react';
 import sinon from 'sinon';
-import { getDOMNode, getInstance } from '@test/testUtils';
+import { getInstance } from '@test/testUtils';
 import TreePicker, { TreePickerProps } from '../TreePicker';
 import { KEY_VALUES } from '../../utils';
 import { PickerHandle } from '../../Picker';
 import { ListHandle } from '../../Windowing';
 import userEvent from '@testing-library/user-event';
+import { testStandardProps } from '@test/commonCases';
 
 const data = [
   {
@@ -36,6 +37,7 @@ const data = [
 ];
 
 describe('TreePicker', () => {
+  testStandardProps(<TreePicker data={data} />);
   it('Should render default value', () => {
     render(<TreePicker defaultOpen data={data} defaultValue={'Master'} />);
 
@@ -43,9 +45,9 @@ describe('TreePicker', () => {
   });
 
   it('Should have "default" appearance by default', () => {
-    const instance = getDOMNode(<TreePicker data={[]} />);
+    const { container } = render(<TreePicker data={[]} />);
 
-    expect(instance).to.have.class('rs-picker-default');
+    expect(container.firstChild).to.have.class('rs-picker-default');
   });
 
   it('Should clean selected value', () => {
@@ -72,15 +74,15 @@ describe('TreePicker', () => {
   });
 
   it('Should be disabled', () => {
-    const instance = getDOMNode(<TreePicker disabled data={[]} />);
+    const { container } = render(<TreePicker disabled data={[]} />);
 
-    expect(instance).to.have.class('rs-picker-disabled');
+    expect(container.firstChild).to.have.class('rs-picker-disabled');
   });
 
   it('Should be block', () => {
-    const instance = getDOMNode(<TreePicker block data={[]} />);
+    const { container } = render(<TreePicker block data={[]} />);
 
-    expect(instance).to.have.class('rs-picker-block');
+    expect(container.firstChild).to.have.class('rs-picker-block');
   });
 
   it('Should active one node by `value`', () => {
@@ -339,16 +341,6 @@ describe('TreePicker', () => {
     expect(screen.getByRole('treeitem', { name: 'tester0' })).to.have.class('rs-tree-node-focus');
   });
 
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<TreePicker className="custom" data={data} />);
-    expect(instance).to.have.class('custom');
-  });
-
-  it('Should have a custom style', () => {
-    const instance = getDOMNode(<TreePicker style={{ fontSize: 12 }} data={data} />);
-    expect(instance).to.have.style('font-size', '12px');
-  });
-
   it('Should have a custom menuStyle', () => {
     const instance = getInstance(<TreePicker open menuStyle={{ fontSize: 12 }} data={data} />);
     expect(instance.overlay).to.have.style('font-size', '12px');
@@ -399,12 +391,6 @@ describe('TreePicker', () => {
     render(<TreePicker data={data} open searchKeyword="M" />);
 
     expect(screen.getAllByRole('treeitem')).to.have.lengthOf(1);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<TreePicker data={data} classPrefix="custom-prefix" />);
-
-    expect(instance.className).to.contain('custom-prefix');
   });
 
   it('Should render tree node with custom dom', () => {

--- a/src/Uploader/test/UploadFileItemSpec.tsx
+++ b/src/Uploader/test/UploadFileItemSpec.tsx
@@ -14,30 +14,31 @@ const file = {
 } as const;
 
 describe('UploadFileItem', () => {
+  testStandardProps(<UploadFileItem file={file} />);
   it('Should output a UploadFileItem', () => {
-    testStandardProps(<UploadFileItem file={file} />);
+    const { container } = render(<UploadFileItem file={file} />);
+    expect(container.firstChild).to.have.class('rs-uploader-file-item');
   });
 
   it('Should render picture-text for layout', () => {
-    testStandardProps(<UploadFileItem listType="picture-text" file={file} />);
     const { container } = render(<UploadFileItem listType="picture-text" file={file} />);
-    // eslint-disable-next-line
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     assert.ok(container.querySelector('.rs-uploader-file-item-panel'));
-    // eslint-disable-next-line
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     assert.ok(container.querySelector('.rs-uploader-file-item-progress'));
   });
 
   it('Should render picture for layout', () => {
-    testStandardProps(<UploadFileItem listType="picture" file={file} />);
     const { container } = render(<UploadFileItem listType="picture" file={file} />);
-    // eslint-disable-next-line
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     assert.equal(container.querySelectorAll('.rs-uploader-file-item-panel').length, 0);
-    // eslint-disable-next-line
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     assert.equal(container.querySelectorAll('.rs-uploader-file-item-progress').length, 0);
   });
 
   it('Should be disabled', () => {
-    testStandardProps(<UploadFileItem file={file} disabled />);
+    const { container } = render(<UploadFileItem file={file} disabled />);
+    expect(container.firstChild).to.have.class('rs-uploader-file-item-disabled');
   });
 
   it('Should call `onCancel` callback', () => {
@@ -55,7 +56,7 @@ describe('UploadFileItem', () => {
       // FIXME Didn't manage to use RTL query here, possibly because RTL bug
       // https://github.com/testing-library/dom-testing-library/issues/846
       //
-      // eslint-disable-next-line
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
       container.querySelector('.rs-uploader-file-item-btn-remove') as HTMLElement
     );
 
@@ -74,7 +75,7 @@ describe('UploadFileItem', () => {
       <UploadFileItem file={file} onPreview={onPreviewSpy} listType="picture-text" />
     );
     ReactTestUtils.Simulate.click(
-      // eslint-disable-next-line
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
       container.querySelector('.rs-uploader-file-item-title') as HTMLElement
     );
     assert.ok(onPreviewSpy.calledOnce);
@@ -86,7 +87,7 @@ describe('UploadFileItem', () => {
       <UploadFileItem file={file} onPreview={onPreviewSpy} listType="picture-text" disabled />
     );
     ReactTestUtils.Simulate.click(
-      // eslint-disable-next-line
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
       container.querySelector('.rs-uploader-file-item-title') as HTMLElement
     );
     assert.equal(onPreviewSpy.calledOnce, false);
@@ -99,7 +100,7 @@ describe('UploadFileItem', () => {
     );
     ReactTestUtils.Simulate.click(
       // FIXME Add accessible name to Reload button
-      // eslint-disable-next-line
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
       container.querySelector('.rs-uploader-file-item-icon-reupload') as HTMLElement
     );
     assert.ok(onReuploadSpy.calledOnce);
@@ -112,14 +113,10 @@ describe('UploadFileItem', () => {
     );
     ReactTestUtils.Simulate.click(
       // FIXME Add accessible name to Reload button
-      // eslint-disable-next-line
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
       container.querySelector('.rs-uploader-file-item-icon-reupload') as HTMLElement
     );
     assert.equal(onReuploadSpy.calledOnce, false);
-  });
-
-  it('Should have a custom className', () => {
-    testStandardProps(<UploadFileItem file={file} className="custom" />);
   });
 
   it('Should output a custom file name', () => {
@@ -138,15 +135,6 @@ describe('UploadFileItem', () => {
     );
 
     expect(screen.getByTestId('custom-info')).to.exist;
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    testStandardProps(<UploadFileItem file={file} style={{ fontSize }} />);
-  });
-
-  it('Should have a custom className prefix', () => {
-    testStandardProps(<UploadFileItem file={file} classPrefix="custom-prefix" />);
   });
 
   it('Should render an <i> tag, when the file status is uploading', () => {

--- a/src/Uploader/test/UploadFileItemSpec.tsx
+++ b/src/Uploader/test/UploadFileItemSpec.tsx
@@ -22,6 +22,7 @@ describe('UploadFileItem', () => {
 
   it('Should render picture-text for layout', () => {
     const { container } = render(<UploadFileItem listType="picture-text" file={file} />);
+    expect(container.firstChild).to.have.class('rs-uploader-file-item-picture-text');
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     assert.ok(container.querySelector('.rs-uploader-file-item-panel'));
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
@@ -30,6 +31,7 @@ describe('UploadFileItem', () => {
 
   it('Should render picture for layout', () => {
     const { container } = render(<UploadFileItem listType="picture" file={file} />);
+    expect(container.firstChild).to.have.class('rs-uploader-file-item-picture');
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     assert.equal(container.querySelectorAll('.rs-uploader-file-item-panel').length, 0);
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access

--- a/src/Uploader/test/UploadFileItemSpec.tsx
+++ b/src/Uploader/test/UploadFileItemSpec.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { render, screen, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
-import { getDOMNode } from '@test/testUtils';
 import UploadFileItem, { formatSize } from '../UploadFileItem';
 import userEvent from '@testing-library/user-event';
+import { testStandardProps } from '@test/commonCases';
 
 const file = {
   fileKey: 'a',
@@ -15,31 +15,29 @@ const file = {
 
 describe('UploadFileItem', () => {
   it('Should output a UploadFileItem', () => {
-    const instance = getDOMNode(<UploadFileItem file={file} />);
-    assert.include(instance.className, 'rs-uploader-file-item');
+    testStandardProps(<UploadFileItem file={file} />);
   });
 
   it('Should render picture-text for layout', () => {
-    const instance = getDOMNode(<UploadFileItem listType="picture-text" file={file} />);
-    assert.include(instance.className, 'rs-uploader-file-item-picture-text');
-    // eslint-disable-next-line testing-library/no-node-access
-    assert.ok(instance.querySelector('.rs-uploader-file-item-panel'));
-    // eslint-disable-next-line testing-library/no-node-access
-    assert.ok(instance.querySelector('.rs-uploader-file-item-progress'));
+    testStandardProps(<UploadFileItem listType="picture-text" file={file} />);
+    const { container } = render(<UploadFileItem listType="picture-text" file={file} />);
+    // eslint-disable-next-line
+    assert.ok(container.querySelector('.rs-uploader-file-item-panel'));
+    // eslint-disable-next-line
+    assert.ok(container.querySelector('.rs-uploader-file-item-progress'));
   });
 
   it('Should render picture for layout', () => {
-    const instance = getDOMNode(<UploadFileItem listType="picture" file={file} />);
-    assert.include(instance.className, 'rs-uploader-file-item-picture');
-    // eslint-disable-next-line testing-library/no-node-access
-    assert.equal(instance.querySelectorAll('.rs-uploader-file-item-panel').length, 0);
-    // eslint-disable-next-line testing-library/no-node-access
-    assert.equal(instance.querySelectorAll('.rs-uploader-file-item-progress').length, 0);
+    testStandardProps(<UploadFileItem listType="picture" file={file} />);
+    const { container } = render(<UploadFileItem listType="picture" file={file} />);
+    // eslint-disable-next-line
+    assert.equal(container.querySelectorAll('.rs-uploader-file-item-panel').length, 0);
+    // eslint-disable-next-line
+    assert.equal(container.querySelectorAll('.rs-uploader-file-item-progress').length, 0);
   });
 
   it('Should be disabled', () => {
-    const instance = getDOMNode(<UploadFileItem file={file} disabled />);
-    assert.include(instance.className, 'rs-uploader-file-item-disabled');
+    testStandardProps(<UploadFileItem file={file} disabled />);
   });
 
   it('Should call `onCancel` callback', () => {
@@ -52,13 +50,13 @@ describe('UploadFileItem', () => {
 
   it('Should not call `onCancel` callback when `disabled=true`', () => {
     const onCancelSpy = sinon.spy();
-    const instance = getDOMNode(<UploadFileItem file={file} onCancel={onCancelSpy} disabled />);
+    const { container } = render(<UploadFileItem file={file} onCancel={onCancelSpy} disabled />);
     ReactTestUtils.Simulate.click(
       // FIXME Didn't manage to use RTL query here, possibly because RTL bug
       // https://github.com/testing-library/dom-testing-library/issues/846
       //
-      // eslint-disable-next-line testing-library/no-node-access
-      instance.querySelector('.rs-uploader-file-item-btn-remove') as HTMLElement
+      // eslint-disable-next-line
+      container.querySelector('.rs-uploader-file-item-btn-remove') as HTMLElement
     );
 
     assert.equal(onCancelSpy.calledOnce, false);
@@ -72,57 +70,56 @@ describe('UploadFileItem', () => {
 
   it('Should call onPreview callback', () => {
     const onPreviewSpy = sinon.spy();
-    const instance = getDOMNode(
+    const { container } = render(
       <UploadFileItem file={file} onPreview={onPreviewSpy} listType="picture-text" />
     );
     ReactTestUtils.Simulate.click(
-      // eslint-disable-next-line testing-library/no-node-access
-      instance.querySelector('.rs-uploader-file-item-title') as HTMLElement
+      // eslint-disable-next-line
+      container.querySelector('.rs-uploader-file-item-title') as HTMLElement
     );
     assert.ok(onPreviewSpy.calledOnce);
   });
 
   it('Should not call onPreview callback if `disabled=true`', () => {
     const onPreviewSpy = sinon.spy();
-    const instance = getDOMNode(
+    const { container } = render(
       <UploadFileItem file={file} onPreview={onPreviewSpy} listType="picture-text" disabled />
     );
     ReactTestUtils.Simulate.click(
-      // eslint-disable-next-line testing-library/no-node-access
-      instance.querySelector('.rs-uploader-file-item-title') as HTMLElement
+      // eslint-disable-next-line
+      container.querySelector('.rs-uploader-file-item-title') as HTMLElement
     );
     assert.equal(onPreviewSpy.calledOnce, false);
   });
 
   it('Should call onReupload callback', () => {
     const onReuploadSpy = sinon.spy();
-    const instance = getDOMNode(
+    const { container } = render(
       <UploadFileItem file={{ ...file, status: 'error' }} onReupload={onReuploadSpy} />
     );
     ReactTestUtils.Simulate.click(
       // FIXME Add accessible name to Reload button
-      // eslint-disable-next-line testing-library/no-node-access
-      instance.querySelector('.rs-uploader-file-item-icon-reupload') as HTMLElement
+      // eslint-disable-next-line
+      container.querySelector('.rs-uploader-file-item-icon-reupload') as HTMLElement
     );
     assert.ok(onReuploadSpy.calledOnce);
   });
 
   it('Should not call onReupload callback', () => {
     const onReuploadSpy = sinon.spy();
-    const instance = getDOMNode(
+    const { container } = render(
       <UploadFileItem file={{ ...file, status: 'error' }} onReupload={onReuploadSpy} disabled />
     );
     ReactTestUtils.Simulate.click(
       // FIXME Add accessible name to Reload button
-      // eslint-disable-next-line testing-library/no-node-access
-      instance.querySelector('.rs-uploader-file-item-icon-reupload') as HTMLElement
+      // eslint-disable-next-line
+      container.querySelector('.rs-uploader-file-item-icon-reupload') as HTMLElement
     );
     assert.equal(onReuploadSpy.calledOnce, false);
   });
 
   it('Should have a custom className', () => {
-    const instance = getDOMNode(<UploadFileItem file={file} className="custom" />);
-    assert.include(instance.className, 'custom');
+    testStandardProps(<UploadFileItem file={file} className="custom" />);
   });
 
   it('Should output a custom file name', () => {
@@ -145,68 +142,70 @@ describe('UploadFileItem', () => {
 
   it('Should have a custom style', () => {
     const fontSize = '12px';
-    const instance = getDOMNode(<UploadFileItem file={file} style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
+    testStandardProps(<UploadFileItem file={file} style={{ fontSize }} />);
   });
 
   it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<UploadFileItem file={file} classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
+    testStandardProps(<UploadFileItem file={file} classPrefix="custom-prefix" />);
   });
 
   it('Should render an <i> tag, when the file status is uploading', () => {
-    const instance = getDOMNode(<UploadFileItem file={{ ...file, status: 'uploading' }} />);
-    const instance2 = getDOMNode(<UploadFileItem file={{ ...file, status: 'inited' }} />);
+    const { container, rerender } = render(
+      <UploadFileItem file={{ ...file, status: 'uploading' }} />
+    );
 
     assert.equal(
-      // eslint-disable-next-line testing-library/no-node-access
-      (instance.querySelector('.rs-uploader-file-item-icon') as HTMLElement).tagName,
+      // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+      (container.querySelector('.rs-uploader-file-item-icon') as HTMLElement).tagName,
       'I'
     );
+
+    rerender(<UploadFileItem file={{ ...file, status: 'inited' }} />);
+
     assert.equal(
-      // eslint-disable-next-line testing-library/no-node-access
-      (instance2.querySelector('.rs-uploader-file-item-icon') as HTMLElement).tagName,
+      // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+      (container.querySelector('.rs-uploader-file-item-icon') as HTMLElement).tagName,
       'svg'
     );
   });
 
   it('Should render an <i> tag, when the file status is uploading', () => {
     const file = { blobFile: new File(['foo'], 'foo.txt'), status: 'finished' } as const;
-    const instance = getDOMNode(<UploadFileItem file={file} />);
+    const { container } = render(<UploadFileItem file={file} />);
     assert.equal(
-      // eslint-disable-next-line testing-library/no-node-access
-      (instance.querySelector('.rs-uploader-file-item-size') as HTMLElement).textContent,
+      // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+      (container.querySelector('.rs-uploader-file-item-size') as HTMLElement).textContent,
       '3B'
     );
   });
 
   it('Should not render a default thumbnail', () => {
-    const instance = getDOMNode(<UploadFileItem file={file} listType="text" />);
-    // eslint-disable-next-line testing-library/no-node-access
-    const thumbnail = instance.querySelector('.rs-uploader-file-item-preview');
+    const { container } = render(<UploadFileItem file={file} listType="text" />);
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    const thumbnail = container.querySelector('.rs-uploader-file-item-preview');
     assert.isNull(thumbnail);
   });
 
   it('Should render a default thumbnail when listType="picture-text" ', () => {
-    const instance = getDOMNode(<UploadFileItem file={file} listType="picture-text" />);
-    // eslint-disable-next-line testing-library/no-node-access
-    const thumbnail = instance.querySelector(
+    const { container } = render(<UploadFileItem file={file} listType="picture-text" />);
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    const thumbnail = container.querySelector(
       '.rs-uploader-file-item-preview .rs-uploader-file-item-icon'
     );
     assert.isNotNull(thumbnail);
   });
 
   it('Should render a default thumbnail when listType="picture"', () => {
-    const instance = getDOMNode(<UploadFileItem file={file} listType="picture" />);
-    // eslint-disable-next-line testing-library/no-node-access
-    const thumbnail = instance.querySelector(
+    const { container } = render(<UploadFileItem file={file} listType="picture" />);
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    const thumbnail = container.querySelector(
       '.rs-uploader-file-item-preview .rs-uploader-file-item-icon'
     );
     assert.isNotNull(thumbnail);
   });
 
   it('Should render a custom thumbnail', () => {
-    const instance = getDOMNode(
+    const { container } = render(
       <UploadFileItem
         file={file}
         listType="picture-text"
@@ -215,8 +214,8 @@ describe('UploadFileItem', () => {
         }}
       />
     );
-    // eslint-disable-next-line testing-library/no-node-access
-    const thumbnail = instance.querySelector('.rs-uploader-file-item-preview') as HTMLElement;
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    const thumbnail = container.querySelector('.rs-uploader-file-item-preview') as HTMLElement;
 
     assert.include(thumbnail.textContent, 'custom-thumbnail');
   });
@@ -230,11 +229,11 @@ describe('UploadFileItem', () => {
       })
     };
 
-    const instance = getDOMNode(<UploadFileItem file={file} listType="picture-text" />);
+    const { container } = render(<UploadFileItem file={file} listType="picture-text" />);
 
     await waitFor(() => {
-      // eslint-disable-next-line testing-library/no-node-access
-      const thumbnail = instance.querySelector(
+      // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+      const thumbnail = container.querySelector(
         '.rs-uploader-file-item-preview img'
       ) as HTMLImageElement;
       assert.equal(thumbnail.src, 'data:image/png;base64,MTA=');

--- a/src/Uploader/test/UploadTriggerSpec.tsx
+++ b/src/Uploader/test/UploadTriggerSpec.tsx
@@ -1,69 +1,77 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import sinon from 'sinon';
-import { getDOMNode } from '@test/testUtils';
 
 import UploadTrigger from '../UploadTrigger';
+import { render } from '@testing-library/react';
+import { testStandardProps } from '@test/commonCases';
 
 describe('UploadTrigger', () => {
+  testStandardProps(<UploadTrigger />); // Not working properly
   it('Should output a UploadTrigger', () => {
-    const instance = getDOMNode(<UploadTrigger />);
-    assert.include(instance.className, 'rs-uploader-trigger');
+    const { container } = render(<UploadTrigger />);
+    expect(container.firstChild).to.have.class('rs-uploader-trigger');
   });
 
   it('Should be disabled', () => {
-    const instance = getDOMNode(<UploadTrigger disabled />);
-    assert.include(instance.className, 'rs-uploader-trigger-disabled');
+    const { container } = render(<UploadTrigger disabled />);
+    expect(container.firstChild).to.have.class('rs-uploader-trigger-disabled');
   });
 
   it('Should be multipled', () => {
-    const instance = getDOMNode(<UploadTrigger multiple />);
-    assert.ok(instance.querySelector('input[multiple]'));
+    const { container } = render(<UploadTrigger multiple />);
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    assert.ok(container.querySelector('input[multiple]'));
   });
 
   it('Should have a accept', () => {
-    const instance = getDOMNode(<UploadTrigger accept=".jpg" />);
-    assert.ok(instance.querySelector('input[accept=".jpg"]'));
+    const { container } = render(<UploadTrigger accept=".jpg" />);
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    assert.ok(container.querySelector('input[accept=".jpg"]'));
   });
 
   it('Should render custom component', () => {
-    const instance = getDOMNode(<UploadTrigger as={'a'} />);
-    assert.equal((instance.querySelector('.rs-uploader-trigger-btn') as HTMLElement).tagName, 'A');
+    const { container } = render(<UploadTrigger as={'a'} />);
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    assert.equal((container.querySelector('.rs-uploader-trigger-btn') as HTMLElement).tagName, 'A');
   });
 
   it('Should call onChange callback', () => {
     const onChange = sinon.spy();
-    const instance = getDOMNode(<UploadTrigger onChange={onChange} />);
-    ReactTestUtils.Simulate.change(instance.querySelector('input') as HTMLElement);
+    const { container } = render(<UploadTrigger onChange={onChange} />);
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    ReactTestUtils.Simulate.change(container.querySelector('input') as HTMLElement);
 
     expect(onChange).to.have.been.calledOnce;
   });
 
   it('Should have a name', () => {
-    const instance = getDOMNode(<UploadTrigger name="file" />);
-    assert.ok(instance.querySelector('input[name="file"]'));
+    const { container } = render(<UploadTrigger name="file" />);
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    assert.ok(container.querySelector('input[name="file"]'));
   });
 
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<UploadTrigger className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
+  // it('Should have a custom className', () => {
+  //   const {container} = render(<UploadTrigger className="custom" />);
+  //   assert.include(container.className, 'custom');
+  // });
 
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<UploadTrigger style={{ fontSize }} />);
-    assert.equal((instance.querySelector('button') as HTMLElement).style.fontSize, fontSize);
-  });
+  // it('Should have a custom style', () => { //MAYBE this is buggy
+  //   const fontSize = '12px';
+  //   const instance = render(<UploadTrigger style={{ fontSize }} />);
+  //   assert.equal((instance.querySelector('button') as HTMLElement).style.fontSize, fontSize);
+  // });
 
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<UploadTrigger classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
-  });
+  // it('Should have a custom className prefix', () => {
+  //   const instance = getDOMNode(<UploadTrigger classPrefix="custom-prefix" />);
+  //   assert.ok(instance.className.match(/\bcustom-prefix\b/));
+  // });
 
   it('Should call `onDragEnter` callback', () => {
     const onDragEnterSpy = sinon.spy();
-    const instance = getDOMNode(<UploadTrigger draggable onDragEnter={onDragEnterSpy} />);
-    const button = instance.querySelector('button') as HTMLElement;
+    const { container } = render(<UploadTrigger draggable onDragEnter={onDragEnterSpy} />);
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    const button = container.querySelector('button') as HTMLElement;
 
     ReactTestUtils.Simulate.dragEnter(button);
     assert.ok(onDragEnterSpy.calledOnce);
@@ -71,8 +79,9 @@ describe('UploadTrigger', () => {
 
   it('Should call `onDragOver` callback', () => {
     const onDragOverSpy = sinon.spy();
-    const instance = getDOMNode(<UploadTrigger draggable onDragOver={onDragOverSpy} />);
-    const button = instance.querySelector('button') as HTMLElement;
+    const { container } = render(<UploadTrigger draggable onDragOver={onDragOverSpy} />);
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    const button = container.querySelector('button') as HTMLElement;
 
     ReactTestUtils.Simulate.dragOver(button);
     assert.ok(onDragOverSpy.calledOnce);
@@ -80,8 +89,9 @@ describe('UploadTrigger', () => {
 
   it('Should call `onDragLeave` callback', () => {
     const onDragLeaveSpy = sinon.spy();
-    const instance = getDOMNode(<UploadTrigger draggable onDragLeave={onDragLeaveSpy} />);
-    const button = instance.querySelector('button') as HTMLElement;
+    const { container } = render(<UploadTrigger draggable onDragLeave={onDragLeaveSpy} />);
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    const button = container.querySelector('button') as HTMLElement;
 
     ReactTestUtils.Simulate.dragLeave(button);
     assert.ok(onDragLeaveSpy.calledOnce);

--- a/src/Uploader/test/UploadTriggerSpec.tsx
+++ b/src/Uploader/test/UploadTriggerSpec.tsx
@@ -45,7 +45,6 @@ describe('UploadTrigger', () => {
 
   it('Should have a name', () => {
     const { container } = render(<UploadTrigger name="file" />);
-    console.log(container);
     // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
     assert.ok(container.querySelector('input[name="file"]'));
   });
@@ -64,8 +63,7 @@ describe('UploadTrigger', () => {
 
   it('Should have a custom className prefix', () => {
     const { container } = render(<UploadTrigger classPrefix="custom-prefix" />);
-    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
-    assert.ok(container.querySelector('.rs-custom-prefix')?.className.match(/\bcustom-prefix\b/));
+    expect(container.firstChild).to.have.class(/\bcustom-prefix\b/);
   });
 
   it('Should call `onDragEnter` callback', () => {

--- a/src/Uploader/test/UploadTriggerSpec.tsx
+++ b/src/Uploader/test/UploadTriggerSpec.tsx
@@ -4,10 +4,8 @@ import sinon from 'sinon';
 
 import UploadTrigger from '../UploadTrigger';
 import { render } from '@testing-library/react';
-import { testStandardProps } from '@test/commonCases';
 
 describe('UploadTrigger', () => {
-  testStandardProps(<UploadTrigger />); // Not working properly
   it('Should output a UploadTrigger', () => {
     const { container } = render(<UploadTrigger />);
     expect(container.firstChild).to.have.class('rs-uploader-trigger');
@@ -47,25 +45,28 @@ describe('UploadTrigger', () => {
 
   it('Should have a name', () => {
     const { container } = render(<UploadTrigger name="file" />);
+    console.log(container);
     // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
     assert.ok(container.querySelector('input[name="file"]'));
   });
 
-  // it('Should have a custom className', () => {
-  //   const {container} = render(<UploadTrigger className="custom" />);
-  //   assert.include(container.className, 'custom');
-  // });
+  it('Should have a custom className', () => {
+    const { container } = render(<UploadTrigger className="custom" />);
+    expect(container.firstChild).to.have.class('custom');
+  });
 
-  // it('Should have a custom style', () => { //MAYBE this is buggy
-  //   const fontSize = '12px';
-  //   const instance = render(<UploadTrigger style={{ fontSize }} />);
-  //   assert.equal((instance.querySelector('button') as HTMLElement).style.fontSize, fontSize);
-  // });
+  it('Should have a custom style', () => {
+    const fontSize = '12px';
+    const { container } = render(<UploadTrigger style={{ fontSize }} />);
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    assert.equal((container.querySelector('button') as HTMLElement).style.fontSize, fontSize);
+  });
 
-  // it('Should have a custom className prefix', () => {
-  //   const instance = getDOMNode(<UploadTrigger classPrefix="custom-prefix" />);
-  //   assert.ok(instance.className.match(/\bcustom-prefix\b/));
-  // });
+  it('Should have a custom className prefix', () => {
+    const { container } = render(<UploadTrigger classPrefix="custom-prefix" />);
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    assert.ok(container.querySelector('.rs-custom-prefix')?.className.match(/\bcustom-prefix\b/));
+  });
 
   it('Should call `onDragEnter` callback', () => {
     const onDragEnterSpy = sinon.spy();

--- a/src/Uploader/test/UploaderSpec.tsx
+++ b/src/Uploader/test/UploaderSpec.tsx
@@ -20,7 +20,7 @@ describe('Uploader', () => {
   it('Should be disabled', () => {
     const { container } = render(<Uploader action="" disabled />);
 
-    // eslint-disable-next-line
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     assert.ok(container.querySelector('.rs-uploader-trigger-disabled'));
   });
 
@@ -40,7 +40,7 @@ describe('Uploader', () => {
     const { container } = render(
       <Uploader action="" fileList={fileList} fileListVisible={false} />
     );
-    // eslint-disable-next-line
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     assert.ok(!container.querySelector('.rs-uploader-file-items'));
   });
 

--- a/src/Uploader/test/UploaderSpec.tsx
+++ b/src/Uploader/test/UploaderSpec.tsx
@@ -2,29 +2,29 @@ import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { render, screen } from '@testing-library/react';
 import sinon from 'sinon';
-import { getDOMNode, getInstance } from '@test/testUtils';
+import { getInstance } from '@test/testUtils';
 
 import Uploader from '../Uploader';
 import Button from '../../Button';
 import userEvent from '@testing-library/user-event';
+import { testStandardProps } from '@test/commonCases';
 
 describe('Uploader', () => {
   it('Should output a Uploader', () => {
-    const instance = getDOMNode(<Uploader action="" />);
+    const { container } = render(<Uploader action="" />);
 
-    assert.include(instance.className, 'rs-uploader');
+    expect(container.firstChild).to.have.class('rs-uploader');
   });
 
   it('Should be disabled', () => {
-    const instance = getDOMNode(<Uploader action="" disabled />);
+    const { container } = render(<Uploader action="" disabled />);
 
-    // eslint-disable-next-line testing-library/no-node-access
-    assert.ok(instance.querySelector('.rs-uploader-trigger-disabled'));
+    // eslint-disable-next-line
+    assert.ok(container.querySelector('.rs-uploader-trigger-disabled'));
   });
 
   it('Should render picture type', () => {
-    const instance = getDOMNode(<Uploader action="" listType="picture" />);
-    assert.include(instance.className, 'rs-uploader-picture');
+    testStandardProps(<Uploader action="" listType="picture" />);
   });
 
   it('Should not render the file list', () => {
@@ -35,9 +35,11 @@ describe('Uploader', () => {
         url: 'https://user-images.githubusercontent.com/1203827/47638792-92414e00-db9a-11e8-89c2-f8f430a23cd3.png'
       }
     ];
-    const instance = getDOMNode(<Uploader action="" fileList={fileList} fileListVisible={false} />);
-    // eslint-disable-next-line testing-library/no-node-access
-    assert.ok(!instance.querySelector('.rs-uploader-file-items'));
+    const { container } = render(
+      <Uploader action="" fileList={fileList} fileListVisible={false} />
+    );
+    // eslint-disable-next-line
+    assert.ok(!container.querySelector('.rs-uploader-file-items'));
   });
 
   it('Should render custom component', () => {
@@ -47,25 +49,21 @@ describe('Uploader', () => {
   });
 
   it('Should have a custom className', () => {
-    const instance = getDOMNode(<Uploader action="" className="custom" />);
-    assert.include(instance.className, 'custom');
+    testStandardProps(<Uploader action="" className="custom" />);
   });
 
   it('Should have a custom style', () => {
     const fontSize = '12px';
-    const instance = getDOMNode(<Uploader action="" style={{ fontSize }} />);
 
-    assert.equal(instance.style.fontSize, fontSize);
+    testStandardProps(<Uploader action="" style={{ fontSize }} />);
   });
 
   it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<Uploader action="" classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
+    testStandardProps(<Uploader action="" classPrefix="custom-prefix" />);
   });
 
   it('Should have draggable className', () => {
-    const instance = getDOMNode(<Uploader action="" draggable />);
-    assert.include(instance.className, 'rs-uploader-draggable');
+    testStandardProps(<Uploader action="" draggable />);
   });
 
   it('Should call `onUpload` callback', () => {

--- a/src/Uploader/test/UploaderSpec.tsx
+++ b/src/Uploader/test/UploaderSpec.tsx
@@ -3,13 +3,14 @@ import ReactTestUtils from 'react-dom/test-utils';
 import { render, screen } from '@testing-library/react';
 import sinon from 'sinon';
 import { getInstance } from '@test/testUtils';
+import { testStandardProps } from '@test/commonCases';
 
 import Uploader from '../Uploader';
 import Button from '../../Button';
 import userEvent from '@testing-library/user-event';
-import { testStandardProps } from '@test/commonCases';
 
 describe('Uploader', () => {
+  testStandardProps(<Uploader action="" />);
   it('Should output a Uploader', () => {
     const { container } = render(<Uploader action="" />);
 
@@ -24,7 +25,8 @@ describe('Uploader', () => {
   });
 
   it('Should render picture type', () => {
-    testStandardProps(<Uploader action="" listType="picture" />);
+    const { container } = render(<Uploader action="" listType="picture" />);
+    expect(container.firstChild).to.have.class('rs-uploader-picture');
   });
 
   it('Should not render the file list', () => {
@@ -48,22 +50,9 @@ describe('Uploader', () => {
     expect(screen.getByRole('button')).to.have.tagName('BUTTON');
   });
 
-  it('Should have a custom className', () => {
-    testStandardProps(<Uploader action="" className="custom" />);
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-
-    testStandardProps(<Uploader action="" style={{ fontSize }} />);
-  });
-
-  it('Should have a custom className prefix', () => {
-    testStandardProps(<Uploader action="" classPrefix="custom-prefix" />);
-  });
-
   it('Should have draggable className', () => {
-    testStandardProps(<Uploader action="" draggable />);
+    const { container } = render(<Uploader action="" draggable />);
+    expect(container.firstChild).to.have.class('rs-uploader-draggable');
   });
 
   it('Should call `onUpload` callback', () => {

--- a/src/Whisper/test/WhisperSpec.tsx
+++ b/src/Whisper/test/WhisperSpec.tsx
@@ -1,24 +1,24 @@
 import React, { CSSProperties, Ref } from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import sinon from 'sinon';
-import { getDOMNode, getInstance } from '@test/testUtils';
+import { getInstance } from '@test/testUtils';
 
 import Whisper, { WhisperInstance } from '../Whisper';
 import Tooltip from '../../Tooltip';
 
 describe('Whisper', () => {
   it('Should create Whisper element', () => {
-    const instance = getDOMNode(
+    const { container } = render(
       <Whisper speaker={<Tooltip>tooltip</Tooltip>}>
         <button type="button">button</button>
       </Whisper>
     );
 
-    expect(instance.nodeName).to.equal('BUTTON');
+    expect(container.firstChild).to.have.tagName('BUTTON');
   });
 
   it('Should maintain overlay classname when trigger click', () => {
-    const whisper = getDOMNode(
+    render(
       <Whisper
         trigger="click"
         speaker={
@@ -30,13 +30,13 @@ describe('Whisper', () => {
         <button>button</button>
       </Whisper>
     );
-    fireEvent.click(whisper);
+    fireEvent.click(screen.getByRole('button'));
 
     expect(screen.getByTestId('tooltip')).to.have.class('test-whisper');
   });
 
   it('Should maintain overlay classname when trigger focus', () => {
-    const whisper = getDOMNode(
+    render(
       <Whisper
         trigger="focus"
         speaker={
@@ -49,32 +49,32 @@ describe('Whisper', () => {
       </Whisper>
     );
 
-    fireEvent.focus(whisper);
+    fireEvent.focus(screen.getByRole('button'));
     expect(screen.getByTestId('tooltip')).to.have.class('test-whisper');
   });
 
   it('Should call onClick callback', () => {
     const onClick = sinon.spy();
-    const whisper = getDOMNode(
+    render(
       <Whisper onClick={onClick} trigger="click" speaker={<Tooltip />}>
         <button>button</button>
       </Whisper>
     );
 
-    fireEvent.click(whisper);
+    fireEvent.click(screen.getByRole('button'));
 
     expect(onClick).to.have.been.calledOnce;
   });
 
   it('Should call onOpen callback', async () => {
     const onOpen = sinon.spy();
-    const whisper = getDOMNode(
+    render(
       <Whisper onOpen={onOpen} trigger="click" speaker={<Tooltip />}>
         <button>button</button>
       </Whisper>
     );
 
-    fireEvent.click(whisper);
+    fireEvent.click(screen.getByRole('button'));
 
     await waitFor(() => {
       expect(onOpen).to.have.been.calledOnce;
@@ -98,13 +98,13 @@ describe('Whisper', () => {
   it('Should call onEntered callback', async () => {
     const onEntered = sinon.spy();
 
-    const whisper = getDOMNode(
+    render(
       <Whisper onEntered={onEntered} trigger="click" speaker={<Tooltip />}>
         <button>button</button>
       </Whisper>
     );
 
-    fireEvent.click(whisper);
+    fireEvent.click(screen.getByRole('button'));
     await waitFor(() => {
       expect(onEntered).to.have.been.calledOnce;
     });
@@ -113,14 +113,14 @@ describe('Whisper', () => {
   it('Should call onClose callback', async () => {
     const onClose = sinon.spy();
 
-    const whisper = getDOMNode(
+    render(
       <Whisper onClose={onClose} trigger="click" speaker={<Tooltip />}>
         <button>button</button>
       </Whisper>
     );
 
-    fireEvent.click(whisper);
-    fireEvent.click(whisper);
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole('button'));
     await waitFor(() => {
       expect(onClose).to.have.been.calledOnce;
     });
@@ -129,14 +129,14 @@ describe('Whisper', () => {
   it('Should call onExited callback', async () => {
     const onExited = sinon.spy();
 
-    const whisper = getDOMNode(
+    render(
       <Whisper onExited={onExited} trigger="click" speaker={<Tooltip />}>
         <button>button</button>
       </Whisper>
     );
 
-    fireEvent.click(whisper);
-    fireEvent.click(whisper);
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole('button'));
     await waitFor(() => {
       expect(onExited).to.have.been.calledOnce;
     });


### PR DESCRIPTION
Why I am doing this: https://github.com/rsuite/rsuite/discussions/3200
What I did: removing the getDOMNode and using the render in @testing-library/react

This update involves 4 component changes: Tree, Treepicker, Uploader, Whisper