### PR TITLE
feat(CSS): use CSS custom properties instead of less variables

### DIFF
--- a/src/Placeholder/styles/index.less
+++ b/src/Placeholder/styles/index.less
@@ -111,7 +111,7 @@
         var(--rs-placeholder) 63%
       );
       background-size: 400% 100% !important;
-      animation: placeholder-active 3s ease infinite;
+      animation: placeholder-active 1.5s ease infinite;
     }
   }
 

--- a/src/styles/color-modes/dark.less
+++ b/src/styles/color-modes/dark.less
@@ -1,6 +1,7 @@
 // see https://rsuitejs.com/design/dark
 & {
   // Gray levels
+  --rs-gray-0: @B000-dark;
   --rs-gray-50: @B050-dark;
   --rs-gray-100: @B100-dark;
   --rs-gray-200: @B200-dark;
@@ -24,12 +25,21 @@
   --rs-primary-800: @H800-dark;
   --rs-primary-900: @H900-dark;
 
+  // Spectrum
+  --rs-color-red: @red-dark;
+  --rs-color-orange: @orange-dark;
+  --rs-color-yellow: @yellow-dark;
+  --rs-color-green: @green-dark;
+  --rs-color-cyan: @cyan-dark;
+  --rs-color-blue: @blue-dark;
+  --rs-color-violet: @violet-dark;
+
   // Spectrum levels
   each(@spectrum, .(@color-name) {
       @color: @@color-name;
       @color-name-50: ~'@{color-name}-50-dark';
       --rs-@{color-name}-50: @@color-name-50;
-  
+
       each(range(9), {
         @level: @{index}00;
         @color-name-level: ~'@{color-name}-@{level}-dark';
@@ -38,294 +48,294 @@
     });
 
   // Stateful colors
-  --rs-state-success: @green-dark;
-  --rs-state-info: @blue-dark;
-  --rs-state-warning: @yellow-dark;
-  --rs-state-error: @red-dark;
+  --rs-state-success: var(--rs-color-green);
+  --rs-state-info: var(--rs-color-blue);
+  --rs-state-warning: var(--rs-color-yellow);
+  --rs-state-error: var(--rs-color-red);
 
   // Reset
-  --rs-body: @B900-dark;
+  --rs-body: var(--rs-gray-900);
 
   // Misc
-  --rs-text-link: @H500-dark;
-  --rs-text-link-hover: @H400-dark;
-  --rs-text-link-active: @H300-dark;
-  --rs-text-primary: @B050-dark;
-  --rs-text-secondary: @B200-dark;
-  --rs-text-tertiary: @B300-dark;
-  --rs-text-heading: @B000-dark;
-  --rs-text-inverse: @B800-dark;
-  --rs-text-heading-inverse: @B900-dark;
-  --rs-text-active: @H500-dark;
-  --rs-text-disabled: @B500-dark;
-  --rs-border-primary: @B600-dark;
-  --rs-border-secondary: @B700-dark;
-  --rs-bg-card: @B800-dark;
-  --rs-bg-overlay: @B700-dark;
-  --rs-bg-well: @B900-dark;
-  --rs-bg-active: @H700-dark;
-  --rs-bg-backdrop: fade(@B900-dark, 80%);
-  --rs-state-hover-bg: @B600-dark;
-  --rs-color-focus-ring: 0 0 0 3px fade(@H500-dark, 25%);
-  --rs-state-focus-shadow: 0 0 0 3px fade(@H500-dark, 25%);
-  --rs-state-focus-outline: 3px solid fade(@H500-dark, 25%);
+  --rs-text-link: var(--rs-primary-500);
+  --rs-text-link-hover: var(--rs-primary-400);
+  --rs-text-link-active: var(--rs-primary-300);
+  --rs-text-primary: var(--rs-gray-50);
+  --rs-text-secondary: var(--rs-gray-200);
+  --rs-text-tertiary: var(--rs-gray-300);
+  --rs-text-heading: var(--rs-gray-0);
+  --rs-text-inverse: var(--rs-gray-800);
+  --rs-text-heading-inverse: var(--rs-gray-900);
+  --rs-text-active: var(--rs-primary-500);
+  --rs-text-disabled: var(--rs-gray-500);
+  --rs-border-primary: var(--rs-gray-600);
+  --rs-border-secondary: var(--rs-gray-700);
+  --rs-bg-card: var(--rs-gray-800);
+  --rs-bg-overlay: var(--rs-gray-700);
+  --rs-bg-well: var(--rs-gray-900);
+  --rs-bg-active: var(--rs-primary-700);
+  --rs-bg-backdrop: rgb(from var(--rs-gray-900) r g b / 80%);
+  --rs-state-hover-bg: var(--rs-gray-600);
+  --rs-color-focus-ring: 0 0 0 3px rgb(from var(--rs-gray-500) r g b / 25%);
+  --rs-state-focus-shadow: 0 0 0 3px rgb(from var(--rs-gray-500) r g b / 25%);
+  --rs-state-focus-outline: 3px solid rgb(from var(--rs-gray-500) r g b / 25%);
   --rs-shadow-overlay: 0 4px 4px rgba(0, 0, 0, 0.12), 0 0 10px rgba(0, 0, 0, 0.06);
 
   // Button
-  --rs-btn-default-bg: @B600-dark;
-  --rs-btn-default-text: @B050-dark;
-  --rs-btn-default-hover-bg: @B500-dark;
-  --rs-btn-default-active-bg: @B300-dark;
-  --rs-btn-default-active-text: @B000-dark;
-  --rs-btn-default-disabled-bg: @B600-dark;
-  --rs-btn-default-disabled-text: @B400-dark;
-  --rs-btn-primary-bg: @H700-dark;
-  --rs-btn-primary-text: @B000-dark;
-  --rs-btn-primary-hover-bg: @H600-dark;
-  --rs-btn-primary-active-bg: @H400-dark;
-  --rs-btn-subtle-text: @B200-dark;
-  --rs-btn-subtle-hover-bg: @B500-dark;
-  --rs-btn-subtle-hover-text: @B050-dark;
-  --rs-btn-subtle-active-bg: @B400-dark;
-  --rs-btn-subtle-active-text: @B000-dark;
-  --rs-btn-subtle-disabled-text: @B500-dark;
-  --rs-btn-ghost-border: @H500-dark;
-  --rs-btn-ghost-text: @H500-dark;
-  --rs-btn-ghost-hover-border: @H400-dark;
-  --rs-btn-ghost-hover-text: @H400-dark;
-  --rs-btn-ghost-active-border: @H200-dark;
-  --rs-btn-ghost-active-text: @H200-dark;
-  --rs-btn-link-text: @H500-dark;
-  --rs-btn-link-hover-text: @H400-dark;
-  --rs-btn-link-active-text: @H200-dark;
+  --rs-btn-default-bg: var(--rs-gray-600);
+  --rs-btn-default-text: var(--rs-gray-50);
+  --rs-btn-default-hover-bg: var(--rs-gray-500);
+  --rs-btn-default-active-bg: var(--rs-gray-300);
+  --rs-btn-default-active-text: var(--rs-gray-0);
+  --rs-btn-default-disabled-bg: var(--rs-gray-600);
+  --rs-btn-default-disabled-text: var(--rs-gray-400);
+  --rs-btn-primary-bg: var(--rs-primary-700);
+  --rs-btn-primary-text: var(--rs-gray-0);
+  --rs-btn-primary-hover-bg: var(--rs-primary-600);
+  --rs-btn-primary-active-bg: var(--rs-primary-400);
+  --rs-btn-subtle-text: var(--rs-gray-200);
+  --rs-btn-subtle-hover-bg: var(--rs-gray-500);
+  --rs-btn-subtle-hover-text: var(--rs-gray-50);
+  --rs-btn-subtle-active-bg: var(--rs-gray-400);
+  --rs-btn-subtle-active-text: var(--rs-gray-0);
+  --rs-btn-subtle-disabled-text: var(--rs-gray-500);
+  --rs-btn-ghost-border: var(--rs-primary-500);
+  --rs-btn-ghost-text: var(--rs-primary-500);
+  --rs-btn-ghost-hover-border: var(--rs-primary-400);
+  --rs-btn-ghost-hover-text: var(--rs-primary-400);
+  --rs-btn-ghost-active-border: var(--rs-primary-200);
+  --rs-btn-ghost-active-text: var(--rs-primary-200);
+  --rs-btn-link-text: var(--rs-primary-500);
+  --rs-btn-link-hover-text: var(--rs-primary-400);
+  --rs-btn-link-active-text: var(--rs-primary-200);
 
   // Icon Button
-  --rs-iconbtn-addon: @B500-dark;
-  --rs-iconbtn-activated-addon: @B400-dark;
-  --rs-iconbtn-pressed-addon: @B200-dark;
-  --rs-iconbtn-primary-addon: @H600-dark;
-  --rs-iconbtn-primary-activated-addon: @H500-dark;
-  --rs-iconbtn-primary-pressed-addon: @H400-dark;
+  --rs-iconbtn-addon: var(--rs-gray-500);
+  --rs-iconbtn-activated-addon: var(--rs-gray-400);
+  --rs-iconbtn-pressed-addon: var(--rs-gray-200);
+  --rs-iconbtn-primary-addon: var(--rs-primary-600);
+  --rs-iconbtn-primary-activated-addon: var(--rs-primary-500);
+  --rs-iconbtn-primary-pressed-addon: var(--rs-primary-400);
 
   // Divider
-  --rs-divider-border: @B600-dark;
+  --rs-divider-border: var(--rs-gray-600);
 
   // Loader
-  --rs-loader-ring: fade(@B050-dark, 30);
-  --rs-loader-rotor: @B000-dark;
-  --rs-loader-backdrop: fade(@B900-dark, 83%);
-  --rs-loader-ring-inverse: fade(@B050-dark, 80);
-  --rs-loader-rotor-inverse: @B500-dark;
-  --rs-loader-backdrop-inverse: fade(@B000-dark, 90);
+  --rs-loader-ring: rgb(from var(--rs-gray-50) r g b / 30%);
+  --rs-loader-rotor: var(--rs-gray-0);
+  --rs-loader-backdrop: rgb(from var(--rs-gray-900) r g b / 83%);
+  --rs-loader-ring-inverse: rgb(from var(--rs-gray-50) r g b / 80%);
+  --rs-loader-rotor-inverse: var(--rs-gray-500);
+  --rs-loader-backdrop-inverse: rgb(from var(--rs-gray-0) r g b / 90%);
 
   // Message
   --rs-message-success-header: #fff;
   --rs-message-success-text: #fff;
   --rs-message-success-icon: #fff;
-  --rs-message-success-bg: @green-500;
+  --rs-message-success-bg: var(--rs-green-500);
   --rs-message-info-header: #fff;
   --rs-message-info-text: #fff;
   --rs-message-info-icon: #fff;
-  --rs-message-info-bg: @blue-500;
-  --rs-message-warning-header: @B900-dark;
-  --rs-message-warning-text: @B900-dark;
-  --rs-message-warning-icon: @B900-dark;
-  --rs-message-warning-bg: @yellow-500;
+  --rs-message-info-bg: var(--rs-blue-500);
+  --rs-message-warning-header: var(--rs-gray-900);
+  --rs-message-warning-text: var(--rs-gray-900);
+  --rs-message-warning-icon: var(--rs-gray-900);
+  --rs-message-warning-bg: var(--rs-yellow-500);
   --rs-message-error-header: #fff;
   --rs-message-error-text: #fff;
   --rs-message-error-icon: #fff;
-  --rs-message-error-bg: @red-500;
+  --rs-message-error-bg: var(--rs-red-500);
 
   // Tooltip
-  --rs-tooltip-bg: @B500-dark;
-  --rs-tooltip-text: @B000-dark;
+  --rs-tooltip-bg: var(--rs-gray-500);
+  --rs-tooltip-text: var(--rs-gray-0);
 
   // Progress
-  --rs-progress-bg: @B700-dark;
-  --rs-progress-bar: @H500-dark;
-  --rs-progress-bar-success: @green;
-  --rs-progress-bar-fail: @red;
+  --rs-progress-bg: var(--rs-gray-700);
+  --rs-progress-bar: var(--rs-primary-500);
+  --rs-progress-bar-success: var(--rs-color-green);
+  --rs-progress-bar-fail: var(--rs-color-red);
 
   // Placeholder
-  --rs-placeholder: @B600-dark;
-  --rs-placeholder-active: lighten(@B600-dark, 5%);
+  --rs-placeholder: var(--rs-gray-600);
+  --rs-placeholder-active: hsl(from var(--rs-gray-600) h s calc(l + l * 0.2));
 
   // Breadcrumb
   --rs-breadcrumb-item-active-text: #fff;
 
   // Dropdown
-  --rs-dropdown-divider: @B600-dark;
-  --rs-dropdown-item-bg-hover: @B600-dark;
-  --rs-dropdown-item-bg-active: fade(@H900-dark, 20);
-  --rs-dropdown-item-text-active: @H500-dark;
-  --rs-dropdown-header-text: @B500-dark;
+  --rs-dropdown-divider: var(--rs-gray-600);
+  --rs-dropdown-item-bg-hover: var(--rs-gray-600);
+  --rs-dropdown-item-bg-active: rgb(from var(--rs-primary-900) r g b / 20%);
+  --rs-dropdown-item-text-active: var(--rs-primary-500);
+  --rs-dropdown-header-text: var(--rs-gray-500);
   --rs-dropdown-shadow: 0 0 10px 1px rgba(0, 0, 0, 0.2), 0 4px 4px 3px rgba(0, 0, 0, 0.24);
 
   // ARIA menu
-  --rs-menuitem-active-bg: @B600-dark;
+  --rs-menuitem-active-bg: var(--rs-gray-600);
   --rs-menuitem-active-text: currentColor;
 
   // Steps
-  --rs-steps-border: @B200-dark;
-  --rs-steps-state-finish: @H500-dark;
-  --rs-steps-border-state-finish: @H500-dark;
-  --rs-steps-state-wait: @B200-dark;
-  --rs-steps-state-process: @H700-dark;
-  --rs-steps-state-error: @red;
-  --rs-steps-border-state-error: @red;
-  --rs-steps-icon-state-process: @H500-dark;
-  --rs-steps-icon-state-error: @red;
+  --rs-steps-border: var(--rs-gray-200);
+  --rs-steps-state-finish: var(--rs-primary-500);
+  --rs-steps-border-state-finish: var(--rs-primary-500);
+  --rs-steps-state-wait: var(--rs-gray-200);
+  --rs-steps-state-process: var(--rs-primary-700);
+  --rs-steps-state-error: var(--rs-color-red);
+  --rs-steps-border-state-error: var(--rs-color-red);
+  --rs-steps-icon-state-process: var(--rs-primary-500);
+  --rs-steps-icon-state-error: var(--rs-color-red);
 
   // Navs
-  --rs-navs-text: @B200-dark;
-  --rs-navs-text-hover: @B100-dark;
-  --rs-navs-bg-hover: @B400-dark;
-  --rs-navs-text-active: @B000-dark;
-  --rs-navs-bg-active: @B400-dark;
-  --rs-navs-tab-border: @B600-dark;
-  --rs-navs-subtle-border: @B600-dark;
-  --rs-navs-selected: @H500-dark;
+  --rs-navs-text: var(--rs-gray-200);
+  --rs-navs-text-hover: var(--rs-gray-100);
+  --rs-navs-bg-hover: var(--rs-gray-400);
+  --rs-navs-text-active: var(--rs-gray-0);
+  --rs-navs-bg-active: var(--rs-gray-400);
+  --rs-navs-tab-border: var(--rs-gray-600);
+  --rs-navs-subtle-border: var(--rs-gray-600);
+  --rs-navs-selected: var(--rs-primary-500);
 
   // Navbar
-  --rs-navbar-default-bg: @B800-dark;
-  --rs-navbar-default-text: @B200-dark;
-  --rs-navbar-default-selected-text: @H500-dark;
-  --rs-navbar-default-hover-bg: @B700-dark;
-  --rs-navbar-default-hover-text: @B050-dark;
-  --rs-navbar-inverse-bg: @H700-dark;
+  --rs-navbar-default-bg: var(--rs-gray-800);
+  --rs-navbar-default-text: var(--rs-gray-200);
+  --rs-navbar-default-selected-text: var(--rs-primary-500);
+  --rs-navbar-default-hover-bg: var(--rs-gray-700);
+  --rs-navbar-default-hover-text: var(--rs-gray-50);
+  --rs-navbar-inverse-bg: var(--rs-primary-700);
   --rs-navbar-inverse-text: #fff;
-  --rs-navbar-inverse-selected-bg: @H400-dark;
-  --rs-navbar-inverse-hover-bg: @H600-dark;
+  --rs-navbar-inverse-selected-bg: var(--rs-primary-400);
+  --rs-navbar-inverse-hover-bg: var(--rs-primary-600);
   --rs-navbar-inverse-hover-text: #fff;
   --rs-navbar-subtle-bg: transparent;
-  --rs-navbar-subtle-text: @B200-dark;
-  --rs-navbar-subtle-selected-text: @H500-dark;
-  --rs-navbar-subtle-hover-bg: @B700-dark;
-  --rs-navbar-subtle-hover-text: @B050-dark;
+  --rs-navbar-subtle-text: var(--rs-gray-200);
+  --rs-navbar-subtle-selected-text: var(--rs-primary-500);
+  --rs-navbar-subtle-hover-bg: var(--rs-gray-700);
+  --rs-navbar-subtle-hover-text: var(--rs-gray-50);
 
   // Sidenav
-  --rs-sidenav-default-bg: @B800-dark;
-  --rs-sidenav-default-text: @B200-dark;
-  --rs-sidenav-default-selected-text: @H500-dark;
-  --rs-sidenav-default-hover-bg: @B700-dark;
-  --rs-sidenav-default-hover-text: @B050-dark;
-  --rs-sidenav-default-footer-border: @B600-dark;
-  --rs-sidenav-inverse-bg: @H700-dark;
+  --rs-sidenav-default-bg: var(--rs-gray-800);
+  --rs-sidenav-default-text: var(--rs-gray-200);
+  --rs-sidenav-default-selected-text: var(--rs-primary-500);
+  --rs-sidenav-default-hover-bg: var(--rs-gray-700);
+  --rs-sidenav-default-hover-text: var(--rs-gray-50);
+  --rs-sidenav-default-footer-border: var(--rs-gray-600);
+  --rs-sidenav-inverse-bg: var(--rs-primary-700);
   --rs-sidenav-inverse-text: #fff;
-  --rs-sidenav-inverse-selected-bg: @H400-dark;
-  --rs-sidenav-inverse-hover-bg: @H600-dark;
-  --rs-sidenav-inverse-footer-border: @H600-dark;
+  --rs-sidenav-inverse-selected-bg: var(--rs-primary-400);
+  --rs-sidenav-inverse-hover-bg: var(--rs-primary-600);
+  --rs-sidenav-inverse-footer-border: var(--rs-primary-600);
   --rs-sidenav-subtle-bg: transparent;
-  --rs-sidenav-subtle-text: @B200-dark;
-  --rs-sidenav-subtle-selected-text: @H500-dark;
-  --rs-sidenav-subtle-hover-bg: @B700-dark;
-  --rs-sidenav-subtle-hover-text: @B050-dark;
-  --rs-sidenav-subtle-footer-border: @B600-dark;
+  --rs-sidenav-subtle-text: var(--rs-gray-200);
+  --rs-sidenav-subtle-selected-text: var(--rs-primary-500);
+  --rs-sidenav-subtle-hover-bg: var(--rs-gray-700);
+  --rs-sidenav-subtle-hover-text: var(--rs-gray-50);
+  --rs-sidenav-subtle-footer-border: var(--rs-gray-600);
 
   // Input
-  --rs-input-bg: @B800-dark;
-  --rs-input-focus-border: @H500-dark;
-  --rs-input-disabled-bg: @B700-dark;
+  --rs-input-bg: var(--rs-gray-800);
+  --rs-input-focus-border: var(--rs-primary-500);
+  --rs-input-disabled-bg: var(--rs-gray-700);
 
   // ARIA Listboxes
-  --rs-listbox-option-hover-bg: @B600-dark;
+  --rs-listbox-option-hover-bg: var(--rs-gray-600);
   --rs-listbox-option-hover-text: currentColor;
-  --rs-listbox-option-selected-text: @H500-dark;
-  --rs-listbox-option-selected-bg: fade(@H900-dark, 20%);
-  --rs-listbox-option-disabled-text: @B500-dark;
-  --rs-listbox-option-disabled-selected-text: @H200-dark;
+  --rs-listbox-option-selected-text: var(--rs-primary-500);
+  --rs-listbox-option-selected-bg: rgb(from var(--rs-primary-900) r g b / 20%);
+  --rs-listbox-option-disabled-text: var(--rs-gray-500);
+  --rs-listbox-option-disabled-selected-text: var(--rs-primary-200);
 
   // Checkbox
-  --rs-checkbox-icon: @B800-dark;
-  --rs-checkbox-border: @B400-dark;
-  --rs-checkbox-checked-bg: @H500-dark;
-  --rs-checkbox-disabled-bg: @B500-dark;
+  --rs-checkbox-icon: var(--rs-gray-800);
+  --rs-checkbox-border: var(--rs-gray-400);
+  --rs-checkbox-checked-bg: var(--rs-primary-500);
+  --rs-checkbox-disabled-bg: var(--rs-gray-500);
 
   // Radio
-  --rs-radio-marker: @B800-dark;
-  --rs-radio-border: @B400-dark;
-  --rs-radio-checked-bg: @H500-dark;
-  --rs-radio-disabled-bg: @B500-dark;
+  --rs-radio-marker: var(--rs-gray-800);
+  --rs-radio-border: var(--rs-gray-400);
+  --rs-radio-checked-bg: var(--rs-primary-500);
+  --rs-radio-disabled-bg: var(--rs-gray-500);
 
   // RadioTile
-  --rs-radio-tile-border: @B300-dark;
-  --rs-radio-tile-bg: @B000-dark;
-  --rs-radio-tile-checked-color: @H500-dark;
-  --rs-radio-tile-checked-mark-color: @B800-dark;
-  --rs-radio-tile-checked-disabled-color: @H900-dark;
+  --rs-radio-tile-border: var(--rs-gray-300);
+  --rs-radio-tile-bg: var(--rs-gray-0);
+  --rs-radio-tile-checked-color: var(--rs-primary-500);
+  --rs-radio-tile-checked-mark-color: var(--rs-gray-800);
+  --rs-radio-tile-checked-disabled-color: var(--rs-primary-900);
 
   // Rate
-  --rs-rate-symbol: @B600-dark;
-  --rs-rate-symbol-checked: @yellow-500;
+  --rs-rate-symbol: var(--rs-gray-600);
+  --rs-rate-symbol-checked: var(--rs-yellow-500);
 
   // Toggle
-  --rs-toggle-bg: @B400-dark;
+  --rs-toggle-bg: var(--rs-gray-400);
   --rs-toggle-thumb: #fff;
-  --rs-toggle-hover-bg: @B300-dark;
-  --rs-toggle-disabled-bg: @B600-dark;
-  --rs-toggle-disabled-thumb: @B500-dark;
-  --rs-toggle-checked-bg: @H700-dark;
+  --rs-toggle-hover-bg: var(--rs-gray-300);
+  --rs-toggle-disabled-bg: var(--rs-gray-600);
+  --rs-toggle-disabled-thumb: var(--rs-gray-500);
+  --rs-toggle-checked-bg: var(--rs-primary-700);
   --rs-toggle-checked-thumb: #fff;
-  --rs-toggle-checked-hover-bg: @H600-dark;
-  --rs-toggle-checked-disabled-bg: @H900-dark;
-  --rs-toggle-checked-disabled-thumb: @B300-dark;
+  --rs-toggle-checked-hover-bg: var(--rs-primary-600);
+  --rs-toggle-checked-disabled-bg: var(--rs-primary-900);
+  --rs-toggle-checked-disabled-thumb: var(--rs-gray-300);
 
   // Slider
-  --rs-slider-bar: @B600-dark;
-  --rs-slider-hover-bar: @B600-dark;
-  --rs-slider-thumb-border: @H500-dark;
-  --rs-slider-thumb-bg: @B700-dark;
-  --rs-slider-thumb-hover-shadow: 0 0 0 8px fade(@H500-dark, 25);
-  --rs-slider-progress: @H500-dark;
+  --rs-slider-bar: var(--rs-gray-600);
+  --rs-slider-hover-bar: var(--rs-gray-600);
+  --rs-slider-thumb-border: var(--rs-primary-500);
+  --rs-slider-thumb-bg: var(--rs-gray-700);
+  --rs-slider-thumb-hover-shadow: 0 0 0 8px rgb(from var(--rs-primary-500) r g b / 25%);
+  --rs-slider-progress: var(--rs-primary-500);
 
   // Uploader
-  --rs-uploader-item-bg: @B300-dark;
-  --rs-uploader-item-hover-bg: @B600-dark;
-  --rs-uploader-overlay-bg: fade(@B600-dark, 80);
-  --rs-uploader-dnd-bg: @B700-dark;
-  --rs-uploader-dnd-border: @B200-dark;
-  --rs-uploader-dnd-hover-border: @H500-dark;
+  --rs-uploader-item-bg: var(--rs-gray-300);
+  --rs-uploader-item-hover-bg: var(--rs-gray-600);
+  --rs-uploader-overlay-bg: rgb(from var(--rs-gray-600) r g b / 80%);
+  --rs-uploader-dnd-bg: var(--rs-gray-700);
+  --rs-uploader-dnd-border: var(--rs-gray-200);
+  --rs-uploader-dnd-hover-border: var(--rs-primary-500);
 
   // Avatar
-  --rs-avatar-bg: @B400-dark;
-  --rs-avatar-text: @B000-dark;
+  --rs-avatar-bg: var(--rs-gray-400);
+  --rs-avatar-text: var(--rs-gray-0);
 
   // Badge
-  --rs-badge-bg: @red;
-  --rs-badge-text: @B000-dark;
+  --rs-badge-bg: var(--rs-color-red);
+  --rs-badge-text: var(--rs-gray-0);
 
   // Tag
-  --rs-tag-bg: @B600-dark;
-  --rs-tag-close: @red;
+  --rs-tag-bg: var(--rs-gray-600);
+  --rs-tag-close: var(--rs-color-red);
 
   // Carousel
-  --rs-carousel-bg: @B600-dark;
-  --rs-carousel-indicator: fade(@B000-dark, 40);
-  --rs-carousel-indicator-hover: @B000-dark;
-  --rs-carousel-indicator-active: @H500-dark;
+  --rs-carousel-bg: var(--rs-gray-600);
+  --rs-carousel-indicator: rgb(from var(--rs-gray-0) r g b / 40%);
+  --rs-carousel-indicator-hover: var(--rs-gray-0);
+  --rs-carousel-indicator-active: var(--rs-primary-500);
 
   // Panel
   --rs-panel-shadow: 0 4px 4px rgba(0, 0, 0, 0.12), 0 0 10px rgba(0, 0, 0, 0.06);
 
   // List
-  --rs-list-bg: @B900-dark;
-  --rs-list-border: @B700-dark;
-  --rs-list-hover-bg: @B600-dark;
-  --rs-list-placeholder-bg: fade(@H900-dark, 20%);
-  --rs-list-placeholder-border: @H500-dark;
+  --rs-list-bg: var(--rs-gray-900);
+  --rs-list-border: var(--rs-gray-700);
+  --rs-list-hover-bg: var(--rs-gray-600);
+  --rs-list-placeholder-bg: rgb(from var(--rs-primary-900) r g b / 20%);
+  --rs-list-placeholder-border: var(--rs-primary-500);
 
   // Timeline
-  --rs-timeline-indicator-bg: @B500-dark;
-  --rs-timeline-indicator-active-bg: @H500-dark;
+  --rs-timeline-indicator-bg: var(--rs-gray-500);
+  --rs-timeline-indicator-active-bg: var(--rs-primary-500);
 
   // Table
   --rs-table-shadow: rgba(9, 9, 9, 0.99);
-  --rs-table-sort: @H500-dark;
-  --rs-table-resize: @H500-dark;
-  --rs-table-scrollbar-track: @B700-dark;
-  --rs-table-scrollbar-thumb: @B200-dark;
-  --rs-table-scrollbar-thumb-active: @B100-dark;
-  --rs-table-scrollbar-vertical-track: @B700-dark;
+  --rs-table-sort: var(--rs-primary-500);
+  --rs-table-resize: var(--rs-primary-500);
+  --rs-table-scrollbar-track: var(--rs-gray-700);
+  --rs-table-scrollbar-thumb: var(--rs-gray-200);
+  --rs-table-scrollbar-thumb-active: var(--rs-gray-100);
+  --rs-table-scrollbar-vertical-track: var(--rs-gray-700);
 
   // Drawer
   --rs-drawer-shadow: 0 4px 4px rgba(0, 0, 0, 0.12), 0 0 10px rgba(0, 0, 0, 0.06);
@@ -335,22 +345,62 @@
 
   // Form
   --rs-form-errormessage-text: #fff;
-  --rs-form-errormessage-bg: @red;
-  --rs-form-errormessage-border: @red;
+  --rs-form-errormessage-bg: var(--rs-color-red);
+  --rs-form-errormessage-border: var(--rs-color-red);
 
   // Picker
-  --rs-picker-value: @H500-dark;
-  --rs-picker-count-bg: @H700-dark;
+  --rs-picker-value: var(--rs-primary-500);
+  --rs-picker-count-bg: var(--rs-primary-700);
   --rs-picker-count-text: #fff;
 
   // Calendar
-  --rs-calendar-today-bg: @H700-dark;
+  --rs-calendar-today-bg: var(--rs-primary-700);
   --rs-calendar-today-text: #fff;
-  --rs-calendar-range-bg: fade(@H900-dark, 50%);
-  --rs-calendar-time-unit-bg: @B600-dark;
+  --rs-calendar-range-bg: rgb(from var(--rs-primary-900) r g b / 50%);
+  --rs-calendar-time-unit-bg: var(--rs-gray-600);
   --rs-calendar-date-selected-text: #fff;
-  --rs-calendar-cell-selected-hover-bg: @H700;
+  --rs-calendar-cell-selected-hover-bg: var(--rs-primary-700);
 
   // Popover
   --rs-popover-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+
+  // CSS relative color syntax is not supported
+  // https://developer.chrome.com/blog/css-relative-color-syntax/
+  @supports not (color: rgb(from white r g b)) {
+    // Misc
+    --rs-bg-backdrop: fade(@B900-dark, 80%);
+    --rs-color-focus-ring: 0 0 0 3px fade(@H500-dark, 25%);
+    --rs-state-focus-shadow: 0 0 0 3px fade(@H500-dark, 25%);
+    --rs-state-focus-outline: 3px solid fade(@H500-dark, 25%);
+
+    // Loader
+    --rs-loader-ring: fade(@B050-dark, 30);
+    --rs-loader-backdrop: fade(@B900-dark, 83%);
+    --rs-loader-ring-inverse: fade(@B050-dark, 80);
+    --rs-loader-backdrop-inverse: fade(@B000-dark, 90);
+
+    // Dropdown
+    --rs-dropdown-item-bg-active: fade(@H900-dark, 20);
+
+    // ARIA Listboxes
+    --rs-listbox-option-selected-bg: fade(@H900-dark, 20%);
+
+    // Slider
+    --rs-slider-thumb-hover-shadow: 0 0 0 8px fade(@H500-dark, 25);
+
+    // Uploader
+    --rs-uploader-overlay-bg: fade(@B600-dark, 80);
+
+    // Carousel
+    --rs-carousel-indicator: fade(@B000-dark, 40);
+
+    // List
+    --rs-list-placeholder-bg: fade(@H900-dark, 20%);
+
+    // Calendar
+    --rs-calendar-range-bg: fade(@H900-dark, 50%);
+
+    // Placeholder
+    --rs-placeholder-active: lighten(@B600-dark, 5%);
+  }
 }

--- a/src/styles/color-modes/high-contrast.less
+++ b/src/styles/color-modes/high-contrast.less
@@ -1,6 +1,7 @@
 // see https://rsuitejs.com/design/dark
 & {
   // Gray levels
+  --rs-gray-0: @B000-high-contrast;
   --rs-gray-50: @B050-high-contrast;
   --rs-gray-100: @B100-high-contrast;
   --rs-gray-200: @B200-high-contrast;
@@ -24,12 +25,21 @@
   --rs-primary-800: @H800-high-contrast;
   --rs-primary-900: @H900-high-contrast;
 
+  // Spectrum
+  --rs-color-red: @red-high-contrast;
+  --rs-color-orange: @orange-high-contrast;
+  --rs-color-yellow: @yellow-high-contrast;
+  --rs-color-green: @green-high-contrast;
+  --rs-color-cyan: @cyan-high-contrast;
+  --rs-color-blue: @blue-high-contrast;
+  --rs-color-violet: @violet-high-contrast;
+
   // Spectrum levels
   each(@spectrum, .(@color-name) {
       @color: @@color-name;
       @color-name-50: ~'@{color-name}-50-high-contrast';
       --rs-@{color-name}-50: @@color-name-50;
-  
+
       each(range(9), {
         @level: @{index}00;
         @color-name-level: ~'@{color-name}-@{level}-high-contrast';
@@ -38,335 +48,370 @@
     });
 
   // Stateful colors
-  --rs-state-success: @green-high-contrast;
-  --rs-state-info: @blue-high-contrast;
-  --rs-state-warning: @yellow-high-contrast;
-  --rs-state-error: @red-high-contrast;
+  --rs-state-success: var(--rs-color-green);
+  --rs-state-info: var(--rs-color-blue);
+  --rs-state-warning: var(--rs-color-yellow);
+  --rs-state-error: var(--rs-color-red);
 
   // Reset
-  --rs-body: @B900-high-contrast;
+  --rs-body: var(--rs-gray-900);
 
   // Misc
-  --rs-text-link: @H500-high-contrast;
-  --rs-text-link-hover: @H400-high-contrast;
-  --rs-text-link-active: @H300-high-contrast;
-  --rs-text-primary: @B050-high-contrast;
-  --rs-text-secondary: @B200-high-contrast;
-  --rs-text-tertiary: @B300-high-contrast;
-  --rs-text-heading: @B000-high-contrast;
-  --rs-text-inverse: @B800-high-contrast;
-  --rs-text-heading-inverse: @B900-high-contrast;
-  --rs-text-active: @H500-high-contrast;
-  --rs-text-disabled: @B500-high-contrast;
-  --rs-border-primary: @B100-high-contrast;
-  --rs-border-secondary: @B700-high-contrast;
-  --rs-bg-card: @B800-high-contrast;
-  --rs-bg-overlay: @B800-high-contrast;
-  --rs-bg-well: @B900-high-contrast;
-  --rs-bg-active: @H500-high-contrast;
-  --rs-bg-backdrop: fade(@B900-high-contrast, 80%);
-  --rs-state-hover-bg: @B600-high-contrast;
-  --rs-color-focus-ring: @B000-high-contrast;
-  --rs-state-focus-shadow: 0 0 0 3px @B900-high-contrast, 0 0 0 5px @B000-high-contrast;
-  --rs-state-focus-shadow-slim: 0 0 0 2px @B000-high-contrast;
-  --rs-state-focus-outline: 3px solid fade(@H500-high-contrast, 25%);
+  --rs-text-link: var(--rs-primary-500);
+  --rs-text-link-hover: var(--rs-primary-400);
+  --rs-text-link-active: var(--rs-primary-300);
+  --rs-text-primary: var(--rs-gray-50);
+  --rs-text-secondary: var(--rs-gray-200);
+  --rs-text-tertiary: var(--rs-gray-300);
+  --rs-text-heading: var(--rs-gray-0);
+  --rs-text-inverse: var(--rs-gray-800);
+  --rs-text-heading-inverse: var(--rs-gray-900);
+  --rs-text-active: var(--rs-primary-500);
+  --rs-text-disabled: var(--rs-gray-500);
+  --rs-border-primary: var(--rs-gray-100);
+  --rs-border-secondary: var(--rs-gray-700);
+  --rs-bg-card: var(--rs-gray-800);
+  --rs-bg-overlay: var(--rs-gray-800);
+  --rs-bg-well: var(--rs-gray-900);
+  --rs-bg-active: var(--rs-primary-500);
+  --rs-bg-backdrop: rgb(from var(--rs-gray-900) r g b / 80%);
+  --rs-state-hover-bg: var(--rs-gray-600);
+  --rs-color-focus-ring: var(--rs-gray-0);
+  --rs-state-focus-shadow: 0 0 0 3px var(--rs-gray-900), 0 0 0 5px var(--rs-gray-0);
+  --rs-state-focus-shadow-slim: 0 0 0 2px var(--rs-gray-0);
+  --rs-state-focus-outline: 3px solid rgb(from var(--rs-primary-500) r g b / 25%);
   --rs-shadow-overlay: 0 4px 4px rgba(0, 0, 0, 0.12), 0 0 10px rgba(0, 0, 0, 0.06);
 
   // Button
   --rs-btn-default-bg: transparent;
-  --rs-btn-default-text: @H500-high-contrast;
-  --rs-btn-default-border: 1px solid @H500-high-contrast;
+  --rs-btn-default-text: var(--rs-primary-500);
+  --rs-btn-default-border: 1px solid var(--rs-primary-500);
   --rs-btn-default-hover-bg: transparent;
-  --rs-btn-default-hover-text: @H400-high-contrast;
+  --rs-btn-default-hover-text: var(--rs-primary-400);
   --rs-btn-default-active-bg: transparent;
-  --rs-btn-default-active-text: @H200-high-contrast;
+  --rs-btn-default-active-text: var(--rs-primary-200);
   --rs-btn-default-disabled-bg: transparent;
-  --rs-btn-default-disabled-text: @H500-high-contrast;
-  --rs-btn-primary-bg: @H500-high-contrast;
-  --rs-btn-primary-text: @B900-high-contrast;
-  --rs-btn-primary-hover-bg: @H400-high-contrast;
-  --rs-btn-primary-active-bg: @H200-high-contrast;
-  --rs-btn-subtle-text: @H500-high-contrast;
+  --rs-btn-default-disabled-text: var(--rs-primary-500);
+  --rs-btn-primary-bg: var(--rs-primary-500);
+  --rs-btn-primary-text: var(--rs-gray-900);
+  --rs-btn-primary-hover-bg: var(--rs-primary-400);
+  --rs-btn-primary-active-bg: var(--rs-primary-200);
+  --rs-btn-subtle-text: var(--rs-primary-500);
   --rs-btn-subtle-hover-bg: transparent;
-  --rs-btn-subtle-hover-text: @H400-high-contrast;
+  --rs-btn-subtle-hover-text: var(--rs-primary-400);
   --rs-btn-subtle-active-bg: transparent;
-  --rs-btn-subtle-active-text: @H200-high-contrast;
-  --rs-btn-subtle-disabled-text: @B500-high-contrast;
-  --rs-btn-ghost-border: @H500-high-contrast;
-  --rs-btn-ghost-text: @H500-high-contrast;
-  --rs-btn-ghost-hover-border: @H400-high-contrast;
-  --rs-btn-ghost-hover-text: @H400-high-contrast;
-  --rs-btn-ghost-active-border: @H200-high-contrast;
-  --rs-btn-ghost-active-text: @H200-high-contrast;
-  --rs-btn-link-text: @H500-high-contrast;
-  --rs-btn-link-hover-text: @H400-high-contrast;
-  --rs-btn-link-active-text: @H200-high-contrast;
+  --rs-btn-subtle-active-text: var(--rs-primary-200);
+  --rs-btn-subtle-disabled-text: var(--rs-gray-500);
+  --rs-btn-ghost-border: var(--rs-primary-500);
+  --rs-btn-ghost-text: var(--rs-primary-500);
+  --rs-btn-ghost-hover-border: var(--rs-primary-400);
+  --rs-btn-ghost-hover-text: var(--rs-primary-400);
+  --rs-btn-ghost-active-border: var(--rs-primary-200);
+  --rs-btn-ghost-active-text: var(--rs-primary-200);
+  --rs-btn-link-text: var(--rs-primary-500);
+  --rs-btn-link-hover-text: var(--rs-primary-400);
+  --rs-btn-link-active-text: var(--rs-primary-200);
 
   // Icon Button
   --rs-iconbtn-addon: transparent;
   --rs-iconbtn-activated-addon: transparent;
   --rs-iconbtn-pressed-addon: transparent;
-  --rs-iconbtn-primary-addon: @H400-high-contrast;
-  --rs-iconbtn-primary-activated-addon: @H300-high-contrast;
-  --rs-iconbtn-primary-pressed-addon: @H100-high-contrast;
+  --rs-iconbtn-primary-addon: var(--rs-primary-400);
+  --rs-iconbtn-primary-activated-addon: var(--rs-primary-300);
+  --rs-iconbtn-primary-pressed-addon: var(--rs-primary-100);
 
   // Divider
-  --rs-divider-border: @B600-high-contrast;
+  --rs-divider-border: var(--rs-gray-600);
 
   // Loader
-  --rs-loader-ring: fade(@B050-high-contrast, 30);
-  --rs-loader-rotor: @B000-high-contrast;
-  --rs-loader-backdrop: fade(@B900-high-contrast, 83%);
-  --rs-loader-ring-inverse: fade(@B050-high-contrast, 80);
-  --rs-loader-rotor-inverse: @B500-high-contrast;
-  --rs-loader-backdrop-inverse: fade(@B000-high-contrast, 90);
+  --rs-loader-ring: rgb(from var(--rs-gray-50) r g b / 30%);
+  --rs-loader-rotor: var(--rs-gray-0);
+  --rs-loader-backdrop: rgb(from var(--rs-gray-900) r g b / 83%);
+  --rs-loader-ring-inverse: rgb(from var(--rs-gray-50) r g b / 80%);
+  --rs-loader-rotor-inverse: var(--rs-gray-500);
+  --rs-loader-backdrop-inverse: rgb(from var(--rs-gray-0) r g b / 90%);
 
   // Message
   --rs-message-success-header: #fff;
   --rs-message-success-text: #fff;
   --rs-message-success-icon: #fff;
-  --rs-message-success-bg: @green-900;
-  --rs-message-success-border: @green-300;
+  --rs-message-success-bg: var(--rs-green-900);
+  --rs-message-success-border: var(--rs-green-300);
   --rs-message-info-header: #fff;
   --rs-message-info-text: #fff;
   --rs-message-info-icon: #fff;
-  --rs-message-info-bg: @blue-900;
-  --rs-message-info-border: @blue-500;
+  --rs-message-info-bg: var(--rs-blue-900);
+  --rs-message-info-border: var(--rs-blue-500);
   --rs-message-warning-header: #fff;
   --rs-message-warning-text: #fff;
   --rs-message-warning-icon: #fff;
-  --rs-message-warning-bg: @yellow-900;
-  --rs-message-warning-border: @yellow-500;
+  --rs-message-warning-bg: var(--rs-yellow-900);
+  --rs-message-warning-border: var(--rs-yellow-500);
   --rs-message-error-header: #fff;
   --rs-message-error-text: #fff;
   --rs-message-error-icon: #fff;
-  --rs-message-error-bg: @red-900;
-  --rs-message-error-border: @red-300;
+  --rs-message-error-bg: var(--rs-red-900);
+  --rs-message-error-border: var(--rs-red-300);
 
   // Tooltip
-  --rs-tooltip-bg: @B800-high-contrast;
-  --rs-tooltip-text: @B000-high-contrast;
+  --rs-tooltip-bg: var(--rs-gray-800);
+  --rs-tooltip-text: var(--rs-gray-0);
 
   // Progress
-  --rs-progress-bg: @B700-high-contrast;
-  --rs-progress-bar: @H500-high-contrast;
-  --rs-progress-bar-success: @green;
-  --rs-progress-bar-fail: @red;
+  --rs-progress-bg: var(--rs-gray-700);
+  --rs-progress-bar: var(--rs-primary-500);
+  --rs-progress-bar-success: var(--rs-color-green);
+  --rs-progress-bar-fail: var(--rs-color-red);
 
   // Placeholder
-  --rs-placeholder: @B600-high-contrast;
-  --rs-placeholder-active: lighten(@B600-high-contrast, 5%);
+  --rs-placeholder: var(--rs-gray-600);
+  --rs-placeholder-active: hsl(from var(--rs-gray-600) h s calc(l + l * 0.2));
 
   // Breadcrumb
   --rs-breadcrumb-item-active-text: #fff;
 
   // Dropdown
-  --rs-dropdown-divider: @B600-high-contrast;
-  --rs-dropdown-item-bg-hover: @B600-high-contrast;
-  --rs-dropdown-item-bg-active: fade(@H900-high-contrast, 20);
-  --rs-dropdown-item-text-active: @H500-high-contrast;
-  --rs-dropdown-header-text: @B500-high-contrast;
+  --rs-dropdown-divider: var(--rs-gray-600);
+  --rs-dropdown-item-bg-hover: var(--rs-gray-600);
+  --rs-dropdown-item-bg-active: rgb(from var(--rs-primary-900) r g b / 20%);
+  --rs-dropdown-item-text-active: var(--rs-primary-500);
+  --rs-dropdown-header-text: var(--rs-gray-500);
   --rs-dropdown-shadow: 0 0 10px 1px rgba(0, 0, 0, 0.2), 0 4px 4px 3px rgba(0, 0, 0, 0.24);
 
   // ARIA menu
   --rs-menuitem-active-bg: transparent;
-  --rs-menuitem-active-text: @H500-high-contrast;
+  --rs-menuitem-active-text: var(--rs-primary-500);
 
   // Steps
-  --rs-steps-border: @B200-high-contrast;
-  --rs-steps-state-finish: @H500-high-contrast;
-  --rs-steps-border-state-finish: @H500-high-contrast;
-  --rs-steps-state-wait: @B200-high-contrast;
-  --rs-steps-state-process: @H700-high-contrast;
-  --rs-steps-state-error: @red;
-  --rs-steps-border-state-error: @red;
-  --rs-steps-icon-state-process: @H500-high-contrast;
-  --rs-steps-icon-state-error: @red;
+  --rs-steps-border: var(--rs-gray-200);
+  --rs-steps-state-finish: var(--rs-primary-500);
+  --rs-steps-border-state-finish: var(--rs-primary-500);
+  --rs-steps-state-wait: var(--rs-gray-200);
+  --rs-steps-state-process: var(--rs-primary-700);
+  --rs-steps-state-error: var(--rs-color-red);
+  --rs-steps-border-state-error: var(--rs-color-red);
+  --rs-steps-icon-state-process: var(--rs-primary-500);
+  --rs-steps-icon-state-error: var(--rs-color-red);
 
   // Navs
-  --rs-navs-text: @B200-high-contrast;
-  --rs-navs-text-hover: @H500-high-contrast;
+  --rs-navs-text: var(--rs-gray-200);
+  --rs-navs-text-hover: var(--rs-primary-500);
   --rs-navs-bg-hover: transparent;
-  --rs-navs-text-active: @H500-high-contrast;
-  --rs-navs-bg-active: @B400-high-contrast;
-  --rs-navs-tab-border: @B600-high-contrast;
-  --rs-navs-subtle-border: @B600-high-contrast;
-  --rs-navs-selected: @H500-high-contrast;
+  --rs-navs-text-active: var(--rs-primary-500);
+  --rs-navs-bg-active: var(--rs-gray-400);
+  --rs-navs-tab-border: var(--rs-gray-600);
+  --rs-navs-subtle-border: var(--rs-gray-600);
+  --rs-navs-selected: var(--rs-primary-500);
 
   // Navbar
-  --rs-navbar-default-bg: @B800-high-contrast;
-  --rs-navbar-default-text: @B050-high-contrast;
-  --rs-navbar-default-selected-text: @H500-high-contrast;
+  --rs-navbar-default-bg: var(--rs-gray-800);
+  --rs-navbar-default-text: var(--rs-gray-50);
+  --rs-navbar-default-selected-text: var(--rs-primary-500);
   --rs-navbar-default-hover-bg: transparent;
-  --rs-navbar-default-hover-text: @H500-high-contrast;
-  --rs-navbar-inverse-bg: @B800-high-contrast;
-  --rs-navbar-inverse-text: @B050-high-contrast;
+  --rs-navbar-default-hover-text: var(--rs-primary-500);
+  --rs-navbar-inverse-bg: var(--rs-gray-800);
+  --rs-navbar-inverse-text: var(--rs-gray-50);
   --rs-navbar-inverse-selected-bg: transparent;
-  --rs-navbar-inverse-selected-text: @H500-high-contrast;
+  --rs-navbar-inverse-selected-text: var(--rs-primary-500);
   --rs-navbar-inverse-hover-bg: transparent;
-  --rs-navbar-inverse-hover-text: @H500-high-contrast;
-  --rs-navbar-subtle-bg: @B800-high-contrast;
-  --rs-navbar-subtle-text: @B050-high-contrast;
-  --rs-navbar-subtle-selected-text: @H500-high-contrast;
+  --rs-navbar-inverse-hover-text: var(--rs-primary-500);
+  --rs-navbar-subtle-bg: var(--rs-gray-800);
+  --rs-navbar-subtle-text: var(--rs-gray-50);
+  --rs-navbar-subtle-selected-text: var(--rs-primary-500);
   --rs-navbar-subtle-hover-bg: transparent;
-  --rs-navbar-subtle-hover-text: @H500-high-contrast;
+  --rs-navbar-subtle-hover-text: var(--rs-primary-500);
 
   // Sidenav
-  --rs-sidenav-default-bg: @B800-high-contrast;
-  --rs-sidenav-default-text: @B050-high-contrast;
-  --rs-sidenav-default-selected-text: @H500-high-contrast;
+  --rs-sidenav-default-bg: var(--rs-gray-800);
+  --rs-sidenav-default-text: var(--rs-gray-50);
+  --rs-sidenav-default-selected-text: var(--rs-primary-500);
   --rs-sidenav-default-hover-bg: transparent;
-  --rs-sidenav-default-hover-text: @H500-high-contrast;
-  --rs-sidenav-default-footer-border: @B050-high-contrast;
-  --rs-sidenav-inverse-bg: @B800-high-contrast;
-  --rs-sidenav-inverse-text: @B050-high-contrast;
+  --rs-sidenav-default-hover-text: var(--rs-primary-500);
+  --rs-sidenav-default-footer-border: var(--rs-gray-50);
+  --rs-sidenav-inverse-bg: var(--rs-gray-800);
+  --rs-sidenav-inverse-text: var(--rs-gray-50);
   --rs-sidenav-inverse-selected-bg: transparent;
-  --rs-sidenav-inverse-selected-text: @H500-high-contrast;
+  --rs-sidenav-inverse-selected-text: var(--rs-primary-500);
   --rs-sidenav-inverse-hover-bg: transparent;
-  --rs-sidenav-inverse-footer-border: @B050-high-contrast;
-  --rs-sidenav-subtle-bg: @B800-high-contrast;
-  --rs-sidenav-subtle-text: @B050-high-contrast;
-  --rs-sidenav-subtle-selected-text: @H500-high-contrast;
+  --rs-sidenav-inverse-footer-border: var(--rs-gray-50);
+  --rs-sidenav-subtle-bg: var(--rs-gray-800);
+  --rs-sidenav-subtle-text: var(--rs-gray-50);
+  --rs-sidenav-subtle-selected-text: var(--rs-primary-500);
   --rs-sidenav-subtle-hover-bg: transparent;
-  --rs-sidenav-subtle-hover-text: @H500-high-contrast;
-  --rs-sidenav-subtle-footer-border: @B050-high-contrast;
+  --rs-sidenav-subtle-hover-text: var(--rs-primary-500);
+  --rs-sidenav-subtle-footer-border: var(--rs-gray-50);
 
   // Input
-  --rs-input-bg: @B800-high-contrast;
-  --rs-input-focus-border: @H500-high-contrast;
-  --rs-input-disabled-bg: @B700-high-contrast;
+  --rs-input-bg: var(--rs-gray-800);
+  --rs-input-focus-border: var(--rs-primary-500);
+  --rs-input-disabled-bg: var(--rs-gray-700);
 
   // ARIA Listboxes
   --rs-listbox-option-hover-bg: transparent;
-  --rs-listbox-option-hover-text: @H500-high-contrast;
-  --rs-listbox-option-selected-text: @H500-high-contrast;
+  --rs-listbox-option-hover-text: var(--rs-primary-500);
+  --rs-listbox-option-selected-text: var(--rs-primary-500);
   --rs-listbox-option-selected-bg: transparent;
-  --rs-listbox-option-disabled-text: @B500-high-contrast;
-  --rs-listbox-option-disabled-selected-text: @H200-high-contrast;
+  --rs-listbox-option-disabled-text: var(--rs-gray-500);
+  --rs-listbox-option-disabled-selected-text: var(--rs-primary-200);
 
   // Checkbox
-  --rs-checkbox-icon: @B800-high-contrast;
-  --rs-checkbox-border: @B100-high-contrast;
-  --rs-checkbox-checked-bg: @H500-high-contrast;
-  --rs-checkbox-disabled-bg: @B500-high-contrast;
+  --rs-checkbox-icon: var(--rs-gray-800);
+  --rs-checkbox-border: var(--rs-gray-100);
+  --rs-checkbox-checked-bg: var(--rs-primary-500);
+  --rs-checkbox-disabled-bg: var(--rs-gray-500);
 
   // Radio
-  --rs-radio-marker: @B800-high-contrast;
-  --rs-radio-border: @B100-high-contrast;
-  --rs-radio-checked-bg: @H500-high-contrast;
-  --rs-radio-disabled-bg: @B500-high-contrast;
+  --rs-radio-marker: var(--rs-gray-800);
+  --rs-radio-border: var(--rs-gray-100);
+  --rs-radio-checked-bg: var(--rs-primary-500);
+  --rs-radio-disabled-bg: var(--rs-gray-500);
 
   // RadioTile
-  --rs-radio-tile-border: @B300-high-contrast;
-  --rs-radio-tile-bg: @B000-high-contrast;
-  --rs-radio-tile-checked-color: @H500-high-contrast;
-  --rs-radio-tile-checked-mark-color: @B800-high-contrast;
-  --rs-radio-tile-checked-disabled-color: @H900-high-contrast;
+  --rs-radio-tile-border: var(--rs-gray-300);
+  --rs-radio-tile-bg: var(--rs-gray-0);
+  --rs-radio-tile-checked-color: var(--rs-primary-500);
+  --rs-radio-tile-checked-mark-color: var(--rs-gray-800);
+  --rs-radio-tile-checked-disabled-color: var(--rs-primary-900);
 
   // Rate
-  --rs-rate-symbol: @B100-high-contrast;
-  --rs-rate-symbol-checked: @H500-high-contrast;
+  --rs-rate-symbol: var(--rs-gray-100);
+  --rs-rate-symbol-checked: var(--rs-primary-500);
 
   // Toggle
-  --rs-toggle-bg: @B800-high-contrast;
-  --rs-toggle-thumb: @B100-high-contrast;
-  --rs-toggle-hover-bg: @B800-high-contrast;
-  --rs-toggle-disabled-bg: @B800-high-contrast;
-  --rs-toggle-disabled-thumb: @B300-high-contrast;
-  --rs-toggle-checked-bg: @H500-high-contrast;
-  --rs-toggle-checked-thumb: @B800-high-contrast;
-  --rs-toggle-checked-hover-bg: @H400-high-contrast;
-  --rs-toggle-checked-disabled-bg: @H900-high-contrast;
-  --rs-toggle-checked-disabled-thumb: @B800-high-contrast;
+  --rs-toggle-bg: var(--rs-gray-800);
+  --rs-toggle-thumb: var(--rs-gray-100);
+  --rs-toggle-hover-bg: var(--rs-gray-800);
+  --rs-toggle-disabled-bg: var(--rs-gray-800);
+  --rs-toggle-disabled-thumb: var(--rs-gray-300);
+  --rs-toggle-checked-bg: var(--rs-primary-500);
+  --rs-toggle-checked-thumb: var(--rs-gray-800);
+  --rs-toggle-checked-hover-bg: var(--rs-primary-400);
+  --rs-toggle-checked-disabled-bg: var(--rs-primary-900);
+  --rs-toggle-checked-disabled-thumb: var(--rs-gray-800);
 
   // Slider
-  --rs-slider-bar: @B600-high-contrast;
-  --rs-slider-hover-bar: @B600-high-contrast;
-  --rs-slider-thumb-border: @H500-high-contrast;
-  --rs-slider-thumb-bg: @B700-high-contrast;
-  --rs-slider-thumb-hover-shadow: 0 0 0 8px fade(@H500-high-contrast, 25);
-  --rs-slider-progress: @H500-high-contrast;
+  --rs-slider-bar: var(--rs-gray-600);
+  --rs-slider-hover-bar: var(--rs-gray-600);
+  --rs-slider-thumb-border: var(--rs-primary-500);
+  --rs-slider-thumb-bg: var(--rs-gray-700);
+  --rs-slider-thumb-hover-shadow: 0 0 0 8px rgb(from var(--rs-primary-500) r g b / 25%);
+  --rs-slider-progress: var(--rs-primary-500);
 
   // Uploader
-  --rs-uploader-item-bg: @B300-high-contrast;
-  --rs-uploader-item-hover-bg: @B800-high-contrast;
-  --rs-uploader-item-hover-text: @H500-high-contrast;
-  --rs-uploader-overlay-bg: fade(@B600-high-contrast, 80);
-  --rs-uploader-dnd-bg: @B700-high-contrast;
-  --rs-uploader-dnd-border: @B200-high-contrast;
-  --rs-uploader-dnd-hover-border: @H500-high-contrast;
+  --rs-uploader-item-bg: var(--rs-gray-300);
+  --rs-uploader-item-hover-bg: var(--rs-gray-800);
+  --rs-uploader-item-hover-text: var(--rs-primary-500);
+  --rs-uploader-overlay-bg: rgb(from var(--rs-gray-600) r g b / 80%);
+  --rs-uploader-dnd-bg: var(--rs-gray-700);
+  --rs-uploader-dnd-border: var(--rs-gray-200);
+  --rs-uploader-dnd-hover-border: var(--rs-primary-500);
 
   // Avatar
-  --rs-avatar-bg: @B400-high-contrast;
-  --rs-avatar-text: @B000-high-contrast;
+  --rs-avatar-bg: var(--rs-gray-400);
+  --rs-avatar-text: var(--rs-gray-0);
 
   // Badge
-  --rs-badge-bg: @red-500;
-  --rs-badge-text: @B000-high-contrast;
+  --rs-badge-bg: var(--rs-red-500);
+  --rs-badge-text: var(--rs-gray-0);
 
   // Tag
-  --rs-tag-bg: @B600-high-contrast;
-  --rs-tag-close: @red;
+  --rs-tag-bg: var(--rs-gray-600);
+  --rs-tag-close: var(--rs-color-red);
 
   // Carousel
-  --rs-carousel-bg: @B600-high-contrast;
-  --rs-carousel-indicator: fade(@B000-high-contrast, 40);
-  --rs-carousel-indicator-hover: @B000-high-contrast;
-  --rs-carousel-indicator-active: @H500-high-contrast;
+  --rs-carousel-bg: var(--rs-gray-600);
+  --rs-carousel-indicator: rgb(from var(--rs-gray-0) r g b / 40%);
+  --rs-carousel-indicator-hover: var(--rs-gray-0);
+  --rs-carousel-indicator-active: var(--rs-primary-500);
 
   // Panel
   --rs-panel-shadow: 0 4px 4px rgba(0, 0, 0, 0.12), 0 0 10px rgba(0, 0, 0, 0.06);
 
   // Pagination
-  --rs-pagination-item-text: @B050-high-contrast;
-  --rs-pagination-item-current-text: @H500-high-contrast;
+  --rs-pagination-item-text: var(--rs-gray-50);
+  --rs-pagination-item-current-text: var(--rs-primary-500);
 
   // List
   --rs-list-bg: transparent;
-  --rs-list-border: @B700-high-contrast;
-  --rs-list-hover-bg: @B600-high-contrast;
-  --rs-list-placeholder-bg: fade(@H900-high-contrast, 20%);
-  --rs-list-placeholder-border: @H500-high-contrast;
+  --rs-list-border: var(--rs-gray-700);
+  --rs-list-hover-bg: var(--rs-gray-600);
+  --rs-list-placeholder-bg: rgb(from var(--rs-primary-900) r g b / 20%);
+  --rs-list-placeholder-border: var(--rs-primary-500);
 
   // Timeline
-  --rs-timeline-indicator-bg: @B500-high-contrast;
-  --rs-timeline-indicator-active-bg: @H500-high-contrast;
+  --rs-timeline-indicator-bg: var(--rs-gray-500);
+  --rs-timeline-indicator-active-bg: var(--rs-primary-500);
 
   // Table
   --rs-table-shadow: rgba(9, 9, 9, 0.99);
-  --rs-table-sort: @H500-high-contrast;
-  --rs-table-resize: @H500-high-contrast;
-  --rs-table-scrollbar-track: @B700-high-contrast;
-  --rs-table-scrollbar-thumb: @B200-high-contrast;
-  --rs-table-scrollbar-thumb-active: @B100-high-contrast;
-  --rs-table-scrollbar-vertical-track: @B700-high-contrast;
+  --rs-table-sort: var(--rs-primary-500);
+  --rs-table-resize: var(--rs-primary-500);
+  --rs-table-scrollbar-track: var(--rs-gray-700);
+  --rs-table-scrollbar-thumb: var(--rs-gray-200);
+  --rs-table-scrollbar-thumb-active: var(--rs-gray-100);
+  --rs-table-scrollbar-vertical-track: var(--rs-gray-700);
 
   // Drawer
-  --rs-drawer-bg: @B700-high-contrast;
+  --rs-drawer-bg: var(--rs-gray-700);
   --rs-drawer-shadow: 0 4px 4px rgba(0, 0, 0, 0.12), 0 0 10px rgba(0, 0, 0, 0.06);
 
   // Modal
   --rs-modal-shadow: 0 4px 4px rgba(0, 0, 0, 0.12), 0 0 10px rgba(0, 0, 0, 0.06);
-  --rs-modal-border: 1px solid @B100-high-contrast;
+  --rs-modal-border: 1px solid var(--rs-gray-100);
 
   // Form
   --rs-form-errormessage-text: #fff;
-  --rs-form-errormessage-bg: @red-500;
-  --rs-form-errormessage-border: @red-500;
+  --rs-form-errormessage-bg: var(--rs-red-500);
+  --rs-form-errormessage-border: var(--rs-red-500);
 
   // Picker
-  --rs-picker-value: @H500-high-contrast;
-  --rs-picker-count-bg: @H500-high-contrast;
-  --rs-picker-count-text: @B900-high-contrast;
+  --rs-picker-value: var(--rs-primary-500);
+  --rs-picker-count-bg: var(--rs-primary-500);
+  --rs-picker-count-text: var(--rs-gray-900);
 
   // Calendar
-  --rs-calendar-today-bg: @H500-high-contrast;
-  --rs-calendar-today-text: @B900-high-contrast;
-  --rs-calendar-range-bg: fade(@H900-high-contrast, 50%);
-  --rs-calendar-time-unit-bg: @B900-high-contrast;
-  --rs-calendar-date-selected-text: @B900-high-contrast;
-  --rs-calendar-cell-selected-hover-bg: @B050-high-contrast;
+  --rs-calendar-today-bg: var(--rs-primary-500);
+  --rs-calendar-today-text: var(--rs-gray-900);
+  --rs-calendar-range-bg: rgb(from var(--rs-primary-900) r g b / 50%);
+  --rs-calendar-time-unit-bg: var(--rs-gray-900);
+  --rs-calendar-date-selected-text: var(--rs-gray-900);
+  --rs-calendar-cell-selected-hover-bg: var(--rs-gray-50);
 
   // Popover
   --rs-popover-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+
+  // CSS relative color syntax is not supported
+  // https://developer.chrome.com/blog/css-relative-color-syntax/
+  @supports not (color: rgb(from white r g b)) {
+    // Misc
+    --rs-bg-backdrop: fade(@B900-high-contrast, 80%);
+    --rs-state-focus-outline: 3px solid fade(@H500-high-contrast, 25%);
+
+    // Loader
+    --rs-loader-ring: fade(@B050-high-contrast, 30);
+    --rs-loader-backdrop: fade(@B900-high-contrast, 83%);
+    --rs-loader-ring-inverse: fade(@B050-high-contrast, 80);
+    --rs-loader-backdrop-inverse: fade(@B000-high-contrast, 90);
+
+    // Dropdown
+    --rs-dropdown-item-bg-active: fade(@H900-high-contrast, 20);
+
+    // Slider
+    --rs-slider-thumb-hover-shadow: 0 0 0 8px fade(@H500-high-contrast, 25);
+
+    // Uploader
+    --rs-uploader-overlay-bg: fade(@B600-high-contrast, 80);
+
+    // Carousel
+    --rs-carousel-indicator: fade(@B000-high-contrast, 40);
+
+    // List
+    --rs-list-placeholder-bg: fade(@H900-high-contrast, 20%);
+
+    // Calendar
+    --rs-calendar-range-bg: fade(@H900-high-contrast, 50%);
+
+    // Placeholder
+    --rs-placeholder-active: lighten(@B600-high-contrast, 5%);
+  }
 }

--- a/src/styles/color-modes/light.less
+++ b/src/styles/color-modes/light.less
@@ -147,7 +147,7 @@
   --rs-message-warning-header: var(--rs-text-heading);
   --rs-message-warning-text: var(--rs-text-primary);
   --rs-message-warning-icon: var(--rs-color-yellow);
-  --rs-message-warning-bg: var(--rs-blue-50);
+  --rs-message-warning-bg: var(--rs-yellow-50);
   --rs-message-error-header: var(--rs-text-heading);
   --rs-message-error-text: var(--rs-text-primary);
   --rs-message-error-icon: var(--rs-color-red);

--- a/src/styles/color-modes/light.less
+++ b/src/styles/color-modes/light.less
@@ -1,6 +1,7 @@
 // see https://rsuitejs.com/design/default
 & {
   // Gray levels
+  --rs-gray-0: @B000;
   --rs-gray-50: @B050;
   --rs-gray-100: @B100;
   --rs-gray-200: @B200;
@@ -24,6 +25,15 @@
   --rs-primary-800: @H800;
   --rs-primary-900: @H900;
 
+  // Spectrum
+  --rs-color-red: @red;
+  --rs-color-orange: @orange;
+  --rs-color-yellow: @yellow;
+  --rs-color-green: @green;
+  --rs-color-cyan: @cyan;
+  --rs-color-blue: @blue;
+  --rs-color-violet: @violet;
+
   // Spectrum levels
   each(@spectrum, .(@color-name) {
     @color: @@color-name;
@@ -38,13 +48,13 @@
   });
 
   // Stateful colors
-  --rs-state-success: @green;
-  --rs-state-info: @blue;
-  --rs-state-warning: @yellow;
-  --rs-state-error: @red;
+  --rs-state-success: var(--rs-color-green);
+  --rs-state-info: var(--rs-color-blue);
+  --rs-state-warning: var(--rs-color-yellow);
+  --rs-state-error: var(--rs-color-red);
 
   // Reset
-  --rs-body: @B000;
+  --rs-body: var(--rs-gray-0);
 
   // States
   --rs-bg-success: #edfae1;
@@ -53,289 +63,289 @@
   --rs-bg-error: #fde9ef;
 
   // Misc
-  --rs-text-link: @H700;
-  --rs-text-link-hover: @H800;
-  --rs-text-link-active: @H900;
-  --rs-text-primary: @B800;
-  --rs-text-secondary: @B600;
-  --rs-text-tertiary: @B500;
-  --rs-text-heading: @B900;
-  --rs-text-inverse: @B050;
-  --rs-text-heading-inverse: @B000;
-  --rs-text-active: @H700;
-  --rs-text-disabled: @B400;
-  --rs-text-error: @red;
-  --rs-border-primary: @B200;
-  --rs-border-secondary: @B100;
-  --rs-bg-card: @B000;
-  --rs-bg-overlay: @B000;
-  --rs-bg-well: @B050;
-  --rs-bg-active: @H500;
-  --rs-bg-backdrop: fade(@B900, 30%);
-  --rs-state-hover-bg: @H050;
-  --rs-color-focus-ring: fade(@H500, 25%);
-  --rs-state-focus-shadow: 0 0 0 3px fade(@H500, 25%);
-  --rs-state-focus-outline: 3px solid fade(@H500, 25%);
+  --rs-text-link: var(--rs-primary-700);
+  --rs-text-link-hover: var(--rs-primary-800);
+  --rs-text-link-active: var(--rs-primary-900);
+  --rs-text-primary: var(--rs-gray-800);
+  --rs-text-secondary: var(--rs-gray-600);
+  --rs-text-tertiary: var(--rs-gray-500);
+  --rs-text-heading: var(--rs-gray-900);
+  --rs-text-inverse: var(--rs-gray-50);
+  --rs-text-heading-inverse: var(--rs-gray-0);
+  --rs-text-active: var(--rs-primary-700);
+  --rs-text-disabled: var(--rs-gray-400);
+  --rs-text-error: var(--rs-color-red);
+  --rs-border-primary: var(--rs-gray-200);
+  --rs-border-secondary: var(--rs-gray-100);
+  --rs-bg-card: var(--rs-gray-0);
+  --rs-bg-overlay: var(--rs-gray-0);
+  --rs-bg-well: var(--rs-gray-50);
+  --rs-bg-active: var(--rs-primary-500);
+  --rs-bg-backdrop: rgb(from var(--rs-gray-900) r g b / 30%);
+  --rs-state-hover-bg: var(--rs-primary-50);
+  --rs-color-focus-ring: rgb(from var(--rs-primary-500) r g b / 25%);
+  --rs-state-focus-shadow: 0 0 0 3px rgb(from var(--rs-primary-500) r g b / 25%);
+  --rs-state-focus-outline: 3px solid rgb(from var(--rs-primary-500) r g b / 25%);
   --rs-shadow-overlay: 0 4px 4px rgba(0, 0, 0, 0.12), 0 0 10px rgba(0, 0, 0, 0.06);
 
   // Button
-  --rs-btn-default-bg: @B050;
-  --rs-btn-default-text: @B800;
-  --rs-btn-default-hover-bg: @B200;
-  --rs-btn-default-active-bg: @B300;
-  --rs-btn-default-active-text: @B900;
-  --rs-btn-default-disabled-bg: @B050;
-  --rs-btn-default-disabled-text: @B400;
-  --rs-btn-primary-bg: @H500;
-  --rs-btn-primary-text: @B000;
-  --rs-btn-primary-hover-bg: @H600;
-  --rs-btn-primary-active-bg: @H700;
-  --rs-btn-subtle-text: @B800;
-  --rs-btn-subtle-hover-bg: @B200;
-  --rs-btn-subtle-hover-text: @B800;
-  --rs-btn-subtle-active-bg: @B200;
-  --rs-btn-subtle-active-text: @B900;
-  --rs-btn-subtle-disabled-text: @B400;
-  --rs-btn-ghost-border: @H700;
-  --rs-btn-ghost-text: @H700;
-  --rs-btn-ghost-hover-border: @H800;
-  --rs-btn-ghost-hover-text: @H800;
-  --rs-btn-ghost-active-border: @H900;
-  --rs-btn-ghost-active-text: @H900;
-  --rs-btn-link-text: @H700;
-  --rs-btn-link-hover-text: @H800;
-  --rs-btn-link-active-text: @H900;
+  --rs-btn-default-bg: var(--rs-gray-50);
+  --rs-btn-default-text: var(--rs-gray-800);
+  --rs-btn-default-hover-bg: var(--rs-gray-200);
+  --rs-btn-default-active-bg: var(--rs-gray-300);
+  --rs-btn-default-active-text: var(--rs-gray-900);
+  --rs-btn-default-disabled-bg: var(--rs-gray-50);
+  --rs-btn-default-disabled-text: var(--rs-gray-400);
+  --rs-btn-primary-bg: var(--rs-primary-500);
+  --rs-btn-primary-text: var(--rs-gray-0);
+  --rs-btn-primary-hover-bg: var(--rs-primary-600);
+  --rs-btn-primary-active-bg: var(--rs-primary-700);
+  --rs-btn-subtle-text: var(--rs-gray-800);
+  --rs-btn-subtle-hover-bg: var(--rs-gray-200);
+  --rs-btn-subtle-hover-text: var(--rs-gray-800);
+  --rs-btn-subtle-active-bg: var(--rs-gray-200);
+  --rs-btn-subtle-active-text: var(--rs-gray-900);
+  --rs-btn-subtle-disabled-text: var(--rs-gray-400);
+  --rs-btn-ghost-border: var(--rs-primary-700);
+  --rs-btn-ghost-text: var(--rs-primary-700);
+  --rs-btn-ghost-hover-border: var(--rs-primary-800);
+  --rs-btn-ghost-hover-text: var(--rs-primary-800);
+  --rs-btn-ghost-active-border: var(--rs-primary-900);
+  --rs-btn-ghost-active-text: var(--rs-primary-900);
+  --rs-btn-link-text: var(--rs-primary-700);
+  --rs-btn-link-hover-text: var(--rs-primary-800);
+  --rs-btn-link-active-text: var(--rs-primary-900);
 
   // Icon Button
-  --rs-iconbtn-addon: @B100;
-  --rs-iconbtn-activated-addon: @B300;
-  --rs-iconbtn-pressed-addon: @B400;
-  --rs-iconbtn-primary-addon: @H600;
-  --rs-iconbtn-primary-activated-addon: @H700;
-  --rs-iconbtn-primary-pressed-addon: @H800;
+  --rs-iconbtn-addon: var(--rs-gray-100);
+  --rs-iconbtn-activated-addon: var(--rs-gray-300);
+  --rs-iconbtn-pressed-addon: var(--rs-gray-400);
+  --rs-iconbtn-primary-addon: var(--rs-primary-600);
+  --rs-iconbtn-primary-activated-addon: var(--rs-primary-700);
+  --rs-iconbtn-primary-pressed-addon: var(--rs-primary-800);
 
   // Divider
-  --rs-divider-border: @B200;
+  --rs-divider-border: var(--rs-gray-200);
 
   // Loader
-  --rs-loader-ring: fade(@B050, 80);
-  --rs-loader-rotor: @B500;
-  --rs-loader-backdrop: fade(@B000, 90%);
-  --rs-loader-ring-inverse: fade(@B050, 30);
-  --rs-loader-rotor-inverse: @B000;
-  --rs-loader-backdrop-inverse: fade(@B900, 83);
+  --rs-loader-ring: rgb(from var(--rs-gray-50) r g b / 80%);
+  --rs-loader-rotor: var(--rs-gray-500);
+  --rs-loader-backdrop: rgb(from var(--rs-gray-0) r g b / 90%);
+  --rs-loader-ring-inverse: rgb(from var(--rs-gray-50) r g b / 30%);
+  --rs-loader-rotor-inverse: var(--rs-gray-0);
+  --rs-loader-backdrop-inverse: rgb(from var(--rs-gray-900) r g b / 83%);
 
   // Message
   --rs-message-success-header: var(--rs-text-heading);
   --rs-message-success-text: var(--rs-text-primary);
-  --rs-message-success-icon: @green;
-  --rs-message-success-bg: @green-50;
+  --rs-message-success-icon: var(--rs-color-green);
+  --rs-message-success-bg: var(--rs-green-50);
   --rs-message-info-header: var(--rs-text-heading);
   --rs-message-info-text: var(--rs-text-primary);
-  --rs-message-info-icon: @blue;
-  --rs-message-info-bg: @blue-50;
+  --rs-message-info-icon: var(--rs-color-blue);
+  --rs-message-info-bg: var(--rs-blue-50);
   --rs-message-warning-header: var(--rs-text-heading);
   --rs-message-warning-text: var(--rs-text-primary);
-  --rs-message-warning-icon: @yellow;
-  --rs-message-warning-bg: @yellow-50;
+  --rs-message-warning-icon: var(--rs-color-yellow);
+  --rs-message-warning-bg: var(--rs-blue-50);
   --rs-message-error-header: var(--rs-text-heading);
   --rs-message-error-text: var(--rs-text-primary);
-  --rs-message-error-icon: @red;
-  --rs-message-error-bg: @red-50;
+  --rs-message-error-icon: var(--rs-color-red);
+  --rs-message-error-bg: var(--rs-red-50);
 
   // Tooltip
-  --rs-tooltip-bg: @B900;
-  --rs-tooltip-text: @B000;
+  --rs-tooltip-bg: var(--rs-gray-900);
+  --rs-tooltip-text: var(--rs-gray-0);
 
   // Progress
-  --rs-progress-bg: @B200;
-  --rs-progress-bar: @H500;
-  --rs-progress-bar-success: @green;
-  --rs-progress-bar-fail: @red;
+  --rs-progress-bg: var(--rs-gray-200);
+  --rs-progress-bar: var(--rs-primary-500);
+  --rs-progress-bar-success: var(--rs-color-green);
+  --rs-progress-bar-fail: var(--rs-color-red);
 
   // Placeholder
-  --rs-placeholder: @B100;
-  --rs-placeholder-active: @B200;
+  --rs-placeholder: var(--rs-gray-100);
+  --rs-placeholder-active: var(--rs-gray-200);
 
   // Breadcrumb
-  --rs-breadcrumb-item-active-text: @B900;
+  --rs-breadcrumb-item-active-text: var(--rs-gray-900);
 
   // Dropdown
-  --rs-dropdown-divider: @B200;
-  --rs-dropdown-item-bg-hover: fade(@H100, 50%);
-  --rs-dropdown-item-bg-active: @H050;
-  --rs-dropdown-item-text-active: @H700;
-  --rs-dropdown-header-text: @B500;
+  --rs-dropdown-divider: var(--rs-gray-200);
+  --rs-dropdown-item-bg-hover: rgb(from var(--rs-primary-100) r g b / 50%);
+  --rs-dropdown-item-bg-active: var(--rs-primary-50);
+  --rs-dropdown-item-text-active: var(--rs-primary-700);
+  --rs-dropdown-header-text: var(--rs-gray-500);
   --rs-dropdown-shadow: 0 0 10px rgba(0, 0, 0, 0.06), 0 4px 4px rgba(0, 0, 0, 0.12);
 
   // ARIA menu
-  --rs-menuitem-active-bg: fade(@H100, 50);
-  --rs-menuitem-active-text: @H700;
+  --rs-menuitem-active-bg: rgb(from var(--rs-primary-100) r g b / 50%);
+  --rs-menuitem-active-text: var(--rs-primary-700);
 
   // Steps
-  --rs-steps-border: @B600;
-  --rs-steps-state-finish: @H500;
-  --rs-steps-border-state-finish: @H500;
-  --rs-steps-state-wait: @B600;
-  --rs-steps-state-process: @H500;
-  --rs-steps-state-error: @red;
-  --rs-steps-border-state-error: @red;
-  --rs-steps-icon-state-process: @H500;
-  --rs-steps-icon-state-error: @red;
+  --rs-steps-border: var(--rs-gray-600);
+  --rs-steps-state-finish: var(--rs-primary-500);
+  --rs-steps-border-state-finish: var(--rs-primary-500);
+  --rs-steps-state-wait: var(--rs-gray-600);
+  --rs-steps-state-process: var(--rs-primary-500);
+  --rs-steps-state-error: var(--rs-color-red);
+  --rs-steps-border-state-error: var(--rs-color-red);
+  --rs-steps-icon-state-process: var(--rs-primary-500);
+  --rs-steps-icon-state-error: var(--rs-color-red);
 
   // Nav
-  --rs-navs-text: @B800;
-  --rs-navs-text-hover: @B800;
-  --rs-navs-bg-hover: @B200;
-  --rs-navs-text-active: @B900;
-  --rs-navs-bg-active: @B200;
-  --rs-navs-tab-border: @B300;
-  --rs-navs-subtle-border: @B050;
-  --rs-navs-selected: @H700;
+  --rs-navs-text: var(--rs-gray-800);
+  --rs-navs-text-hover: var(--rs-gray-800);
+  --rs-navs-bg-hover: var(--rs-gray-200);
+  --rs-navs-text-active: var(--rs-gray-900);
+  --rs-navs-bg-active: var(--rs-gray-200);
+  --rs-navs-tab-border: var(--rs-gray-300);
+  --rs-navs-subtle-border: var(--rs-gray-50);
+  --rs-navs-selected: var(--rs-primary-700);
 
   // Navbar
-  --rs-navbar-default-bg: @B050;
-  --rs-navbar-default-text: @B800;
-  --rs-navbar-default-selected-text: @H700;
-  --rs-navbar-default-hover-bg: @B200;
-  --rs-navbar-default-hover-text: @B800;
-  --rs-navbar-inverse-bg: @H500;
+  --rs-navbar-default-bg: var(--rs-gray-50);
+  --rs-navbar-default-text: var(--rs-gray-800);
+  --rs-navbar-default-selected-text: var(--rs-primary-700);
+  --rs-navbar-default-hover-bg: var(--rs-gray-200);
+  --rs-navbar-default-hover-text: var(--rs-gray-800);
+  --rs-navbar-inverse-bg: var(--rs-primary-500);
   --rs-navbar-inverse-text: #fff;
-  --rs-navbar-inverse-selected-bg: @H700;
-  --rs-navbar-inverse-hover-bg: @H600;
+  --rs-navbar-inverse-selected-bg: var(--rs-primary-700);
+  --rs-navbar-inverse-hover-bg: var(--rs-primary-600);
   --rs-navbar-inverse-hover-text: #fff;
   --rs-navbar-subtle-bg: #fff;
-  --rs-navbar-subtle-text: @B800;
-  --rs-navbar-subtle-selected-text: @H700;
-  --rs-navbar-subtle-hover-bg: @B050;
-  --rs-navbar-subtle-hover-text: @B800;
+  --rs-navbar-subtle-text: var(--rs-gray-800);
+  --rs-navbar-subtle-selected-text: var(--rs-primary-700);
+  --rs-navbar-subtle-hover-bg: var(--rs-gray-50);
+  --rs-navbar-subtle-hover-text: var(--rs-gray-800);
 
   // Sidenav
-  --rs-sidenav-default-bg: @B050;
-  --rs-sidenav-default-text: @B800;
-  --rs-sidenav-default-selected-text: @H700;
-  --rs-sidenav-default-hover-bg: @B200;
-  --rs-sidenav-default-hover-text: @B800;
-  --rs-sidenav-default-footer-border: @B200;
-  --rs-sidenav-inverse-bg: @H500;
+  --rs-sidenav-default-bg: var(--rs-gray-50);
+  --rs-sidenav-default-text: var(--rs-gray-800);
+  --rs-sidenav-default-selected-text: var(--rs-primary-700);
+  --rs-sidenav-default-hover-bg: var(--rs-gray-200);
+  --rs-sidenav-default-hover-text: var(--rs-gray-800);
+  --rs-sidenav-default-footer-border: var(--rs-gray-200);
+  --rs-sidenav-inverse-bg: var(--rs-primary-500);
   --rs-sidenav-inverse-text: #fff;
-  --rs-sidenav-inverse-selected-bg: @H700;
-  --rs-sidenav-inverse-hover-bg: @H600;
-  --rs-sidenav-inverse-footer-border: @H600;
+  --rs-sidenav-inverse-selected-bg: var(--rs-primary-700);
+  --rs-sidenav-inverse-hover-bg: var(--rs-primary-600);
+  --rs-sidenav-inverse-footer-border: var(--rs-primary-600);
   --rs-sidenav-subtle-bg: #fff;
-  --rs-sidenav-subtle-text: @B800;
-  --rs-sidenav-subtle-selected-text: @H700;
-  --rs-sidenav-subtle-hover-bg: @B050;
-  --rs-sidenav-subtle-hover-text: @B800;
-  --rs-sidenav-subtle-footer-border: @B200;
+  --rs-sidenav-subtle-text: var(--rs-gray-800);
+  --rs-sidenav-subtle-selected-text: var(--rs-primary-700);
+  --rs-sidenav-subtle-hover-bg: var(--rs-gray-50);
+  --rs-sidenav-subtle-hover-text: var(--rs-gray-800);
+  --rs-sidenav-subtle-footer-border: var(--rs-gray-200);
 
   // Input
-  --rs-input-bg: @B000;
-  --rs-input-focus-border: @H500;
-  --rs-input-disabled-bg: @B050;
+  --rs-input-bg: var(--rs-gray-0);
+  --rs-input-focus-border: var(--rs-primary-500);
+  --rs-input-disabled-bg: var(--rs-gray-50);
 
   // ARIA Listboxes
-  --rs-listbox-option-hover-bg: fade(@H100, 50%);
-  --rs-listbox-option-hover-text: @H700;
-  --rs-listbox-option-selected-text: @H700;
-  --rs-listbox-option-selected-bg: @H050;
-  --rs-listbox-option-disabled-text: @B400;
-  --rs-listbox-option-disabled-selected-text: @H200;
+  --rs-listbox-option-hover-bg: rgb(from var(--rs-primary-100) r g b / 50%);
+  --rs-listbox-option-hover-text: var(--rs-primary-700);
+  --rs-listbox-option-selected-text: var(--rs-primary-700);
+  --rs-listbox-option-selected-bg: var(--rs-primary-50);
+  --rs-listbox-option-disabled-text: var(--rs-gray-400);
+  --rs-listbox-option-disabled-selected-text: var(--rs-primary-200);
 
   // Checkbox
   --rs-checkbox-icon: #fff;
-  --rs-checkbox-border: @B300;
-  --rs-checkbox-checked-bg: @H500;
-  --rs-checkbox-disabled-bg: @B050;
+  --rs-checkbox-border: var(--rs-gray-300);
+  --rs-checkbox-checked-bg: var(--rs-primary-500);
+  --rs-checkbox-disabled-bg: var(--rs-gray-50);
 
   // Radio
   --rs-radio-marker: #fff;
-  --rs-radio-border: @B300;
-  --rs-radio-checked-bg: @H500;
-  --rs-radio-disabled-bg: @B050;
+  --rs-radio-border: var(--rs-gray-300);
+  --rs-radio-checked-bg: var(--rs-primary-500);
+  --rs-radio-disabled-bg: var(--rs-gray-50);
 
   // RadioTile
-  --rs-radio-tile-border: @B300;
-  --rs-radio-tile-bg: @B000;
-  --rs-radio-tile-checked-color: @H500;
+  --rs-radio-tile-border: var(--rs-gray-300);
+  --rs-radio-tile-bg: var(--rs-gray-0);
+  --rs-radio-tile-checked-color: var(--rs-primary-500);
   --rs-radio-tile-checked-mark-color: #fff;
-  --rs-radio-tile-checked-disabled-color: @H100;
+  --rs-radio-tile-checked-disabled-color: var(--rs-primary-100);
   --rs-radio-tile-icon-size: 32px;
 
   // Rate
-  --rs-rate-symbol: @B600;
-  --rs-rate-symbol-checked: @yellow-500;
+  --rs-rate-symbol: var(--rs-gray-600);
+  --rs-rate-symbol-checked: var(--rs-blue-500);
 
   // Toggle
-  --rs-toggle-bg: @B300;
+  --rs-toggle-bg: var(--rs-gray-300);
   --rs-toggle-thumb: #fff;
-  --rs-toggle-loader-ring: fade(@B050, 30%);
-  --rs-toggle-loader-rotor: @B000;
-  --rs-toggle-hover-bg: @B400;
-  --rs-toggle-disabled-bg: @B050;
+  --rs-toggle-loader-ring: rgb(from var(--rs-gray-50) r g b / 30%);
+  --rs-toggle-loader-rotor: var(--rs-gray-0);
+  --rs-toggle-hover-bg: var(--rs-gray-400);
+  --rs-toggle-disabled-bg: var(--rs-gray-50);
   --rs-toggle-disabled-thumb: #fff;
-  --rs-toggle-checked-bg: @H500;
+  --rs-toggle-checked-bg: var(--rs-primary-500);
   --rs-toggle-checked-thumb: #fff;
-  --rs-toggle-checked-hover-bg: @H600;
-  --rs-toggle-checked-disabled-bg: @H100;
+  --rs-toggle-checked-hover-bg: var(--rs-primary-600);
+  --rs-toggle-checked-disabled-bg: var(--rs-primary-100);
   --rs-toggle-checked-disabled-thumb: #fff;
 
   // Slider
-  --rs-slider-bar: @B100;
-  --rs-slider-hover-bar: @B200;
-  --rs-slider-thumb-border: @H500;
+  --rs-slider-bar: var(--rs-gray-100);
+  --rs-slider-hover-bar: var(--rs-gray-200);
+  --rs-slider-thumb-border: var(--rs-primary-500);
   --rs-slider-thumb-bg: #fff;
-  --rs-slider-thumb-hover-shadow: 0 0 0 8px fade(@H500, 25);
-  --rs-slider-progress: @H500;
+  --rs-slider-thumb-hover-shadow: 0 0 0 8px rgb(from var(--rs-gray-500) r g b / 25%);
+  --rs-slider-progress: var(--rs-primary-500);
 
   // Uploader
-  --rs-uploader-item-bg: @B300;
-  --rs-uploader-item-hover-bg: @B050;
-  --rs-uploader-overlay-bg: fade(#fff, 80);
-  --rs-uploader-dnd-bg: @B000;
-  --rs-uploader-dnd-border: @B200;
-  --rs-uploader-dnd-hover-border: @H500;
+  --rs-uploader-item-bg: var(--rs-gray-300);
+  --rs-uploader-item-hover-bg: var(--rs-gray-50);
+  --rs-uploader-overlay-bg: rgb(from #fff r g b / 80%);
+  --rs-uploader-dnd-bg: var(--rs-gray-0);
+  --rs-uploader-dnd-border: var(--rs-gray-200);
+  --rs-uploader-dnd-hover-border: var(--rs-primary-500);
 
   // Avatar
-  --rs-avatar-bg: @B300;
-  --rs-avatar-text: @B000;
+  --rs-avatar-bg: var(--rs-gray-300);
+  --rs-avatar-text: var(--rs-gray-0);
 
   // Badge
-  --rs-badge-bg: @red;
-  --rs-badge-text: @B000;
+  --rs-badge-bg: var(--rs-color-red);
+  --rs-badge-text: var(--rs-gray-0);
 
   // Tag
-  --rs-tag-bg: @B050;
-  --rs-tag-close: @red;
+  --rs-tag-bg: var(--rs-gray-50);
+  --rs-tag-close: var(--rs-color-red);
 
   // Carousel
-  --rs-carousel-bg: @B600;
-  --rs-carousel-indicator: fade(@B000, 40);
-  --rs-carousel-indicator-hover: @B000;
-  --rs-carousel-indicator-active: @H500;
+  --rs-carousel-bg: var(--rs-gray-600);
+  --rs-carousel-indicator: rgb(from var(--rs-gray-0) r g b / 40%);
+  --rs-carousel-indicator-hover: var(--rs-gray-0);
+  --rs-carousel-indicator-active: var(--rs-primary-500);
 
   // Panel
   --rs-panel-shadow: 0 4px 4px rgba(0, 0, 0, 0.12), 0 0 10px rgba(0, 0, 0, 0.06);
 
   // List
-  --rs-list-bg: @B000;
-  --rs-list-border: @B200;
-  --rs-list-hover-bg: @H050;
-  --rs-list-placeholder-bg: fade(@H050, 50%);
-  --rs-list-placeholder-border: @H500;
+  --rs-list-bg: var(--rs-gray-0);
+  --rs-list-border: var(--rs-gray-200);
+  --rs-list-hover-bg: var(--rs-primary-50);
+  --rs-list-placeholder-bg: rgb(from var(--rs-primary-50) r g b / 50%);
+  --rs-list-placeholder-border: var(--rs-primary-500);
 
   // Timeline
-  --rs-timeline-indicator-bg: @B300;
-  --rs-timeline-indicator-active-bg: @H500;
+  --rs-timeline-indicator-bg: var(--rs-gray-300);
+  --rs-timeline-indicator-active-bg: var(--rs-primary-500);
 
   // Table
   --rs-table-shadow: rgba(9, 9, 9, 0.08);
-  --rs-table-sort: @H500;
-  --rs-table-resize: @H500;
-  --rs-table-scrollbar-track: @B200;
-  --rs-table-scrollbar-thumb: @B800;
-  --rs-table-scrollbar-thumb-active: @B900;
-  --rs-table-scrollbar-vertical-track: fade(@B200, 40%);
+  --rs-table-sort: var(--rs-primary-500);
+  --rs-table-resize: var(--rs-primary-500);
+  --rs-table-scrollbar-track: var(--rs-gray-200);
+  --rs-table-scrollbar-thumb: var(--rs-gray-800);
+  --rs-table-scrollbar-thumb-active: var(--rs-gray-900);
+  --rs-table-scrollbar-vertical-track: rgb(from var(--rs-gray-200) r g b / 40%);
 
   // Drawer
   --rs-drawer-shadow: 0 4px 4px rgba(0, 0, 0, 0.12), 0 0 10px rgba(0, 0, 0, 0.06);
@@ -344,23 +354,69 @@
   --rs-modal-shadow: 0 4px 4px rgba(0, 0, 0, 0.12), 0 0 10px rgba(0, 0, 0, 0.06);
 
   // Form
-  --rs-form-errormessage-text: @red;
+  --rs-form-errormessage-text: var(--rs-color-red);
   --rs-form-errormessage-bg: #fff;
-  --rs-form-errormessage-border: @B200;
+  --rs-form-errormessage-border: var(--rs-gray-200);
 
   // Picker
-  --rs-picker-value: @H700;
-  --rs-picker-count-bg: @H500;
+  --rs-picker-value: var(--rs-primary-700);
+  --rs-picker-count-bg: var(--rs-primary-500);
   --rs-picker-count-text: #fff;
 
   // Calendar
-  --rs-calendar-today-bg: @H500;
+  --rs-calendar-today-bg: var(--rs-primary-500);
   --rs-calendar-today-text: #fff;
-  --rs-calendar-range-bg: fade(@H100, 50%);
-  --rs-calendar-time-unit-bg: @B050;
+  --rs-calendar-range-bg: rgb(from var(--rs-primary-100) r g b / 50%);
+  --rs-calendar-time-unit-bg: var(--rs-gray-50);
   --rs-calendar-date-selected-text: #fff;
-  --rs-calendar-cell-selected-hover-bg: @H700;
+  --rs-calendar-cell-selected-hover-bg: var(--rs-primary-700);
 
   // Popover
   --rs-popover-shadow: 0 1px 8px rgba(0, 0, 0, 0.12);
+
+  // CSS relative color syntax is not supported
+  // https://developer.chrome.com/blog/css-relative-color-syntax/
+  @supports not (color: rgb(from white r g b)) {
+    // Misc
+    --rs-bg-backdrop: fade(@B900, 30%);
+    --rs-color-focus-ring: fade(@H500, 25%);
+    --rs-state-focus-shadow: 0 0 0 3px fade(@H500, 25%);
+    --rs-state-focus-outline: 3px solid fade(@H500, 25%);
+
+    // Loader
+    --rs-loader-ring: fade(@B050, 80);
+    --rs-loader-backdrop: fade(@B000, 90%);
+    --rs-loader-ring-inverse: fade(@B050, 30%);
+    --rs-loader-backdrop-inverse: fade(@B900, 83%);
+
+    // Dropdown
+    --rs-dropdown-item-bg-hover: fade(@H100, 50%);
+
+    // ARIA menu
+    --rs-menuitem-active-bg: fade(@H100, 50);
+
+    // ARIA Listboxes
+    --rs-listbox-option-hover-bg: fade(@H100, 50%);
+
+    // Toggle
+    --rs-toggle-loader-ring: fade(@B050, 30%);
+
+    // Slider
+    --rs-slider-thumb-hover-shadow: 0 0 0 8px fade(@H500, 25%);
+
+    // Uploader
+    --rs-uploader-overlay-bg: fade(#fff, 80);
+
+    // Carousel
+    --rs-carousel-indicator: fade(@B000, 40);
+
+    // List
+    --rs-list-placeholder-bg: fade(@H050, 50%);
+
+    // Table
+    --rs-table-scrollbar-vertical-track: fade(@B200, 40%);
+
+    // Calendar
+    --rs-calendar-range-bg: fade(@H100, 50%);
+  }
 }


### PR DESCRIPTION
The main purpose is to make the color used by each component depend on the CSS custom properties in the color palette, rather than directly hard-coding the color value. This allows us to easily change the theme through CSS custom properties in the application without modifying the color value in the component.

- [x] Use CSS custom properties instead of less variables.
- [x] Use CSS relative colors to replace less's fade and lighten function.