### PR TITLE
docs(button): fix markdown syntax errors

### DIFF
--- a/docs/pages/components/button/en-US/index.md
+++ b/docs/pages/components/button/en-US/index.md
@@ -21,11 +21,11 @@ Commonly used operating buttons, button combinations, button layouts.
 
 `appearance` property can set appearance of button:
 
-- 'default'(default) default button.
-- 'primary' Emphasi, guide button.
-- 'link' Button like link.
-- 'subtle' Weakened button.
-- 'ghost' Ghost button, background transparent, place button on background element.
+- `default`(default) default button.
+- `primary` Emphasi, guide button.
+- `link` Button like link.
+- `subtle` Weakened button.
+- `ghost` Ghost button, background transparent, place button on background element.
 
 <!--{include:`appearance.md`}-->
 


### PR DESCRIPTION
This pull request fixed docs of  button markdown syntax errors.

## Before
<img width="555" alt="image" src="https://github.com/rsuite/rsuite/assets/12592949/2644645d-d21e-423d-9ca1-e117af3e3fbd">

https://rsuitejs.com/components/button/#appearance

## After
<img width="660" alt="image" src="https://github.com/rsuite/rsuite/assets/12592949/6ec25600-b654-4ce0-b6a0-826c25f31e0d">

https://rsuite-nextjs-git-docs-fix-markdown-syntax-errors-rsuite.vercel.app/components/button/#appearance
