### PR TITLE
fix(RadioGroup): unexpected wrapped text in picker appearance

### DIFF
--- a/src/RadioGroup/styles/index.less
+++ b/src/RadioGroup/styles/index.less
@@ -49,6 +49,7 @@
 
   .rs-radio-checker > label {
     display: inline-block;
+    white-space: nowrap;
     font-size: @font-size-base;
     line-height: @line-height-base;
     border-radius: 0;


### PR DESCRIPTION
Fix issue mentioned in https://github.com/rsuite/rsuite/pull/3274#discussion_r1271910072

Before ([CodeSandbox](https://codesandbox.io/s/goofy-black-yrctjd?file=/src/index.js))

![image](https://github.com/rsuite/rsuite/assets/8225666/a6013053-1733-43a2-adbb-130ac535df8e)

After ([CodeSandbox](https://codesandbox.io/s/rsuite-tp-ci-forked-spdnhw))

<img width="301" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/9df83df8-d570-4f57-b416-fefddb081c8f">
