### PR TITLE
fix: NavItem and DropDownItem rendering icon without overriding className

### DIFF
--- a/src/Dropdown/DropdownItem.tsx
+++ b/src/Dropdown/DropdownItem.tsx
@@ -15,6 +15,7 @@ import warnOnce from '../utils/warnOnce';
 import Nav from '../Nav';
 import DropdownSeparator, { DropdownSeparatorProps } from './DropdownSeparator';
 import _ from 'lodash';
+import classNames from 'classnames';
 
 export interface DropdownMenuItemProps<T = any>
   extends WithAsProps,
@@ -186,7 +187,10 @@ const DropdownItem: RsRefForwardingComponent<'li', DropdownMenuItemProps> = Reac
             ...restProps,
             children: (
               <>
-                {icon && React.cloneElement(icon, { className: prefix('menu-icon') })}
+                {icon &&
+                  React.cloneElement(icon, {
+                    className: classNames(prefix('menu-icon'), icon.props.className)
+                  })}
                 {children}
               </>
             )

--- a/src/Dropdown/test/DropdownItemSpec.tsx
+++ b/src/Dropdown/test/DropdownItemSpec.tsx
@@ -82,12 +82,20 @@ describe('<Dropdown.Item>', () => {
 
   it('Should render a icon', () => {
     render(
-      <Dropdown>
-        <DropdownItem icon={<User data-testid="icon" />} data-testid="item" />
+      <Dropdown open>
+        <DropdownItem icon={<User data-testid="icon" />} />
       </Dropdown>
     );
 
-    expect(screen.getByTestId('item')).to.contain(screen.getByTestId('icon'));
+    expect(screen.getByRole('menuitem')).to.contain(screen.getByTestId('icon'));
+  });
+  it('Should render a icon without overriding className', () => {
+    render(
+      <Dropdown open>
+        <DropdownItem icon={<div className="custom-class" />} data-testid="item" />
+      </Dropdown>
+    );
+    expect(screen.getByRole('menuitem')).to.contain('.custom-class');
   });
 
   it('Should call onSelect callback with correct `eventKey`', () => {

--- a/src/Nav/NavDropdownItem.tsx
+++ b/src/Nav/NavDropdownItem.tsx
@@ -8,6 +8,7 @@ import isNil from 'lodash/isNil';
 import { mergeRefs, shallowEqual, useClassNames } from '../utils';
 import NavContext from './NavContext';
 import { useRenderDropdownItem } from '../Dropdown/useRenderDropdownItem';
+import classNames from 'classnames';
 
 export interface NavDropdownItemProps<T = any>
   extends WithAsProps,
@@ -143,7 +144,10 @@ const NavDropdownItem: RsRefForwardingComponent<'li', NavDropdownItemProps> = Re
             ...restProps,
             children: (
               <>
-                {icon && React.cloneElement(icon, { className: prefix('menu-icon') })}
+                {icon &&
+                  React.cloneElement(icon, {
+                    className: classNames(prefix('menu-icon'), icon.props.className)
+                  })}
                 {children}
               </>
             )

--- a/src/Nav/NavItem.tsx
+++ b/src/Nav/NavItem.tsx
@@ -7,6 +7,7 @@ import { shallowEqual, useClassNames } from '../utils';
 import { RsRefForwardingComponent, WithAsProps } from '../@types/common';
 import { IconProps } from '@rsuite/icons/lib/Icon';
 import NavContext from './NavContext';
+import classNames from 'classnames';
 
 export interface NavItemProps<T = string>
   extends WithAsProps,
@@ -124,7 +125,10 @@ const NavItem: RsRefForwardingComponent<'a', NavItemProps> = React.forwardRef(
         style={style}
         aria-selected={active || undefined}
       >
-        {icon && React.cloneElement(icon, { className: prefix('icon') })}
+        {icon &&
+          React.cloneElement(icon, {
+            className: classNames(prefix('icon'), icon.props.className)
+          })}
         {children}
         <Ripple />
       </Component>

--- a/src/Nav/test/NavItemSpec.tsx
+++ b/src/Nav/test/NavItemSpec.tsx
@@ -157,4 +157,60 @@ describe('<Nav.Item>', () => {
       expect(screen.getByRole('tooltip'), 'Tooltip').not.to.be.null;
     });
   });
+
+  context('rendering icon', () => {
+    it('Should render an icon', () => {
+      render(
+        <Nav>
+          <Nav.Item icon={<div data-testid="icon" />} />
+        </Nav>
+      );
+
+      expect(screen.getByTestId('icon')).to.exist;
+    });
+
+    it('Should render an icon without overriding className', () => {
+      render(
+        <Nav>
+          <Nav.Item icon={<div data-testid="icon" className="custom-icon" />} />
+        </Nav>
+      );
+      expect(screen.getByTestId('icon')).to.have.class('custom-icon');
+    });
+
+    context('Within <Navbar>', () => {
+      it('Should render an icon without overriding className', () => {
+        render(
+          <Navbar>
+            <Nav>
+              <Nav.Item icon={<div data-testid="icon" className="custom-icon" />} />
+            </Nav>
+          </Navbar>
+        );
+        expect(screen.getByTestId('icon')).to.have.class('custom-icon');
+      });
+    });
+    context('Within <Sidenav>', () => {
+      it('When expanded is true Should render an icon without overriding className', () => {
+        render(
+          <Sidenav>
+            <Nav>
+              <Nav.Item icon={<div data-testid="icon" className="custom-icon" />} />
+            </Nav>
+          </Sidenav>
+        );
+        expect(screen.getByTestId('icon')).to.have.class('custom-icon');
+      });
+      it('When expanded is false Should render an icon without overriding className', () => {
+        render(
+          <Sidenav expanded={false}>
+            <Nav>
+              <Nav.Item icon={<div data-testid="icon" className="custom-icon" />} />
+            </Nav>
+          </Sidenav>
+        );
+        expect(screen.getByTestId('icon')).to.have.class('custom-icon');
+      });
+    });
+  });
 });

--- a/src/Nav/test/NavMenuSpec.tsx
+++ b/src/Nav/test/NavMenuSpec.tsx
@@ -97,4 +97,69 @@ describe('<Nav.Menu>', () => {
       expect(screen.getByText('Menu item')).to.be.visible;
     });
   });
+  context('rendering icon', () => {
+    it('Should render an icon', () => {
+      render(
+        <Nav>
+          <Nav.Menu title="Menu">
+            <Nav.Item icon={<div data-testid="icon" />} />
+          </Nav.Menu>
+        </Nav>
+      );
+
+      expect(screen.getByTestId('icon')).to.exist;
+    });
+
+    it('Should render an icon without overriding className', () => {
+      render(
+        <Nav>
+          <Nav.Menu title="Menu">
+            <Nav.Item icon={<div data-testid="icon" className="custom-icon" />} />
+          </Nav.Menu>
+        </Nav>
+      );
+      expect(screen.getByTestId('icon')).to.have.class('custom-icon');
+    });
+
+    context('Within <Navbar>', () => {
+      it('Should render an icon without overriding className', () => {
+        render(
+          <Navbar>
+            <Nav>
+              <Nav.Menu title="Menu">
+                <Nav.Item icon={<div data-testid="icon" className="custom-icon" />} />
+              </Nav.Menu>
+            </Nav>
+          </Navbar>
+        );
+        expect(screen.getByTestId('icon')).to.have.class('custom-icon');
+      });
+    });
+    context('Within <Sidenav>', () => {
+      it('When expanded is true Should render an icon without overriding className', () => {
+        render(
+          <Sidenav>
+            <Nav>
+              <Nav.Menu title="Menu">
+                <Nav.Item icon={<div data-testid="icon" className="custom-icon" />} />
+              </Nav.Menu>
+            </Nav>
+          </Sidenav>
+        );
+        expect(screen.getByTestId('icon')).to.have.class('custom-icon');
+      });
+      it('When expanded is false Should render an icon without overriding className', () => {
+        render(
+          <Sidenav expanded={false}>
+            <Nav>
+              <Nav.Menu title="Menu">
+                <Nav.Item icon={<div data-testid="icon" className="custom-icon" />} />
+              </Nav.Menu>
+            </Nav>
+          </Sidenav>
+        );
+        expect(screen.getByTestId('icon')).to.have.class('custom-icon');
+      });
+    });
+  });
 });

--- a/src/Navbar/NavbarDropdownItem.tsx
+++ b/src/Navbar/NavbarDropdownItem.tsx
@@ -9,6 +9,7 @@ import { NavbarContext } from './Navbar';
 import DisclosureContext, { DisclosureActionTypes } from '../Disclosure/DisclosureContext';
 import { useRenderDropdownItem } from '../Dropdown/useRenderDropdownItem';
 import NavContext from '../Nav/NavContext';
+import classNames from 'classnames';
 
 export interface NavbarDropdownItemProps<T = any>
   extends WithAsProps,
@@ -156,7 +157,10 @@ const NavbarDropdownItem: RsRefForwardingComponent<'li', NavbarDropdownItemProps
       onClick: createChainedFunction(handleClickNavbarDropdownItem, restProps.onClick),
       children: (
         <>
-          {icon && React.cloneElement(icon, { className: prefix('menu-icon') })}
+          {icon &&
+            React.cloneElement(icon, {
+              className: classNames(prefix('menu-icon'), icon.props.className)
+            })}
           {children}
         </>
       )

--- a/src/Navbar/NavbarItem.tsx
+++ b/src/Navbar/NavbarItem.tsx
@@ -7,6 +7,7 @@ import SafeAnchor from '../SafeAnchor';
 import { shallowEqual, useClassNames } from '../utils';
 import { RsRefForwardingComponent, WithAsProps } from '../@types/common';
 import NavContext, { NavContextProps } from '../Nav/NavContext';
+import classNames from 'classnames';
 
 export interface NavbarItemProps<T = string>
   extends WithAsProps,
@@ -84,7 +85,10 @@ const NavbarItem: RsRefForwardingComponent<'a', NavbarItemProps> = React.forward
         onClick={handleClick}
         style={style}
       >
-        {icon && React.cloneElement(icon, { className: prefix('icon') })}
+        {icon &&
+          React.cloneElement(icon, {
+            className: classNames(prefix('icon'), icon.props.className)
+          })}
         {children}
         <Ripple />
       </Component>

--- a/src/Navbar/test/NavbarStylesSpec.tsx
+++ b/src/Navbar/test/NavbarStylesSpec.tsx
@@ -19,7 +19,7 @@ describe('Navbar styles', () => {
       render(
         <Navbar>
           <Nav>
-            <Nav.Item icon={<i className="rs-icon" data-testid="icon" />}>Home</Nav.Item>
+            <Nav.Item icon={<i data-testid="icon" />}>Home</Nav.Item>
           </Nav>
         </Navbar>
       );

--- a/src/Sidenav/ExpandedSidenavDropdownItem.tsx
+++ b/src/Sidenav/ExpandedSidenavDropdownItem.tsx
@@ -9,6 +9,7 @@ import Ripple from '../Ripple';
 import SafeAnchor from '../SafeAnchor';
 import NavContext from '../Nav/NavContext';
 import { useRenderDropdownItem } from '../Dropdown/useRenderDropdownItem';
+import classNames from 'classnames';
 
 export interface SidenavDropdownItemProps<T = any>
   extends WithAsProps,
@@ -139,7 +140,10 @@ const ExpandedSidenavDropdownItem: RsRefForwardingComponent<'li', SidenavDropdow
         ...menuitemEventHandlers,
         children: (
           <>
-            {icon && React.cloneElement(icon, { className: prefix('menu-icon') })}
+            {icon &&
+              React.cloneElement(icon, {
+                className: classNames(prefix('menu-icon'), icon.props.className)
+              })}
             {children}
             <Ripple />
           </>

--- a/src/Sidenav/SidenavDropdownItem.tsx
+++ b/src/Sidenav/SidenavDropdownItem.tsx
@@ -10,6 +10,7 @@ import { mergeRefs, shallowEqual, useClassNames } from '../utils';
 import NavContext from '../Nav/NavContext';
 import { useRenderDropdownItem } from '../Dropdown/useRenderDropdownItem';
 import ExpandedSidenavDropdownItem from './ExpandedSidenavDropdownItem';
+import classNames from 'classnames';
 
 export interface SidenavDropdownItemProps<T = any>
   extends WithAsProps,
@@ -162,7 +163,10 @@ const SidenavDropdownItem: RsRefForwardingComponent<'li', SidenavDropdownItemPro
             ...restProps,
             children: (
               <>
-                {icon && React.cloneElement(icon, { className: prefix('menu-icon') })}
+                {icon &&
+                  React.cloneElement(icon, {
+                    className: classNames(prefix('menu-icon'), icon.props.className)
+                  })}
                 {children}
               </>
             )

--- a/src/Sidenav/SidenavItem.tsx
+++ b/src/Sidenav/SidenavItem.tsx
@@ -12,6 +12,7 @@ import omit from 'lodash/omit';
 import { SidenavContext } from './Sidenav';
 import Whisper, { WhisperInstance } from '../Whisper';
 import Tooltip from '../Tooltip';
+import classNames from 'classnames';
 
 export interface SidenavItemProps<T = any>
   extends WithAsProps,
@@ -90,6 +91,12 @@ const SidenavItem: RsRefForwardingComponent<'li', SidenavItemProps> = React.forw
     [disabled, onSelect, onSelectFromNav, eventKey, onClick]
   );
 
+  const clonedIcon = icon
+    ? React.cloneElement(icon, {
+        className: classNames(prefix('icon'), icon.props.className)
+      })
+    : null;
+
   if (!sidenav.expanded) {
     return (
       <Whisper
@@ -122,7 +129,7 @@ const SidenavItem: RsRefForwardingComponent<'li', SidenavItemProps> = React.forw
                   )}
                   onMouseOut={createChainedFunction(menuitem.onMouseOut, triggerProps.onMouseOut)}
                 >
-                  {icon && React.cloneElement(icon, { className: prefix('icon') })}
+                  {clonedIcon}
                   {children}
                   <Ripple />
                 </Component>
@@ -170,7 +177,7 @@ const SidenavItem: RsRefForwardingComponent<'li', SidenavItemProps> = React.forw
       data-event-key={eventKey}
       {...rest}
     >
-      {icon && React.cloneElement(icon, { className: prefix('icon') })}
+      {clonedIcon}
       {children}
       <Ripple />
     </Component>


### PR DESCRIPTION
In both NavItem and DropdownItem, the className attribute assigned to the icon prop will be overridden.

<img width="1159" alt="image" src="https://github.com/rsuite/rsuite/assets/53305259/34ac855d-e7f2-471b-8e72-e45301a107f8">

notice:  there's an extra test case change, but I think it was wrong before. 
