### PR TITLE
fix: Typo in docs

### DIFF
--- a/docs/pages/guide/v5-features/en-US/index.md
+++ b/docs/pages/guide/v5-features/en-US/index.md
@@ -365,7 +365,7 @@ All pop-up notification messages are managed using the new API toaster. The Aler
 // for rsuite v4
 Alert.info('description');
 
-// for rsutie v5
+// for rsuite v5
 toaster.push(
   <Message type="info" closable>
     description

--- a/docs/pages/guide/v5-features/zh-CN/index.md
+++ b/docs/pages/guide/v5-features/zh-CN/index.md
@@ -367,7 +367,7 @@ return (
 // for rsuite v4
 Alert.info('description');
 
-// for rsutie v5
+// for rsuite v5
 toaster.push(
   <Message type="info" closable>
     description


### PR DESCRIPTION
<img width="948" alt="image" src="https://github.com/rsuite/rsuite/assets/25799103/529689fe-53b1-4bd7-ad95-87c881dc134e">
I noticed a small typo in the documentation at v5-features documentation(https://github.com/rsuite/rsuite/blob/main/docs/pages/guide/v5-features/). This pull request fixes the typo by replacing 'rsutie' with 'rsuite'. This change improves the readability and correctness of the documentation.