### PR TITLE
fix: typo in Next.js guide

### DIFF
--- a/docs/pages/guide/use-next-app/en-US/index.md
+++ b/docs/pages/guide/use-next-app/en-US/index.md
@@ -30,7 +30,7 @@ When installing, you will see the following prompt:
 
 ## 3、Import styles
 
-Edit the `./src/app/loyout.tsx` file and add `import 'rsuite/dist/rsuite-no-reset.min.css';`, as follows:
+Edit the `./src/app/layout.tsx` file and add `import 'rsuite/dist/rsuite-no-reset.min.css';`, as follows:
 
 ```diff
 import type { Metadata } from 'next';
@@ -55,7 +55,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
 ## 4. Provider Setup
 
-Continue editing the `./src/app/loyout.tsx` file, import `CustomProvider`, and wrap it in the `body` tag, as follows:
+Continue editing the `./src/app/layout.tsx` file, import `CustomProvider`, and wrap it in the `body` tag, as follows:
 
 ```diff
 import type { Metadata } from 'next';

--- a/docs/pages/guide/use-next-app/zh-CN/index.md
+++ b/docs/pages/guide/use-next-app/zh-CN/index.md
@@ -30,7 +30,7 @@ npx create-next-app@latest
 
 ## 3、导入样式
 
-编辑 `./src/app/loyout.tsx` 文件, 添加 `import 'rsuite/dist/rsuite-no-reset.min.css';`, 如下:
+编辑 `./src/app/layout.tsx` 文件, 添加 `import 'rsuite/dist/rsuite-no-reset.min.css';`, 如下:
 
 ```diff
 import type { Metadata } from 'next';
@@ -55,7 +55,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
 ## 4、设置 Provider
 
-继续编辑 `./src/app/loyout.tsx` 文件, 导入 `CustomProvider` , 将其包裹在 `body` 标签中, 如下:
+继续编辑 `./src/app/layout.tsx` 文件, 导入 `CustomProvider` , 将其包裹在 `body` 标签中, 如下:
 
 ```diff
 import type { Metadata } from 'next';


### PR DESCRIPTION
This PR fixes `loyout` -> `layout`