### PR TITLE
fix(CSS Reset): fix `rsuite-no-reset.css` overrides the default styles of the app

### DIFF
--- a/docs/less/index.less
+++ b/docs/less/index.less
@@ -18,6 +18,7 @@
 @import './pages/index.less';
 
 @enable-dark-mode: true;
+@enable-css-reset: true;
 
 @media-xs: 768px;
 @media-md: 992px;

--- a/src/Cascader/styles/index.less
+++ b/src/Cascader/styles/index.less
@@ -80,6 +80,7 @@
     margin: 0;
     padding: 0;
     list-style: none;
+    font-size: @font-size-base;
   }
 }
 

--- a/src/InputPicker/test/InputPickerStylesSpec.tsx
+++ b/src/InputPicker/test/InputPickerStylesSpec.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import InputPicker from '../index';
 import Button from '../../Button';
-import { getStyle, toRGB, inChrome } from '@test/utils';
+import { toRGB } from '@test/utils';
 
 import '../styles/index.less';
-import { PickerHandle } from '../../Picker';
 
 const data = [
   {
@@ -27,53 +26,43 @@ const data = [
 
 describe('InputPicker styles', () => {
   it('Should render correct toggle styles', () => {
-    const instanceRef = React.createRef<PickerHandle>();
-    render(<InputPicker ref={instanceRef} data={data} />);
-    const dom = (instanceRef.current as PickerHandle).root as HTMLElement;
-    const toggleDom = dom.querySelector('.rs-picker-toggle') as HTMLElement;
-    const toggleInputDom = dom.querySelector('.rs-picker-search-input') as HTMLElement;
-    inChrome &&
-      assert.equal(getStyle(dom, 'border'), `1px solid ${toRGB('#e5e5ea')}`, 'Picker border');
+    const { container } = render(<InputPicker data={data} />);
 
-    assert.equal(getStyle(dom, 'backgroundColor'), `${toRGB('#fff')}`, 'Toggle background color');
-    assert.equal(getStyle(toggleDom, 'height'), '34px', 'Toggle height');
-    inChrome &&
-      assert.equal(getStyle(toggleInputDom, 'border-style'), 'none', 'Toggle input border');
+    expect(container.firstChild).to.have.style('border', `1px solid ${toRGB('#e5e5ea')}`);
+    expect(container.firstChild).to.have.style('background-color', `${toRGB('#fff')}`);
+    expect(screen.getByRole('combobox')).to.have.style('height', '34px');
+    expect(screen.getByRole('textbox')).to.have.style('border-style', 'none');
   });
 
   it('Should render correct large size', () => {
-    const instanceRef = React.createRef<PickerHandle>();
-    render(<InputPicker toggleAs={Button} size="lg" ref={instanceRef} data={data} />);
-    const dom = (instanceRef.current as PickerHandle).root as HTMLElement;
-    assert.equal(getStyle(dom, 'height'), '42px', 'Toggle height');
+    render(<InputPicker toggleAs={Button} size="lg" data={data} />);
+    expect(screen.getByRole('combobox')).to.have.class('rs-btn-lg');
+    expect(screen.getByRole('combobox')).to.have.style('height', '40px');
   });
 
   it('Should render correct middle size ', () => {
-    const instanceRef = React.createRef<PickerHandle>();
-    render(<InputPicker toggleAs={Button} size="md" ref={instanceRef} data={data} />);
-    const dom = (instanceRef.current as PickerHandle).root as HTMLElement;
-    assert.equal(getStyle(dom, 'height'), '36px', 'Toggle height');
+    render(<InputPicker toggleAs={Button} size="md" data={data} />);
+
+    expect(screen.getByRole('combobox')).to.have.class('rs-btn-md');
+    expect(screen.getByRole('combobox')).to.have.style('height', '34px');
   });
 
   it('Should render correct small size ', () => {
-    const instanceRef = React.createRef<PickerHandle>();
-    render(<InputPicker toggleAs={Button} size="sm" ref={instanceRef} data={data} />);
-    const dom = (instanceRef.current as PickerHandle).root as HTMLElement;
-    assert.equal(getStyle(dom, 'height'), '30px', 'Toggle height');
+    render(<InputPicker toggleAs={Button} size="sm" data={data} />);
+    expect(screen.getByRole('combobox')).to.have.class('rs-btn-sm');
+    expect(screen.getByRole('combobox')).to.have.style('height', '28px');
   });
 
   it('Should render correct xsmall size ', () => {
-    const instanceRef = React.createRef<PickerHandle>();
-    render(<InputPicker toggleAs={Button} size="xs" ref={instanceRef} data={data} />);
-    const dom = (instanceRef.current as PickerHandle).root as HTMLElement;
-    assert.equal(getStyle(dom, 'height'), '24px', 'Toggle height');
+    render(<InputPicker toggleAs={Button} size="xs" data={data} />);
+
+    expect(screen.getByRole('combobox')).to.have.class('rs-btn-xs');
+    expect(screen.getByRole('combobox')).to.have.style('height', '22px');
   });
 
   it('Should have correct height when disabled', () => {
-    const instanceRef = React.createRef<PickerHandle>();
-    render(<InputPicker ref={instanceRef} data={data} disabled />);
-    const dom = (instanceRef.current as PickerHandle).root as HTMLElement;
+    render(<InputPicker data={data} disabled />);
 
-    assert.equal(getStyle(dom, 'height'), '36px', 'InputPicker height');
+    expect(screen.getByRole('combobox')).to.have.style('height', '34px');
   });
 });

--- a/src/RangeSlider/test/RangeSliderSpec.tsx
+++ b/src/RangeSlider/test/RangeSliderSpec.tsx
@@ -4,6 +4,7 @@ import { Simulate } from 'react-dom/test-utils';
 import sinon from 'sinon';
 import { getDOMNode, testStandardProps } from '@test/utils';
 import RangeSlider from '../RangeSlider';
+import { addStyle } from 'dom-lib';
 
 import '../../Slider/styles/index.less';
 
@@ -233,6 +234,9 @@ describe('RangeSlider', () => {
     // eslint-disable-next-line testing-library/no-node-access
     const sliderBar = instance.querySelector('.rs-slider-bar') as HTMLElement;
 
+    // `margin` will cause the values of `pageX` and `pageY` to be inaccurate in the test environment, so you need to set them manually here.
+    addStyle(document.body, 'margin', '0');
+
     act(() => {
       Simulate.click(sliderBar, { pageX: 0, pageY: 80 });
     });
@@ -247,7 +251,6 @@ describe('RangeSlider', () => {
      * fix: https://github.com/rsuite/rsuite/issues/2425
      * Error thrown before fix: expected [ 100, 20 ] to deeply equal [ 20, 100 ]
      */
-
     expect(onChangeSpy).to.have.been.calledWith([20, 100]);
 
     expect(onChangeSpy).to.have.been.calledTwice;

--- a/src/Sidenav/styles/index.less
+++ b/src/Sidenav/styles/index.less
@@ -49,6 +49,7 @@
       background: none;
       padding-right: (@sidenav-padding-horizontal + @sidenav-dropdown-toggle-caret-width);
       position: relative;
+      border-width: 0;
 
       .rs-sidenav-collapse-in & {
         padding-left: @sidenav-level2-retract;
@@ -178,6 +179,7 @@
   display: block;
   outline: 0;
   overflow: hidden;
+  text-decoration: none;
 
   &:hover,
   &:focus {

--- a/src/styles/normalize.less
+++ b/src/styles/normalize.less
@@ -6,243 +6,242 @@
 // Heads up! This reset may cause conflicts with some third-party widgets.
 // For recommendations on resolving such conflicts, see
 // http://getbootstrap.com/getting-started/#third-box-sizing
-* {
+*[class*='rs-'] {
   box-sizing: border-box;
-}
 
-*::before,
-*::after {
-  box-sizing: border-box;
-}
-
-body {
-  // Remove default margin.
-  margin: 0;
-  // Optimize for the retina screen
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-// Address `[hidden]` styling not present in IE 10.
-// Hide the `template` element in IE 10/11, Safari, and Firefox < 22.
-[hidden],
-template {
-  display: none;
-}
-
-// Links
-// ==========================================================================
-
-// Remove the gray background color from active links in IE 10.
-a {
-  background-color: transparent;
-}
-
-// Improve readability of focused elements when they are also in an
-// active/hover state.
-a:active,
-a:hover {
-  outline: 0;
-}
-
-// Text-level semantics
-// ==========================================================================
-
-// Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
-b,
-strong {
-  font-weight: bold;
-}
-
-// Prevent `sub` and `sup` affecting `line-height` in all browsers.
-sub,
-sup {
-  font-size: 75%;
-  line-height: 0;
-  position: relative;
-  vertical-align: baseline;
-}
-
-sup {
-  top: -0.5em;
-}
-
-sub {
-  bottom: -0.25em;
-}
-
-// Embedded content
-// ==========================================================================
-
-// Remove border when inside `a` element in IE 10.
-img {
-  border: 0;
-}
-
-// Correct overflow not hidden in IE 10/11.
-svg:not(:root) {
-  overflow: hidden;
-}
-
-// Address differences between Firefox and other browsers.
-hr {
-  box-sizing: content-box;
-  height: 0;
-}
-
-// Contain overflow in all browsers.
-pre {
-  overflow: auto;
-}
-
-// Forms
-// ==========================================================================
-
-// Known limitation: by default, Chrome and Safari on OS X allow very limited
-// styling of `select`, unless a `border` property is set.
-
-// 1. Correct color not being inherited.
-//    Known issue: affects color of disabled elements.
-// 2. Correct font properties not being inherited.
-// 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
-button,
-input,
-optgroup,
-select,
-textarea {
-  color: inherit; // 1
-  font: inherit; // 2
-  margin: 0; // 3
-}
-
-// Address `overflow` set to `hidden` in IE 10/11.
-button {
-  overflow: visible;
-}
-
-// Remove border radius in Chrome 62+
-button {
-  border-radius: 0;
-}
-
-// Address inconsistent `text-transform` inheritance for `button` and `select`.
-// All other form control elements do not inherit `text-transform` values.
-// Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
-// Correct `select` style inheritance in Firefox.
-button,
-select {
-  text-transform: none;
-}
-
-// 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
-//    and `video` controls.
-// 2. Correct inability to style clickable `input` types in iOS.
-// 3. Improve usability and consistency of cursor style between image-type
-//    `input` and others.
-button,
-html input[type='button'],
-input[type='reset'],
-input[type='submit'] {
-  -webkit-appearance: button; // 2
-  cursor: pointer; // 3
-}
-
-// Re-set default cursor for disabled elements.
-button[disabled],
-html input[disabled] {
-  cursor: not-allowed;
-}
-
-// Remove inner padding and border in Firefox 4+.
-button::-moz-focus-inner,
-input::-moz-focus-inner {
-  border: 0;
-  padding: 0;
-}
-
-// Address Firefox 4+ setting `line-height` on `input` using `!important` in
-// the UA stylesheet.
-input {
-  line-height: normal;
-}
-
-// It's recommended that you don't attempt to style these elements.
-// Firefox's implementation doesn't respect box-sizing, padding, or width.
-//
-// 1. Address box sizing set to `content-box` in IE 10.
-// 2. Remove excess padding in IE 10.
-input[type='checkbox'],
-input[type='radio'] {
-  box-sizing: border-box; // 1
-  padding: 0; // 2
-}
-
-// Fix the cursor style for Chrome's increment/decrement buttons. For certain
-// `font-size` values of the `input`, it causes the cursor style of the
-// decrement button to change from `default` to `text`.
-input[type='number']::-webkit-inner-spin-button,
-input[type='number']::-webkit-outer-spin-button {
-  height: auto;
-}
-
-// Remove default vertical scrollbar in IE 10/11.
-textarea {
-  overflow: auto;
-}
-
-// Tables
-// ==========================================================================
-
-// Remove most spacing between table cells.
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-
-td,
-th {
-  padding: 0;
-}
-
-// Remove tabIndex component outline
-[tabindex='-1'] {
-  outline: none;
-}
-
-// Remove Default button Style
-input[type='button'],
-input[type='submit'],
-input[type='reset'],
-button {
-  border-width: 0;
-}
-
-// Remove IE10's “clear field” X button on certain inputs
-input::-ms-clear {
-  display: none;
-}
-
-// Remove File button Style
-input[type='file']::-webkit-file-upload-button,
-input[type='file']::-ms-browse {
-  border-width: 0;
-  background: transparent;
-  color: currentColor;
-}
-
-// Reset fonts for relevant elements
-input,
-button,
-select,
-textarea {
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
+  &::before,
+  &::after {
+    box-sizing: border-box;
+  }
 }
 
 // import reset styles
 & when (@enable-css-reset = true) {
+  body {
+    // Remove default margin.
+    margin: 0;
+    // Optimize for the retina screen
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  // Address `[hidden]` styling not present in IE 10.
+  // Hide the `template` element in IE 10/11, Safari, and Firefox < 22.
+  [hidden],
+  template {
+    display: none;
+  }
+
+  // Links
+  // ==========================================================================
+
+  // Remove the gray background color from active links in IE 10.
+  a {
+    background-color: transparent;
+  }
+
+  // Improve readability of focused elements when they are also in an
+  // active/hover state.
+  a:active,
+  a:hover {
+    outline: 0;
+  }
+
+  // Text-level semantics
+  // ==========================================================================
+
+  // Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+  b,
+  strong {
+    font-weight: bold;
+  }
+
+  // Prevent `sub` and `sup` affecting `line-height` in all browsers.
+  sub,
+  sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  sup {
+    top: -0.5em;
+  }
+
+  sub {
+    bottom: -0.25em;
+  }
+
+  // Embedded content
+  // ==========================================================================
+
+  // Remove border when inside `a` element in IE 10.
+  img {
+    border: 0;
+  }
+
+  // Correct overflow not hidden in IE 10/11.
+  svg:not(:root) {
+    overflow: hidden;
+  }
+
+  // Address differences between Firefox and other browsers.
+  hr {
+    box-sizing: content-box;
+    height: 0;
+  }
+
+  // Contain overflow in all browsers.
+  pre {
+    overflow: auto;
+  }
+
+  // Forms
+  // ==========================================================================
+
+  // Known limitation: by default, Chrome and Safari on OS X allow very limited
+  // styling of `select`, unless a `border` property is set.
+
+  // 1. Correct color not being inherited.
+  //    Known issue: affects color of disabled elements.
+  // 2. Correct font properties not being inherited.
+  // 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    color: inherit; // 1
+    font: inherit; // 2
+    margin: 0; // 3
+  }
+
+  // Address `overflow` set to `hidden` in IE 10/11.
+  button {
+    overflow: visible;
+  }
+
+  // Remove border radius in Chrome 62+
+  button {
+    border-radius: 0;
+  }
+
+  // Address inconsistent `text-transform` inheritance for `button` and `select`.
+  // All other form control elements do not inherit `text-transform` values.
+  // Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+  // Correct `select` style inheritance in Firefox.
+  button,
+  select {
+    text-transform: none;
+  }
+
+  // 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+  //    and `video` controls.
+  // 2. Correct inability to style clickable `input` types in iOS.
+  // 3. Improve usability and consistency of cursor style between image-type
+  //    `input` and others.
+  button,
+  html input[type='button'],
+  input[type='reset'],
+  input[type='submit'] {
+    -webkit-appearance: button; // 2
+    cursor: pointer; // 3
+  }
+
+  // Re-set default cursor for disabled elements.
+  button[disabled],
+  html input[disabled] {
+    cursor: not-allowed;
+  }
+
+  // Remove inner padding and border in Firefox 4+.
+  button::-moz-focus-inner,
+  input::-moz-focus-inner {
+    border: 0;
+    padding: 0;
+  }
+
+  // Address Firefox 4+ setting `line-height` on `input` using `!important` in
+  // the UA stylesheet.
+  input {
+    line-height: normal;
+  }
+
+  // It's recommended that you don't attempt to style these elements.
+  // Firefox's implementation doesn't respect box-sizing, padding, or width.
+  //
+  // 1. Address box sizing set to `content-box` in IE 10.
+  // 2. Remove excess padding in IE 10.
+  input[type='checkbox'],
+  input[type='radio'] {
+    box-sizing: border-box; // 1
+    padding: 0; // 2
+  }
+
+  // Fix the cursor style for Chrome's increment/decrement buttons. For certain
+  // `font-size` values of the `input`, it causes the cursor style of the
+  // decrement button to change from `default` to `text`.
+  input[type='number']::-webkit-inner-spin-button,
+  input[type='number']::-webkit-outer-spin-button {
+    height: auto;
+  }
+
+  // Remove default vertical scrollbar in IE 10/11.
+  textarea {
+    overflow: auto;
+  }
+
+  // Tables
+  // ==========================================================================
+
+  // Remove most spacing between table cells.
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+
+  td,
+  th {
+    padding: 0;
+  }
+
+  // Remove tabIndex component outline
+  [tabindex='-1'] {
+    outline: none;
+  }
+
+  // Remove Default button Style
+  input[type='button'],
+  input[type='submit'],
+  input[type='reset'],
+  button {
+    border-width: 0;
+  }
+
+  // Remove IE10's “clear field” X button on certain inputs
+  input::-ms-clear {
+    display: none;
+  }
+
+  // Remove File button Style
+  input[type='file']::-webkit-file-upload-button,
+  input[type='file']::-ms-browse {
+    border-width: 0;
+    background: transparent;
+    color: currentColor;
+  }
+
+  // Reset fonts for relevant elements
+  input,
+  button,
+  select,
+  textarea {
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+  }
+
   @import 'scaffolding';
   @import 'typography';
 }
-

--- a/webpack.karma.js
+++ b/webpack.karma.js
@@ -51,7 +51,8 @@ module.exports = {
             loader: 'less-loader', // compiles Less to CSS,
             options: {
               lessOptions: {
-                javascriptEnabled: true
+                javascriptEnabled: true,
+                modifyVars: { '@enable-css-reset': false }
               }
             }
           }


### PR DESCRIPTION
fix: https://github.com/rsuite/rsuite/issues/3513
fix: https://github.com/rsuite/rsuite/issues/1953
fix: https://github.com/rsuite/rsuite/issues/3367