### PR TITLE
feat(TagPicker,TagInput): add support for onTagRemove

### DIFF
--- a/docs/pages/components/tag-input/en-US/index.md
+++ b/docs/pages/components/tag-input/en-US/index.md
@@ -44,6 +44,7 @@ Learn more in [Accessibility](/guide/accessibility).
 | disabled     | boolean                                                      | Whether disabled component                              |
 | onChange     | (value:string[], event) => void                              | Callback fired when value change                        |
 | onClean      | (event) => void                                              | Callback fired when value clean                         |
+| onTagRemove  | (value: string, event: MouseEvent) => void                   | Callback fired when tag remove                          |
 | size         | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')`            | A picker can have different sizes                       |
 | trigger      | 'Enter' &#124; 'Space' &#124; 'Comma' `(['Enter', 'Space'])` | Set the trigger for creating tags                       |
 | value        | string[]                                                     | Specifies the values of the selected items (Controlled) |

--- a/docs/pages/components/tag-input/zh-CN/index.md
+++ b/docs/pages/components/tag-input/zh-CN/index.md
@@ -44,6 +44,7 @@
 | disabled     | boolean                                                      | 禁用组件               |
 | onChange     | (value:string, event) => void                                | 值发生改变时的回调函数 |
 | onClean      | (event) => void                                              | 值清理后触发回调       |
+| onTagRemove  | (value: string, event: MouseEvent) => void                   | 移除标签时的回调函数   |
 | size         | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')`            | 设置组件尺寸           |
 | trigger      | 'Enter' &#124; 'Space' &#124; 'Comma' `(['Enter', 'Space'])` | 设置创建标签的触发事件 |
 | value        | string[]                                                     | 设置值 `受控`          |

--- a/docs/pages/components/tag-picker/en-US/index.md
+++ b/docs/pages/components/tag-picker/en-US/index.md
@@ -63,8 +63,8 @@ Learn more in [Accessibility](/guide/accessibility).
 | labelKey           | string `('label')`                                                             | Set label key in data                                       |
 | listProps          | [ListProps][listprops]                                                         | Properties of virtualized lists.                            |
 | locale             | [PickerLocaleType](/guide/i18n/#pickers)                                       | Locale text                                                 |
-| menuMaxHeight      | number `(320)`                                                                 | The max height of Dropdown                                  |
 | menuClassName      | string                                                                         | A css class to apply to the Menu DOM node.                  |
+| menuMaxHeight      | number `(320)`                                                                 | The max height of Dropdown                                  |
 | menuStyle          | CSSProperties                                                                  | A style to apply to the Menu DOM node.                      |
 | onChange           | (value:string[], event) => void                                                | Callback fired when value change                            |
 | onClean            | (event) => void                                                                | Callback fired when value clean                             |
@@ -80,6 +80,7 @@ Learn more in [Accessibility](/guide/accessibility).
 | onOpen             | () => void                                                                     | Callback fired when open component                          |
 | onSearch           | (searchKeyword:string, event) => void                                          | Callback fired when search                                  |
 | onSelect           | (value:string[], item: [ItemDataType][item] , event) => void                   | Callback fired when item is selected                        |
+| onTagRemove        | (value: string, event: MouseEvent) => void                                     | Callback fired when tag remove                              |
 | open               | boolean                                                                        | Whether open the component                                  |
 | placeholder        | ReactNode `('Select')`                                                         | Setting placeholders                                        |
 | placement          | [Placement](#code-ts-placement-code)`('bottomStart')`                          | The placement of component                                  |

--- a/docs/pages/components/tag-picker/zh-CN/index.md
+++ b/docs/pages/components/tag-picker/zh-CN/index.md
@@ -64,8 +64,8 @@
 | groupBy            | string                                                                           | 设置分组条件在 `data` 中的 `key`           |
 | labelKey           | string `('label')`                                                               | 设置选项显示内容在 `data` 中的 `key`       |
 | listProps          | [ListProps][listprops]                                                           | 虚拟化长列表的相关属性                     |
-| menuMaxHeight      | number `(320)`                                                                   | 设置 Dropdown 的最大高度                   |
 | menuClassName      | string                                                                           | 应用于菜单 DOM 节点的 css class            |
+| menuMaxHeight      | number `(320)`                                                                   | 设置 Dropdown 的最大高度                   |
 | menuStyle          | CSSProperties                                                                    | 应用于菜单 DOM 节点的 style                |
 | onChange           | (value:string, event) => void                                                    | `value` 发生改变时的回调函数               |
 | onClean            | (event) => void                                                                  | 值清理时触发回调                           |
@@ -81,6 +81,7 @@
 | onOpen             | () => void                                                                       | 打开回调函数                               |
 | onSearch           | (searchKeyword: string, event) => void                                           | 搜索的回调函数                             |
 | onSelect           | (value: string, item: [ItemDataType][item] , event) => void                      | 选项被点击选择后的回调函数                 |
+| onTagRemove        | (value: string, event: MouseEvent) => void                                       | 移除标签时的回调函数                       |
 | open               | boolean                                                                          | 是否打开                                   |
 | placeholder        | ReactNode `('Select')`                                                           | 占位符                                     |
 | placement          | [Placement](#code-ts-placement-code)`('bottomStart')`                            | 位置                                       |

--- a/src/InputPicker/InputPicker.tsx
+++ b/src/InputPicker/InputPicker.tsx
@@ -71,6 +71,9 @@ export interface InputPickerContextProps {
    * No overlay provides options
    */
   disabledOptions?: boolean;
+
+  /** Callback fired when a tag is removed. */
+  onTagRemove?: (tag: string, event: React.MouseEvent) => void;
 }
 
 export const InputPickerContext = React.createContext<InputPickerContextProps>({
@@ -178,7 +181,8 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
       ...rest
     } = props;
 
-    const { multi, tagProps, trigger, disabledOptions } = useContext(InputPickerContext);
+    const { multi, tagProps, trigger, disabledOptions, onTagRemove } =
+      useContext(InputPickerContext);
 
     if (groupBy === valueKey || groupBy === labelKey) {
       throw Error('`groupBy` can not be equal to `valueKey` and `labelKey`');
@@ -332,8 +336,9 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
         remove(val, itemVal => shallowEqual(itemVal, tag));
         setValue(val);
         handleChange(val, event);
+        onTagRemove?.(tag, event);
       },
-      [setValue, cloneValue, handleChange]
+      [cloneValue, setValue, handleChange, onTagRemove]
     );
 
     const handleSelect = useCallback(

--- a/src/TagInput/index.tsx
+++ b/src/TagInput/index.tsx
@@ -17,13 +17,16 @@ export interface TagInputProps extends Omit<InputPickerProps<readonly string[]>,
    * @todo Declare as readonly array
    */
   trigger?: TriggerType | TriggerType[];
+
+  /** Callback fired when a tag is removed. */
+  onTagRemove?: (tag: string, event: React.MouseEvent) => void;
 }
 
 const TagInput: PickerComponent<TagInputProps> = React.forwardRef((props: TagInputProps, ref) => {
-  const { tagProps = {}, trigger = 'Enter', value, defaultValue, ...rest } = props;
+  const { tagProps = {}, trigger = 'Enter', value, defaultValue, onTagRemove, ...rest } = props;
   const contextValue = useMemo(
-    () => ({ multi: true, disabledOptions: true, trigger, tagProps }),
-    [tagProps, trigger]
+    () => ({ multi: true, disabledOptions: true, trigger, tagProps, onTagRemove }),
+    [onTagRemove, tagProps, trigger]
   );
 
   const data = useMemo(

--- a/src/TagInput/test/TagInputSpec.tsx
+++ b/src/TagInput/test/TagInputSpec.tsx
@@ -135,4 +135,13 @@ describe('TagInput', () => {
 
     expect(onCreateSpy).to.calledOnce;
   });
+
+  it('Should call `onTagRemove` callback', () => {
+    const onTagRemove = sinon.spy();
+    render(<TagInput defaultValue={['New tag']} onTagRemove={onTagRemove} />);
+    fireEvent.click(screen.getAllByRole('button', { name: /close/i })[0]);
+
+    expect(onTagRemove).to.have.been.calledOnce;
+    expect(onTagRemove).to.have.been.calledWith('New tag');
+  });
 });

--- a/src/TagPicker/index.tsx
+++ b/src/TagPicker/index.tsx
@@ -15,12 +15,18 @@ export interface TagPickerProps extends InputPickerProps {
    * Set the trigger for creating tags. only valid when creatable
    */
   trigger?: TriggerType | TriggerType[];
+
+  /** Callback fired when a tag is removed. */
+  onTagRemove?: (tag: string, event: React.MouseEvent) => void;
 }
 
 const TagPicker: PickerComponent<TagPickerProps> = React.forwardRef(
   (props: TagPickerProps, ref) => {
-    const { tagProps = {}, trigger = 'Enter', ...rest } = props;
-    const contextValue = useMemo(() => ({ multi: true, trigger, tagProps }), [tagProps, trigger]);
+    const { tagProps = {}, trigger = 'Enter', onTagRemove, ...rest } = props;
+    const contextValue = useMemo(
+      () => ({ multi: true, trigger, tagProps, onTagRemove }),
+      [onTagRemove, tagProps, trigger]
+    );
 
     return (
       <InputPickerContext.Provider value={contextValue}>

--- a/src/TagPicker/test/TagPickerSpec.tsx
+++ b/src/TagPicker/test/TagPickerSpec.tsx
@@ -457,4 +457,13 @@ describe('TagPicker', () => {
     assert.isEmpty(instance3.target.style.marginLeft);
     assert.equal(instance4.target.style.marginLeft, '-6px');
   });
+
+  it('Should call `onTagRemove` callback', () => {
+    const onTagRemove = sinon.spy();
+    render(<TagPicker data={data} defaultValue={['Kariane']} onTagRemove={onTagRemove} />);
+    fireEvent.click(screen.getAllByRole('button', { name: /close/i })[0]);
+
+    expect(onTagRemove).to.have.been.calledOnce;
+    expect(onTagRemove).to.have.been.calledWith('Kariane');
+  });
 });


### PR DESCRIPTION
```ts
/** Callback fired when a tag is removed. */
onTagRemove?: (tag: string, event: React.MouseEvent) => void;
```

> https://github.com/rsuite/rsuite/issues/3410