### PR TITLE
fix(SelectPicker): fix display options not updating when data prop is updated

### DIFF
--- a/src/CheckPicker/test/CheckPickerSpec.tsx
+++ b/src/CheckPicker/test/CheckPickerSpec.tsx
@@ -87,6 +87,18 @@ describe('CheckPicker', () => {
     expect(container.firstChild).to.have.class('rs-picker-plaintext');
   });
 
+  it('Should update display options when `data` is updated', () => {
+    const { rerender } = render(<CheckPicker open data={[{ label: 'Item', value: 1 }]} />);
+
+    expect(screen.getAllByRole('option').map(option => option.textContent)).to.deep.equal(['Item']);
+
+    rerender(<CheckPicker open data={[{ label: 'New Item', value: 1 }]} />);
+
+    expect(screen.getAllByRole('option').map(option => option.textContent)).to.deep.equal([
+      'New Item'
+    ]);
+  });
+
   it('Should active item by `value`', () => {
     const value = ['Louisa'];
     render(<CheckPicker defaultOpen data={data} value={value} />);

--- a/src/InputPicker/test/InputPickerSpec.tsx
+++ b/src/InputPicker/test/InputPickerSpec.tsx
@@ -106,6 +106,18 @@ describe('InputPicker', () => {
     expect(instance).to.have.class('rs-picker-block');
   });
 
+  it('Should update display options when `data` is updated', () => {
+    const { rerender } = render(<InputPicker open data={[{ label: 'Item', value: 1 }]} />);
+
+    expect(screen.getAllByRole('option').map(option => option.textContent)).to.deep.equal(['Item']);
+
+    rerender(<InputPicker open data={[{ label: 'New Item', value: 1 }]} />);
+
+    expect(screen.getAllByRole('option').map(option => option.textContent)).to.deep.equal([
+      'New Item'
+    ]);
+  });
+
   it('Should active item by `value`', () => {
     const value = 'Louisa';
     render(<InputPicker defaultOpen data={data} value={value} />);

--- a/src/Picker/utils.ts
+++ b/src/Picker/utils.ts
@@ -1,4 +1,4 @@
-import React, { useState, useImperativeHandle, useCallback } from 'react';
+import React, { useState, useImperativeHandle, useCallback, useMemo } from 'react';
 import kebabCase from 'lodash/kebabCase';
 import trim from 'lodash/trim';
 import isFunction from 'lodash/isFunction';
@@ -606,17 +606,12 @@ export function useSearch<T>(data: readonly T[], props: SearchOptions<T>): UseSe
     [labelKey, searchBy, searchKeyword]
   );
 
-  // TODO-Doma
-  // filteredData should be derived from data and searchKeyword
-  // This redundant state might be here for preventing callback firing multiple times
-  // Find out if this is the case and remove this state if possible
-  const [filteredData, setFilteredData] = useState<T[]>(() =>
-    data.filter(item => checkShouldDisplay(item))
-  );
+  const filteredData = useMemo(() => {
+    return data.filter(item => checkShouldDisplay(item, searchKeyword));
+  }, [checkShouldDisplay, data, searchKeyword]);
 
   const handleSearch = (searchKeyword: string, event: React.SyntheticEvent) => {
     const filteredData = data.filter(item => checkShouldDisplay(item, searchKeyword));
-    setFilteredData(filteredData);
     setSearchKeyword(searchKeyword);
     callback?.(searchKeyword, filteredData, event);
   };

--- a/src/SelectPicker/test/SelectPickerSpec.tsx
+++ b/src/SelectPicker/test/SelectPickerSpec.tsx
@@ -101,6 +101,18 @@ describe('SelectPicker', () => {
     expect(instance).to.have.class('rs-picker-block');
   });
 
+  it('Should update display options when `data` is updated', () => {
+    const { rerender } = render(<SelectPicker open data={[{ label: 'Item', value: 1 }]} />);
+
+    expect(screen.getAllByRole('option').map(option => option.textContent)).to.deep.equal(['Item']);
+
+    rerender(<SelectPicker open data={[{ label: 'New Item', value: 1 }]} />);
+
+    expect(screen.getAllByRole('option').map(option => option.textContent)).to.deep.equal([
+      'New Item'
+    ]);
+  });
+
   it('Should active item by `value`', () => {
     const value = 'Louisa';
     render(<SelectPicker defaultOpen data={data} value={value} />);


### PR DESCRIPTION
Fix #3318

SelectPicker displays options according to `filteredData` returned from `useSearch`. It used to manually update `filteredData` via `updateFilteredData` method when `data` prop updates, which was not a proper state flow and was removed in #3301. However `filteredData` is not directly derived from `data` prop either, but manually updated in `handleSearch` (and then-removed `updateFilteredData` which was supposed to be called by SelectPicker). This edit makes `filteredData` directly derived from `data` and `searchKeyword`.