### PR TITLE
fix(Nav.Item): fix vertical mis-alignment of icon

### DIFF
--- a/src/Nav/styles/index.less
+++ b/src/Nav/styles/index.less
@@ -98,6 +98,12 @@
 .rs-nav-horizontal {
   white-space: nowrap;
 
+  > .rs-nav-item {
+    display: inline-flex;
+    align-items: center;
+    vertical-align: top;
+  }
+
   // Waterline
   .rs-nav-bar {
     position: absolute;
@@ -112,19 +118,12 @@
   }
 }
 
-.rs-nav-item,
-.rs-dropdown {
-  .rs-nav-horizontal > & {
-    display: inline-block;
-    vertical-align: top;
-  }
-
-  .rs-nav-vertical > & {
-    display: block;
-  }
-}
-
 .rs-nav-vertical {
+  > .rs-nav-item {
+    display: flex;
+    align-items: center;
+  }
+
   > .rs-dropdown {
     width: 100%;
 


### PR DESCRIPTION
## What's fixed

Icon in Nav.Item was not vertically centered.

Before

<img width="491" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/abfe42d9-6fa2-4d2a-9f9d-0ffdc546ddf6">

After

<img width="488" alt="image" src="https://github.com/rsuite/rsuite/assets/8225666/3e98bc55-616c-4472-a9e3-2c18e3deb158">

## How its done

Apply `display: flex/inline-flex` with `align-items: center` on Nav.Item.