### PR TITLE
fix(tree): improve the hover and focus status of Tree nodes

### DIFF
--- a/src/CheckTreePicker/CheckTreeNode.tsx
+++ b/src/CheckTreePicker/CheckTreeNode.tsx
@@ -176,7 +176,7 @@ const CheckTreeNode: RsRefForwardingComponent<'div', CheckTreeNodeProps> = forwa
           title={getTitle()}
           onSelect={handleSelect}
         >
-          <span className={prefix('text-wrapper')}>
+          <span className={prefix('label-content')}>
             {typeof renderTreeNode === 'function' ? renderTreeNode(nodeData) : label}
           </span>
         </ListCheckItem>

--- a/src/CheckTreePicker/styles/index.less
+++ b/src/CheckTreePicker/styles/index.less
@@ -16,31 +16,29 @@
     overflow: hidden;
   }
 
-  .rs-check-item .rs-checkbox-checker {
-    > label {
-      text-align: left;
-      position: relative;
-      margin: 0;
-      //padding-left: 16px;
-      padding: @picker-tree-node-padding-vertical @picker-tree-node-padding-horizontal;
-      //text gap + checkbox space + label gap
-      padding-left: 50px; // 10px + 36px + 4px
+  .rs-check-tree-node-label {
+    .rs-check-item .rs-checkbox-checker {
+      > label {
+        text-align: left;
+        position: relative;
+        margin: 0;
+        padding: 1px 0 1px 42px;
+      }
 
-      &::before {
-        content: '';
-        position: absolute;
-        width: (
-          @picker-tree-arrow-down-width + @picker-tree-arrow-down-gap + 30px
-        ); // checkbox-spacing = 30
+      .rs-checkbox-wrapper {
+        left: (@checkbox-sense-width + 10px);
+      }
 
-        height: 100%;
-        top: 0;
-        margin-left: -52px; // 10px + 36px + 6px
+      .rs-check-tree-node-label-content {
+        padding: 6px 8px;
+        width: auto;
       }
     }
 
-    .rs-checkbox-wrapper {
-      left: (@checkbox-sense-width + 10px);
+    &:focus-visible {
+      .rs-check-tree-node-label-content {
+        .focus-ring();
+      }
     }
   }
 }
@@ -68,6 +66,18 @@
 
   .rs-check-item {
     display: inline-block;
+
+    &:hover,
+    &:focus,
+    &-focus {
+      background-color: transparent !important;
+
+      .rs-check-tree-node-label-content {
+        background-color: var(--rs-listbox-option-hover-bg);
+        color: var(--rs-listbox-option-hover-text);
+        border-radius: 6px;
+      }
+    }
 
     .rs-picker-popup & {
       display: block;
@@ -161,16 +171,16 @@
   &.rs-check-tree-menu {
     padding-top: @picker-menu-padding;
   }
+}
 
-  .rs-check-tree {
-    padding-right: @picker-menu-padding;
+.rs-check-tree {
+  padding-right: @picker-menu-padding;
 
-    &-node > .rs-check-tree-node-label .rs-check-tree-node-text-wrapper {
-      .ellipsis();
+  &-node > .rs-check-tree-node-label .rs-check-tree-node-label-content {
+    .ellipsis();
 
-      display: inline-block;
-      vertical-align: top;
-    }
+    display: inline-block;
+    vertical-align: top;
   }
 }
 

--- a/src/CheckTreePicker/test/CheckTreePickerStylesSpec.tsx
+++ b/src/CheckTreePicker/test/CheckTreePickerStylesSpec.tsx
@@ -14,7 +14,7 @@ describe('CheckTreePicker styles', () => {
 
     expect(screen.getByRole('tree').querySelector('.rs-checkbox-checker label')).to.have.style(
       'padding',
-      '8px 12px 8px 50px'
+      '1px 0px 1px 42px'
     );
   });
 
@@ -23,7 +23,7 @@ describe('CheckTreePicker styles', () => {
 
     expect(screen.getByRole('tree').querySelector('.rs-checkbox-checker label')).to.have.style(
       'padding',
-      '8px 12px 8px 32px'
+      '1px 0px 1px 42px'
     );
   });
 
@@ -41,7 +41,7 @@ describe('CheckTreePicker styles', () => {
 
     expect(screen.getByRole('tree').querySelector('.rs-checkbox-checker label')).to.have.style(
       'padding',
-      '8px 12px 8px 22px'
+      '1px 0px 1px 42px'
     );
   });
 });

--- a/src/Tree/test/TreeStylesSpec.tsx
+++ b/src/Tree/test/TreeStylesSpec.tsx
@@ -1,24 +1,19 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import Tree from '../index';
-import { getStyle, inChrome } from '@test/utils';
+import { itChrome } from '@test/utils';
 import { mockTreeData } from '@test/mocks/data-mock';
-import { PickerHandle } from '../../internals/Picker';
 
 const data = mockTreeData([['Master', 'tester0', ['tester1', 'tester2']], 'disabled']);
 
 describe('Tree styles', () => {
-  it('Should render the correct styles', () => {
-    const instanceRef = React.createRef<PickerHandle>();
+  itChrome('Should render the correct styles', () => {
+    render(<Tree virtualized={false} data={data} />);
 
-    // FIXME `ref` should be type Ref<PickerHandle>
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    render(<Tree virtualized={false} data={data} ref={instanceRef} />);
+    const itemLabel = screen
+      .getByRole('tree')
+      .querySelector('.rs-tree .rs-tree-node-label') as HTMLElement;
 
-    const itemLabel = ((instanceRef.current as PickerHandle).root as HTMLElement).querySelector(
-      '.rs-tree .rs-tree-node-label'
-    ) as HTMLElement;
-    inChrome && assert.equal(getStyle(itemLabel, 'padding'), '0px 0px 0px 16px');
+    expect(itemLabel).to.have.style('padding', '1px 1px 1px 16px');
   });
 });

--- a/src/TreePicker/styles/index.less
+++ b/src/TreePicker/styles/index.less
@@ -42,18 +42,22 @@
     position: relative;
     margin: 0;
     //text gap
-    padding-left: (@picker-tree-arrow-down-width + 8px);
+    padding: 1px 1px 1px (@picker-tree-arrow-down-width + 8px);
     display: inline-block;
     cursor: pointer;
     font-size: @picker-tree-node-font-size;
     line-height: @picker-tree-node-line-height;
 
+    &:focus-visible {
+      .rs-tree-node-label-content {
+        .focus-ring();
+      }
+    }
+
     &-content {
-      padding: @custom-picker-tree-node-padding-vertical @picker-tree-node-padding-horizontal
-        @custom-picker-tree-node-padding-vertical @picker-tree-arrow-down-gap;
+      padding: 6px 8px;
       display: inline-block;
-      border-top: 2px solid transparent;
-      border-bottom: 2px solid transparent;
+      border-radius: 6px;
 
       &:hover,
       &:focus,

--- a/src/TreePicker/test/TreePickerStylesSpec.tsx
+++ b/src/TreePicker/test/TreePickerStylesSpec.tsx
@@ -16,6 +16,6 @@ describe('TreePicker styles', () => {
 
     expect(tree).to.have.style('padding', '0px 12px 0px 0px');
     expect(treeNode).to.have.style('font-size', '0px');
-    expect(treeNode).to.have.style('height', '36px');
+    expect(treeNode).to.have.style('height', '34px');
   });
 });

--- a/src/internals/Picker/ListCheckItem.tsx
+++ b/src/internals/Picker/ListCheckItem.tsx
@@ -64,7 +64,7 @@ const ListCheckItem: RsRefForwardingComponent<'div', ListCheckItemProps> = React
     });
 
     const { id } = useCombobox();
-    const { withClassPrefix } = useClassNames(classPrefix);
+    const { withClassPrefix, merge, rootPrefix } = useClassNames(classPrefix);
     const checkboxItemClasses = withClassPrefix({ focus });
 
     const checkboxProps: CheckboxProps = {
@@ -81,6 +81,8 @@ const ListCheckItem: RsRefForwardingComponent<'div', ListCheckItemProps> = React
       onCheckboxClick: handleCheck
     };
 
+    console.log(className, 'className');
+
     return (
       <Component
         role="option"
@@ -90,7 +92,7 @@ const ListCheckItem: RsRefForwardingComponent<'div', ListCheckItemProps> = React
         data-key={value}
         {...rest}
         ref={ref}
-        className={className}
+        className={merge(className, rootPrefix`picker-list-item`)}
         tabIndex={-1}
       >
         {renderMenuItemCheckbox ? (

--- a/src/internals/Picker/ListItem.tsx
+++ b/src/internals/Picker/ListItem.tsx
@@ -43,7 +43,7 @@ const ListItem: RsRefForwardingComponent<'div', ListItemProps> = React.forwardRe
       }
     });
 
-    const { withClassPrefix } = useClassNames(classPrefix);
+    const { withClassPrefix, merge, rootPrefix } = useClassNames(classPrefix);
     const classes = withClassPrefix({ active, focus, disabled });
 
     return (
@@ -55,7 +55,7 @@ const ListItem: RsRefForwardingComponent<'div', ListItemProps> = React.forwardRe
         data-key={value}
         {...rest}
         ref={ref}
-        className={className}
+        className={merge(className, rootPrefix`picker-list-item`)}
         tabIndex={-1}
         onKeyDown={disabled ? null : onKeyDown}
         onClick={handleClick}

--- a/src/internals/Picker/TreeView.tsx
+++ b/src/internals/Picker/TreeView.tsx
@@ -13,7 +13,7 @@ const TreeView = React.forwardRef((props: TreeViewProps, ref: React.Ref<HTMLDivE
   return (
     <div
       role="tree"
-      id={`${id}-${popupType}`}
+      id={id ? `${id}-${popupType}` : undefined}
       aria-multiselectable={multiselectable}
       aria-labelledby={labelId}
       ref={ref}

--- a/src/internals/Picker/styles/index.less
+++ b/src/internals/Picker/styles/index.less
@@ -354,7 +354,7 @@
   &:not(.rs-checkbox-disabled):hover,
   &:focus,
   &&-focus {
-    .listbox-option-active(true);
+    .listbox-option-active();
 
     .high-contrast-mode({
       .rs-check-tree-node-text-wrapper {

--- a/src/styles/mixins/listbox.less
+++ b/src/styles/mixins/listbox.less
@@ -38,14 +38,9 @@
 }
 
 // "-active" for aria-activedescendant
-.listbox-option-active(@multiselectable: false) {
+.listbox-option-active() {
   background-color: var(--rs-listbox-option-hover-bg);
-
-  // No need to change text color in multiselectable listboxes
-  // in favor of checkbox state changes
-  & when (@multiselectable = false) {
-    color: var(--rs-listbox-option-hover-text);
-  }
+  color: var(--rs-listbox-option-hover-text);
 
   .high-contrast-mode({
     .focus-ring(slim-inset);


### PR DESCRIPTION
## Before

<img width="299" alt="image" src="https://github.com/rsuite/rsuite/assets/1203827/52f6c6e4-da05-4ed5-a1b9-92ad46118d55">



## After 

<img width="303" alt="image" src="https://github.com/rsuite/rsuite/assets/1203827/802e46e8-7522-4d3d-9a5e-6820c7a6d6ab">
