### PR TITLE
fix(DatePicker,DateRangePicker): fix calendar styles per design

### DIFF
--- a/src/Calendar/styles/index.less
+++ b/src/Calendar/styles/index.less
@@ -346,6 +346,7 @@
 }
 
 // Calendar Table
+// TODO-Doma Use CSS grid layout.
 .rs-calendar-table {
   display: table;
   table-layout: fixed;
@@ -438,7 +439,7 @@
 
 .rs-calendar-table-cell-week-number {
   display: table-cell;
-  width: 1%;
+  min-width: 30px;
   padding: @calendar-table-cell-padding;
   text-align: center;
   vertical-align: middle;
@@ -473,13 +474,13 @@
 
   &-row {
     position: relative;
-    padding-left: (40px + @calendar-picker-padding);
+    padding-left: @calendar-picker-padding + 38px; // 30px for the year label + 8px gap
     padding-right: @calendar-picker-padding;
     padding-top: 5px;
     padding-bottom: 5px;
 
     &:not(:last-child) {
-      border-bottom: 1px dotted var(--rs-border-primary);
+      border-bottom: 1px dashed var(--rs-border-primary);
     }
   }
 
@@ -495,13 +496,14 @@
 
   &-list {
     display: block;
+    min-width: 30px * 6 + 4px * 5;
     .clearfix();
   }
 
   &-cell {
     display: inline-block;
     float: left;
-    width: ~'calc((100% - @{calendar-table-cell-content-today-border-width} * 12 ) / 6)';
+    // width: ~'calc((100% - @{calendar-table-cell-content-today-border-width} * 12 ) / 6)';
     margin: 1px;
     text-align: center;
     vertical-align: middle;

--- a/src/Calendar/test/CalendarStyleSpec.tsx
+++ b/src/Calendar/test/CalendarStyleSpec.tsx
@@ -121,7 +121,7 @@ describe('Calendar styles', () => {
       .getByTestId('body')
       .querySelector('.rs-calendar-month-dropdown-row') as HTMLElement;
 
-    expect(getStyle(row, 'borderBottom')).to.equal(`1px dotted ${toRGB('#e5e5ea')}`);
+    expect(getStyle(row, 'borderBottom')).to.equal(`1px dashed ${toRGB('#e5e5ea')}`);
   });
 
   it('Should render compact calendar', () => {

--- a/src/DatePicker/styles/index.less
+++ b/src/DatePicker/styles/index.less
@@ -49,9 +49,11 @@
 
 // Calendar in DatePicker popup
 .rs-picker-menu {
-  @calendar-width: (
-    @datepicker-calendar-cell-gap-x * 6 + 30px * 7 + @datepicker-calendar-padding-x * 2
-  );
+  @calendar-width: 264px; // This is a fixed value per design.
+
+  @calendar-padding-x: 15px;
+  // The padding used when show week numbers.
+  @calendar-padding-x-condensed: 12px;
 
   .rs-picker-toolbar {
     max-width: 100%;
@@ -68,15 +70,23 @@
     margin: 0 auto;
 
     &-show-week-numbers {
-      @calendar-width: (
-        @datepicker-calendar-cell-gap-x * 7 + 30px * 8 + @datepicker-calendar-padding-x * 2
-      );
+      @calendar-width: 278px; // This is a fixed value per design.
 
       min-width: @calendar-width;
+
+      & .rs-calendar-body {
+        padding-left: @calendar-padding-x-condensed;
+        padding-right: @calendar-padding-x-condensed;
+      }
     }
 
     &-header {
       width: 100%;
+    }
+
+    &-body {
+      padding-left: @calendar-padding-x;
+      padding-right: @calendar-padding-x;
     }
 
     &-table {

--- a/src/DateRangePicker/test/DateRangePickerStylesSpec.tsx
+++ b/src/DateRangePicker/test/DateRangePickerStylesSpec.tsx
@@ -17,6 +17,6 @@ describe('DateRangePicker styles', () => {
     const instance = getInstance(<DateRangePicker block defaultOpen />);
 
     expect(instance.root).to.have.class('rs-picker-block');
-    expect(getWidth(instance.overlay)).to.equal(492);
+    expect(getWidth(instance.overlay)).to.equal(264 * 2);
   });
 });


### PR DESCRIPTION
## What's fixed

### Month selection button overlapped

The month buttons should have 2px horizontal gap but overlapped.

Before

<img width="595" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/ac4bb2c9-8690-4a3a-9fa8-d427ce392300">

After

<img width="296" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/2a088c2d-69f1-4f02-8d66-1625fe7354b5">

### Divider of month selection panel in dashed style

It was dotted but should be dashed per design.

Before

<img width="267" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/5cec56a2-dd16-4328-83b5-f6077ad9780a">

After

<img width="287" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/ed3c880c-80c6-499e-ae6a-111f8528c4e9">

### Week number column shrank

The week number column should be 30px wide but shrank.

Before

<img width="307" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/5e46fdc2-dea6-447d-a8b8-c9fb49582f7d">

After

<img width="322" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/6d241307-86e9-4795-8169-4562cdfeeb93">

## How it's done

The overlapping of month selection buttons was related to design issues. The width of the calendar panel was 246px, which could not contain the month selection buttons with appropriate gap. It's increased to 264px now. As a result, the horizontal gap between date buttons on the calendar panel (without week numbers) is increased from 2px to 4px, and horizontal padding of the calendar panel (without week numbers) is increased from 12px to 15px.

Design before vs. after

<img width="244" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/4f530b76-5400-4df6-a7be-12f051960e9b">

The week number column shrank because it's not given a correct width value (assigned `width: 1%`). As the calendar is implemented with `display: table`, adding `width: 30px` to the cell does not take effect. A quick fix is to assign `min-width: 30px`, but I think it's better reimplement it with grid layout.