### PR TITLE
build(deps): bump rsuite-table from 5.12.0 to 5.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "prop-types": "^15.8.1",
         "react-use-set": "^1.0.0",
         "react-window": "^1.8.8",
-        "rsuite-table": "^5.12.0",
+        "rsuite-table": "^5.14.0",
         "schema-typed": "^2.1.3"
       },
       "devDependencies": {
@@ -18798,9 +18798,9 @@
       }
     },
     "node_modules/rsuite-table": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.12.0.tgz",
-      "integrity": "sha512-Di7PPjVgoAYs+FANJ37xKfcInw/MK7+wvxDEVDvfsM0zCiXGTnfQMv+ahXEcBAEU776fMlLAQWbCpXIUzXCHFg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.14.0.tgz",
+      "integrity": "sha512-zuxofj33T7AFmhQnYoBuPsC9MazrRZPNUirR6UMg90Vl19rKPZXa3+qx95OtXEHKXGwVzldZrPg0r6uSofeDkQ==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",
@@ -37353,9 +37353,9 @@
       }
     },
     "rsuite-table": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.12.0.tgz",
-      "integrity": "sha512-Di7PPjVgoAYs+FANJ37xKfcInw/MK7+wvxDEVDvfsM0zCiXGTnfQMv+ahXEcBAEU776fMlLAQWbCpXIUzXCHFg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.14.0.tgz",
+      "integrity": "sha512-zuxofj33T7AFmhQnYoBuPsC9MazrRZPNUirR6UMg90Vl19rKPZXa3+qx95OtXEHKXGwVzldZrPg0r6uSofeDkQ==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "prop-types": "^15.8.1",
     "react-use-set": "^1.0.0",
     "react-window": "^1.8.8",
-    "rsuite-table": "^5.12.0",
+    "rsuite-table": "^5.14.0",
     "schema-typed": "^2.1.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
# [5.14.0](https://github.com/rsuite/rsuite-table/compare/5.13.0...5.14.0) (2023-10-19)

### Features

* **Table:** add an option to define rowExpandedHeight as function [#465](https://github.com/rsuite/rsuite-table/pull/465)


# [5.13.0](https://github.com/rsuite/rsuite-table/compare/5.12.0...5.13.0) (2023-10-17)


### Bug Fixes

* **Table:** fix table scroll width not excluding scroll bar width ([#461](https://github.com/rsuite/rsuite-table/issues/461)) ([88b0575](https://github.com/rsuite/rsuite-table/commit/88b0575954460539e7d5f29ee06d9251f89e8d23))
* **TreeTable:** fix incorrect scrolling position of tree nodes after collapse ([#462](https://github.com/rsuite/rsuite-table/issues/462)) ([0e0c8dc](https://github.com/rsuite/rsuite-table/commit/0e0c8dc6357846997533f82aeea6da64d315034a))


### Features

* **Table:** support table scrolling through keyboard arrow keys ([#463](https://github.com/rsuite/rsuite-table/issues/463)) ([bf451a8](https://github.com/rsuite/rsuite-table/commit/bf451a8c65ab24a3812fd16e1f176a977eddd223))

