### PR TITLE
feat(Input): add support for htmlSize prop

### DIFF
--- a/docs/pages/components/input/en-US/index.md
+++ b/docs/pages/components/input/en-US/index.md
@@ -22,6 +22,13 @@ Instead of HTML native controls, input, textarea.
 
 <!--{include:`size.md`}-->
 
+If you want to use the native DOM size attribute you can use the `htmlSize` prop.
+For it to work as expected you will also need to provide the `style={{ width: 'auto' }}` prop.
+
+```jsx
+<Input htmlSize={10} style={{ width: 'auto' }} />
+```
+
 ### Textarea
 
 <!--{include:`textarea.md`}-->
@@ -60,15 +67,16 @@ MaskedInput is an input mask component. It can create input masks for phone numb
 
 ### `<Input>`
 
-| Property     | Type `(Default)`                                  | Description                                      |
-| ------------ | ------------------------------------------------- | ------------------------------------------------ |
-| classPrefix  | string `('input')`                                | The prefix of the component CSS class            |
-| defaultValue | string                                            | Default value                                    |
-| disabled     | boolean                                           | Disabled component                               |
-| onChange     | (value: string, event) => void                    | The callback function in which value is changed. |
-| size         | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')` | An input can have different sizes                |
-| type         | string `('text' )`                                | HTML input type                                  |
-| value        | string                                            | Value (Controlled)                               |
+| Property     | Type `(Default)`                                  | Description                                              |
+| ------------ | ------------------------------------------------- | -------------------------------------------------------- |
+| classPrefix  | string `('input')`                                | The prefix of the component CSS class                    |
+| defaultValue | string                                            | Default value                                            |
+| disabled     | boolean                                           | Disabled component                                       |
+| htmlSize     | number                                            | The native HTML size attribute to be passed to the input |
+| onChange     | (value: string, event) => void                    | The callback function in which value is changed.         |
+| size         | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')` | An input can have different sizes                        |
+| type         | string `('text' )`                                | HTML input type                                          |
+| value        | string                                            | Value (Controlled)                                       |
 
 ### `<InputGroup>`
 
@@ -84,8 +92,8 @@ MaskedInput is an input mask component. It can create input masks for phone numb
 
 | Property          | Type `(Default)`      | Description                                                                                             |
 | ----------------- | --------------------- | ------------------------------------------------------------------------------------------------------- |
-| mask (\*)         | array &#124; function | Used to define how to block user input.                                                                 |
 | guide             | boolean               | In guide mode or no guide mode                                                                          |
-| placeholderChar   | string `('_')`        | The placeholder character represents the fillable spot in the mask                                      |
 | keepCharPositions | boolean `(false)`     | When `true`, adding or deleting characters will not affect the position of existing characters.         |
+| mask (\*)         | array &#124; function | Used to define how to block user input.                                                                 |
+| placeholderChar   | string `('_')`        | The placeholder character represents the fillable spot in the mask                                      |
 | showMask          | boolean               | When the input value is empty, the mask is displayed as a placeholder instead of a regular placeholder. |

--- a/docs/pages/components/input/fragments/basic.md
+++ b/docs/pages/components/input/fragments/basic.md
@@ -5,7 +5,7 @@ import { Input } from 'rsuite';
 
 const App = () => (
   <>
-    <Input placeholder="Default Input" />
+    <Input placeholder="Default Input" htmlSize={10} />
   </>
 );
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/docs/pages/components/input/fragments/basic.md
+++ b/docs/pages/components/input/fragments/basic.md
@@ -5,7 +5,7 @@ import { Input } from 'rsuite';
 
 const App = () => (
   <>
-    <Input placeholder="Default Input" htmlSize={10} />
+    <Input placeholder="Default Input" />
   </>
 );
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/docs/pages/components/input/zh-CN/index.md
+++ b/docs/pages/components/input/zh-CN/index.md
@@ -22,6 +22,13 @@
 
 <!--{include:`size.md`}-->
 
+如果你想使用原生 DOM 的 size 属性，你可以使用 `htmlSize` 属性。
+为了使其按预期工作，您还需要提供 `style={{ width: 'auto' }}` 属性。
+
+```jsx
+<Input htmlSize={10} style={{ width: 'auto' }} />
+```
+
 ### Textarea
 
 <!--{include:`textarea.md`}-->
@@ -60,15 +67,16 @@ MaskedInput 是一个输入掩码组件。 它可以为电话、日期、货币�
 
 ### `<Input>`
 
-| 属性名称     | 类型 `(默认值)`                                   | 描述                     |
-| ------------ | ------------------------------------------------- | ------------------------ |
-| classPrefix  | string `('input')`                                | 组件 CSS 类的前缀        |
-| defaultValue | string                                            | 设置默认值               |
-| disabled     | boolean                                           | 禁用                     |
-| onChange     | (value: string, event) => void                    | value 发生变化的回调函数 |
-| size         | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')` | 设置输入框尺寸           |
-| type         | string `('text' )`                                | HTML input type.         |
-| value        | string                                            | 设置值 `受控`            |
+| 属性名称     | 类型 `(默认值)`                                   | 描述                        |
+| ------------ | ------------------------------------------------- | --------------------------- |
+| classPrefix  | string `('input')`                                | 组件 CSS 类的前缀           |
+| defaultValue | string                                            | 设置默认值                  |
+| disabled     | boolean                                           | 禁用                        |
+| htmlSize     | number                                            | 设置原生 input 的 size 属性 |
+| onChange     | (value: string, event) => void                    | value 发生变化的回调函数    |
+| size         | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')` | 设置输入框尺寸              |
+| type         | string `('text' )`                                | HTML input type.            |
+| value        | string                                            | 设置值 `受控`               |
 
 ### `<InputGroup>`
 
@@ -84,8 +92,8 @@ MaskedInput 是一个输入掩码组件。 它可以为电话、日期、货币�
 
 | 属性名称          | 类型 `(默认值)`       | 描述                                               |
 | ----------------- | --------------------- | -------------------------------------------------- |
-| mask (\*)         | array &#124; function | 用于定义如何阻止用户输入。                         |
 | guide             | boolean               | 在引导模式或无引导模式                             |
-| placeholderChar   | string `('_')`        | 占位符代表遮罩中的可填充点                         |
 | keepCharPositions | boolean `(false)`     | 当为 true 时，添加或删除字符不会影响现有字符的位置 |
+| mask (\*)         | array &#124; function | 用于定义如何阻止用户输入。                         |
+| placeholderChar   | string `('_')`        | 占位符代表遮罩中的可填充点                         |
 | showMask          | boolean               | 在输入值为空时将掩码显示为占位符而不是常规占位符   |

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { FormGroupContext } from '../FormGroup/FormGroup';
 import { InputGroupContext } from '../InputGroup/InputGroup';
@@ -32,6 +32,17 @@ export interface InputProps
   /** Ref of input element */
   inputRef?: React.Ref<any>;
 
+  /**
+   * The htmlSize attribute defines the width of the <input> element.
+   *
+   * @see MDN https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/size
+   * @version 5.49.0
+   */
+  htmlSize?: number;
+
+  /**
+   * The callback function in which value is changed.
+   */
   onChange?: PrependParameters<React.ChangeEventHandler<HTMLInputElement>, [value: string]>;
 
   /** Called on press enter */
@@ -40,6 +51,7 @@ export interface InputProps
 
 /**
  * The `<Input>` component is used to get user input in a text field.
+ *
  * @see https://rsuitejs.com/components/input
  */
 const Input: RsRefForwardingComponent<'input', InputProps> = React.forwardRef(
@@ -55,6 +67,7 @@ const Input: RsRefForwardingComponent<'input', InputProps> = React.forwardRef(
       inputRef,
       id,
       size,
+      htmlSize,
       plaintext,
       readOnly,
       onPressEnter,
@@ -65,22 +78,16 @@ const Input: RsRefForwardingComponent<'input', InputProps> = React.forwardRef(
       ...rest
     } = props;
 
-    const handleKeyDown = useCallback(
-      (event: React.KeyboardEvent<HTMLInputElement>) => {
-        if (event.key === KEY_VALUES.ENTER) {
-          onPressEnter?.(event);
-        }
-        onKeyDown?.(event);
-      },
-      [onPressEnter, onKeyDown]
-    );
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === KEY_VALUES.ENTER) {
+        onPressEnter?.(event);
+      }
+      onKeyDown?.(event);
+    };
 
-    const handleChange = useCallback(
-      (event: React.ChangeEvent<HTMLInputElement>) => {
-        onChange?.(event.target?.value, event);
-      },
-      [onChange]
-    );
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChange?.(event.target?.value, event);
+    };
 
     const { withClassPrefix, merge } = useClassNames(classPrefix);
     const classes = merge(className, withClassPrefix(size, { plaintext }));
@@ -97,10 +104,10 @@ const Input: RsRefForwardingComponent<'input', InputProps> = React.forwardRef(
       );
     }
 
-    const operable = !disabled && !readOnly;
+    const inputable = !disabled && !readOnly;
     const eventProps: React.HTMLAttributes<HTMLInputElement> = {};
 
-    if (operable) {
+    if (inputable) {
       eventProps.onChange = handleChange;
       eventProps.onKeyDown = handleKeyDown;
       eventProps.onFocus = createChainedFunction(onFocus, inputGroupContext?.onFocus);
@@ -119,6 +126,7 @@ const Input: RsRefForwardingComponent<'input', InputProps> = React.forwardRef(
         defaultValue={defaultValue}
         disabled={disabled}
         readOnly={readOnly}
+        size={htmlSize}
       />
     );
   }

--- a/src/Input/test/InputSpec.tsx
+++ b/src/Input/test/InputSpec.tsx
@@ -14,6 +14,11 @@ describe('Input', () => {
     expect(screen.getByRole('textbox')).to.have.class('rs-input');
   });
 
+  it('Should have a size attribute on input element', () => {
+    render(<Input htmlSize={20} />);
+    expect(screen.getByRole('textbox')).to.have.attribute('size', '20');
+  });
+
   it('Should call onChange callback', () => {
     const onChange = Sinon.spy();
     render(<Input onChange={onChange} />);


### PR DESCRIPTION
If you want to use the native DOM size attribute you can use the `htmlSize` prop. For it to work as expected you will also need to provide the `style={{ width: 'auto' }}` prop.

```jsx
<Input htmlSize={10} style={{ width: 'auto' }} />
```