### PR TITLE
docs: fix searching icon isn't working

### DIFF
--- a/docs/utils/component.config.json
+++ b/docs/utils/component.config.json
@@ -33,6 +33,7 @@
   {
     "id": "icon",
     "name": "Icons",
+    "components": ["Icon"],
     "title": "图标"
   },
   {


### PR DESCRIPTION
### before

<img width="1165" alt="image" src="https://github.com/rsuite/rsuite/assets/53305259/4347570b-57f5-4fd8-a42a-d92939d78ec0">

### after

<img width="1077" alt="image" src="https://github.com/rsuite/rsuite/assets/53305259/df7a71a8-f33e-48a3-b790-feee5854a198">


close #3577 