### PR TITLE
feat(Form): add support for `nestedField` prop on Form

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -33,7 +33,7 @@
         "react-device-detect": "^2.2.2",
         "react-dom": "^17.0.2",
         "react-icons": "^4.2.0",
-        "react-json-tree": "^0.17.0",
+        "react-json-tree": "^0.18.0",
         "react-select": "^5.5.9",
         "rsuite": "^5.50.0",
         "svg-sprite-loader": "^6.0.11",
@@ -1843,11 +1843,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "version": "7.23.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
+      "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2919,9 +2919,9 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.187",
-      "resolved": "https://registry.npmmirror.com/@types/lodash/-/lodash-4.14.187.tgz",
-      "integrity": "sha512-MrO/xLXCaUgZy3y96C/iOsaIqZSeupyTImKClHunL5GrmaiII2VwvWmLBu2hwa0Kp0sV19CsyjtrTc/Fx8rg/A=="
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -9760,19 +9760,17 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-json-tree": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmmirror.com/react-json-tree/-/react-json-tree-0.17.0.tgz",
-      "integrity": "sha512-hcWjibI/fAvsKnfYk+lka5OrE1Lvb1jH5pSnFhIU5T8cCCxB85r6h/NOzDPggSSgErjmx4rl3+2EkeclIKBOhg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-json-tree/-/react-json-tree-0.18.0.tgz",
+      "integrity": "sha512-Qe6HKSXrr++n9Y31nkRJ3XvQMATISpqigH1vEKhLwB56+nk5thTP0ITThpjxY6ZG/ubpVq/aEHIcyLP/OPHxeA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@types/lodash": "^4.14.182",
-        "@types/prop-types": "^15.7.5",
-        "prop-types": "^15.8.1",
+        "@babel/runtime": "^7.20.6",
+        "@types/lodash": "^4.14.191",
         "react-base16-styling": "^0.9.1"
       },
       "peerDependencies": {
-        "@types/react": "^16.3.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-select": {
@@ -10042,9 +10040,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmmirror.com/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -14233,11 +14231,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "version": "7.23.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
+      "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
       "requires": {
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.14.0"
       }
     },
     "@babel/template": {
@@ -15015,9 +15013,9 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "@types/lodash": {
-      "version": "4.14.187",
-      "resolved": "https://registry.npmmirror.com/@types/lodash/-/lodash-4.14.187.tgz",
-      "integrity": "sha512-MrO/xLXCaUgZy3y96C/iOsaIqZSeupyTImKClHunL5GrmaiII2VwvWmLBu2hwa0Kp0sV19CsyjtrTc/Fx8rg/A=="
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
     },
     "@types/minimatch": {
       "version": "5.1.2",
@@ -20363,14 +20361,12 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-json-tree": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmmirror.com/react-json-tree/-/react-json-tree-0.17.0.tgz",
-      "integrity": "sha512-hcWjibI/fAvsKnfYk+lka5OrE1Lvb1jH5pSnFhIU5T8cCCxB85r6h/NOzDPggSSgErjmx4rl3+2EkeclIKBOhg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-json-tree/-/react-json-tree-0.18.0.tgz",
+      "integrity": "sha512-Qe6HKSXrr++n9Y31nkRJ3XvQMATISpqigH1vEKhLwB56+nk5thTP0ITThpjxY6ZG/ubpVq/aEHIcyLP/OPHxeA==",
       "requires": {
-        "@babel/runtime": "^7.18.3",
-        "@types/lodash": "^4.14.182",
-        "@types/prop-types": "^15.7.5",
-        "prop-types": "^15.8.1",
+        "@babel/runtime": "^7.20.6",
+        "@types/lodash": "^4.14.191",
         "react-base16-styling": "^0.9.1"
       }
     },
@@ -20594,9 +20590,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmmirror.com/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "regenerator-transform": {
       "version": "0.15.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -41,7 +41,7 @@
     "react-device-detect": "^2.2.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.2.0",
-    "react-json-tree": "^0.17.0",
+    "react-json-tree": "^0.18.0",
     "react-select": "^5.5.9",
     "rsuite": "^5.50.0",
     "svg-sprite-loader": "^6.0.11",

--- a/docs/pages/components/form-validation/en-US/index.md
+++ b/docs/pages/components/form-validation/en-US/index.md
@@ -115,6 +115,10 @@ There are `checkTrigger` properties on the `<Form>` and `<Form.Control>` compone
 
 <!--{include:`dynamic-form.md`}-->
 
+### Nested fields
+
+<!--{include:`form-nested-fields.md`}-->
+
 ## Props & Methods
 
 - [Form props](/components/form)

--- a/docs/pages/components/form-validation/fragments/form-nested-fields.md
+++ b/docs/pages/components/form-validation/fragments/form-nested-fields.md
@@ -16,30 +16,14 @@ const JSONView = ({ formValue, formError }) => (
   </div>
 );
 
-const { StringType, NumberType } = Schema.Types;
+const { StringType, ObjectType, NumberType } = Schema.Types;
 
 const model = Schema.Model({
   name: StringType().isRequired('This field is required.'),
-  email: StringType()
-    .isEmail('Please enter a valid email address.')
-    .isRequired('This field is required.'),
-  age: NumberType('Please enter a valid number.').range(
-    18,
-    30,
-    'Please enter a number from 18 to 30'
-  ),
-  password: StringType().isRequired('This field is required.'),
-  verifyPassword: StringType()
-    .addRule((value, data) => {
-      console.log(data);
-
-      if (value !== data.password) {
-        return false;
-      }
-
-      return true;
-    }, 'The two passwords do not match')
-    .isRequired('This field is required.')
+  address: ObjectType().shape({
+    city: StringType().isRequired('This field is required.'),
+    postCode: NumberType('Post Code must be a number').isRequired('This field is required.')
+  })
 });
 
 const TextField = React.forwardRef((props, ref) => {
@@ -53,57 +37,40 @@ const TextField = React.forwardRef((props, ref) => {
 });
 
 const App = () => {
-  const formRef = React.useRef();
+  const form = React.useRef();
   const [formError, setFormError] = React.useState({});
   const [formValue, setFormValue] = React.useState({
-    name: '',
-    email: '',
-    age: '',
-    password: '',
-    verifyPassword: ''
+    name: 'Tom',
+    address: { city: 'ShangHai', postCode: '200000' }
   });
 
   const handleSubmit = () => {
-    if (!formRef.current.check()) {
+    if (!form.current.check()) {
       console.error('Form Error');
       return;
     }
     console.log(formValue, 'Form Value');
   };
 
-  const handleCheckEmail = () => {
-    formRef.current.checkForField('email', checkResult => {
-      console.log(checkResult);
-    });
-  };
-
   return (
     <FlexboxGrid>
       <FlexboxGrid.Item colspan={12}>
         <Form
-          ref={formRef}
+          nestedField
+          ref={form}
           onChange={setFormValue}
           onCheck={setFormError}
           formValue={formValue}
           model={model}
         >
-          <TextField name="name" label="Username" />
-          <TextField name="email" label="Email" />
-          <TextField name="age" label="Age" />
-          <TextField name="password" label="Password" type="password" autoComplete="off" />
-          <TextField
-            name="verifyPassword"
-            label="Verify password"
-            type="password"
-            autoComplete="off"
-          />
+          <TextField name="name" label="Name" />
+          <TextField name="address.city" label="City" />
+          <TextField name="address.postCode" label="Post Code" />
 
           <ButtonToolbar>
             <Button appearance="primary" onClick={handleSubmit}>
               Submit
             </Button>
-
-            <Button onClick={handleCheckEmail}>Check Email</Button>
           </ButtonToolbar>
         </Form>
       </FlexboxGrid.Item>

--- a/docs/pages/components/form-validation/zh-CN/index.md
+++ b/docs/pages/components/form-validation/zh-CN/index.md
@@ -117,6 +117,10 @@ return (
 
 <!--{include:`dynamic-form.md`}-->
 
+### 表单数据嵌套
+
+<!--{include:`form-nested-fields.md`}-->
+
 ## Props & Methods
 
 - [Form props](/zh/components/form)

--- a/docs/pages/components/form/en-US/index.md
+++ b/docs/pages/components/form/en-US/index.md
@@ -99,6 +99,8 @@ HTML:
 
 ### `<Form>`
 
+<!-- prettier-sort-markdown-table -->
+
 | Property         | Type `(default)`                                              | Description                                                                                                |
 | ---------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 | checkTrigger     | 'change' &#124; 'blur' &#124; 'none' `('change')`             | Trigger the type of form validation                                                                        |
@@ -111,13 +113,14 @@ HTML:
 | formValue        | object                                                        | Value of form (Controlled)                                                                                 |
 | layout           | 'horizontal' &#124; 'vertical' &#124; 'inline' `('vertical')` | Set the left and right columns of the layout of the elements within the form                               |
 | model            | Schema                                                        | SchemaModel object                                                                                         |
+| nestedField      | boolean `(false)`                                             | Whether to support nested fields                                                                           |
 | onChange         | (formValue: object, event) => void                            | Callback fired when data changing                                                                          |
 | onCheck          | (formError: object) => void                                   | Callback fired when data cheking                                                                           |
 | onError          | (formError: object) => void                                   | Callback fired when error checking                                                                         |
 | plaintext        | boolean `(false)`                                             | Render the form as plain text                                                                              |
 | readOnly         | boolean `(false)`                                             | Make the form readonly                                                                                     |
 
-### Form methods
+### Form ref
 
 - check
 

--- a/docs/pages/components/form/en-US/index.md
+++ b/docs/pages/components/form/en-US/index.md
@@ -66,6 +66,10 @@ Error message can be set in 2 ways:
 
 ## Accessibility
 
+### ARIA properties
+
+- You should set the `aria-label` or `aria-labelledby` property for each form so that the screen reader can read the purpose of the form correctly.
+
 - Through the `controlId` prop of `<Form.Group>`, you can set `id` on `<Form.Control>` and set `htmlFor` on `<Form.ControlLabel>`. In addition, `aria-labelledby` and `aria-describeby` will be generated for `<Form.Control>`, corresponding to the `id` of `<Form.ControlLabel>` and `<Form.HelpText>`.
 
 ```html
@@ -92,6 +96,8 @@ HTML:
   <span id="name-help-text" class="rs-form-help-text">Username is required</span>
 </div>
 ```
+
+### Required JavaScript features
 
 - Click the button of `type='submit'` in the Form, and the submit event of the form will be triggered automatically.
 

--- a/docs/pages/components/form/fragments/status.md
+++ b/docs/pages/components/form/fragments/status.md
@@ -75,7 +75,6 @@ const App = () => {
 
   return (
     <Panel>
-      dsdfsdf
       <Form
         disabled={disabled}
         readOnly={readOnly}

--- a/docs/pages/components/form/zh-CN/index.md
+++ b/docs/pages/components/form/zh-CN/index.md
@@ -99,6 +99,8 @@
 
 ### `<Form>`
 
+<!-- prettier-sort-markdown-table -->
+
 | 名称             | 类型 `(默认值)`                                               | 描述                                               |
 | ---------------- | ------------------------------------------------------------- | -------------------------------------------------- |
 | checkTrigger     | 'change' &#124; 'blur' &#124; 'none' `('change')`             | 触发表单校验的类型                                 |
@@ -111,13 +113,14 @@
 | formValue        | object                                                        | 表单的值 `受控组件`                                |
 | layout           | 'horizontal' &#124; 'vertical' &#124; 'inline' `('vertical')` | 设置表单内的元素左右两栏布局                       |
 | model            | Schema                                                        | SchemaModel 对象                                   |
+| nestedField      | boolean `(false)`                                             | 是否支持表单数据嵌套                               |
 | onChange         | (formValue: object, event) => void                            | 数据改变后的回调函数                               |
 | onCheck          | (formError: object) => void                                   | 数据校验的回调函数                                 |
 | onError          | (formError: object) => void                                   | 校验出错的回调函数                                 |
 | plaintext        | boolean `(false)`                                             | 表单显示为纯文本                                   |
 | readOnly         | boolean `(false)`                                             | 只读表单                                           |
 
-### Form methods
+### Form ref
 
 - check 检验表单数据
 

--- a/docs/pages/components/form/zh-CN/index.md
+++ b/docs/pages/components/form/zh-CN/index.md
@@ -64,8 +64,11 @@
 
 <!--{include:`status.md`}-->
 
-## 无障碍设计
+## 可访问性
 
+### ARIA 属性
+
+- 您应该为每个表单设置 `aria-label` 或 `aria-labelledby` 属性，以便屏幕阅读器可以正确地读取表单的目的。
 - 通过 `<Form.Group>` 的 `controlId` 属性，可以在 `<Form.Control>` 上设置 `id` 同时在 `<Form.ControlLabel>` 上设置 `htmlFor`。另外会为 `<Form.Control>` 生成`aria-labelledby` 和 `aria- describeby`， 对应到 `<Form.ControlLabel>` 与 `<Form.HelpText>` 的 `id`。
 
 ```html
@@ -92,6 +95,8 @@
   <span id="name-help-text" class="rs-form-help-text">Username is required</span>
 </div>
 ```
+
+### 必需的 JavaScript 功能
 
 - 在 Form 内点击 `type='submit'` 的按钮，会自动触发表单的 submit 事件。
 

--- a/src/Form/FormContext.tsx
+++ b/src/Form/FormContext.tsx
@@ -10,6 +10,7 @@ interface TrulyFormContextValue<
 > {
   getCombinedModel: () => Schema;
   formError: E;
+  nestedField: boolean;
   removeFieldValue: (name: string) => void;
   removeFieldError: (name: string) => void;
   pushFieldRule: (name: string, fieldRule: FieldRuleType) => void;

--- a/src/Form/styles/mixin.less
+++ b/src/Form/styles/mixin.less
@@ -114,10 +114,9 @@
   @height: ~'input-height-@{size-name}';
   @useable-height: (@@height - 2px);
   @vertical: ~'padding-@{size-name}-vertical';
-  @add-on-padding: ~'input-group-padding-for-add-on-@{size-name}';
 
   &.rs-input-group-inside > .rs-input {
-    padding-right: @@add-on-padding;
+    padding-right: 0;
   }
 
   &.rs-input-group {

--- a/src/Form/test/FormSpec.tsx
+++ b/src/Form/test/FormSpec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent, act, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
-import { getInstance, testStandardProps, itChrome } from '@test/utils';
+import { getInstance, testStandardProps } from '@test/utils';
 
 import Form, { FormInstance } from '../Form';
 import FormControl from '../../FormControl';
@@ -54,41 +54,26 @@ describe('Form', () => {
     expect(screen.getByRole('form')).to.have.class('rs-form-inline');
   });
 
-  itChrome('Should be disabled', () => {
-    const onSubmit = sinon.spy();
+  it('Should be disabled', () => {
     render(
-      <Form aria-label="form" disabled onSubmit={onSubmit}>
+      <Form aria-label="form" disabled>
         <button type="submit">submit</button>
       </Form>
     );
 
     expect(screen.getByRole('form')).to.have.class('rs-form-disabled');
-
-    fireEvent.click(screen.getByRole('button'));
-
-    expect(onSubmit).to.be.not.called;
   });
 
-  itChrome('Should be readOnly', () => {
-    const onSubmit = sinon.spy();
-    render(<Form aria-label="form" readOnly onSubmit={onSubmit} />);
+  it('Should be readOnly', () => {
+    render(<Form aria-label="form" readOnly />);
 
     expect(screen.getByRole('form')).to.have.class('rs-form-readonly');
-
-    fireEvent.submit(screen.getByRole('form'));
-
-    expect(onSubmit).to.be.not.called;
   });
 
-  itChrome('Should be plaintext', () => {
-    const onSubmit = sinon.spy();
-    render(<Form aria-label="form" plaintext onSubmit={onSubmit} />);
+  it('Should be plaintext', () => {
+    render(<Form aria-label="form" plaintext />);
 
     expect(screen.getByRole('form')).to.have.class('rs-form-plaintext');
-
-    fireEvent.submit(screen.getByRole('form'));
-
-    expect(onSubmit).to.be.not.called;
   });
 
   it('Should have a value', () => {

--- a/src/Form/test/FormSpec.tsx
+++ b/src/Form/test/FormSpec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent, act, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
-import { getInstance, testStandardProps } from '@test/utils';
+import { getInstance, testStandardProps, itChrome } from '@test/utils';
 
 import Form, { FormInstance } from '../Form';
 import FormControl from '../../FormControl';
@@ -54,18 +54,22 @@ describe('Form', () => {
     expect(screen.getByRole('form')).to.have.class('rs-form-inline');
   });
 
-  it('Should be disabled', () => {
+  itChrome('Should be disabled', () => {
     const onSubmit = sinon.spy();
-    render(<Form aria-label="form" disabled onSubmit={onSubmit} />);
+    render(
+      <Form aria-label="form" disabled onSubmit={onSubmit}>
+        <button type="submit">submit</button>
+      </Form>
+    );
 
     expect(screen.getByRole('form')).to.have.class('rs-form-disabled');
 
-    fireEvent.submit(screen.getByRole('form'));
+    fireEvent.click(screen.getByRole('button'));
 
     expect(onSubmit).to.be.not.called;
   });
 
-  it('Should be readOnly', () => {
+  itChrome('Should be readOnly', () => {
     const onSubmit = sinon.spy();
     render(<Form aria-label="form" readOnly onSubmit={onSubmit} />);
 
@@ -76,7 +80,7 @@ describe('Form', () => {
     expect(onSubmit).to.be.not.called;
   });
 
-  it('Should be plaintext', () => {
+  itChrome('Should be plaintext', () => {
     const onSubmit = sinon.spy();
     render(<Form aria-label="form" plaintext onSubmit={onSubmit} />);
 

--- a/src/Form/test/FormSpec.tsx
+++ b/src/Form/test/FormSpec.tsx
@@ -38,20 +38,53 @@ describe('Form', () => {
   testStandardProps(<Form />);
 
   it('Should render a Form', () => {
-    const title = 'Test';
-    const { container } = render(<Form>{title}</Form>);
-    expect(container.firstChild).to.have.tagName('FORM');
-    expect(container.firstChild).to.have.text(title);
+    render(<Form aria-label="form">My Form</Form>);
+
+    expect(screen.getByRole('form')).to.have.tagName('FORM');
+    expect(screen.getByRole('form')).to.have.text('My Form');
   });
 
   it('Should be horizontal', () => {
-    const { container } = render(<Form layout="horizontal" />);
-    expect(container.firstChild).to.have.class('rs-form-horizontal');
+    render(<Form aria-label="form" layout="horizontal" />);
+    expect(screen.getByRole('form')).to.have.class('rs-form-horizontal');
   });
 
   it('Should be inline', () => {
-    const { container } = render(<Form layout="inline" />);
-    expect(container.firstChild).to.have.class('rs-form-inline');
+    render(<Form aria-label="form" layout="inline" />);
+    expect(screen.getByRole('form')).to.have.class('rs-form-inline');
+  });
+
+  it('Should be disabled', () => {
+    const onSubmit = sinon.spy();
+    render(<Form aria-label="form" disabled onSubmit={onSubmit} />);
+
+    expect(screen.getByRole('form')).to.have.class('rs-form-disabled');
+
+    fireEvent.submit(screen.getByRole('form'));
+
+    expect(onSubmit).to.be.not.called;
+  });
+
+  it('Should be readOnly', () => {
+    const onSubmit = sinon.spy();
+    render(<Form aria-label="form" readOnly onSubmit={onSubmit} />);
+
+    expect(screen.getByRole('form')).to.have.class('rs-form-readonly');
+
+    fireEvent.submit(screen.getByRole('form'));
+
+    expect(onSubmit).to.be.not.called;
+  });
+
+  it('Should be plaintext', () => {
+    const onSubmit = sinon.spy();
+    render(<Form aria-label="form" plaintext onSubmit={onSubmit} />);
+
+    expect(screen.getByRole('form')).to.have.class('rs-form-plaintext');
+
+    fireEvent.submit(screen.getByRole('form'));
+
+    expect(onSubmit).to.be.not.called;
   });
 
   it('Should have a value', () => {
@@ -108,7 +141,7 @@ describe('Form', () => {
         model={model}
         formDefaultValue={values}
         onError={formError => {
-          assert.equal(formError.name, checkEmail);
+          expect(formError.name).to.equal(checkEmail);
         }}
       >
         <FormControl name="name" />
@@ -211,18 +244,18 @@ describe('Form', () => {
       name: 'abc'
     };
 
-    const onChangeSpy = sinon.spy();
+    const onChange = sinon.spy();
 
     render(
-      <Form formDefaultValue={values} onChange={onChangeSpy}>
+      <Form formDefaultValue={values} onChange={onChange}>
         <FormControl name="name" />
       </Form>
     );
 
     userEvent.type(screen.getByRole('textbox'), 'd');
 
-    expect(onChangeSpy).to.be.called;
-    expect(onChangeSpy).to.be.calledWith({ name: 'abcd' });
+    expect(onChange).to.be.called;
+    expect(onChange).to.be.calledWith({ name: 'abcd' });
   });
 
   it('Should call onError callback', () => {

--- a/src/FormControl/test/FormControlSpec.tsx
+++ b/src/FormControl/test/FormControlSpec.tsx
@@ -43,28 +43,6 @@ describe('FormControl', () => {
     expect(onChange).to.have.been.calledOnce;
   });
 
-  it('Should set correctly defaultValue', () => {
-    render(
-      <Form formDefaultValue={{ user: { name: ['name0', 'name1'] } }}>
-        <FormControl name="user.name.1" />
-      </Form>
-    );
-
-    expect(screen.getByRole('textbox')).to.have.value('name1');
-  });
-
-  it('Should return correctly value when onChange called', () => {
-    let formValue: Record<string, any> = { user: { name: ['name0', 'name1'] } };
-    render(
-      <Form formValue={formValue} onChange={value => (formValue = value)}>
-        <FormControl name="user.name.1" />
-      </Form>
-    );
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'name2' } });
-
-    expect(formValue.user.name[1]).to.equal('name2');
-  });
-
   it('Should be readOnly', () => {
     render(
       <Form readOnly>
@@ -472,6 +450,76 @@ describe('FormControl', () => {
       );
 
       expect(screen.getByRole('switch')).to.not.be.checked;
+    });
+  });
+
+  describe('Nested Fields', () => {
+    it('Should set correctly defaultValue', () => {
+      render(
+        <Form formDefaultValue={{ user: { name: ['name0', 'name1'] } }} nestedField>
+          <FormControl name="user.name.1" />
+        </Form>
+      );
+
+      expect(screen.getByRole('textbox')).to.have.value('name1');
+    });
+
+    it('Should return correctly value when onChange called', () => {
+      let formValue: Record<string, any> = { user: { name: ['name0', 'name1'] } };
+      render(
+        <Form formValue={formValue} onChange={value => (formValue = value)} nestedField>
+          <FormControl name="user.name.1" />
+        </Form>
+      );
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'name2' } });
+
+      expect(formValue.user.name[1]).to.equal('name2');
+    });
+
+    it('Should render an error message when the value changes', () => {
+      const model = Schema.Model({
+        user: Schema.Types.ObjectType().shape({
+          age: Schema.Types.NumberType('Age must be a number ')
+        })
+      });
+
+      render(
+        <Form formDefaultValue={{ user: { age: '10' } }} model={model} nestedField>
+          <FormControl name="user.age" />
+        </Form>
+      );
+
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'a' } });
+
+      expect(screen.getByRole('alert')).to.have.text('Age must be a number ');
+    });
+
+    it('Should render an error message when the form is checked', () => {
+      const model = Schema.Model({
+        user: Schema.Types.ObjectType().shape({
+          age: Schema.Types.NumberType('Age must be a number ')
+        })
+      });
+
+      const ref = React.createRef<any>();
+
+      render(
+        <Form
+          formDefaultValue={{ user: { age: '10' } }}
+          model={model}
+          nestedField
+          ref={ref}
+          checkTrigger="none"
+        >
+          <FormControl name="user.age" />
+        </Form>
+      );
+
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'a' } });
+
+      ref.current.check();
+
+      expect(screen.getByRole('alert')).to.have.text('Age must be a number ');
     });
   });
 });

--- a/src/FormControl/test/FormControlSpec.tsx
+++ b/src/FormControl/test/FormControlSpec.tsx
@@ -456,24 +456,34 @@ describe('FormControl', () => {
   describe('Nested Fields', () => {
     it('Should set correctly defaultValue', () => {
       render(
-        <Form formDefaultValue={{ user: { name: ['name0', 'name1'] } }} nestedField>
+        <Form formDefaultValue={{ user: { name: ['foo', 'bar'] } }} nestedField>
           <FormControl name="user.name.1" />
         </Form>
       );
 
-      expect(screen.getByRole('textbox')).to.have.value('name1');
+      expect(screen.getByRole('textbox')).to.have.value('bar');
+    });
+
+    it('Should render the value on the FormControl', () => {
+      render(
+        <Form formDefaultValue={{ user: { name: ['foo', 'bar'] } }} nestedField>
+          <FormControl name="user.name.1" value="tom" />
+        </Form>
+      );
+
+      expect(screen.getByRole('textbox')).to.have.value('tom');
     });
 
     it('Should return correctly value when onChange called', () => {
-      let formValue: Record<string, any> = { user: { name: ['name0', 'name1'] } };
+      let formValue: Record<string, any> = { user: { name: ['foo', 'bar'] } };
       render(
         <Form formValue={formValue} onChange={value => (formValue = value)} nestedField>
           <FormControl name="user.name.1" />
         </Form>
       );
-      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'name2' } });
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'tom' } });
 
-      expect(formValue.user.name[1]).to.equal('name2');
+      expect(formValue.user.name[1]).to.equal('tom');
     });
 
     it('Should render an error message when the value changes', () => {
@@ -486,6 +496,22 @@ describe('FormControl', () => {
       render(
         <Form formDefaultValue={{ user: { age: '10' } }} model={model} nestedField>
           <FormControl name="user.age" />
+        </Form>
+      );
+
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'a' } });
+
+      expect(screen.getByRole('alert')).to.have.text('Age must be a number ');
+    });
+
+    it('Should render an error message when the value changes', () => {
+      const model = Schema.Model({
+        age: Schema.Types.NumberType('Age must be a number ')
+      });
+
+      render(
+        <Form formDefaultValue={{ age: '10' }} model={model} nestedField>
+          <FormControl name="age" />
         </Form>
       );
 

--- a/src/FormControl/test/FormControlSpec.tsx
+++ b/src/FormControl/test/FormControlSpec.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
 import { getDOMNode } from '@test/utils';
 import Form, { FormInstance } from '../../Form';
@@ -494,7 +494,7 @@ describe('FormControl', () => {
       expect(screen.getByRole('alert')).to.have.text('Age must be a number ');
     });
 
-    it('Should render an error message when the form is checked', () => {
+    it('Should render an error message when the form is checked', async () => {
       const model = Schema.Model({
         user: Schema.Types.ObjectType().shape({
           age: Schema.Types.NumberType('Age must be a number ')
@@ -519,7 +519,9 @@ describe('FormControl', () => {
 
       ref.current.check();
 
-      expect(screen.getByRole('alert')).to.have.text('Age must be a number ');
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).to.have.text('Age must be a number ');
+      });
     });
   });
 });

--- a/src/FormGroup/FormGroup.tsx
+++ b/src/FormGroup/FormGroup.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { useClassNames } from '../utils';
+import { useClassNames, useUniqueId } from '../utils';
 import { WithAsProps, RsRefForwardingComponent } from '../@types/common';
 
 export interface FormGroupProps extends WithAsProps {
@@ -22,13 +22,14 @@ const FormGroup: RsRefForwardingComponent<'div', FormGroupProps> = React.forward
     const {
       as: Component = 'div',
       classPrefix = 'form-group',
-      controlId,
+      controlId: controlIdProp,
       className,
       ...rest
     } = props;
 
     const { withClassPrefix, merge } = useClassNames(classPrefix);
     const classes = merge(className, withClassPrefix());
+    const controlId = useUniqueId('rs-', controlIdProp);
     const contextValue = useMemo(() => ({ controlId }), [controlId]);
 
     return (


### PR DESCRIPTION
`nestedField` can make the form support nested data, default is false.

```tsx

const model = Schema.Model({
  name: StringType().isRequired('This field is required.'),
  address: ObjectType().shape({
    city: StringType().isRequired('This field is required.'),
    postCode: NumberType('Post Code must be a number').isRequired('This field is required.')
  })
});

const formValue = {
  name: 'Tom',
  address: { city: 'ShangHai', postCode: '200000' }
};

<Form formValue={formValue} nestedField model={model} >
  <FormControl name="name" />
  <FormControl name="address.city" />
  <FormControl name="address.postCode" />
</Form>
```