### PR TITLE
build(deps): bump rsuite-table from 5.11.0 to 5.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "prop-types": "^15.8.1",
         "react-use-set": "^1.0.0",
         "react-window": "^1.8.8",
-        "rsuite-table": "^5.11.0",
+        "rsuite-table": "^5.12.0",
         "schema-typed": "^2.1.3"
       },
       "devDependencies": {
@@ -18765,9 +18765,9 @@
       }
     },
     "node_modules/rsuite-table": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.11.0.tgz",
-      "integrity": "sha512-KDNcVdz7ROrAkDob/q5aUXcinhNIRCso+QeYFwzP8vvFFo8LebQ4S5JCPfCjI+Aw45ztUfWsd0tOEdusiIuxUg==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.12.0.tgz",
+      "integrity": "sha512-Di7PPjVgoAYs+FANJ37xKfcInw/MK7+wvxDEVDvfsM0zCiXGTnfQMv+ahXEcBAEU776fMlLAQWbCpXIUzXCHFg==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",
@@ -37314,9 +37314,9 @@
       }
     },
     "rsuite-table": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.11.0.tgz",
-      "integrity": "sha512-KDNcVdz7ROrAkDob/q5aUXcinhNIRCso+QeYFwzP8vvFFo8LebQ4S5JCPfCjI+Aw45ztUfWsd0tOEdusiIuxUg==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.12.0.tgz",
+      "integrity": "sha512-Di7PPjVgoAYs+FANJ37xKfcInw/MK7+wvxDEVDvfsM0zCiXGTnfQMv+ahXEcBAEU776fMlLAQWbCpXIUzXCHFg==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "prop-types": "^15.8.1",
     "react-use-set": "^1.0.0",
     "react-window": "^1.8.8",
-    "rsuite-table": "^5.11.0",
+    "rsuite-table": "^5.12.0",
     "schema-typed": "^2.1.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
# [5.12.0](https://github.com/rsuite/rsuite-table/compare/5.11.1...5.12.0) (2023-09-06)


### Features

* **Next.js:** add 'use client' to all components ([#456](https://github.com/rsuite/rsuite-table/issues/456)) ([ed49fe1](https://github.com/rsuite/rsuite-table/commit/ed49fe1a76a23878bcad62f4f521ffc95cf4b8e9))



## [5.11.1](https://github.com/rsuite/rsuite-table/compare/5.11.0...5.11.1) (2023-08-31)


### Bug Fixes

* **HeaderCell:** fix type extension ([#448](https://github.com/rsuite/rsuite-table/issues/448)) ([a8c9246](https://github.com/rsuite/rsuite-table/commit/a8c9246c362ef43545ecc021f273de58d05faedf))
* **Column:** fix column width reset after children update ([#447](https://github.com/rsuite/rsuite-table/pull/447))