### PR TITLE
fix(Navbar): fix background color of the subtle navigation items incorrect

### DIFF
--- a/src/Navbar/styles/index.less
+++ b/src/Navbar/styles/index.less
@@ -192,7 +192,7 @@
   .rs-dropdown .rs-dropdown-toggle {
     &:hover,
     &:focus {
-      background-color: transparent;
+      background-color: var(--rs-navbar-subtle-hover-bg);
       color: var(--rs-navbar-subtle-hover-text);
     }
   }


### PR DESCRIPTION
## Before
![image](https://github.com/rsuite/rsuite/assets/1203827/2cc60823-796d-48a1-9bf0-61dea6dd5e57)

## After 
![image](https://github.com/rsuite/rsuite/assets/1203827/5c464bfe-c2a9-4fed-ab87-686b3cccb080)
> https://rsuitejs.com//design/default/index.html#s30