### PR TITLE
fix(CheckPicker): wrong padding of grouped options

### DIFF
--- a/src/CheckPicker/styles/index.less
+++ b/src/CheckPicker/styles/index.less
@@ -15,4 +15,14 @@
   .rs-check-item.rs-checkbox-checked .rs-checkbox-checker > label {
     .picker-item-active();
   }
+
+  &.rs-picker-check-menu-grouped {
+    .rs-check-item .rs-checkbox-checker > label {
+      padding-left: 52px;
+    }
+
+    .rs-check-item .rs-checkbox-checker .rs-checkbox-wrapper {
+      left: 26px;
+    }
+  }
 }

--- a/src/Picker/styles/index.less
+++ b/src/Picker/styles/index.less
@@ -397,21 +397,19 @@
         cursor: not-allowed;
       }
 
-      .rs-checkbox-wrapper {
-        left: @picker-item-content-padding-horizontal;
-
-        .grouped &,
-        .@{ckpns}-menu-group-children & {
-          left: (
-            @picker-item-content-padding-horizontal + @picker-children-check-item-padding-left
-          );
-        }
-      }
-
       .grouped &,
       .@{ckpns}-menu-group-children & {
         padding-left: @picker-check-item-content-padding-left +
           @picker-children-check-item-padding-left;
+      }
+    }
+
+    .rs-checkbox-wrapper {
+      left: @picker-item-content-padding-horizontal;
+
+      .grouped &,
+      .@{ckpns}-menu-group-children & {
+        left: (@picker-item-content-padding-horizontal + @picker-children-check-item-padding-left);
       }
     }
   }


### PR DESCRIPTION
Before fix

<img width="254" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/b080f091-c54b-41fc-917a-74266a856721">


After fix

<img width="258" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/a9eaf2e3-7fed-4211-8aaa-0f44fce6d3d6">

Design

<img width="261" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/bc170448-d944-4ad3-9d63-1db4b39a8627">

