### PR TITLE
fix: use toString instead of an empty string

### DIFF
--- a/src/utils/useUniqueId.ts
+++ b/src/utils/useUniqueId.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import uniqueId from 'lodash/uniqueId';
 
-const reactUseId: undefined | (() => string) = (React as any)['useId' + ''];
+const reactUseId: undefined | (() => string) = (React as any)['useId'.toString()];
 
 /**
  * Used for generating unique ID for DOM elements


### PR DESCRIPTION
ref: https://github.com/webpack/webpack/issues/14814

summary: when using `'useId' + ''`, the bundler will optimize it to `'useId'`.  Then webpack will analyze if `useId` is in `React`.  As a result, it will throw a warning `useId isn't in React`. However `'useId'.toString` will not be optimized. Therefore it will prevent webpack throw this error