### PR TITLE
fix(InputGroup): fix that the bg color of `InputGroup.Addon` is inconsistent with `Input`

### DIFF
--- a/src/InputGroup/styles/index.less
+++ b/src/InputGroup/styles/index.less
@@ -119,7 +119,7 @@
 
   &.rs-input-group-inside {
     width: 100%;
-    //border-radius: 0;
+    background-color: var(--rs-input-bg);
 
     .rs-input {
       display: block;


### PR DESCRIPTION
### Before

<img width="430" alt="image" src="https://github.com/rsuite/rsuite/assets/1203827/325bbe80-4191-4739-a8eb-9693c549dc53">


### After

<img width="344" alt="image" src="https://github.com/rsuite/rsuite/assets/1203827/4ec9fa41-9a14-4991-b5d8-360da058ee60">
