### PR TITLE
fix(Drawer): change Drawer title font-size to 18px

### DIFF
--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -123,6 +123,7 @@
 
 @font-family-base:      Apple-System, Arial, Helvetica, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', STXihei, sans-serif;
 
+@font-size-extra-large: 18px;
 @font-size-large:       16px;
 @font-size-base:        14px;
 @font-size-small:       12px;
@@ -147,6 +148,7 @@
 @line-height-large-computed:  22px;
 
 // Unit-less `line-height` for use in components like buttons.
+@line-height-extra-large:     unit((@line-height-large-computed / @font-size-extra-large)); // ~1.222
 @line-height-large:           unit((@line-height-large-computed / @font-size-large)); // ~1.375
 @line-height-base:            unit((@line-height-computed / @font-size-base)); // ~1.4285714285714286
 @line-height-small:           unit((@line-height-computed / @font-size-small)); // ~1.6666666666666667
@@ -517,9 +519,9 @@
 @modal-body-margin:             20px;
 @modal-border-radius:           @border-radius;
 
-@modal-title-font-size:         @font-size-large;
+@modal-title-font-size:         @font-size-extra-large;
 @modal-title-color:             var(--rs-text-primary);
-@modal-title-line-height:       @line-height-large;
+@modal-title-line-height:       @line-height-extra-large;
 
 @modal-close-btn-size:          @font-size-small;
 @modal-close-btn-line-height:   @line-height-small;


### PR DESCRIPTION
## Issue
The current font-size of the Drawer title is 16px, not expected as [Drawer Design](https://rsuitejs.com/design/default/index.html#s20).

<img width="897" alt="image" src="https://github.com/rsuite/rsuite/assets/12592949/fdb69a4d-cec0-4179-b915-e5bed2827b81">


## Solution
In this pull request, I propose a fix to address this issue. Specifically, I've adjusted the style settings for the Drawer title to set the font-size to 18px, aligning it with the desired styling.

## Testing
I conducted testing to verify that the font-size of the Drawer title is indeed set to 18px as intended. 

## Screenshots
<img width="1383" alt="image" src="https://github.com/rsuite/rsuite/assets/12592949/b590da89-d4f9-484d-8ece-e8e6fc789a98">
