### PR TITLE
Fix InputPicker select bug

### DIFF
--- a/src/InputPicker/InputPicker.tsx
+++ b/src/InputPicker/InputPicker.tsx
@@ -594,10 +594,6 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
       }
     }, [readOnly]);
 
-    const handleBlur = useCallback(() => {
-      setOpen(false);
-    }, []);
-
     const handleEnter = useCallback(() => {
       focusInput();
       setOpen(true);
@@ -849,7 +845,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
                   {...inputProps}
                   tabIndex={tabIndex}
                   readOnly={readOnly}
-                  onBlur={createChainedFunction(handleBlur, onBlur)}
+                  onBlur={onBlur}
                   onFocus={createChainedFunction(handleFocus, onFocus)}
                   inputRef={inputRef}
                   onChange={handleSearch}


### PR DESCRIPTION
Fix: #3245

InputPicker with virtualization item selects only after double clicks.

Calling set Open(false) in onBlur is incorrect because InputPicker onBlur is also called when clicking on InputPicker items. Closing InputPicker works without this function, when clicking outside the component.

For reproduce:
```
import React from "react";
import ReactDOM from "react-dom";
import { InputPicker, Loader } from 'rsuite';
import "rsuite/dist/rsuite.min.css";
import "./styles.css";

const fetchData = (start, length) => {
  return Array.from({ length }).map((_, index) => {
    return {
      label: `Item ${start + index}`,
      value: `Item ${start + index}`
    };
  });
};

const FixedLoader = () => (
  <Loader
    content="Loading..."
    style={{
      display: 'flex',
      justifyContent: 'center',
      position: 'absolute',
      bottom: '0',
      background: '#fff',
      width: '100%',
      padding: '4px 0'
    }}
  />
);

const App = () => {
  const [data, setData] = React.useState(fetchData(0, 30));
  const [loading, setLoading] = React.useState(false);

  const loadMore = () => {
    setLoading(true);
    setTimeout(() => {
      setData([...data, ...fetchData(data.length, 30)]);
      setLoading(false);
    }, 1000);
  };

  const onItemsRendered = props => {
    if (props.visibleStopIndex >= data.length - 1) {
      loadMore();
    }
  };

  const renderMenu = menu => {
    return (
      <>
        {menu}
        {loading && <FixedLoader />}
      </>
    );
  };

  return (
    <InputPicker
      data={data}
      style={{ width: 224 }}
      virtualized
      renderMenu={renderMenu}
      listProps={{
        onItemsRendered
      }}
    />
  );
};

ReactDOM.render(<App />, document.getElementById('root'));
```