### PR TITLE
fix: improve accessibility of picker related components

### DIFF
--- a/src/Cascader/Cascader.tsx
+++ b/src/Cascader/Cascader.tsx
@@ -273,11 +273,6 @@ const Cascader = React.forwardRef(<T extends number | string>(props: CascaderPro
     getParent: item => parentMap.get(item),
     callback: useCallback(
       value => {
-        const selectedElement = overlayRef.current?.querySelector(
-          `[data-key="${value}"]`
-        ) as HTMLElement;
-
-        selectedElement?.focus();
         setActiveItem(flattenedData.find(item => item[valueKey] === value));
       },
       [flattenedData, setActiveItem, valueKey]
@@ -326,7 +321,10 @@ const Cascader = React.forwardRef(<T extends number | string>(props: CascaderPro
 
   const handleClose = useCallback(() => {
     triggerRef.current?.close();
-  }, [triggerRef]);
+
+    // The focus is on the trigger button after closing
+    targetRef.current?.focus?.();
+  }, []);
 
   const handleClean = useCallback(
     (event: React.SyntheticEvent) => {

--- a/src/CheckPicker/test/CheckPickerSpec.tsx
+++ b/src/CheckPicker/test/CheckPickerSpec.tsx
@@ -605,4 +605,39 @@ describe('CheckPicker', () => {
       expect(instance.list).to.exist;
     });
   });
+
+  describe('Accessibility', () => {
+    it('Should have a role combobox', () => {
+      render(<CheckPicker data={data} />);
+
+      expect(screen.getByRole('combobox')).to.exist;
+    });
+
+    it('Should have a role listbox', () => {
+      render(<CheckPicker data={data} defaultOpen />);
+
+      expect(screen.getByRole('listbox')).to.exist;
+    });
+
+    it('Should have a role option', () => {
+      render(<CheckPicker data={data} defaultOpen />);
+
+      expect(screen.getAllByRole('option')).to.have.lengthOf(3);
+    });
+
+    it('Should have a role searchbox', () => {
+      render(<CheckPicker data={data} defaultOpen />);
+
+      expect(screen.getByRole('searchbox')).to.exist;
+    });
+
+    it('Should be the focus switch option via keyboard', () => {
+      render(<CheckPicker data={data} />);
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' });
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'ArrowDown' });
+
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(document.activeElement).to.have.text('Eugenia');
+    });
+  });
 });

--- a/src/InputPicker/InputPicker.tsx
+++ b/src/InputPicker/InputPicker.tsx
@@ -220,7 +220,10 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
 
     const handleClose = useCallback(() => {
       triggerRef?.current?.close();
-    }, [triggerRef]);
+
+      // The focus is on the trigger button after closing
+      targetRef.current?.focus?.();
+    }, []);
 
     // Used to hover the focuse item  when trigger `onKeydown`
     const { focusItemValue, setFocusItemValue, onKeyDown } = useFocusItemValue(
@@ -829,7 +832,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
             plaintext={plaintext}
             ref={targetRef}
             as={toggleAs}
-            tabIndex={undefined}
+            tabIndex={tabIndex}
             onClean={handleClean}
             cleanable={cleanable && !disabled}
             hasValue={hasValue}
@@ -848,7 +851,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
               {displaySearchInput && (
                 <InputSearch
                   {...inputProps}
-                  tabIndex={tabIndex}
+                  tabIndex={-1}
                   readOnly={readOnly}
                   onBlur={onBlur}
                   onFocus={createChainedFunction(handleFocus, onFocus)}

--- a/src/InputPicker/test/InputPickerSpec.tsx
+++ b/src/InputPicker/test/InputPickerSpec.tsx
@@ -374,12 +374,6 @@ describe('InputPicker', () => {
     expect(container.firstChild).to.not.have.class('rs-picker-has-value');
   });
 
-  it('Should set a tabindex for input', () => {
-    render(<InputPicker data={[]} tabIndex={10} />);
-
-    expect(screen.getByRole('textbox')).to.have.attribute('tabindex', '10');
-  });
-
   it('Should call `onCreate` callback with correct value', () => {
     const inputRef = React.createRef<PickerHandle>();
 
@@ -462,6 +456,41 @@ describe('InputPicker', () => {
       });
 
       expect(screen.queryByRole('listbox')).not.to.exist;
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('Should have a role combobox', () => {
+      render(<InputPicker data={data} />);
+
+      expect(screen.getByRole('combobox')).to.exist;
+    });
+
+    it('Should have a role listbox', () => {
+      render(<InputPicker data={data} defaultOpen />);
+
+      expect(screen.getByRole('listbox')).to.exist;
+    });
+
+    it('Should have a role option', () => {
+      render(<InputPicker data={data} defaultOpen />);
+
+      expect(screen.getAllByRole('option')).to.have.lengthOf(3);
+    });
+
+    it('Should set a tabindex for input', () => {
+      render(<InputPicker data={[]} tabIndex={10} />);
+
+      expect(screen.getByRole('combobox')).to.have.attribute('tabindex', '10');
+    });
+
+    it('Should be the focus switch option via keyboard', () => {
+      render(<InputPicker data={data} />);
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' });
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'ArrowDown' });
+
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(document.activeElement).to.have.text('Eugenia');
     });
   });
 });

--- a/src/Picker/utils.ts
+++ b/src/Picker/utils.ts
@@ -237,6 +237,17 @@ export const useFocusItemValue = <T, D>(
   const [layer, setLayer] = useState(defaultLayer);
   const [keys, setKeys] = useState<any[]>([]);
 
+  const focusCallback = useCallback(
+    (value: any, event: React.KeyboardEvent) => {
+      const menu = isFunction(target) ? target() : target;
+      const focusElement = menu?.querySelector(`[data-key="${value}"]`) as HTMLElement;
+
+      focusElement?.focus();
+      callback?.(value, event);
+    },
+    [callback, target]
+  );
+
   const getScrollContainer = useCallback(() => {
     const menu = isFunction(target) ? target() : target;
 
@@ -331,12 +342,12 @@ export const useFocusItemValue = <T, D>(
 
         if (!isUndefined(focusItem)) {
           setFocusItemValue(focusItem[valueKey]);
-          callback?.(focusItem[valueKey], event);
+          focusCallback(focusItem[valueKey], event);
           scrollListItem('bottom', focusItem[valueKey], willOverflow);
         }
       });
     },
-    [callback, findFocusItemIndex, scrollListItem, valueKey]
+    [focusCallback, findFocusItemIndex, scrollListItem, valueKey]
   );
 
   const focusPrevMenuItem = useCallback(
@@ -347,12 +358,12 @@ export const useFocusItemValue = <T, D>(
         const focusItem = items[nextIndex];
         if (!isUndefined(focusItem)) {
           setFocusItemValue(focusItem[valueKey]);
-          callback?.(focusItem[valueKey], event);
+          focusCallback(focusItem[valueKey], event);
           scrollListItem('top', focusItem[valueKey], willOverflow);
         }
       });
     },
-    [callback, findFocusItemIndex, scrollListItem, valueKey]
+    [focusCallback, findFocusItemIndex, scrollListItem, valueKey]
   );
 
   const getSubMenuKeys = useCallback(
@@ -380,10 +391,10 @@ export const useFocusItemValue = <T, D>(
         setKeys(nextKeys);
         setLayer(nextLayer);
         setFocusItemValue(nextKeys[0]);
-        callback?.(nextKeys[0], event);
+        focusCallback(nextKeys[0], event);
       }
     },
-    [callback, getSubMenuKeys, layer]
+    [focusCallback, getSubMenuKeys, layer]
   );
 
   const focusPrevLevelMenu = useCallback(
@@ -400,11 +411,11 @@ export const useFocusItemValue = <T, D>(
 
         if (parentItemValue) {
           setFocusItemValue(parentItemValue);
-          callback?.(parentItemValue, event);
+          focusCallback(parentItemValue, event);
         }
       }
     },
-    [callback, data, focusItemValue, getParent, getSubMenuKeys, layer, valueKey]
+    [focusCallback, data, focusItemValue, getParent, getSubMenuKeys, layer, valueKey]
   );
 
   const handleKeyDown = useCallback(
@@ -475,8 +486,11 @@ export const useToggleKeyDownEvent = (props: ToggleKeyDownEventProps) => {
 
   const handleClose = useCallback(() => {
     triggerRef.current?.close?.();
+
+    // The focus is on the trigger button after closing
+    targetRef.current?.focus?.();
     onClose?.();
-  }, [onClose, triggerRef]);
+  }, [onClose, targetRef, triggerRef]);
 
   const handleOpen = useCallback(() => {
     triggerRef.current?.open?.();

--- a/src/SelectPicker/test/SelectPickerSpec.tsx
+++ b/src/SelectPicker/test/SelectPickerSpec.tsx
@@ -535,4 +535,39 @@ describe('SelectPicker', () => {
       }).to.not.throw();
     });
   });
+
+  describe('Accessibility', () => {
+    it('Should have a role combobox', () => {
+      render(<SelectPicker data={data} />);
+
+      expect(screen.getByRole('combobox')).to.exist;
+    });
+
+    it('Should have a role listbox', () => {
+      render(<SelectPicker data={data} defaultOpen />);
+
+      expect(screen.getByRole('listbox')).to.exist;
+    });
+
+    it('Should have a role option', () => {
+      render(<SelectPicker data={data} defaultOpen />);
+
+      expect(screen.getAllByRole('option')).to.have.lengthOf(3);
+    });
+
+    it('Should have a role searchbox', () => {
+      render(<SelectPicker data={data} defaultOpen />);
+
+      expect(screen.getByRole('searchbox')).to.exist;
+    });
+
+    it('Should be the focus switch option via keyboard', () => {
+      render(<SelectPicker data={data} />);
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' });
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'ArrowDown' });
+
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(document.activeElement).to.have.text('Eugenia');
+    });
+  });
 });

--- a/src/TagPicker/test/TagPickerSpec.tsx
+++ b/src/TagPicker/test/TagPickerSpec.tsx
@@ -382,12 +382,6 @@ describe('TagPicker', () => {
     expect(container.firstChild).not.to.have.class('rs-picker-has-value');
   });
 
-  it('Should set a tabindex for input', () => {
-    render(<TagPicker data={[]} tabIndex={10} />);
-
-    expect(screen.getByRole('textbox')).to.have.attr('tabIndex', '10');
-  });
-
   it('Should call `onCreate` with correct value', async () => {
     const onCreate = sinon.spy();
 
@@ -490,6 +484,41 @@ describe('TagPicker', () => {
       });
 
       expect(screen.queryByRole('listbox')).not.to.exist;
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('Should have a role combobox', () => {
+      render(<TagPicker data={data} />);
+
+      expect(screen.getByRole('combobox')).to.exist;
+    });
+
+    it('Should have a role listbox', () => {
+      render(<TagPicker data={data} defaultOpen />);
+
+      expect(screen.getByRole('listbox')).to.exist;
+    });
+
+    it('Should have a role option', () => {
+      render(<TagPicker data={data} defaultOpen />);
+
+      expect(screen.getAllByRole('option')).to.have.lengthOf(3);
+    });
+
+    it('Should set a tabindex for input', () => {
+      render(<TagPicker data={[]} tabIndex={10} />);
+
+      expect(screen.getByRole('combobox')).to.have.attribute('tabindex', '10');
+    });
+
+    it('Should be the focus switch option via keyboard', () => {
+      render(<TagPicker data={data} />);
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' });
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'ArrowDown' });
+
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(document.activeElement).to.have.text('Eugenia');
     });
   });
 });


### PR DESCRIPTION
- Focus the selected element when selecting a value using the up and down keys on the keyboard.  fix: https://github.com/rsuite/rsuite/issues/3442
- Focus returns to trigger button after options list is closed.