### PR TITLE
feat: add a script to prepend the use client directive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
         "glob": "^7.1.4",
         "gulp": "^4.0.2",
         "gulp-babel": "^8.0.0",
+        "gulp-insert": "^0.5.0",
         "gulp-less": "^4.0.1",
         "gulp-postcss": "^9.0.1",
         "gulp-rename": "^1.2.2",
@@ -12188,6 +12189,40 @@
         "xtend": "~4.0.1"
       }
     },
+    "node_modules/gulp-insert": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/gulp-insert/-/gulp-insert-0.5.0.tgz",
+      "integrity": "sha512-SDKCWmjomAo0N0Bzj9qEKIfURORJR/72p6AbDBIK9yKZw794ROTrQHliBem+NJzS2GsTWSm8dGWJ5L7KtjnMRA==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^1.0.26-4",
+        "streamqueue": "0.0.6"
+      }
+    },
+    "node_modules/gulp-insert/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
+    "node_modules/gulp-insert/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/gulp-insert/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true
+    },
     "node_modules/gulp-less": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/gulp-less/-/gulp-less-4.0.1.tgz",
@@ -19848,6 +19883,42 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "dev": true
+    },
+    "node_modules/streamqueue": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/streamqueue/-/streamqueue-0.0.6.tgz",
+      "integrity": "sha512-l09LNfTUkmLMckTB1Mm8Um5GMS1uTZ/KTodg/SMf5Nx758IOsmaqIQ/AJumAnNMkDgZBG39btq3LVkN90knq8w==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^1.0.26-2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/streamqueue/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
+    "node_modules/streamqueue/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/streamqueue/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "dev": true
     },
     "node_modules/streamroller": {
@@ -32393,6 +32464,42 @@
         }
       }
     },
+    "gulp-insert": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/gulp-insert/-/gulp-insert-0.5.0.tgz",
+      "integrity": "sha512-SDKCWmjomAo0N0Bzj9qEKIfURORJR/72p6AbDBIK9yKZw794ROTrQHliBem+NJzS2GsTWSm8dGWJ5L7KtjnMRA==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^1.0.26-4",
+        "streamqueue": "0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+          "dev": true
+        }
+      }
+    },
     "gulp-less": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/gulp-less/-/gulp-less-4.0.1.tgz",
@@ -38193,6 +38300,41 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
+    },
+    "streamqueue": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/streamqueue/-/streamqueue-0.0.6.tgz",
+      "integrity": "sha512-l09LNfTUkmLMckTB1Mm8Um5GMS1uTZ/KTodg/SMf5Nx758IOsmaqIQ/AJumAnNMkDgZBG39btq3LVkN90knq8w==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^1.0.26-2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+          "dev": true
+        }
+      }
     },
     "streamroller": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "glob": "^7.1.4",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
+    "gulp-insert": "^0.5.0",
     "gulp-less": "^4.0.1",
     "gulp-postcss": "^9.0.1",
     "gulp-rename": "^1.2.2",

--- a/scripts/gulpfile.js
+++ b/scripts/gulpfile.js
@@ -9,6 +9,7 @@ const sourcemaps = require('gulp-sourcemaps');
 const rename = require('gulp-rename');
 const babel = require('gulp-babel');
 const rtlcss = require('gulp-rtlcss');
+const insert = require('gulp-insert');
 const gulp = require('gulp');
 const babelrc = require('../babel.config');
 const { default: proxyDirectories } = require('./proxyDirectories');
@@ -101,20 +102,31 @@ function minifyCSS() {
 }
 
 function buildCjs() {
-  return gulp.src(tsSources).pipe(babel(babelrc())).pipe(gulp.dest(cjsRoot));
+  return (
+    gulp
+      .src(tsSources)
+      .pipe(babel(babelrc()))
+      // adds the "use-client" directive to /cjs exported from rsuite
+      .pipe(insert.prepend(`'use client';\n`))
+      .pipe(gulp.dest(cjsRoot))
+  );
 }
 
 function buildEsm() {
-  return gulp
-    .src(tsSources)
-    .pipe(
-      babel(
-        babelrc(null, {
-          NODE_ENV: 'esm'
-        })
+  return (
+    gulp
+      .src(tsSources)
+      .pipe(
+        babel(
+          babelrc(null, {
+            NODE_ENV: 'esm'
+          })
+        )
       )
-    )
-    .pipe(gulp.dest(esmRoot));
+      // adds the "use-client" directive to /esm exported from rsuite
+      .pipe(insert.prepend(`'use client';\n`))
+      .pipe(gulp.dest(esmRoot))
+  );
 }
 
 function copyTypescriptDeclarationFiles() {

--- a/test/validateBuilds.js
+++ b/test/validateBuilds.js
@@ -1,6 +1,7 @@
 const { assert } = require('chai');
 const fs = require('fs');
 const path = require('path');
+const glob = require('glob');
 const flatten = require('lodash/flatten');
 const { findResources } = require('../scripts/proxyDirectories');
 
@@ -95,4 +96,15 @@ it('Ensure file existence', () => {
 it('Should enable Dark mode by default', () => {
   const css = fs.readFileSync(path.join(__dirname, '../lib/dist/rsuite.css'));
   assert.isTrue(/\.rs-theme-dark/.test(css), 'Dark mode styles are included');
+});
+
+it('Prepends the `use client` directive to components', () => {
+  const libfiles = glob.sync('lib/{cjs,esm}/**/*.js');
+
+  libfiles.forEach(file => {
+    const content = fs.readFileSync(file, 'utf-8');
+    assert.isTrue(content.startsWith(`'use client';`), `File ${file} has 'use client' directive`);
+  });
+
+  console.log(`  ✅ ${libfiles.length} files have been validated.`);
 });


### PR DESCRIPTION
This PR adds the "use-client" directive to esm and cjs exported from rsuite, and a test case to check it.
