### PR TITLE
fix: formControll will pass undefined as value when value is null defaultValue is undefined

### DIFF
--- a/src/FormControl/FormControl.tsx
+++ b/src/FormControl/FormControl.tsx
@@ -193,7 +193,8 @@ const FormControl: FormControlComponent = React.forwardRef((props: FormControlPr
   }
 
   const accepterProps = {
-    [valueKey]: val ?? defaultValue
+    // need to distinguish between undefined and null
+    [valueKey]: val === undefined ? defaultValue : val
   };
 
   return (

--- a/src/FormControl/test/FormControlSpec.tsx
+++ b/src/FormControl/test/FormControlSpec.tsx
@@ -291,6 +291,21 @@ describe('FormControl', () => {
     expect(refError).to.deep.equal({ email: 'The length cannot exceed 2' });
   });
 
+  it('should pass null as value to component when value is null', () => {
+    let refValue = void 0;
+    function CostumeComponent({ value }) {
+      refValue = value;
+      return null;
+    }
+    render(
+      <Form formValue={{ username: null }}>
+        <FormControl accepter={CostumeComponent} name="username" />
+      </Form>
+    );
+
+    expect(refValue).to.be.null;
+  });
+
   describe('rule', () => {
     it("should check the field's rule", () => {
       const formRef = React.createRef<FormInstance>();


### PR DESCRIPTION
fix #3453 

Components do not clear the value because when the `form`'s value becomes null, `formControl` passes undefined to the components. The `useControlled` hook will cache the old value and display it upon the second click of clear. Therefore, it is necessary to distinguish between null and undefined."

