### PR TITLE
fix(InputGroup): fix inside addon overlapping input text

### DIFF
--- a/docs/pages/components/input/fragments/input-group-inside.md
+++ b/docs/pages/components/input/fragments/input-group-inside.md
@@ -30,6 +30,11 @@ const App = () => (
     </InputGroup>
 
     <InputGroup inside style={styles}>
+      <InputGroup.Addon>https://</InputGroup.Addon>
+      <Input defaultValue="www." />
+    </InputGroup>
+
+    <InputGroup inside style={styles}>
       <Input />
       <InputGroup.Addon>
         <SearchIcon />

--- a/src/InputGroup/styles/index.less
+++ b/src/InputGroup/styles/index.less
@@ -129,12 +129,12 @@
       display: block;
       width: 100%;
       border: none;
+      outline: none;
       padding-right: @input-group-padding-for-add-on-base;
     }
 
     .rs-input-group-btn,
     .rs-input-group-addon {
-      position: absolute;
       z-index: @zindex-input-group-icon;
       flex: 0 0 auto;
       width: auto;
@@ -165,7 +165,7 @@
       top: 0;
       background: none;
       border: none;
-      padding: 10px 13px;
+      padding: 10px 12px;
 
       &.rs-input-group-btn {
         padding: 8px 13px;
@@ -178,7 +178,7 @@
     .rs-input-group-addon ~ .rs-auto-complete > input.rs-input,
     .rs-input-group-addon ~ .rs-form-control-wrapper > input.rs-input,
     .rs-input-group-btn ~ .rs-form-control-wrapper > input.rs-input {
-      padding-left: @input-group-padding-for-add-on-base;
+      padding-left: 0;
       padding-right: 12px;
     }
 


### PR DESCRIPTION
## What's fixed

This edit fix 2 spacing issues with `<InputGroup inside>` addons

- The addon overlaps with input text when its content is long
- Gap between the addon content and input text was 13px, which should be 12px per design

Before

<img width="324" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/205b336c-29e6-4f62-b569-b3f0c3b614c7">

After

<img width="319" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/7fc08fb2-2f61-4e34-b9e6-4ca6cdbe3157">

```jsx
<InputGroup inside>
  <InputGroup.Addon>https://</InputGroup.Addon>
  <Input defaultValue="www." />
</InputGroup>
```

As a side effect, this edit also fixes the doubled focus ring when InputGroup has focus

Before

<img width="323" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/7580ee10-0fd2-478b-a2ac-46e14b8f210c">

After

<img width="321" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/a9f0e035-2378-436c-aef3-14e0bb85330b">

## How it's done

The InputGroup with inside addons used to be implemented by setting `position: absolute` on the addon, making the Input the same size of the InputGroup, then increase the horizontal padding of Input to make room for the addon.

<img width="318" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/f5688f76-d2ac-4e21-af90-5a5da7fcd56e">

This caused the overlapping because when addon content increases the padding of Input doesn't change.

<img width="316" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/162ad696-e803-48ff-a997-bf312bc14f35">

It's fixed by removing `position: absolute` from the addon and remove left padding of Input.

<img width="317" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/eb788be9-7259-4d8a-a2eb-72613e90cfc3">

As a result, the Input's border-box does not fill the InputGroup, and the double focus ring problem was revealed.

<img width="323" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/ab4a71cf-8dcb-4606-976a-4fde298f6f99">

It's fixed by removing the focus ring from Input when it's within an InputGroup.