### PR TITLE
Fix type extension

### DIFF
--- a/src/Overlay/OverlayTrigger.tsx
+++ b/src/Overlay/OverlayTrigger.tsx
@@ -36,7 +36,7 @@ function mergeEvents(events = {}, props = {}) {
   return nextEvents;
 }
 
-export interface OverlayTriggerProps extends StandardProps, AnimationEventProps {
+export interface OverlayTriggerProps extends Omit<StandardProps, 'children'>, AnimationEventProps {
   /** Triggering events */
   trigger?: OverlayTriggerType | OverlayTriggerType[];
 


### PR DESCRIPTION
```
node_modules/rsuite/esm/Overlay/OverlayTrigger.d.ts:6:18 - error TS2430: Interface 'OverlayTriggerProps' incorrectly extends interface 'StandardProps'.
  Types of property 'children' are incompatible.
    Type 'ReactElement<any, string | JSXElementConstructor<any>> | ((props: any, ref: any) => ReactElement<any, string | JSXElementConstructor<any>>)' is not assignable to type 'ReactNode'.
      Type '(props: any, ref: any) => ReactElement<any, string | JSXElementConstructor<any>>' is not assignable to type 'ReactNode'.

6 export interface OverlayTriggerProps extends StandardProps, AnimationEventProps {
                   ~~~~~~~~~~~~~~~~~~~
```