### PR TITLE
fix(InputPicker): cursor should be text

### DIFF
--- a/src/Dropdown/styles/mixin.less
+++ b/src/Dropdown/styles/mixin.less
@@ -39,7 +39,6 @@
   padding-right: @dropdown-toggle-padding-right;
   // Fixed: Content is not centered when customizing renderTitle.
   display: inline-block;
-  cursor: pointer;
 }
 
 // Horizontal dividers


### PR DESCRIPTION
## What's fixed

InputPicker has `cursor: text` style specified for its toggle, but was overridden by `.rs-picker-default .rs-picker-toggle` styles, which turns out to be redundant.

<img width="416" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/54d1a287-59c2-4a3f-b738-82710d623631">

After fix

<img width="416" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/80f86c05-eca4-4974-bad6-cc876236971c">

### How's it done

The `cursor: pointer` in `.rs-picker-default .rs-picker-toggle` selector is introduced via a `.dropdown-toggle()` mixin, which is used on the Dropdown's toggle and Picker's toggles - where they already have `cursor: pointer` inherited from `.rs-btn`. So it's safe to remove `cursor: pointer` from `.dropdown-toggle()`.

---

Fix #3328
