### PR TITLE
feat(Next.js): add 'use client'

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Base
 export { default as Button } from './Button';
 export type { ButtonProps } from './Button';


### PR DESCRIPTION
Added 'use client' to index.tsx to make components compatible with Next.js 13. Next.js requires the 'use client' directive for all components with client-side interactivity before they can be directly imported into server components. A more thorough approach would be to review all components to see if they can be used as server components and therefore not requiring the 'use client' directive, but that is realistically infeasible. Also, adding this only to index.tsx does not work with default imports, only with named imports (e.g. import { Button } from 'rsuite').