### PR TITLE
fix(Cascader): fix bug in value selection via Enter key

### DIFF
--- a/src/Cascader/Cascader.tsx
+++ b/src/Cascader/Cascader.tsx
@@ -273,6 +273,11 @@ const Cascader = React.forwardRef(<T extends number | string>(props: CascaderPro
     getParent: item => parentMap.get(item),
     callback: useCallback(
       value => {
+        const selectedElement = overlayRef.current?.querySelector(
+          `[data-key="${value}"]`
+        ) as HTMLElement;
+
+        selectedElement?.focus();
         setActiveItem(flattenedData.find(item => item[valueKey] === value));
       },
       [flattenedData, setActiveItem, valueKey]
@@ -285,6 +290,12 @@ const Cascader = React.forwardRef(<T extends number | string>(props: CascaderPro
 
       setSearchKeyword(value);
       onSearch?.(value, event);
+
+      if (!value || items.length === 0) {
+        setFocusItemValue(undefined);
+        return;
+      }
+
       if (items.length > 0) {
         setFocusItemValue(items[0][valueKey]);
         setLayer(0);
@@ -494,6 +505,8 @@ const Cascader = React.forwardRef(<T extends number | string>(props: CascaderPro
         aria-disabled={disabled}
         data-key={item[valueKey]}
         className={itemClasses}
+        tabIndex={-1}
+        role="option"
         onClick={event => {
           if (!disabled) {
             handleSearchRowSelect(item, nodes, event);
@@ -512,7 +525,7 @@ const Cascader = React.forwardRef(<T extends number | string>(props: CascaderPro
 
     const items = getSearchResult();
     return (
-      <div className={prefix('cascader-search-panel')} data-layer={0}>
+      <div className={prefix('cascader-search-panel')} data-layer={0} role="listbox">
         {items.length ? (
           items.map(renderSearchRow)
         ) : (

--- a/src/Cascader/test/CascaderSpec.tsx
+++ b/src/Cascader/test/CascaderSpec.tsx
@@ -7,6 +7,7 @@ import { getInstance } from '@test/testUtils';
 import { PickerHandle } from '../../Picker';
 import '../styles/index.less';
 import { testStandardProps } from '@test/commonCases';
+import userEvent from '@testing-library/user-event';
 
 const items = [
   {
@@ -673,6 +674,27 @@ describe('Cascader', () => {
       expect(focusItems).to.length(1);
       expect(focusItems[0]).to.have.text('2');
     });
+
+    it('Should be selected for focus item by Enter key', () => {
+      render(<Cascader data={items} />);
+
+      userEvent.click(screen.getByRole('combobox'));
+
+      // eslint-disable-next-line testing-library/no-node-access
+      const input = screen.getByRole('searchbox').querySelector('input') as HTMLInputElement;
+
+      userEvent.type(input, '1');
+      userEvent.type(screen.getByRole('combobox'), '{enter}');
+
+      expect(screen.getByRole('combobox')).to.have.text('1');
+
+      userEvent.click(screen.getByRole('button', { name: 'Clear' }));
+      userEvent.click(screen.getByRole('combobox'));
+      userEvent.type(input, '12');
+      userEvent.type(screen.getByRole('combobox'), '{enter}');
+
+      expect(screen.getByRole('combobox')).to.have.text('Select');
+    });
   });
 
   describe('Loading state', () => {
@@ -687,7 +709,7 @@ describe('Cascader', () => {
 
       fireEvent.click(screen.getByRole('combobox'));
 
-      expect(screen.queryByRole('listbox')).not.to.exist;
+      expect(screen.queryByRole('tree')).not.to.exist;
     });
 
     it('Should not open menu on Enter key when loading=true', () => {
@@ -697,7 +719,7 @@ describe('Cascader', () => {
         key: 'Enter'
       });
 
-      expect(screen.queryByRole('listbox')).not.to.exist;
+      expect(screen.queryByRole('tree')).not.to.exist;
     });
   });
 });

--- a/src/MultiCascader/test/MultiCascaderSpec.tsx
+++ b/src/MultiCascader/test/MultiCascaderSpec.tsx
@@ -483,7 +483,7 @@ describe('MultiCascader', () => {
 
       fireEvent.click(screen.getByRole('combobox'));
 
-      expect(screen.queryByRole('listbox')).not.to.exist;
+      expect(screen.queryByRole('tree')).not.to.exist;
     });
 
     it('Should not open menu on Enter key when loading=true', () => {
@@ -493,7 +493,7 @@ describe('MultiCascader', () => {
         key: 'Enter'
       });
 
-      expect(screen.queryByRole('listbox')).not.to.exist;
+      expect(screen.queryByRole('tree')).not.to.exist;
     });
   });
 });


### PR DESCRIPTION
When no option is found in Cascader, clicking the Enter key will select an incorrect value.

https://github.com/rsuite/rsuite/assets/1203827/865207dd-e43b-4749-a825-c1d7582a6d6d


> After fixed:  https://rsuite-nextjs-git-fix-cascader-selected-rsuite.vercel.app/components/cascader/

