### PR TITLE
refactor(Panel): remove legacy getDOMNode from tests

### DIFF
--- a/src/Panel/test/PanelSpec.tsx
+++ b/src/Panel/test/PanelSpec.tsx
@@ -1,8 +1,8 @@
+/* eslint-disable testing-library/no-node-access */
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
-import { getDOMNode } from '@test/testUtils';
 import { testStandardProps } from '@test/commonCases';
 import Panel from '../Panel';
 
@@ -11,32 +11,48 @@ describe('Panel', () => {
 
   it('Should render a panel', () => {
     const title = 'Test';
-    const instance = getDOMNode(<Panel>{title}</Panel>);
-    assert.equal(instance.tagName, 'DIV');
-    assert.ok(instance.className.match(/\bpanel\b/));
-    assert.equal(instance.textContent, title);
+    render(<Panel data-testid="panel">{title}</Panel>);
+    const panel = screen.getByTestId('panel');
+
+    expect(panel).to.have.tagName('div');
+    expect(panel).to.have.class(/\bpanel\b/);
+    expect(panel).to.have.text(title);
   });
 
   it('Should default expanded', () => {
-    const instance = getDOMNode(<Panel collapsible defaultExpanded />);
+    const text = 'Text';
+    render(
+      <Panel collapsible defaultExpanded>
+        {text}
+      </Panel>
+    );
     // eslint-disable-next-line testing-library/no-node-access
-    assert.isNotNull(instance.querySelector('.rs-panel-collapse.rs-anim-in'));
+    expect(screen.getByText(text).parentNode).to.have.class('rs-panel-collapse');
+    expect(screen.getByText(text).parentNode).to.have.class('rs-anim-in');
   });
 
   it('Should show border', () => {
-    const instance = getDOMNode(<Panel bordered />);
-    assert.include(instance.className, 'rs-panel-bordered');
+    render(<Panel data-testid="panel" bordered />);
+
+    expect(screen.getByTestId('panel')).to.have.class('rs-panel-bordered');
   });
 
   it('Should with shadow', () => {
-    const instance = getDOMNode(<Panel shaded />);
-    assert.include(instance.className, 'rs-panel-shaded');
+    render(<Panel data-testid="panel" shaded />);
+
+    expect(screen.getByTestId('panel')).to.have.class('rs-panel-shaded');
   });
 
   it('Should be expanded', () => {
-    const instance = getDOMNode(<Panel collapsible expanded />);
-    // eslint-disable-next-line testing-library/no-node-access
-    assert.isNotNull(instance.querySelector('.rs-panel-collapse.rs-anim-in'));
+    const text = 'Text';
+    render(
+      <Panel collapsible expanded>
+        {text}
+      </Panel>
+    );
+
+    expect(screen.getByText(text).parentNode).to.have.class('rs-panel-collapse');
+    expect(screen.getByText(text).parentNode).to.have.class('rs-anim-in');
   });
 
   it('Should render the custom header', () => {
@@ -46,21 +62,18 @@ describe('Panel', () => {
   });
 
   it('Should have a role in header', () => {
-    const instance = getDOMNode(<Panel headerRole="button" collapsible header={'abc'} />);
-    assert.equal(
-      // eslint-disable-next-line testing-library/no-node-access
-      (instance.querySelector('.rs-panel-header') as HTMLElement).getAttribute('role'),
-      'button'
-    );
+    const headerText = 'abc';
+    const headerRole = 'button';
+    render(<Panel headerRole={headerRole} collapsible header={headerText} />);
+
+    expect(screen.getByRole(headerRole)).to.have.text(headerText);
+    expect(screen.getByRole(headerRole)).to.have.class('rs-panel-header');
   });
 
   it('Should have a role in body', () => {
-    const instance = getDOMNode(<Panel panelRole="button" collapsible />);
-    assert.equal(
-      // eslint-disable-next-line testing-library/no-node-access
-      (instance.querySelector('.rs-panel-body') as HTMLElement).getAttribute('role'),
-      'button'
-    );
+    render(<Panel panelRole="button" collapsible />);
+
+    expect(screen.getByRole('button')).to.have.class('rs-panel-body');
   });
 
   describe('Collapsible - `collapsible=true`', () => {

--- a/src/Panel/test/PanelStylesSpec.tsx
+++ b/src/Panel/test/PanelStylesSpec.tsx
@@ -1,23 +1,19 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import Panel from '../index';
-import { getDOMNode, getStyle, toRGB, inChrome, itChrome } from '@test/testUtils';
+import { toRGB, inChrome, itChrome } from '@test/testUtils';
 
 import '../styles/index.less';
 
 describe('Panel styles', () => {
   it('Should render the correct styles', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    render(<Panel ref={instanceRef} />);
-    const dom = getDOMNode(instanceRef.current);
-    inChrome && assert.equal(getStyle(dom, 'borderRadius'), '6px', 'Panel border-radius');
-    assert.equal(getStyle(dom, 'overflow'), 'hidden', 'Panel overflow');
+    render(<Panel data-testid="panel" />);
+    inChrome && expect(screen.getByTestId('panel')).to.have.style('border-radius', '6px');
+    expect(screen.getByTestId('panel')).to.have.style('overflow', 'hidden');
   });
 
   itChrome('Should render the correct border', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    render(<Panel ref={instanceRef} bordered />);
-    const dom = getDOMNode(instanceRef.current);
-    assert.equal(getStyle(dom, 'border'), `1px solid ${toRGB('#e5e5ea')}`);
+    render(<Panel data-testid="panel" bordered />);
+    expect(screen.getByTestId('panel')).to.have.style('border', `1px solid ${toRGB('#e5e5ea')}`);
   });
 });


### PR DESCRIPTION
I had to add /* eslint-disable testing-library/no-node-access */ for a whole file because we have a few places where the linter doesn't like it when we query the DOM node this way: screen.getByText(text).parentNode. Unfortunately, as we don't have any 'role' or other appropriate data attribute, currently, I do not see other options. If you have any ideas, please share.