### PR TITLE
refactor(SelectPicker): move grouped options into group element

### DIFF
--- a/src/Picker/styles/mixin.less
+++ b/src/Picker/styles/mixin.less
@@ -41,6 +41,8 @@
       top: @padding-y;
       right: @padding-x;
       padding: 3px;
+      // FIXME-Doma
+      // color should be @B600
     }
   }
 }

--- a/src/SelectPicker/Listbox.tsx
+++ b/src/SelectPicker/Listbox.tsx
@@ -1,0 +1,304 @@
+import React, { useRef, useState, useEffect, useCallback } from 'react';
+import isUndefined from 'lodash/isUndefined';
+import getPosition from 'dom-lib/getPosition';
+import scrollTop from 'dom-lib/scrollTop';
+import getHeight from 'dom-lib/getHeight';
+import { List, AutoSizer, ListProps, ListHandle } from '../Windowing';
+import shallowEqual from '../utils/shallowEqual';
+import { mergeRefs, useClassNames, useMount } from '../utils';
+import ListboxOptionGroup from './ListboxOptionGroup';
+import { CompareFn, Group, groupOptions } from '../utils/getDataGroupBy';
+import { StandardProps, Offset } from '../@types/common';
+import ListboxOption from './ListboxOption';
+
+interface ListboxProps<T, K>
+  extends StandardProps,
+    Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
+  classPrefix: string;
+  options: readonly T[];
+  getOptionKey?: (option: T) => K;
+  sort?: <B extends boolean>(isGroup: B) => B extends true ? CompareFn<Group<T>> : CompareFn<T>;
+  groupBy?: string;
+  disabledOptionKeys?: readonly K[];
+  selectedOptionKey?: K;
+  activeOptionKey?: K;
+  maxHeight?: number;
+  labelKey?: string;
+  className?: string;
+  style?: React.CSSProperties;
+  optionClassPrefix?: string;
+  rowHeight?: number;
+  rowGroupHeight?: number;
+  virtualized?: boolean;
+  listProps?: Partial<ListProps>;
+  listRef?: React.Ref<ListHandle>;
+
+  /** Custom selected option */
+  renderMenuItem?: (itemLabel: React.ReactNode, item: any) => React.ReactNode;
+  renderMenuGroup?: (title: React.ReactNode, item: any) => React.ReactNode;
+  onSelect?: (value: K, item: T, event: React.MouseEvent) => void;
+  onGroupTitleClick?: (event: React.MouseEvent) => void;
+}
+
+type ListboxComponent = <T, K>(
+  p: ListboxProps<T, K> & { ref?: React.ForwardedRef<HTMLDivElement> }
+) => JSX.Element;
+
+const Listbox = React.forwardRef(function Listbox<T, K extends React.Key = React.Key>(
+  props: ListboxProps<T, K>,
+  ref: React.ForwardedRef<HTMLDivElement>
+) {
+  const {
+    options = [],
+    getOptionKey,
+    groupBy,
+    sort,
+    maxHeight = 320,
+    selectedOptionKey,
+    disabledOptionKeys = [],
+    classPrefix = 'dropdown-menu',
+    labelKey = 'label',
+    virtualized,
+    listProps,
+    listRef: virtualizedListRef,
+    className,
+    style,
+    activeOptionKey,
+    optionClassPrefix,
+    rowHeight = 36,
+    rowGroupHeight = 48,
+    renderMenuGroup,
+    renderMenuItem,
+    onGroupTitleClick,
+    onSelect,
+    ...rest
+  } = props;
+
+  const group = typeof groupBy !== 'undefined';
+
+  const { withClassPrefix, prefix, merge } = useClassNames(classPrefix);
+  const classes = merge(className, withClassPrefix('items', { grouped: group }));
+
+  const menuBodyContainerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<ListHandle>(null);
+
+  const [foldedGroupKeys, setFoldedGroupKeys] = useState<string[]>([]);
+
+  const handleGroupTitleClick = useCallback(
+    (key: string, event: React.MouseEvent) => {
+      const nextGroupKeys = foldedGroupKeys.filter(item => item !== key);
+      if (nextGroupKeys.length === foldedGroupKeys.length) {
+        nextGroupKeys.push(key);
+      }
+      setFoldedGroupKeys(nextGroupKeys);
+      onGroupTitleClick?.(event);
+
+      // See example https://codesandbox.io/s/grouped-list-with-sticky-headers-shgok?fontsize=14&file=/index.js:1314-1381
+      listRef.current?.resetAfterIndex(0); // use group index to reduce calculation
+    },
+    [onGroupTitleClick, foldedGroupKeys]
+  );
+
+  useEffect(() => {
+    const container = menuBodyContainerRef.current;
+
+    if (!container) {
+      return;
+    }
+
+    let activeItem = container.querySelector(`.${prefix('item-focus')}`);
+
+    if (!activeItem) {
+      activeItem = container.querySelector(`.${prefix('item-active')}`);
+    }
+
+    if (!activeItem) {
+      return;
+    }
+
+    const position = getPosition(activeItem, container) as Offset;
+    const sTop = scrollTop(container);
+    const sHeight = getHeight(container);
+    if (sTop > position.top) {
+      scrollTop(container, Math.max(0, position.top - 20));
+    } else if (position.top > sTop + sHeight) {
+      scrollTop(container, Math.max(0, position.top - sHeight + 32));
+    }
+  }, [activeOptionKey, menuBodyContainerRef, prefix]);
+
+  useMount(function scrollToSelectedOption() {
+    if (virtualized && selectedOptionKey) {
+      if (typeof groupBy === 'undefined') {
+        const selectedOptionIndex = options.findIndex(
+          option => getOptionKey?.(option) === selectedOptionKey
+        );
+        listRef.current?.scrollToItem(selectedOptionIndex);
+      } else {
+        const groups = groupOptions(options, groupBy, sort?.(false), sort?.(true));
+        const selectedGroupIndex = groups.findIndex(group => group.key === selectedOptionKey);
+        // TODO-Doma
+        // This only scrolls the list to the group, not to the selected item within the group
+        // .scrollToItem does not support specifying an px offset
+        // Find a way to scroll to the selected item within the group
+        listRef.current?.scrollToItem(selectedGroupIndex);
+      }
+    }
+  });
+
+  const renderOption = useCallback(
+    (option: T) => {
+      const optionKey = getOptionKey?.(option) ?? JSON.stringify(option);
+      const label = option[labelKey];
+
+      const disabled = disabledOptionKeys?.some(disabledValue =>
+        shallowEqual(disabledValue, optionKey)
+      );
+      const selected = shallowEqual(selectedOptionKey, optionKey);
+      const focus = !isUndefined(activeOptionKey) && shallowEqual(activeOptionKey, optionKey);
+
+      return (
+        <ListboxOption
+          key={optionKey}
+          disabled={disabled}
+          selected={selected}
+          active={focus}
+          data-key={optionKey}
+          classPrefix={optionClassPrefix}
+          onClick={event => {
+            if (!disabled) {
+              onSelect?.(optionKey as K, option, event);
+            }
+          }}
+        >
+          {renderMenuItem ? renderMenuItem(label, option) : label}
+        </ListboxOption>
+      );
+    },
+    [
+      getOptionKey,
+      labelKey,
+      disabledOptionKeys,
+      selectedOptionKey,
+      activeOptionKey,
+      optionClassPrefix,
+      renderMenuItem,
+      onSelect
+    ]
+  );
+
+  const renderOptions = useCallback(
+    (options: readonly T[]) => {
+      return options.map(option => renderOption(option));
+    },
+    [renderOption]
+  );
+
+  const renderOptionGroup = useCallback(
+    (group: Group<T>) => {
+      const groupKey = group.key;
+      const expanded = !foldedGroupKeys.includes(groupKey);
+
+      return (
+        <ListboxOptionGroup
+          key={groupKey}
+          title={renderMenuGroup ? renderMenuGroup(groupKey, group) : groupKey}
+          classPrefix={'picker-menu-group'}
+          expanded={expanded}
+          onClickTitle={e => handleGroupTitleClick(group.key, e)}
+        >
+          {renderOptions(group.options)}
+        </ListboxOptionGroup>
+      );
+    },
+    [foldedGroupKeys, handleGroupTitleClick, renderMenuGroup, renderOptions]
+  );
+
+  const renderOptionGroups = useCallback(
+    (groupKey: string) => {
+      const groups = groupOptions(options, groupKey, sort?.(false), sort?.(true));
+      return groups.map(group => renderOptionGroup(group));
+    },
+    [options, renderOptionGroup, sort]
+  );
+
+  const renderVirtualizedOptions = useCallback(() => {
+    return (
+      <AutoSizer defaultHeight={maxHeight} style={{ width: 'auto', height: 'auto' }}>
+        {({ height }) => (
+          <List
+            ref={mergeRefs(listRef, virtualizedListRef)}
+            height={height || maxHeight}
+            itemCount={options.length}
+            itemSize={rowHeight}
+            {...listProps}
+          >
+            {({ index }) => renderOption(options[index])}
+          </List>
+        )}
+      </AutoSizer>
+    );
+  }, [listProps, maxHeight, options, renderOption, rowHeight, virtualizedListRef]);
+
+  // Example of rendering option groups in VariableSizeList
+  // https://github.com/bvaughn/react-window/issues/358
+  const renderVirtualizedOptionGroups = useCallback(
+    (groupKey: string) => {
+      const groups = groupOptions(options, groupKey, sort?.(false), sort?.(true));
+      return (
+        <AutoSizer defaultHeight={maxHeight} style={{ width: 'auto', height: 'auto' }}>
+          {({ height }) => (
+            <List
+              ref={mergeRefs(listRef, virtualizedListRef)}
+              height={height || maxHeight}
+              itemCount={groups.length}
+              itemSize={index => {
+                const item = groups[index];
+
+                const expanded = !foldedGroupKeys.includes(item.key);
+                if (expanded) {
+                  return item.options.length * rowHeight + rowGroupHeight;
+                }
+
+                return rowGroupHeight;
+              }}
+              {...listProps}
+            >
+              {({ index }) => renderOptionGroup(groups[index])}
+            </List>
+          )}
+        </AutoSizer>
+      );
+    },
+    [
+      foldedGroupKeys,
+      listProps,
+      maxHeight,
+      options,
+      renderOptionGroup,
+      rowGroupHeight,
+      rowHeight,
+      sort,
+      virtualizedListRef
+    ]
+  );
+
+  return (
+    <div
+      role="listbox"
+      {...rest}
+      className={classes}
+      ref={mergeRefs(menuBodyContainerRef, ref)}
+      style={{ ...style, maxHeight }}
+    >
+      {typeof groupBy === 'undefined'
+        ? virtualized
+          ? renderVirtualizedOptions()
+          : renderOptions(options)
+        : virtualized
+        ? renderVirtualizedOptionGroups(groupBy)
+        : renderOptionGroups(groupBy)}
+    </div>
+  );
+}) as ListboxComponent;
+
+export default Listbox;

--- a/src/SelectPicker/ListboxOption.tsx
+++ b/src/SelectPicker/ListboxOption.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useClassNames } from '../utils';
+import { StandardProps } from '../@types/common';
+
+interface ListboxOptionProps extends StandardProps, React.HTMLAttributes<HTMLDivElement> {
+  selected?: boolean;
+  disabled?: boolean;
+  active?: boolean;
+  title?: string;
+  onKeyDown?: (event: React.KeyboardEvent) => void;
+}
+
+const ListboxOption = React.forwardRef<HTMLDivElement, ListboxOptionProps>(function ListboxOption(
+  props,
+  ref
+) {
+  const {
+    selected,
+    classPrefix = 'dropdown-menu-item',
+    children,
+    className,
+    disabled,
+    active,
+    onKeyDown,
+    ...rest
+  } = props;
+
+  const { withClassPrefix } = useClassNames(classPrefix);
+  const classes = withClassPrefix({ active: selected, focus: active, disabled });
+
+  return (
+    <div
+      ref={ref}
+      role="option"
+      aria-selected={selected || undefined}
+      aria-disabled={disabled}
+      {...rest}
+      className={className}
+      onKeyDown={disabled ? undefined : onKeyDown}
+    >
+      <span className={classes}>{children}</span>
+    </div>
+  );
+});
+ListboxOption.displayName = 'Listbox.Option';
+
+export default ListboxOption;

--- a/src/SelectPicker/ListboxOptionGroup.tsx
+++ b/src/SelectPicker/ListboxOptionGroup.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import classNames from 'classnames';
+import { useClassNames } from '../utils';
+import { StandardProps } from '../@types/common';
+import ArrowDown from '@rsuite/icons/legacy/ArrowDown';
+import useUniqueId from '../utils/useUniqueId';
+
+interface ListboxOptionGroupProps
+  extends StandardProps,
+    Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
+  title?: React.ReactNode;
+  expanded?: boolean;
+  onClickTitle?: React.MouseEventHandler;
+}
+
+const ListboxOptionGroup = React.forwardRef<HTMLDivElement, ListboxOptionGroupProps>(
+  (props, ref) => {
+    const {
+      classPrefix = 'dropdown-menu-group',
+      title,
+      children,
+      className,
+      expanded = true,
+      onClickTitle,
+      ...rest
+    } = props;
+    const { withClassPrefix, prefix, merge } = useClassNames(classPrefix);
+    const classes = merge(className, withClassPrefix());
+
+    const groupId = useUniqueId('listbox-group-');
+    const labelId = groupId + '-label';
+
+    return (
+      <div
+        role="group"
+        id={groupId}
+        aria-expanded={expanded}
+        aria-labelledby={labelId}
+        {...rest}
+        ref={ref}
+        className={classNames(classes, {
+          folded: !expanded
+        })}
+      >
+        <div className={prefix`title`} tabIndex={-1} onClick={onClickTitle}>
+          <span id={labelId}>{title}</span>
+          <ArrowDown aria-hidden className={prefix`caret`} />
+        </div>
+        {children}
+      </div>
+    );
+  }
+);
+ListboxOptionGroup.displayName = 'Listbox.OptionGroup';
+
+export default ListboxOptionGroup;

--- a/src/SelectPicker/styles/index.less
+++ b/src/SelectPicker/styles/index.less
@@ -11,10 +11,6 @@
   .picker-menu-group-common(picker);
   .picker-menu-group-title(picker);
   .picker-menu-group-closed(picker);
-
-  .rs-picker-menu-group ~ [role='option'] > .rs-picker-select-menu-item {
-    padding-left: 26px;
-  }
 }
 
 // Menu item (the option)
@@ -44,4 +40,12 @@
   .rs-picker-select-menu-group-children & {
     padding-left: @picker-group-children-padding-left;
   }
+}
+
+.rs-picker-menu-group .rs-picker-select-menu-item {
+  padding-left: @picker-group-children-padding-left;
+}
+
+.rs-picker-menu-group.folded [role='option'] {
+  display: none;
 }

--- a/src/Windowing/List.tsx
+++ b/src/Windowing/List.tsx
@@ -11,7 +11,7 @@ import { useCustom } from '../utils';
 
 export interface ListProps<T = any> extends WithAsProps {
   /**
-   * @deprecated use itemSize instead
+   * @deprecated use {@link itemSize} instead
    * Either a fixed row height (number) or a function that returns the height of a row given its index: ({ index: number }): number
    */
   rowHeight?: number | (({ index: number }) => number);
@@ -47,7 +47,8 @@ export interface ListProps<T = any> extends WithAsProps {
   onScroll?: (props: ListOnScrollProps) => void;
 }
 
-export interface ListHandle extends Partial<VariableSizeList> {
+export interface ListHandle
+  extends Pick<VariableSizeList, 'resetAfterIndex' | 'scrollTo' | 'scrollToItem'> {
   /**
    * @deprecated use scrollToItem instead
    * Ensure row is visible. This method can be used to safely scroll back to a cell that a user has scrolled away from even if it was previously scrolled to.

--- a/src/styles/mixins/listbox.less
+++ b/src/styles/mixins/listbox.less
@@ -32,6 +32,8 @@
   font-weight: normal;
   line-height: @line-height-base;
   color: var(--rs-text-primary);
+  // FIXME-Doma
+  // No need to use pointer, just use default
   cursor: pointer;
   text-decoration: none;
   width: 100%;

--- a/src/utils/getDataGroupBy.ts
+++ b/src/utils/getDataGroupBy.ts
@@ -5,6 +5,10 @@ const hasSymbol = typeof Symbol === 'function';
 export const KEY_GROUP = hasSymbol ? Symbol('_$grouped') : '_$grouped';
 export const KEY_GROUP_TITLE = 'groupTitle';
 
+/**
+ * Chunk data into groups
+ * @returns [group, child, child, group, child, child]
+ */
 export function getDataGroupBy<T>(
   data: readonly T[],
   key: string,
@@ -27,4 +31,34 @@ export function getDataGroupBy<T>(
   // Because I want the result to be [group, child, child, group, child, child]
   // rather than [group, group, child, child, child, child]
   return flattenTree(groups, group => group.children, WalkTreeStrategy.DFS);
+}
+
+/**
+ * Chunk options into groups
+ * @returns [
+ *   group {
+ *     key
+ *     options
+ *   }
+ *   group {
+ *     key
+ *     options
+ *   }
+ * ]
+ */
+export type Group<T> = { key: string; options: T[] };
+export type CompareFn<T> = (a: T, b: T) => number;
+export function groupOptions<T>(
+  options: readonly T[],
+  groupKey: string,
+  compareOptions?: CompareFn<T>,
+  compareGroups?: CompareFn<Group<T>>
+): Group<T>[] {
+  const groupMap = _.groupBy(options, groupKey);
+  const groups = Object.entries(groupMap).map(([key, options]) => ({
+    key,
+    options: typeof compareOptions === 'function' ? options.sort(compareOptions) : options
+  }));
+
+  return typeof compareGroups === 'function' ? groups.sort(compareGroups) : groups;
 }


### PR DESCRIPTION
Before: grouped option elements are siblings of group element

<img width="512" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/56cd5477-c05c-4091-9b17-ef84b4154aa5">

a11y inspector:
<img width="369" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/f39b1d14-c3c2-402a-8734-bd4b4a97333b">

After: grouped option elements are within group element

<img width="487" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/48d73c56-a05d-438d-801f-21d4488c3da6">

a11y inspector:
<img width="376" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/3ffa0144-d30a-410b-8259-bb748449388d">

