### PR TITLE
fix(DatePicker): improve DatePicker accessibility

### DIFF
--- a/docs/pages/components/date-picker/fragments/basic.md
+++ b/docs/pages/components/date-picker/fragments/basic.md
@@ -5,10 +5,10 @@ import { DatePicker, Stack } from 'rsuite';
 
 const App = () => (
   <Stack direction="column" alignItems="flex-start" spacing={6}>
-    <DatePicker format="yyyy-MM" ranges={[]} />
-    <DatePicker />
-    <DatePicker format="yyyy-MM-dd HH:mm" />
-    <DatePicker format="yyyy-MM-dd HH:mm:ss" />
+    <DatePicker format="MM/yyyy" ranges={[]} />
+    <DatePicker format="MM/dd/yyyy" />
+    <DatePicker format="MM/dd/yyyy HH:mm" />
+    <DatePicker format="MM/dd/yyyy HH:mm:ss" />
     <DatePicker format="HH:mm:ss" ranges={[]} />
   </Stack>
 );

--- a/docs/pages/components/date-picker/fragments/disabled.md
+++ b/docs/pages/components/date-picker/fragments/disabled.md
@@ -14,11 +14,11 @@ const App = () => (
     <DatePicker disabled style={{ width: 200 }} />
     <br />
     <Label>Disabled date: </Label>
-    <DatePicker disabledDate={date => isBefore(date, new Date())} style={{ width: 200 }} />
+    <DatePicker shouldDisableDate={date => isBefore(date, new Date())} style={{ width: 200 }} />
     <br />
     <Label>Disabled month: </Label>
     <DatePicker
-      disabledDate={date => isBefore(date, new Date())}
+      shouldDisableDate={date => isBefore(date, new Date())}
       format="yyyy-MM"
       style={{ width: 200 }}
     />
@@ -28,9 +28,9 @@ const App = () => (
       format="HH:mm:ss"
       ranges={[]}
       defaultValue={new Date('2017-12-12 09:15:30')}
-      disabledHours={hour => hour < 8 || hour > 18}
-      disabledMinutes={minute => minute % 15 !== 0}
-      disabledSeconds={second => second % 30 !== 0}
+      shouldDisableHour={hour => hour < 8 || hour > 18}
+      shouldDisableMinute={minute => minute % 15 !== 0}
+      shouldDisableSecond={second => second % 30 !== 0}
       style={{ width: 200 }}
     />
     <br />

--- a/src/Calendar/CalendarContainer.tsx
+++ b/src/Calendar/CalendarContainer.tsx
@@ -145,8 +145,8 @@ const CalendarContainer: RsRefForwardingComponent<'div', CalendarProps> = React.
       inline,
       ...rest
     } = props;
-    const { withClassPrefix, merge, prefix } = useClassNames(classPrefix);
 
+    const { withClassPrefix, merge, prefix } = useClassNames(classPrefix);
     const { calendarState, reset, openMonth, openTime } = useCalendarState(defaultState);
 
     const isDisabledDate = useCallback(

--- a/src/Calendar/MonthDropdown.tsx
+++ b/src/Calendar/MonthDropdown.tsx
@@ -107,7 +107,7 @@ const MonthDropdown: RsRefForwardingComponent<'div', MonthDropdownProps> = React
             <div className={titleClassName} role="rowheader">
               {year}
             </div>
-            <div className={prefix('list')} role="gridcell">
+            <div className={prefix('list')}>
               {monthMap.map((item, month) => {
                 return (
                   <MonthDropdownItem

--- a/src/Calendar/MonthDropdownItem.tsx
+++ b/src/Calendar/MonthDropdownItem.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { composeFunctions, useClassNames } from '../utils';
+import { composeFunctions, useClassNames, useCustom } from '../utils';
 import { setMonth, setYear } from '../utils/dateUtils';
 import { RsRefForwardingComponent, WithAsProps } from '../@types/common';
 import { useCalendarContext } from './CalendarContext';
+import { getAriaLabel } from './utils';
 
 export interface MonthDropdownItemProps extends WithAsProps {
   month?: number;
@@ -25,6 +26,18 @@ const MonthDropdownItem: RsRefForwardingComponent<'div', MonthDropdownItemProps>
       ...rest
     } = props;
     const { date, onChangeMonth: onSelect } = useCalendarContext();
+    const { locale, formatDate } = useCustom('Calendar');
+    const formatStr = locale.formattedMonthPattern;
+
+    const currentMonth = useMemo(() => {
+      if (year && month) {
+        return composeFunctions(
+          d => setYear(d, year),
+          d => setMonth(d, month - 1)
+        )(date);
+      }
+      return date;
+    }, [date, month, year]);
 
     const handleClick = useCallback(
       (event: React.MouseEvent) => {
@@ -32,29 +45,27 @@ const MonthDropdownItem: RsRefForwardingComponent<'div', MonthDropdownItemProps>
           return;
         }
 
-        if (year && month && date) {
-          const nextMonth = composeFunctions(
-            d => setYear(d, year),
-            d => setMonth(d, month - 1)
-          )(date);
-
-          onSelect?.(nextMonth, event);
-        }
+        onSelect?.(currentMonth, event);
       },
-      [date, disabled, month, onSelect, year]
+      [currentMonth, disabled, onSelect]
     );
 
     const { prefix, merge, withClassPrefix } = useClassNames(classPrefix);
     const classes = merge(className, withClassPrefix({ active }), { disabled });
+    const ariaLabel = currentMonth ? getAriaLabel(currentMonth, formatStr, formatDate) : '';
 
     return (
       <Component
-        {...rest}
+        key={month}
+        role="gridcell"
+        aria-selected={active ? true : undefined}
+        aria-disabled={disabled ? true : undefined}
+        aria-label={ariaLabel}
+        tabIndex={active ? 0 : -1}
         ref={ref}
         className={classes}
         onClick={handleClick}
-        key={month}
-        tabIndex={-1}
+        {...rest}
       >
         <span className={prefix('content')}>{month}</span>
       </Component>

--- a/src/Calendar/TableCell.tsx
+++ b/src/Calendar/TableCell.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import partial from 'lodash/partial';
+import { DateUtils, useClassNames, useCustom } from '../utils';
+import { isSameDay } from '../utils/dateUtils';
+import { useCalendarContext } from './CalendarContext';
+import { RsRefForwardingComponent, WithAsProps } from '../@types/common';
+import { getAriaLabel } from './utils';
+
+export interface TableCellProps extends WithAsProps {
+  date: Date;
+  disabled?: boolean;
+  selected?: boolean;
+  unSameMonth?: boolean;
+  rangeStart?: boolean;
+  rangeEnd?: boolean;
+  inRange?: boolean;
+  onSelect?: (date: Date, disabled: boolean | void, event: React.MouseEvent) => void;
+}
+
+const TableCell: RsRefForwardingComponent<'div', TableCellProps> = React.forwardRef(
+  (props: TableCellProps, ref) => {
+    const {
+      as: Component = 'div',
+      classPrefix = 'calendar-table',
+      disabled,
+      selected,
+      date,
+      onSelect,
+      unSameMonth,
+      rangeStart,
+      rangeEnd,
+      inRange,
+      ...rest
+    } = props;
+
+    const { onMouseMove, cellClassName, renderCell, locale: overrideLocale } = useCalendarContext();
+    const { prefix, merge } = useClassNames(classPrefix);
+    const { locale, formatDate } = useCustom('Calendar', overrideLocale);
+    const formatStr = locale.formattedDayPattern;
+    const ariaLabel = getAriaLabel(date, formatStr, formatDate);
+    const todayDate = new Date();
+    const isToday = isSameDay(date, todayDate);
+
+    const classes = merge(
+      prefix('cell', {
+        'cell-un-same-month': unSameMonth,
+        'cell-is-today': isToday,
+        'cell-selected': selected,
+        'cell-selected-start': rangeStart,
+        'cell-selected-end': rangeEnd,
+        'cell-in-range': !unSameMonth && inRange,
+        'cell-disabled': disabled
+      }),
+      cellClassName?.(date)
+    );
+
+    return (
+      <Component
+        ref={ref}
+        role="gridcell"
+        aria-label={ariaLabel}
+        aria-selected={selected || undefined}
+        aria-disabled={disabled || undefined}
+        tabIndex={selected ? 0 : -1}
+        title={isToday ? `${ariaLabel} (${locale?.today})` : ariaLabel}
+        className={classes}
+        onMouseEnter={!disabled && onMouseMove ? onMouseMove.bind(null, date) : undefined}
+        onClick={onSelect ? partial(onSelect, date, disabled) : undefined}
+        {...rest}
+      >
+        <div className={prefix('cell-content')}>
+          <span className={prefix('cell-day')}>{DateUtils.getDate(date)}</span>
+          {renderCell?.(date)}
+        </div>
+      </Component>
+    );
+  }
+);
+
+TableCell.displayName = 'CalendarTableCell';
+
+export default TableCell;

--- a/src/Calendar/TableHeaderRow.tsx
+++ b/src/Calendar/TableHeaderRow.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import upperFirst from 'lodash/upperFirst';
 import { useClassNames } from '../utils';
 import { RsRefForwardingComponent, WithAsProps } from '../@types/common';
 import { useCalendarContext } from './CalendarContext';
@@ -25,7 +26,12 @@ const TableHeaderRow: RsRefForwardingComponent<'div', TableHeaderRowProps> = Rea
       <Component role="row" {...rest} ref={ref} className={classes}>
         {showWeekNumbers && <div className={prefix('header-cell')} role="columnheader" />}
         {items.map(key => (
-          <div key={key} className={prefix('header-cell')} role="columnheader">
+          <div
+            key={key}
+            className={prefix('header-cell')}
+            role="columnheader"
+            aria-label={upperFirst(key)}
+          >
             <span className={prefix('header-cell-content')}>{locale?.[key]}</span>
           </div>
         ))}

--- a/src/Calendar/TableRow.tsx
+++ b/src/Calendar/TableRow.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
-import partial from 'lodash/partial';
-import { DateUtils, useClassNames, DATERANGE_DISABLED_TARGET, useCustom } from '../utils';
+import { useClassNames, DATERANGE_DISABLED_TARGET } from '../utils';
+import { isSameDay, addDays, isBefore, isAfter, format } from '../utils/dateUtils';
 import { useCalendarContext } from './CalendarContext';
 import { RsRefForwardingComponent, WithAsProps } from '../@types/common';
-
+import TableCell from './TableCell';
 export interface TableRowProps extends WithAsProps {
   weekendDate?: Date;
 }
@@ -25,14 +25,9 @@ const TableRow: RsRefForwardingComponent<'div', TableRowProps> = React.forwardRe
       hoverRangeValue,
       inSameMonth,
       isoWeek,
-      onMouseMove,
       onSelect,
-      cellClassName,
-      renderCell,
-      locale: overrideLocale,
       showWeekNumbers
     } = useCalendarContext();
-    const { locale, formatDate } = useCustom('Calendar', overrideLocale);
     const { prefix, merge } = useClassNames(classPrefix);
 
     const handleSelect = useCallback(
@@ -40,104 +35,64 @@ const TableRow: RsRefForwardingComponent<'div', TableRowProps> = React.forwardRe
         if (disabled) {
           return;
         }
-
         onSelect?.(date, event);
       },
       [onSelect]
     );
 
     const renderDays = () => {
-      const formatStr = locale.formattedDayPattern;
       const days: React.ReactElement[] = [];
       const [selectedStartDate, selectedEndDate] = dateRange || [];
       const [hoverStartDate, hoverEndDate] = hoverRangeValue ?? [];
       const isRangeSelectionMode = typeof dateRange !== 'undefined';
-      const todayDate = new Date();
 
       for (let i = 0; i < 7; i += 1) {
-        const thisDate = DateUtils.addDays(weekendDate, i);
+        const thisDate = addDays(weekendDate, i);
         const disabled = disabledDate?.(thisDate, dateRange, DATERANGE_DISABLED_TARGET.CALENDAR);
-        const isToday = DateUtils.isSameDay(thisDate, todayDate);
+
         const unSameMonth = !inSameMonth?.(thisDate);
-        const isStartSelected =
-          !unSameMonth && selectedStartDate && DateUtils.isSameDay(thisDate, selectedStartDate);
-        const isEndSelected =
-          !unSameMonth && selectedEndDate && DateUtils.isSameDay(thisDate, selectedEndDate);
+        const rangeStart =
+          !unSameMonth && selectedStartDate && isSameDay(thisDate, selectedStartDate);
+        const rangeEnd = !unSameMonth && selectedEndDate && isSameDay(thisDate, selectedEndDate);
         const isSelected = isRangeSelectionMode
-          ? isStartSelected || isEndSelected
-          : DateUtils.isSameDay(thisDate, selected);
+          ? rangeStart || rangeEnd
+          : isSameDay(thisDate, selected);
 
         // TODO-Doma Move those logic that's for DatePicker/DateRangePicker to a separate component
         //           Calendar is not supposed to be reused this way
         let inRange = false;
         // for Selected
         if (selectedStartDate && selectedEndDate) {
-          if (
-            DateUtils.isBefore(thisDate, selectedEndDate) &&
-            DateUtils.isAfter(thisDate, selectedStartDate)
-          ) {
+          if (isBefore(thisDate, selectedEndDate) && isAfter(thisDate, selectedStartDate)) {
             inRange = true;
           }
-          if (
-            DateUtils.isBefore(thisDate, selectedStartDate) &&
-            DateUtils.isAfter(thisDate, selectedEndDate)
-          ) {
+          if (isBefore(thisDate, selectedStartDate) && isAfter(thisDate, selectedEndDate)) {
             inRange = true;
           }
         }
 
         // for Hovering
         if (!isSelected && hoverStartDate && hoverEndDate) {
-          if (
-            !DateUtils.isAfter(thisDate, hoverEndDate) &&
-            !DateUtils.isBefore(thisDate, hoverStartDate)
-          ) {
+          if (!isAfter(thisDate, hoverEndDate) && !isBefore(thisDate, hoverStartDate)) {
             inRange = true;
           }
-          if (
-            !DateUtils.isAfter(thisDate, hoverStartDate) &&
-            !DateUtils.isBefore(thisDate, hoverEndDate)
-          ) {
+          if (!isAfter(thisDate, hoverStartDate) && !isBefore(thisDate, hoverEndDate)) {
             inRange = true;
           }
         }
 
-        const classes = merge(
-          prefix('cell', {
-            'cell-un-same-month': unSameMonth,
-            'cell-is-today': isToday,
-            'cell-selected': isSelected,
-            'cell-selected-start': isStartSelected,
-            'cell-selected-end': isEndSelected,
-            'cell-in-range': !unSameMonth && inRange,
-            'cell-disabled': disabled
-          }),
-          cellClassName?.(thisDate)
-        );
-
-        const title = formatDate
-          ? formatDate(thisDate, formatStr)
-          : DateUtils.format(thisDate, formatStr);
         days.push(
-          <div
-            role="gridcell"
-            key={title}
-            aria-label={title}
-            aria-selected={isSelected || undefined}
-            className={classes}
-          >
-            <div
-              role="button"
-              className={prefix('cell-content')}
-              tabIndex={-1}
-              title={isToday ? `${title} (${locale?.today})` : title}
-              onMouseEnter={!disabled && onMouseMove ? onMouseMove.bind(null, thisDate) : undefined}
-              onClick={partial(handleSelect, thisDate, disabled)}
-            >
-              <span className={prefix('cell-day')}>{DateUtils.getDate(thisDate)}</span>
-              {renderCell && renderCell(thisDate)}
-            </div>
-          </div>
+          <TableCell
+            key={format(thisDate, 'yyyy-MM-dd')}
+            date={thisDate}
+            disabled={disabled}
+            selected={isSelected}
+            onSelect={handleSelect}
+            unSameMonth={unSameMonth}
+            rangeStart={rangeStart}
+            rangeEnd={rangeEnd}
+            inRange={inRange}
+          />
         );
       }
       return days;
@@ -149,7 +104,7 @@ const TableRow: RsRefForwardingComponent<'div', TableRowProps> = React.forwardRe
       <Component {...rest} ref={ref} role="row" className={classes}>
         {showWeekNumbers && (
           <div className={prefix('cell-week-number')} role="rowheader">
-            {DateUtils.format(weekendDate, isoWeek ? 'I' : 'w')}
+            {format(weekendDate, isoWeek ? 'I' : 'w')}
           </div>
         )}
         {renderDays()}

--- a/src/Calendar/test/CalendarMonthDropdownItemSpec.tsx
+++ b/src/Calendar/test/CalendarMonthDropdownItemSpec.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import ReactTestUtils from 'react-dom/test-utils';
+import { render, fireEvent, screen } from '@testing-library/react';
 import MonthDropdownItem from '../MonthDropdownItem';
 import { format } from '../../utils/dateUtils';
 import CalendarContext from '../CalendarContext';
@@ -10,11 +9,10 @@ import { testStandardProps } from '@test/commonCases';
 describe('Calendar-MonthDropdownItem', () => {
   testStandardProps(<MonthDropdownItem />);
 
-  it('Should output a  `1` ', () => {
-    const { container } = render(<MonthDropdownItem month={1} />);
+  it('Should output a `1` ', () => {
+    render(<MonthDropdownItem month={1} />);
 
-    expect(container.firstChild).to.have.tagName('DIV');
-    expect(container.firstChild).to.have.text('1');
+    expect(screen.getByRole('gridcell')).to.have.text('1');
   });
 
   it('Should call `onSelect` callback with correct date', () => {
@@ -29,9 +27,42 @@ describe('Calendar-MonthDropdownItem', () => {
       </CalendarContext.Provider>
     );
 
-    ReactTestUtils.Simulate.click(ref.current as HTMLDivElement);
+    fireEvent.click(ref.current as HTMLDivElement);
 
     expect(onChangeMonth).to.have.been.calledOnce;
     expect(format(onChangeMonth.firstCall.args[0], 'yyyy-MM')).to.equal('2017-01');
+  });
+
+  describe('Accessibility', () => {
+    it('Should have a aria-disabled attribute', () => {
+      render(<MonthDropdownItem disabled />);
+
+      expect(screen.getByRole('gridcell')).to.have.attribute('aria-disabled');
+    });
+
+    it('Should have a aria-selected attribute', () => {
+      render(<MonthDropdownItem active />);
+
+      expect(screen.getByRole('gridcell')).to.have.attribute('aria-selected');
+    });
+
+    it('Should have a aria-label attribute', () => {
+      render(
+        <CalendarContext.Provider value={{ date: new Date(), locale: {}, isoWeek: false }}>
+          <MonthDropdownItem month={1} year={2023} />
+        </CalendarContext.Provider>
+      );
+      expect(screen.getByRole('gridcell')).to.have.attribute('aria-label', 'Jan 2023');
+    });
+
+    it('Should have a tabIndex attribute', () => {
+      const { rerender } = render(<MonthDropdownItem />);
+
+      expect(screen.getByRole('gridcell')).to.have.attribute('tabindex', '-1');
+
+      rerender(<MonthDropdownItem active />);
+
+      expect(screen.getByRole('gridcell')).to.have.attribute('tabindex', '0');
+    });
   });
 });

--- a/src/Calendar/test/CalendarMonthDropdownSpec.tsx
+++ b/src/Calendar/test/CalendarMonthDropdownSpec.tsx
@@ -19,9 +19,10 @@ describe('Calendar-MonthDropdown', () => {
       </CalendarContext.Provider>
     );
 
+    console.log(screen.getAllByRole('gridcell', { hidden: true }).length);
+
     expect(screen.getAllByRole('rowheader', { hidden: true })).to.be.lengthOf(7);
-    expect(screen.getAllByRole('gridcell', { hidden: true })).to.be.lengthOf(7);
-    expect(screen.getAllByRole('gridcell', { hidden: true })[0].childNodes).to.be.lengthOf(12);
+    expect(screen.getAllByRole('gridcell', { hidden: true })).to.be.lengthOf(7 * 12);
   });
 
   it('Should output year and month of current year', () => {

--- a/src/Calendar/test/CalendarTableCellSpec.tsx
+++ b/src/Calendar/test/CalendarTableCellSpec.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import sinon from 'sinon';
+import TableCell from '../TableCell';
+import CalendarContext from '../CalendarContext';
+import { testStandardProps } from '@test/commonCases';
+
+describe('Calendar-TableHeaderRow', () => {
+  testStandardProps(<TableCell date={new Date()} />);
+
+  it('Should render a div with "rs-calendar-table-cell" class', () => {
+    render(<TableCell date={new Date()} />);
+
+    expect(screen.getByRole('gridcell')).to.have.class('rs-calendar-table-cell');
+  });
+
+  it('Should be disabled', () => {
+    render(<TableCell date={new Date()} disabled />);
+    expect(screen.getByRole('gridcell')).to.have.class('rs-calendar-table-cell-disabled');
+  });
+
+  it('Should be selected', () => {
+    render(<TableCell date={new Date()} selected />);
+    expect(screen.getByRole('gridcell')).to.have.class('rs-calendar-table-cell-selected');
+  });
+
+  it('Should be selected start', () => {
+    render(<TableCell date={new Date()} rangeStart />);
+    expect(screen.getByRole('gridcell')).to.have.class('rs-calendar-table-cell-selected-start');
+  });
+
+  it('Should be selected end', () => {
+    render(<TableCell date={new Date()} rangeEnd />);
+    expect(screen.getByRole('gridcell')).to.have.class('rs-calendar-table-cell-selected-end');
+  });
+
+  it('Should be in range', () => {
+    render(<TableCell date={new Date()} inRange />);
+    expect(screen.getByRole('gridcell')).to.have.class('rs-calendar-table-cell-in-range');
+  });
+
+  it('Should be unSameMonth', () => {
+    render(<TableCell date={new Date()} unSameMonth />);
+    expect(screen.getByRole('gridcell')).to.have.class('rs-calendar-table-cell-un-same-month');
+  });
+
+  it('Should be today', () => {
+    render(<TableCell date={new Date()} />);
+    expect(screen.getByRole('gridcell')).to.have.class('rs-calendar-table-cell-is-today');
+  });
+
+  it('Should call `onMouseMove` callback', () => {
+    const onMouseMove = sinon.spy();
+    render(
+      <CalendarContext.Provider
+        value={{ onMouseMove, date: new Date(2022, 10, 2), locale: {}, isoWeek: false }}
+      >
+        <TableCell date={new Date()} />
+      </CalendarContext.Provider>
+    );
+    fireEvent.mouseEnter(screen.getByRole('gridcell'));
+    expect(onMouseMove).to.have.been.calledOnce;
+  });
+
+  it('Should call `onSelect` callback', () => {
+    const onSelect = sinon.spy();
+    render(<TableCell date={new Date()} onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('gridcell'));
+
+    expect(onSelect).to.have.been.calledOnce;
+  });
+
+  describe('Accessibility', () => {
+    it('Should have a aria-label', () => {
+      render(<TableCell date={new Date(2022, 10, 2)} />);
+      expect(screen.getByRole('gridcell')).to.have.attr('aria-label', '02 Nov 2022');
+    });
+
+    it('Should have a aria-selected', () => {
+      render(<TableCell date={new Date(2022, 10, 2)} selected />);
+      expect(screen.getByRole('gridcell')).to.have.attr('aria-selected', 'true');
+    });
+
+    it('Should have a aria-disabled', () => {
+      render(<TableCell date={new Date(2022, 10, 2)} disabled />);
+      expect(screen.getByRole('gridcell')).to.have.attr('aria-disabled', 'true');
+    });
+
+    it('Should have a tabIndex attribute', () => {
+      const { rerender } = render(<TableCell date={new Date()} />);
+
+      expect(screen.getByRole('gridcell')).to.have.attribute('tabindex', '-1');
+
+      rerender(<TableCell selected date={new Date()} />);
+
+      expect(screen.getByRole('gridcell')).to.have.attribute('tabindex', '0');
+    });
+  });
+});

--- a/src/Calendar/test/CalendarTableHeaderRowSpec.tsx
+++ b/src/Calendar/test/CalendarTableHeaderRowSpec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import TableHeaderRow from '../TableHeaderRow';
 import CalendarContext from '../CalendarContext';
 import { testStandardProps } from '@test/commonCases';
@@ -8,9 +8,9 @@ describe('Calendar-TableHeaderRow', () => {
   testStandardProps(<TableHeaderRow />);
 
   it('Should render a div with "table-header-row" class', () => {
-    const { container } = render(<TableHeaderRow />);
+    render(<TableHeaderRow />);
 
-    expect(container.firstChild).to.match('div.rs-calendar-table-header-row');
+    expect(screen.getByRole('row')).to.have.class('rs-calendar-table-header-row');
   });
 
   it('Should render an empty cell for a week number column', () => {
@@ -22,6 +22,19 @@ describe('Calendar-TableHeaderRow', () => {
         <TableHeaderRow ref={ref} />
       </CalendarContext.Provider>
     );
-    assert.equal((ref.current as HTMLDivElement).childNodes.length, 8);
+
+    expect((ref.current as HTMLDivElement).childNodes).to.be.length(8);
+  });
+
+  describe('Accessibility', () => {
+    it('Should have a columnheader attribute on header cell ', () => {
+      render(<TableHeaderRow />);
+      expect(screen.queryAllByRole('columnheader')).to.be.length(7);
+    });
+
+    it('Should have a aria-label attribute on header cell ', () => {
+      render(<TableHeaderRow />);
+      expect(screen.getByLabelText(/sunday/i)).to.exist;
+    });
   });
 });

--- a/src/Calendar/test/CalendarTableRowSpec.tsx
+++ b/src/Calendar/test/CalendarTableRowSpec.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import ReactTestUtils from 'react-dom/test-utils';
+import { render, screen, fireEvent } from '@testing-library/react';
 import TableRow from '../TableRow';
 import { getDate, format } from '../../utils/dateUtils';
 import CalendarContext from '../CalendarContext';
@@ -12,9 +11,8 @@ describe('Calendar-TableRow', () => {
   testStandardProps(<TableRow />);
 
   it('Should render a div with `table-row` class', () => {
-    const { container } = render(<TableRow />);
-
-    expect(container.firstChild).to.match('div.rs-calendar-table-row');
+    render(<TableRow />);
+    expect(screen.getByRole('row')).to.have.class('rs-calendar-table-row');
   });
 
   it('Should be active today', () => {
@@ -35,7 +33,7 @@ describe('Calendar-TableRow', () => {
         <TableRow ref={ref} />
       </CalendarContext.Provider>
     );
-    ReactTestUtils.Simulate.click(
+    fireEvent.click(
       // eslint-disable-next-line testing-library/no-node-access
       (ref.current as HTMLDivElement).querySelector(
         '.rs-calendar-table-cell .rs-calendar-table-cell-content'
@@ -110,5 +108,12 @@ describe('Calendar-TableRow', () => {
         '.rs-calendar-table-cell-is-today'
       ) as HTMLElement
     ).to.have.class('custom-cell');
+  });
+
+  describe('Accessibility', () => {
+    it('Should have a role attribute', () => {
+      render(<TableRow />);
+      expect(screen.getByRole('row')).to.have.attribute('role', 'row');
+    });
   });
 });

--- a/src/Calendar/useCalendarDate.ts
+++ b/src/Calendar/useCalendarDate.ts
@@ -7,7 +7,7 @@ const useCalendarDate = (value: Date | null | undefined, defaultDate: Date | und
   const [calendarDate, setValue] = useState<Date>(value ?? defaultDate ?? new Date());
 
   const setCalendarDate = useCallback(
-    (date: Date | undefined) => {
+    (date: React.SetStateAction<Date> | undefined) => {
       if (date && date?.valueOf() !== calendarDate?.valueOf()) {
         setValue(date);
       }

--- a/src/Calendar/utils.ts
+++ b/src/Calendar/utils.ts
@@ -1,0 +1,15 @@
+import { DateUtils } from '../utils';
+
+/**
+ * Get aria-label for the date.
+ * @param date - The date.
+ * @param formatStr - The format string.
+ * @param format - The format function.
+ */
+export function getAriaLabel(
+  date: Date,
+  formatStr: string,
+  format: (date: Date, formatStr: string) => string
+) {
+  return format ? format(date, formatStr) : DateUtils.format(date, formatStr);
+}

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import mapValues from 'lodash/mapValues';
 import pick from 'lodash/pick';
 import omit from 'lodash/omit';
+import delay from 'lodash/delay';
 import debounce from 'lodash/debounce';
 import IconCalendar from '@rsuite/icons/legacy/Calendar';
 import IconClockO from '@rsuite/icons/legacy/ClockO';
@@ -16,13 +17,32 @@ import { DatePickerLocale } from '../locales';
 import {
   composeFunctions,
   createChainedFunction,
-  DateUtils,
   mergeRefs,
   useClassNames,
   useControlled,
   useCustom
 } from '../utils';
-
+import {
+  shouldRenderMonth,
+  shouldRenderDate,
+  shouldRenderTime,
+  shouldOnlyRenderTime,
+  setHours,
+  getHours,
+  addMonths,
+  addDays,
+  setMinutes,
+  getMinutes,
+  setSeconds,
+  getSeconds,
+  isValid,
+  format,
+  getDateMask,
+  disabledTime,
+  isMatch,
+  calendarOnlyProps,
+  CalendarOnlyPropsType
+} from '../utils/dateUtils';
 import {
   PickerOverlay,
   OverlayTriggerHandle,
@@ -35,12 +55,14 @@ import {
   usePickerClassName,
   usePublicMethods,
   useToggleKeyDownEvent,
-  PickerToggleProps
+  PickerToggleProps,
+  onMenuKeyDown
 } from '../Picker';
 
 import { FormControlBaseProps, PickerBaseProps, RsRefForwardingComponent } from '../@types/common';
 import { OverlayCloseCause } from '../Overlay/OverlayTrigger';
 import { deprecatePropTypeNew } from '../utils/deprecatePropType';
+import { getAriaLabel } from '../Calendar/utils';
 
 export type { RangeType } from './Toolbar';
 
@@ -238,12 +260,17 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
       overrideLocale
     );
     const { merge, prefix } = useClassNames(classPrefix);
-
     const [value, setValue] = useControlled(valueProp, defaultValue);
     const { calendarDate, setCalendarDate, resetCalendarDate } = useCalendarDate(
       value,
       calendarDefaultDate
     );
+
+    const [showMonthDropdown, setShowMonthDropdown] = useState<boolean>(false);
+
+    // Show only the calendar month panel. formatStr = 'yyyy-MM'
+    const onlyShowMonth = shouldRenderMonth(formatStr) && !shouldRenderDate(formatStr);
+    const showMonth = onlyShowMonth || showMonthDropdown;
 
     const [inputState, setInputState] = useState<InputState>();
 
@@ -311,9 +338,9 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
      * The callback triggered when PM/AM is switched.
      */
     const handleToggleMeridian = useCallback(() => {
-      const hours = DateUtils.getHours(calendarDate);
+      const hours = getHours(calendarDate);
       const nextHours = hours >= 12 ? hours - 12 : hours + 12;
-      const nextDate = DateUtils.setHours(calendarDate, nextHours);
+      const nextDate = setHours(calendarDate, nextHours);
 
       handleChangeTime(nextDate);
     }, [calendarDate, handleChangeTime]);
@@ -353,14 +380,65 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
     );
 
     /**
+     * Get the corresponding container based on date selection and month selection
+     */
+    const getOverlayContainer = useCallback(() => {
+      return overlayRef.current?.querySelector(
+        showMonth ? '[role="menu"]' : '[role="grid"]'
+      ) as HTMLElement;
+    }, [showMonth]);
+
+    /**
+     * Check whether the date is focusable
+     */
+    const checkFocusable = useCallback(
+      (date: Date) => {
+        const formatStr = showMonth ? locale.formattedMonthPattern : locale.formattedDayPattern;
+        const ariaLabel = getAriaLabel(date, formatStr as string, formatDate);
+        const container = getOverlayContainer();
+
+        const dateElement = container.querySelector(`[aria-label="${ariaLabel}"]`);
+
+        if (dateElement?.hasAttribute('aria-disabled')) {
+          return false;
+        }
+
+        return true;
+      },
+      [formatDate, getOverlayContainer, locale, showMonth]
+    );
+
+    /**
+     * Focus on the currently selected date element
+     */
+    const focusSelectedDate = useCallback(() => {
+      delay(() => {
+        const container = getOverlayContainer();
+
+        const selectedElement = container?.querySelector('[aria-selected="true"]') as HTMLElement;
+        selectedElement?.focus();
+      }, 1);
+    }, [getOverlayContainer]);
+
+    /**
+     * Focus on the input element
+     */
+    const focusTargetButton = useCallback(() => {
+      delay(() => {
+        targetRef.current?.querySelector('input')?.focus();
+      }, 100);
+    }, []);
+
+    /**
      * The callback triggered after clicking the OK button.
      */
     const handleOK = useCallback(
       (event: React.SyntheticEvent) => {
         updateValue(event);
         onOk?.(calendarDate, event);
+        focusTargetButton();
       },
-      [updateValue, onOk, calendarDate]
+      [updateValue, onOk, calendarDate, focusTargetButton]
     );
 
     /**
@@ -374,14 +452,78 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
       [resetCalendarDate, updateValue]
     );
 
+    const handlePickerToggleKeyDown = useCallback(
+      (event: React.KeyboardEvent) => {
+        const tagName = (event.target as HTMLElement)?.tagName;
+
+        if (tagName === 'INPUT') {
+          if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            focusSelectedDate();
+          } else if (event.key === 'Enter') {
+            triggerRef.current?.open?.();
+          }
+        }
+      },
+      [focusSelectedDate]
+    );
+
+    const handlePickerOverlayKeyDown = useCallback(
+      (event: React.KeyboardEvent) => {
+        let delta = 0;
+
+        const step = showMonth ? 6 : 7;
+        const changeDateFunc = showMonth ? addMonths : addDays;
+
+        onMenuKeyDown(event, {
+          down: () => {
+            delta = step;
+          },
+          up: () => {
+            delta = -step;
+          },
+          right: () => {
+            delta = 1;
+          },
+          left: () => {
+            delta = -1;
+          },
+          enter: () => {
+            handleOK(event);
+          }
+        });
+
+        const nextDate = changeDateFunc(calendarDate, delta);
+
+        if (checkFocusable(nextDate)) {
+          setCalendarDate(nextDate);
+          focusSelectedDate();
+        }
+      },
+      [showMonth, calendarDate, checkFocusable, handleOK, setCalendarDate, focusSelectedDate]
+    );
+
+    /**
+     * The callback triggered after the month selection box is opened or closed.
+     */
+    const handleToggleMonthDropdown = useCallback(
+      (toggle: boolean) => {
+        onToggleMonthDropdown?.(toggle);
+        setShowMonthDropdown(toggle);
+      },
+      [onToggleMonthDropdown]
+    );
+
     /**
      * Handle keyboard events.
      */
     const onPickerKeyDown = useToggleKeyDownEvent({
       triggerRef,
       targetRef,
+      overlayRef,
       active,
       onExit: handleClean,
+      onKeyDown: handlePickerToggleKeyDown,
       ...rest
     });
 
@@ -392,12 +534,12 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
       (nextValue: Date, event: React.SyntheticEvent, updatableValue = true) => {
         setCalendarDate(
           // Determine whether the current value contains time, if not, use calendarDate.
-          DateUtils.shouldRenderTime(formatStr)
+          shouldRenderTime(formatStr)
             ? nextValue
             : composeFunctions(
-                (d: Date) => DateUtils.setHours(d, DateUtils.getHours(calendarDate)),
-                (d: Date) => DateUtils.setMinutes(d, DateUtils.getMinutes(calendarDate)),
-                (d: Date) => DateUtils.setSeconds(d, DateUtils.getSeconds(calendarDate))
+                (d: Date) => setHours(d, getHours(calendarDate)),
+                (d: Date) => setMinutes(d, getMinutes(calendarDate)),
+                (d: Date) => setSeconds(d, getSeconds(calendarDate))
               )(nextValue)
         );
 
@@ -406,7 +548,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
           updateValue(event, nextValue);
         }
       },
-      [formatStr, handleDateChange, oneTap, calendarDate, setCalendarDate, updateValue]
+      [setCalendarDate, formatStr, handleDateChange, oneTap, calendarDate, updateValue]
     );
 
     /**
@@ -416,16 +558,13 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
       (nextPageDate: Date, event: React.MouseEvent) => {
         setCalendarDate(nextPageDate);
         handleDateChange(nextPageDate);
-
-        // Show only the calendar month panel. formatStr = 'yyyy-MM'
-        const onlyShowMonth =
-          DateUtils.shouldRenderMonth(formatStr) && !DateUtils.shouldRenderDate(formatStr);
+        focusSelectedDate();
 
         if (oneTap && onlyShowMonth) {
           updateValue(event, nextPageDate);
         }
       },
-      [formatStr, handleDateChange, oneTap, setCalendarDate, updateValue]
+      [focusSelectedDate, handleDateChange, oneTap, onlyShowMonth, setCalendarDate, updateValue]
     );
 
     const isDateDisabled = useCallback(
@@ -452,7 +591,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
 
         // isMatch('01/11/2020', 'MM/dd/yyyy') ==> true
         // isMatch('2020-11-01', 'MM/dd/yyyy') ==> false
-        if (!DateUtils.isMatch(value, formatStr, { locale: locale.dateLocale })) {
+        if (!isMatch(value, formatStr, { locale: locale.dateLocale })) {
           setInputState('Error');
 
           return;
@@ -461,11 +600,11 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
         let date = parseDate(value, formatStr);
 
         // If only the time is included in the characters, it will default to today.
-        if (DateUtils.shouldOnlyRenderTime(formatStr)) {
-          date = new Date(`${DateUtils.format(new Date(), 'yyyy-MM-dd')} ${value}`);
+        if (shouldOnlyRenderTime(formatStr)) {
+          date = new Date(`${format(new Date(), 'yyyy-MM-dd')} ${value}`);
         }
 
-        if (!DateUtils.isValid(date)) {
+        if (!isValid(date)) {
           setInputState('Error');
           return;
         }
@@ -519,7 +658,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
     const disabledToolbarHandle = useCallback(
       (date: Date): boolean => {
         const allowDate = DEPRECATED_disabledDate?.(date) ?? false;
-        const allowTime = DateUtils.disabledTime(props, date);
+        const allowTime = disabledTime(props, date);
 
         return allowDate || allowTime;
       },
@@ -534,7 +673,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
      */
     const isOKButtonDisabled = useCallback(
       (selectedDate: Date): boolean => {
-        if (DateUtils.shouldRenderMonth(formatStr) && !DateUtils.shouldRenderDate(formatStr)) {
+        if (shouldRenderMonth(formatStr) && !shouldRenderDate(formatStr)) {
           return isEveryDateInMonth(
             selectedDate.getFullYear(),
             selectedDate.getMonth(),
@@ -550,10 +689,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
     const calendarProps = useMemo(
       () =>
         mapValues(
-          pick<DatePickerProps, DateUtils.CalendarOnlyPropsType>(
-            props,
-            DateUtils.calendarOnlyProps
-          ),
+          pick<DatePickerProps, CalendarOnlyPropsType>(props, calendarOnlyProps),
           disabledOrHiddenTimeFunc =>
             (next: number, date: Date): boolean =>
               disabledOrHiddenTimeFunc?.(next, date) ?? false
@@ -579,7 +715,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
         onMoveForward={handleMoveForward}
         onMoveBackward={handleMoveBackward}
         onSelect={handleSelect}
-        onToggleMonthDropdown={onToggleMonthDropdown}
+        onToggleMonthDropdown={handleToggleMonthDropdown}
         onToggleTimeDropdown={onToggleTimeDropdown}
         onChangeMonth={handleChangeMonth}
         onChangeTime={handleChangeTime}
@@ -587,7 +723,10 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
       />
     );
 
+    // The shortcut option on the left side of the calendar panel
     const sideRanges = ranges?.filter(range => range?.placement === 'left') || [];
+
+    // The shortcut option on the bottom of the calendar panel
     const bottomRanges =
       ranges?.filter(range => range?.placement === 'bottom' || range?.placement === undefined) ||
       [];
@@ -603,6 +742,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
           ref={mergeRefs(overlayRef, speakerRef)}
           style={styles}
           target={triggerRef}
+          onKeyDown={handlePickerOverlayKeyDown}
         >
           <Stack alignItems="flex-start">
             {sideRanges.length > 0 && (
@@ -656,8 +796,21 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
     }, [formatStr, formatDate, placeholder, renderValue, value]);
 
     const caretAs = useMemo(
-      () => caretAsProp || (DateUtils.shouldOnlyRenderTime(formatStr) ? IconClockO : IconCalendar),
+      () => caretAsProp || (shouldOnlyRenderTime(formatStr) ? IconClockO : IconCalendar),
       [caretAsProp, formatStr]
+    );
+
+    const handleTriggerClose = useCallback(
+      cause => {
+        // Unless overlay is closing on user clicking "OK" button,
+        // reset the selected date on calendar panel
+        if (cause !== OverlayCloseCause.ImperativeHandle) {
+          resetCalendarDate();
+        }
+
+        setShowMonthDropdown(false);
+      },
+      [resetCalendarDate]
     );
 
     return (
@@ -666,13 +819,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
         pickerProps={pick(props, pickTriggerPropKeys)}
         ref={triggerRef}
         placement={placement}
-        onClose={cause => {
-          // Unless overlay is closing on user clicking "OK" button,
-          // reset the selected date on calendar panel
-          if (cause !== OverlayCloseCause.ImperativeHandle) {
-            resetCalendarDate();
-          }
-        }}
+        onClose={handleTriggerClose}
         onEntered={createChainedFunction(handleEntered, onEntered)}
         onExited={createChainedFunction(handleExited, onExited)}
         speaker={renderDropdownMenu}
@@ -682,7 +829,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
             {...omit(rest, [
               ...omitTriggerPropKeys,
               ...usedClassNamePropKeys,
-              ...DateUtils.calendarOnlyProps
+              ...calendarOnlyProps
             ])}
             className={prefix({ error: inputState === 'Error' })}
             as={toggleAs}
@@ -693,7 +840,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
             inputPlaceholder={
               typeof placeholder === 'string' && placeholder ? placeholder : formatStr
             }
-            inputMask={DateUtils.getDateMask(formatStr)}
+            inputMask={getDateMask(formatStr)}
             onInputChange={handleInputChange}
             onInputBlur={handleInputPressEnd}
             onInputPressEnter={handleInputPressEnd}

--- a/src/DatePicker/styles/index.less
+++ b/src/DatePicker/styles/index.less
@@ -93,6 +93,21 @@
       width: unset;
     }
 
+    &-month-dropdown-cell:focus-visible {
+      .rs-calendar-month-dropdown-cell-content {
+        outline: 3px solid var(--rs-color-focus-ring);
+      }
+    }
+
+    &-table-cell {
+      &:focus-visible {
+        outline: none;
+        .rs-calendar-table-cell-content {
+          outline: 3px solid var(--rs-color-focus-ring);
+        }
+      }
+    }
+
     .rs-calendar-month-dropdown-cell-content,
     .rs-calendar-table-cell-content {
       width: @calendar-in-menu-content-side-length;

--- a/src/DatePicker/test/DatePickerSpec.tsx
+++ b/src/DatePicker/test/DatePickerSpec.tsx
@@ -1113,4 +1113,210 @@ describe('DatePicker', () => {
       expect(screen.queryByRole('listbox')).not.to.exist;
     });
   });
+
+  describe('Accessibility', () => {
+    it('Should have a aria-label attribute', () => {
+      render(<DatePicker aria-label="Custom label" />);
+
+      expect(screen.getByRole('combobox')).to.have.attribute('aria-label', 'Custom label');
+    });
+
+    it('Should have a aria-labelledby attribute', () => {
+      render(<DatePicker aria-labelledby="custom-label" />);
+
+      expect(screen.getByRole('combobox')).to.have.attribute('aria-labelledby', 'custom-label');
+    });
+
+    it('Should focus on specified date by ArrowDown key', async () => {
+      render(<DatePicker defaultValue={new Date('2023-10-01')} />);
+
+      // eslint-disable-next-line testing-library/no-node-access
+      const input = screen.getByRole('combobox').querySelector('input') as HTMLInputElement;
+
+      fireEvent.click(input);
+      fireEvent.keyDown(input, {
+        key: 'ArrowDown'
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('gridcell', { name: '01 Oct 2023' })).to.have.focus;
+      });
+
+      fireEvent.keyDown(screen.getByRole('grid'), {
+        key: 'ArrowDown'
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('gridcell', { name: '08 Oct 2023' })).to.have.focus;
+      });
+    });
+
+    it('Should focus on specified date by ArrowUp key', async () => {
+      render(<DatePicker defaultValue={new Date('2023-10-01')} />);
+
+      // eslint-disable-next-line testing-library/no-node-access
+      const input = screen.getByRole('combobox').querySelector('input') as HTMLInputElement;
+
+      fireEvent.click(input);
+      fireEvent.keyDown(input, {
+        key: 'ArrowDown'
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('gridcell', { name: '01 Oct 2023' })).to.have.focus;
+      });
+
+      fireEvent.keyDown(screen.getByRole('grid'), {
+        key: 'ArrowUp'
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('gridcell', { name: '24 Sep 2023' })).to.have.focus;
+      });
+    });
+
+    it('Should focus on specified date by ArrowRight key', async () => {
+      render(<DatePicker defaultValue={new Date('2023-10-01')} />);
+
+      // eslint-disable-next-line testing-library/no-node-access
+      const input = screen.getByRole('combobox').querySelector('input') as HTMLInputElement;
+
+      fireEvent.click(input);
+      fireEvent.keyDown(input, {
+        key: 'ArrowDown'
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('gridcell', { name: '01 Oct 2023' })).to.have.focus;
+      });
+
+      fireEvent.keyDown(screen.getByRole('grid'), {
+        key: 'ArrowRight'
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('gridcell', { name: '02 Oct 2023' })).to.have.focus;
+      });
+    });
+
+    it('Should focus on specified date by ArrowLeft key', async () => {
+      render(<DatePicker defaultValue={new Date('2023-10-01')} />);
+
+      // eslint-disable-next-line testing-library/no-node-access
+      const input = screen.getByRole('combobox').querySelector('input') as HTMLInputElement;
+
+      fireEvent.click(input);
+      fireEvent.keyDown(input, {
+        key: 'ArrowDown'
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('gridcell', { name: '01 Oct 2023' })).to.have.focus;
+      });
+
+      fireEvent.keyDown(screen.getByRole('grid'), {
+        key: 'ArrowLeft'
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('gridcell', { name: '30 Sep 2023' })).to.have.focus;
+      });
+    });
+
+    it('Should focus on specified month by ArrowDown key', async () => {
+      render(<DatePicker defaultValue={new Date('2023-10-01')} format="yyyy-MM" />);
+
+      // eslint-disable-next-line testing-library/no-node-access
+      const input = screen.getByRole('combobox').querySelector('input') as HTMLInputElement;
+
+      fireEvent.click(input);
+      fireEvent.keyDown(input, {
+        key: 'ArrowDown'
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('gridcell', { name: 'Oct 2023' })).to.have.focus;
+      });
+
+      fireEvent.keyDown(screen.getByRole('dialog'), {
+        key: 'ArrowDown'
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('gridcell', { name: 'Apr 2024' })).to.have.focus;
+      });
+    });
+
+    it('Should focus on specified month by ArrowUp key', async () => {
+      render(<DatePicker defaultValue={new Date('2023-10-01')} format="yyyy-MM" />);
+
+      // eslint-disable-next-line testing-library/no-node-access
+      const input = screen.getByRole('combobox').querySelector('input') as HTMLInputElement;
+
+      fireEvent.click(input);
+      fireEvent.keyDown(input, {
+        key: 'ArrowDown'
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('gridcell', { name: 'Oct 2023' })).to.have.focus;
+      });
+
+      fireEvent.keyDown(screen.getByRole('dialog'), {
+        key: 'ArrowUp'
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('gridcell', { name: 'Apr 2023' })).to.have.focus;
+      });
+    });
+
+    it('Should focus on specified month by ArrowRight key', async () => {
+      render(<DatePicker defaultValue={new Date('2023-10-01')} format="yyyy-MM" />);
+
+      // eslint-disable-next-line testing-library/no-node-access
+      const input = screen.getByRole('combobox').querySelector('input') as HTMLInputElement;
+
+      fireEvent.click(input);
+      fireEvent.keyDown(input, {
+        key: 'ArrowDown'
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('gridcell', { name: 'Oct 2023' })).to.have.focus;
+      });
+
+      fireEvent.keyDown(screen.getByRole('dialog'), {
+        key: 'ArrowRight'
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('gridcell', { name: 'Nov 2023' })).to.have.focus;
+      });
+    });
+
+    it('Should focus on specified month by ArrowLeft key', async () => {
+      render(<DatePicker defaultValue={new Date('2023-10-01')} format="yyyy-MM" />);
+
+      // eslint-disable-next-line testing-library/no-node-access
+      const input = screen.getByRole('combobox').querySelector('input') as HTMLInputElement;
+
+      fireEvent.click(input);
+      fireEvent.keyDown(input, {
+        key: 'ArrowDown'
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('gridcell', { name: 'Oct 2023' })).to.have.focus;
+      });
+
+      fireEvent.keyDown(screen.getByRole('dialog'), {
+        key: 'ArrowLeft'
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('gridcell', { name: 'Sep 2023' })).to.have.focus;
+      });
+    });
+  });
 });

--- a/src/DateRangePicker/test/DateRangePickerSpec.tsx
+++ b/src/DateRangePicker/test/DateRangePickerSpec.tsx
@@ -377,11 +377,15 @@ describe('DateRangePicker', () => {
 
   it('Should select a whole month', () => {
     const onOkSpy = sinon.spy();
-    const menu = getInstance(<DateRangePicker onOk={onOkSpy} hoverRange="month" open />).overlay;
-    // eslint-disable-next-line testing-library/no-node-access
-    const today = menu?.querySelector(
-      '.rs-calendar-table-cell-is-today .rs-calendar-table-cell-content'
-    );
+
+    render(<DateRangePicker onOk={onOkSpy} hoverRange="month" open />);
+
+    const today = screen
+      .getByRole('dialog')
+      // eslint-disable-next-line testing-library/no-node-access
+      ?.querySelector(
+        '.rs-calendar-table-cell-is-today .rs-calendar-table-cell-content'
+      ) as HTMLElement;
 
     fireEvent.click(today);
 

--- a/src/Picker/PickerToggle.tsx
+++ b/src/Picker/PickerToggle.tsx
@@ -200,6 +200,8 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
     const renderInput = useCallback(
       (ref, props) => (
         <input
+          type="text"
+          autoComplete="off"
           ref={mergeRefs(inputRef, ref)}
           name={name}
           style={{ pointerEvents: editable ? undefined : 'none' }}
@@ -255,6 +257,7 @@ const PickerToggle: RsRefForwardingComponent<typeof ToggleButton, PickerTogglePr
             ) : (
               <>
                 <TextMask
+                  keepCharPositions
                   mask={inputMask}
                   value={Array.isArray(inputValue) ? inputValue.toString() : inputValue}
                   onBlur={handleInputBlur}


### PR DESCRIPTION
- Use the <kbd>↓</kbd> <kbd>↑</kbd> <kbd>→</kbd> <kbd>←</kbd> keys to switch focus on the calendar.

