### PR TITLE
docs(Calendar): add example for cellClassName usage

### DIFF
--- a/docs/pages/components/calendar/en-US/index.md
+++ b/docs/pages/components/calendar/en-US/index.md
@@ -12,6 +12,12 @@ A component that displays data by calendar
 
 <!--{include:`basic.md`}-->
 
+### Custom cell styles
+
+Use `cellClassName` function to specify the custom class name added to each cell. For example, in the following code, we specify that the `.bg-gray` class name is added on Monday, Wednesday, and Friday, so that the background color of the cells in these three columns is gray.
+
+<!--{include:`custom-cell.md`}-->
+
 ### Compact
 
 <!--{include:`compact.md`}-->

--- a/docs/pages/components/calendar/fragments/custom-cell.md
+++ b/docs/pages/components/calendar/fragments/custom-cell.md
@@ -1,0 +1,24 @@
+<!--start-code-->
+
+```js
+import { Calendar } from 'rsuite';
+
+const App = () => {
+  return (
+    <>
+      <style>
+        {`
+      .bg-gray {
+        background-color: rgba(242, 242, 242, 0.3);
+      }
+      `}
+      </style>
+      <Calendar bordered cellClassName={date => (date.getDay() % 2 ? 'bg-gray' : undefined)} />
+    </>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/calendar/zh-CN/index.md
+++ b/docs/pages/components/calendar/zh-CN/index.md
@@ -12,6 +12,12 @@
 
 <!--{include:`basic.md`}-->
 
+### 自定义单元格样式
+
+使用 `cellClassName` 函数指定各单元格添加的自定义类名。例如，下面的代码中，我们指定周一、周三、周五添加 `.bg-gray` 类名，从而实现这三列的单元格背景色为灰色。
+
+<!--{include:`custom-cell.md`}-->
+
 ### 紧凑型
 
 <!--{include:`compact.md`}-->


### PR DESCRIPTION
Preview at https://rsuite-nextjs-git-docs-calendar-cellclassname-rsuite.vercel.app/components/calendar/#custom-cell-styles

<img width="821" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/0aa6a715-2cb7-4e51-87a4-0490f5ab76c5">
