### PR TITLE
build(deps): bump rsuite-table from 5.14.0 to 5.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "prop-types": "^15.8.1",
         "react-use-set": "^1.0.0",
         "react-window": "^1.8.8",
-        "rsuite-table": "^5.14.0",
+        "rsuite-table": "^5.15.0",
         "schema-typed": "^2.1.3"
       },
       "devDependencies": {
@@ -18833,9 +18833,9 @@
       }
     },
     "node_modules/rsuite-table": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.14.0.tgz",
-      "integrity": "sha512-zuxofj33T7AFmhQnYoBuPsC9MazrRZPNUirR6UMg90Vl19rKPZXa3+qx95OtXEHKXGwVzldZrPg0r6uSofeDkQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.15.0.tgz",
+      "integrity": "sha512-XYspPlGz5g9DUp3L/NITXDKei3Oc9tnVjJmF+NAzXkxVJyNv/E8jVE57C7oU+dsD/hdvR3OKRc4NqT9gNjquVA==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",
@@ -37460,9 +37460,9 @@
       }
     },
     "rsuite-table": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.14.0.tgz",
-      "integrity": "sha512-zuxofj33T7AFmhQnYoBuPsC9MazrRZPNUirR6UMg90Vl19rKPZXa3+qx95OtXEHKXGwVzldZrPg0r6uSofeDkQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.15.0.tgz",
+      "integrity": "sha512-XYspPlGz5g9DUp3L/NITXDKei3Oc9tnVjJmF+NAzXkxVJyNv/E8jVE57C7oU+dsD/hdvR3OKRc4NqT9gNjquVA==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "prop-types": "^15.8.1",
     "react-use-set": "^1.0.0",
     "react-window": "^1.8.8",
-    "rsuite-table": "^5.14.0",
+    "rsuite-table": "^5.15.0",
     "schema-typed": "^2.1.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
# [5.15.0](https://github.com/rsuite/rsuite-table/compare/5.14.0...5.15.0) (2023-10-26)


### Bug Fixes

* **Table:** fix table cell text cannot be copied ([8a9f06b](https://github.com/rsuite/rsuite-table/commit/8a9f06bf34c83ba6c48c5da2c0988c83faea2d5c))


### Features

* add a script to prepend the use client directive ([#466](https://github.com/rsuite/rsuite-table/issues/466)) ([24369c5](https://github.com/rsuite/rsuite-table/commit/24369c583786fea1757131b417ce25aa3bc3a4f8))

