### PR TITLE
fix(CheckTree): searchKeyword is not updated as expected

### DIFF
--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -243,7 +243,7 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
         }).filter(item => item.visible);
       }
 
-      return getFormattedTree(filteredData, flattenNodes, {
+      return getFormattedTree(flattenNodes, filteredData, {
         childrenKey,
         cascade
       }).map(node => render?.(node, 1));

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.tsx
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.tsx
@@ -730,4 +730,16 @@ describe('CheckTreePicker', () => {
     fireEvent.click(screen.getByLabelText('Clear'));
     expect(screen.getByRole('combobox')).to.text('Master (All)1');
   });
+
+  it('Should render correctly when searchKeyword changed', () => {
+    const { rerender } = render(<CheckTreePicker defaultOpen data={data} />);
+
+    expect(screen.getAllByRole('treeitem')).to.have.lengthOf(2);
+    rerender(<CheckTreePicker defaultOpen data={data} searchKeyword="Disabled" />);
+    expect(screen.getAllByRole('treeitem')).to.have.lengthOf(1);
+    rerender(<CheckTreePicker defaultOpen data={data} searchKeyword="Master" />);
+    expect(screen.getAllByRole('treeitem')).to.have.lengthOf(1);
+    rerender(<CheckTreePicker defaultOpen data={data} searchKeyword="Tree" />);
+    expect(screen.queryAllByRole('treeitem')).to.have.lengthOf(0);
+  });
 });

--- a/src/CheckTreePicker/utils.ts
+++ b/src/CheckTreePicker/utils.ts
@@ -114,8 +114,8 @@ export function isNodeUncheckable(
 }
 
 export function getFormattedTree(
-  data: any[],
   nodes: TreeNodesType,
+  data: any[],
   props: Required<Pick<CheckTreePickerProps, 'childrenKey' | 'cascade'>>
 ) {
   const { childrenKey, cascade } = props;
@@ -132,7 +132,7 @@ export function getFormattedTree(
       attachParent(formatted, curNode.parent);
       formatted.checkState = checkState;
       if (node[childrenKey]?.length > 0) {
-        formatted[childrenKey] = getFormattedTree(formatted[childrenKey], nodes, props);
+        formatted[childrenKey] = getFormattedTree(nodes, formatted[childrenKey], props);
       }
     }
 

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -930,10 +930,22 @@ export function useTreeSearch<T>(props: TreeSearchProps<T>) {
   );
 
   // Use search keywords to filter options.
-  const [searchKeywordState, setSearchKeyword] = useState(() => searchKeyword ?? '');
+  const [searchKeywordState, setSearchKeyword] = useState(searchKeyword ?? '');
   const [filteredData, setFilteredData] = useState(() =>
     filterVisibleData(data, searchKeywordState)
   );
+
+  const handleSearch = (searchKeyword: string, event?: React.ChangeEvent) => {
+    const filteredData = filterVisibleData(data, searchKeyword);
+    setFilteredData(filteredData);
+    setSearchKeyword(searchKeyword);
+    event && callback?.(searchKeyword, filteredData, event);
+  };
+
+  useEffect(() => {
+    handleSearch(searchKeyword ?? '');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchKeyword]);
 
   const handleSetFilteredData = useCallback(
     (data: T[], searchKeyword: string) => {
@@ -941,13 +953,6 @@ export function useTreeSearch<T>(props: TreeSearchProps<T>) {
     },
     [filterVisibleData]
   );
-
-  const handleSearch = (searchKeyword: string, event: React.ChangeEvent) => {
-    const filteredData = filterVisibleData(data, searchKeyword);
-    setFilteredData(filteredData);
-    setSearchKeyword(searchKeyword);
-    callback?.(searchKeyword, filteredData, event);
-  };
 
   return {
     searchKeywordState,


### PR DESCRIPTION
## Issue
The searchKeyword prop of the CheckTree component is not updating as expected. 

close #3196 

## Cause
The problem is rooted in the logic responsible for updating the searchKeyword within the CheckTree component.

## Solution
In this pull request, I address the issue by reviewing and adjusting the code related to the searchKeyword functionality in the CheckTree component. This ensures that the searchKeyword state is updated appropriately and reflects user input accurately.

## Changes Made
I reviewed the relevant code sections responsible for handling the searchKeyword and made the necessary modifications to enable its proper updating. This included checking for event listeners, data binding, and any conditional statements that might be affecting the searchKeyword state.

## Testing
I thoroughly tested the changes by simulating various search scenarios and confirming that the searchKeyword state now updates correctly. And I also add a test case for this problem.

Screenshots 

https://github.com/rsuite/rsuite/assets/12592949/44448f45-5f56-4b98-aeef-1542d8d270e8


