### PR TITLE
fix(Picker): change color of caret on option group title

### DIFF
--- a/src/Picker/styles/mixin.less
+++ b/src/Picker/styles/mixin.less
@@ -41,6 +41,7 @@
       top: @padding-y;
       right: @padding-x;
       padding: 3px;
+      color: var(--rs-text-secondary);
     }
   }
 }


### PR DESCRIPTION
The caret color should be `@B600` per design, but was implemented as `@B800`.

Design

<img width="273" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/27bfe919-6d0e-4f8c-a562-a93fe297dae0">

Before fix

<img width="256" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/e6123776-b0c5-410f-a9f2-9a7278201205">

After fix

<img width="261" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/02123caa-fc0f-4ae2-9076-c74fae31b143">
