### PR TITLE
refactor(Progress): remove legacy getDOMNode

### DIFF
--- a/src/Progress/test/ProgressCircleSpec.tsx
+++ b/src/Progress/test/ProgressCircleSpec.tsx
@@ -1,5 +1,7 @@
+/* eslint-disable testing-library/no-node-access */
 import React from 'react';
-import { getDOMNode, testStandardProps } from '@test/utils';
+import { render, screen } from '@testing-library/react';
+import { testStandardProps } from '@test/utils';
 import ProgressCircle from '../ProgressCircle';
 
 describe('Progress - Circle', () => {
@@ -8,82 +10,91 @@ describe('Progress - Circle', () => {
   });
 
   it('Should render a Circle', () => {
-    const instance = getDOMNode(<ProgressCircle />);
-    assert.ok(instance.className.match(/\brs-progress-circle\b/));
+    render(<ProgressCircle />);
+
+    expect(screen.getByRole('progressbar')).to.have.class('rs-progress-circle');
   });
 
   it('Should have a percentage', () => {
-    const instance = getDOMNode(<ProgressCircle percent={10} />);
-    assert.equal(instance.textContent, '10%');
+    render(<ProgressCircle percent={10} />);
+    expect(screen.getByRole('progressbar')).to.have.text('10%');
   });
 
   it('Should have a width', () => {
-    const instance = getDOMNode(<ProgressCircle trailWidth={0} percent={1} strokeWidth={10} />);
+    render(<ProgressCircle trailWidth={0} percent={1} strokeWidth={10} />);
 
-    assert.equal(
-      (instance.querySelector('.rs-progress-trail') as HTMLElement).getAttribute('stroke-width'),
+    expect(screen.getByRole('progressbar').querySelector('.rs-progress-trail')).to.have.attr(
+      'stroke-width',
       '10'
     );
-    assert.equal(
-      (instance.querySelector('.rs-progress-stroke') as HTMLElement).getAttribute('stroke-width'),
+    expect(screen.getByRole('progressbar').querySelector('.rs-progress-stroke')).to.have.attr(
+      'stroke-width',
       '10'
     );
   });
 
   it('Should have a background color', () => {
-    const instance = getDOMNode(<ProgressCircle strokeColor={'#ff0000'} />);
+    render(<ProgressCircle strokeColor={'#ff0000'} />);
 
-    assert.equal(
-      (instance.querySelector('.rs-progress-stroke') as HTMLElement).style.stroke,
+    expect(screen.getByRole('progressbar').querySelector('.rs-progress-stroke')).to.have.style(
+      'stroke',
       'rgb(255, 0, 0)'
     );
   });
 
   it('Should render info', () => {
-    const instance = getDOMNode(<ProgressCircle />);
-    const instance2 = getDOMNode(<ProgressCircle showInfo={false} />);
+    render(<ProgressCircle />);
 
-    assert.ok(instance.querySelector('.rs-progress-circle-info'));
-    assert.ok(!instance2.querySelector('.rs-progress-circle-info'));
+    expect(screen.getByRole('progressbar').querySelector('.rs-progress-circle-info')).to.exist;
+  });
+
+  it('Should not render info', () => {
+    render(<ProgressCircle showInfo={false} />);
+
+    expect(screen.getByRole('progressbar').querySelector('.rs-progress-circle-info')).to.not.exist;
   });
 
   it('Should render a status', () => {
-    const instance = getDOMNode(<ProgressCircle status="success" />);
-    assert.ok(instance.className.match(/\brs-progress-circle-success\b/));
+    render(<ProgressCircle status="success" />);
+
+    expect(screen.getByRole('progressbar')).to.have.class('rs-progress-circle-success');
   });
 
   it('Should be able to customize the Path type', () => {
-    const instance = getDOMNode(<ProgressCircle strokeLinecap="butt" />);
+    render(<ProgressCircle strokeLinecap="butt" />);
 
-    assert.equal(
-      (instance.querySelector('.rs-progress-stroke') as HTMLElement).getAttribute('stroke-linecap'),
+    expect(screen.getByRole('progressbar').querySelector('.rs-progress-stroke')).to.have.attr(
+      'stroke-linecap',
       'butt'
     );
   });
 
   it('Should render start position by `gapPosition`', () => {
-    const instance1 = getDOMNode(<ProgressCircle gapPosition="top" />);
-    const instance2 = getDOMNode(<ProgressCircle gapPosition="bottom" />);
-    const instance3 = getDOMNode(<ProgressCircle gapPosition="left" />);
-    const instance4 = getDOMNode(<ProgressCircle gapPosition="right" />);
+    render(
+      <>
+        <ProgressCircle gapPosition="top" />
+        <ProgressCircle gapPosition="bottom" />
+        <ProgressCircle gapPosition="left" />
+        <ProgressCircle gapPosition="right" />
+      </>
+    );
 
-    assert.equal(
-      (instance1.querySelector('.rs-progress-trail') as HTMLElement).getAttribute('d'),
+    const progressCircles = screen.getAllByRole('progressbar');
+
+    expect(progressCircles[0].querySelector('.rs-progress-trail')).to.have.attr(
+      'd',
       'M 50,50 m 0,-47 a 47,47 0 1 1 0,94 a 47,47 0 1 1 0,-94'
     );
-
-    assert.equal(
-      (instance2.querySelector('.rs-progress-trail') as HTMLElement).getAttribute('d'),
+    expect(progressCircles[1].querySelector('.rs-progress-trail')).to.have.attr(
+      'd',
       'M 50,50 m 0,47 a 47,47 0 1 1 0,-94 a 47,47 0 1 1 0,94'
     );
-
-    assert.equal(
-      (instance3.querySelector('.rs-progress-trail') as HTMLElement).getAttribute('d'),
+    expect(progressCircles[2].querySelector('.rs-progress-trail')).to.have.attr(
+      'd',
       'M 50,50 m -47,0 a 47,47 0 1 1 94,0 a 47,47 0 1 1 -94,0'
     );
-
-    assert.equal(
-      (instance4.querySelector('.rs-progress-trail') as HTMLElement).getAttribute('d'),
+    expect(progressCircles[3].querySelector('.rs-progress-trail')).to.have.attr(
+      'd',
       'M 50,50 m 47,0 a 47,47 0 1 1 -94,0 a 47,47 0 1 1 94,0'
     );
   });

--- a/src/Progress/test/ProgressLineSpec.tsx
+++ b/src/Progress/test/ProgressLineSpec.tsx
@@ -1,13 +1,15 @@
+/* eslint-disable testing-library/no-node-access */
 import React from 'react';
-import { getDOMNode, testStandardProps } from '@test/utils';
+import { testStandardProps, getDOMNode } from '@test/utils';
+import { render, screen } from '@testing-library/react';
 import ProgressLine from '../ProgressLine';
 
 describe('Progress - Line', () => {
   testStandardProps(<ProgressLine />);
 
   it('Should render a Line', () => {
-    const instance = getDOMNode(<ProgressLine />);
-    assert.ok(instance.className.match(/\brs-progress-line\b/));
+    render(<ProgressLine />);
+    expect(screen.getByRole('progressbar')).to.have.class('rs-progress-line');
   });
 
   it('Should have a percentage', () => {
@@ -21,36 +23,40 @@ describe('Progress - Line', () => {
   });
 
   it('Should have a height', () => {
-    const instance = getDOMNode(<ProgressLine strokeWidth={10} />);
-    assert.equal(
-      (instance.querySelector('.rs-progress-line-bg') as HTMLElement).style.height,
+    render(<ProgressLine strokeWidth={10} />);
+    expect(screen.getByRole('progressbar').querySelector('.rs-progress-line-bg')).to.have.style(
+      'height',
       '10px'
     );
   });
 
   it('Should have a background color', () => {
-    const instance = getDOMNode(<ProgressLine strokeColor={'#ff0000'} />);
-    assert.equal(
-      (instance.querySelector('.rs-progress-line-bg') as HTMLElement).style.backgroundColor,
+    render(<ProgressLine strokeColor="#ff0000" />);
+    expect(screen.getByRole('progressbar').querySelector('.rs-progress-line-bg')).to.have.style(
+      'background-color',
       'rgb(255, 0, 0)'
     );
   });
 
   it('Should render info', () => {
-    const instance = getDOMNode(<ProgressLine />);
-    const instance2 = getDOMNode(<ProgressLine showInfo={false} />);
+    render(<ProgressLine />);
 
-    assert.ok(instance.querySelector('.rs-progress-info'));
-    assert.ok(!instance2.querySelector('.rs-progress-info'));
+    expect(screen.getByRole('progressbar').querySelector('.rs-progress-info')).to.exist;
+  });
+
+  it('Should not render info', () => {
+    render(<ProgressLine showInfo={false} />);
+
+    expect(screen.getByRole('progressbar').querySelector('.rs-progress-info')).to.not.exist;
   });
 
   it('Should render a status', () => {
-    const instance = getDOMNode(<ProgressLine status="success" />);
-    assert.ok(instance.className.match(/\brs-progress-line-success\b/));
+    render(<ProgressLine status="success" />);
+    expect(screen.getByRole('progressbar')).to.have.class('rs-progress-line-success');
   });
 
   it('Should be vertical', () => {
-    const instance = getDOMNode(<ProgressLine vertical />);
-    assert.ok(instance.className.match(/\brs-progress-line-vertical\b/));
+    render(<ProgressLine vertical />);
+    expect(screen.getByRole('progressbar')).to.have.class('rs-progress-line-vertical');
   });
 });

--- a/src/Progress/test/ProgressLineStylesSpec.tsx
+++ b/src/Progress/test/ProgressLineStylesSpec.tsx
@@ -1,28 +1,24 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import ProgressLine from '../ProgressLine';
-import { getDOMNode, getStyle, toRGB, inChrome } from '@test/utils';
+import { toRGB } from '@test/utils';
 
 import '../styles/index.less';
 
 describe('ProgressLine styles', () => {
   it('Should render the correct styles', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    render(<ProgressLine ref={instanceRef} />);
-    const dom = getDOMNode(instanceRef.current);
-    const outerDom = dom.querySelector('.rs-progress-line-outer') as HTMLElement;
-    const innerDom = dom.querySelector('.rs-progress-line-inner') as HTMLElement;
-    const infoDom = dom.querySelector('.rs-progress-info') as HTMLElement;
-    assert.equal(getStyle(dom, 'fontSize'), '16px', 'ProgressLine font-size');
-    assert.equal(getStyle(dom, 'height'), '36px', 'ProgressLine height');
-    inChrome &&
-      assert.equal(getStyle(outerDom, 'borderRadius'), '5px', 'ProgressLine outer border-radius');
-    assert.equal(
-      getStyle(innerDom, 'backgroundColor'),
-      toRGB('#e5e5ea'),
-      'ProgressLine inner border-radius'
-    );
-    inChrome &&
-      assert.equal(getStyle(infoDom, 'paddingLeft'), '12px', 'ProgressLine inner padding-left');
+    render(<ProgressLine />);
+    const progressBar = screen.getByRole('progressbar');
+    const lineOuter = progressBar.querySelector('.rs-progress-line-outer') as HTMLElement;
+    const lineInner = progressBar.querySelector('.rs-progress-line-inner') as HTMLElement;
+    const info = progressBar.querySelector('.rs-progress-info') as HTMLElement;
+
+    expect(progressBar).to.have.style('font-size', '16px');
+    expect(progressBar).to.have.style('height', '36px');
+
+    expect(lineOuter).to.have.style('border-radius', '5px');
+
+    expect(lineInner).to.have.style('background-color', toRGB('#e5e5ea'));
+    expect(info).to.have.style('padding-left', '12px');
   });
 });


### PR DESCRIPTION
Only one test is left in Progress component:

```
it('Should have a percentage', () => {
    const instance = getDOMNode(<ProgressLine percent={10} />);

    assert.equal(
      (instance.querySelector('.rs-progress-line-bg') as HTMLElement).style.width,
      '10%'
    );
    assert.equal(instance.textContent, '10%');
  });
```

The problem:

```
it('Should have a percentage', () => {
    render(<ProgressLine percent={10} />);
   
    // Returns styles in "px" instead of "%" ?!?!?!
    expect(screen.getByRole('progressbar').querySelector('.rs-progress-line-bg')).to.have.style(
      'width',
      '10%'
    );
    expect(screen.getByRole('progressbar')).to.have.text('10%');
  });
```
 
  