### PR TITLE
feat(Message): add support for `bordered` and `centered` props on Message

### DIFF
--- a/docs/pages/components/message/en-US/index.md
+++ b/docs/pages/components/message/en-US/index.md
@@ -24,6 +24,14 @@ Used to show important tips on a page.
 
 <!--{include:`icons.md`}-->
 
+### Bordered
+
+<!--{include:`bordered.md`}-->
+
+### Centered
+
+<!--{include:`centered.md`}-->
+
 ### Closable
 
 <!--{include:`close.md`}-->
@@ -52,8 +60,12 @@ No keyboard interaction needed.
 
 ### `<Message>`
 
+<!-- prettier-sort-markdown-table -->
+
 | Property    | Type `(Default)`                                        | Description                                                                                                                                                                   |
 | ----------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| bordered    | boolean                                                 | Show a border around the message box.<br/>![](https://img.shields.io/badge/min-v5.53.0-blue)                                                                                  |
+| centered    | boolean                                                 | Center the message vertically.<br/>![](https://img.shields.io/badge/min-v5.53.0-blue)                                                                                         |
 | children    | ReactNode                                               | The description information for the message.                                                                                                                                  |
 | classPrefix | string `('message')`                                    | The prefix of the component CSS class.                                                                                                                                        |
 | closable    | boolean                                                 | Whether it is possible to close the message box                                                                                                                               |

--- a/docs/pages/components/message/fragments/bordered.md
+++ b/docs/pages/components/message/fragments/bordered.md
@@ -1,0 +1,26 @@
+<!--start-code-->
+
+```js
+import { Message } from 'rsuite';
+
+const App = () => (
+  <>
+    <Message type="info" bordered showIcon>
+      <strong>Info!</strong> You can use the `Message` component to display a info message.
+    </Message>
+    <Message type="success" bordered showIcon>
+      <strong>Success!</strong> You can use the `Message` component to display a success message.
+    </Message>
+    <Message type="warning" bordered showIcon>
+      <strong>Warning!</strong> You can use the `Message` component to display a warning message.
+    </Message>
+    <Message type="error" bordered showIcon>
+      <strong>Error!</strong> You can use the `Message` component to display a error message.
+    </Message>
+  </>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/message/fragments/centered.md
+++ b/docs/pages/components/message/fragments/centered.md
@@ -1,0 +1,21 @@
+<!--start-code-->
+
+```js
+import { Message } from 'rsuite';
+
+const App = () => (
+  <Message type="success" centered showIcon header="Application has been accepted !">
+    <p>
+      Your application has been successfully submitted, and we will process it within 1-3 working
+      days.
+    </p>
+    <p>
+      You can check the application status in the <a href="#">application record</a>.
+    </p>
+  </Message>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/message/fragments/header.md
+++ b/docs/pages/components/message/fragments/header.md
@@ -5,11 +5,11 @@ import { Message, Button, Divider } from 'rsuite';
 
 const App = () => (
   <>
-    <Message showIcon type="warning" header={<strong>Cannot delete the file</strong>}>
+    <Message showIcon type="warning" header="Cannot delete the file">
       We are sorry, the file cannot be deleted. Please try again later.
     </Message>
 
-    <Message showIcon type="error" header={<strong>A problem occurred</strong>}>
+    <Message showIcon type="error" header="A problem occurred">
       <ol>
         <li>Please check your network connection.</li>
         <li>Please check the file permissions.</li>
@@ -18,8 +18,8 @@ const App = () => (
       </ol>
     </Message>
 
-    <Message showIcon type="info" header={<strong>Do you want to allow notifications?</strong>}>
-      We can let you know when new messages arrive.
+    <Message showIcon type="info" header="Do you want to allow notifications?">
+      <p> We can let you know when new messages arrive.</p>
       <hr />
       <ButtonToolbar>
         <Button size="sm">Don't allow</Button>

--- a/docs/pages/components/message/zh-CN/index.md
+++ b/docs/pages/components/message/zh-CN/index.md
@@ -24,6 +24,14 @@
 
 <!--{include:`icons.md`}-->
 
+### 带边框
+
+<!--{include:`bordered.md`}-->
+
+### 垂直居中
+
+<!--{include:`centered.md`}-->
+
 ### 可关闭的
 
 <!--{include:`close.md`}-->
@@ -52,8 +60,12 @@ Message 的 `role` 为 `alert`。
 
 ### `<Message>`
 
+<!-- prettier-sort-markdown-table -->
+
 | 属性名称    | 类型 `(默认值)`                                                    | 描述                                                                                            |
 | ----------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| bordered    | boolean                                                            | 显示消息框边框 <br/>![](https://img.shields.io/badge/min-v5.53.0-blue)                          |
+| centered    | boolean                                                            | 垂直居中消息框 <br/>![](https://img.shields.io/badge/min-v5.53.0-blue)                          |
 | children    | ReactNode                                                          | 消息描述信息                                                                                    |
 | classPrefix | string `('message')`                                               | 组件 CSS 类的前缀                                                                               |
 | closable    | boolean                                                            | 可以关闭消息框                                                                                  |

--- a/src/Message/Message.tsx
+++ b/src/Message/Message.tsx
@@ -20,12 +20,14 @@ export interface MessageProps extends WithAsProps {
   type?: TypeAttributes.Status;
 
   /**
-   * Show a border around the message box
+   * Show a border around the message box.
+   * @version 5.53.0
    */
   bordered?: boolean;
 
   /**
    * Center the message vertically.
+   * @version 5.53.0
    */
   centered?: boolean;
 

--- a/src/Message/stories/Message.stories.tsx
+++ b/src/Message/stories/Message.stories.tsx
@@ -87,6 +87,35 @@ export const Closable: Story = {
   }
 };
 
+export const Bordered: Story = {
+  args: {
+    ...defaultArgs,
+    showIcon: true,
+    bordered: true
+  }
+};
+
+export const Centered: Story = {
+  args: {
+    ...defaultArgs,
+    showIcon: true,
+    centered: true,
+    type: 'success',
+    header: 'Application has been accepted !',
+    children: (
+      <>
+        <p>
+          Your application has been successfully submitted, and we will process it within 1-3
+          working days.
+        </p>
+        <p>
+          You can check the application status in the <a href="#">application record</a>.
+        </p>
+      </>
+    )
+  }
+};
+
 export const WithToaster: Story = {
   render: props => (
     <ButtonToolbar>

--- a/src/Message/styles/index.less
+++ b/src/Message/styles/index.less
@@ -24,8 +24,30 @@
     display: flex;
   }
 
-  // Icon wrapper
-  &-icon-wrapper {
+  &-centered {
+    .rs-message-container {
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      gap: 20px;
+    }
+
+    .rs-message-icon {
+      align-self: center !important;
+
+      .rs-icon {
+        font-size: 40px !important;
+      }
+    }
+
+    &.rs-message-bordered {
+      border-left-width: 1px !important;
+      border-top-width: 4px !important;
+    }
+  }
+
+  // Message icon
+  &-icon {
     align-self: center;
     font-size: 0; // remove whitespace before svg
     margin-right: 10px;
@@ -45,6 +67,7 @@
   &-header {
     color: var(--rs-text-heading);
     line-height: unit((round((@message-icon-large-size / @message-title-size), 16)));
+    font-weight: bold;
     .ellipsis();
 
     & + .rs-message-body {
@@ -66,7 +89,7 @@
   // Message with a title
   &.rs-message-has-title {
     // Bigger icon
-    .rs-message-icon-wrapper {
+    .rs-message-icon {
       align-self: flex-start;
 
       .rs-icon {
@@ -125,6 +148,8 @@
     var(--rs-message-success-header);
     var(--rs-message-success-text);
     var(--rs-message-success-icon);
+    var(--rs-message-success-border);
+    var(--rs-message-success-icon-border);
   );
 
   .high-contrast-mode({
@@ -138,6 +163,8 @@
     var(--rs-message-info-header);
     var(--rs-message-info-text);
     var(--rs-message-info-icon);
+    var(--rs-message-info-border);
+    var(--rs-message-info-icon-border);
   );
 
   .high-contrast-mode({
@@ -151,6 +178,8 @@
     var(--rs-message-warning-header);
     var(--rs-message-warning-text);
     var(--rs-message-warning-icon);
+    var(--rs-message-warning-border);
+    var(--rs-message-warning-icon-border);
   );
 
   .high-contrast-mode({
@@ -164,6 +193,8 @@
     var(--rs-message-error-header);
     var(--rs-message-error-text);
     var(--rs-message-error-icon);
+    var(--rs-message-error-border);
+    var(--rs-message-error-icon-border);
   );
 
   .high-contrast-mode({

--- a/src/Message/styles/mixin.less
+++ b/src/Message/styles/mixin.less
@@ -1,7 +1,18 @@
 // Messages
 
-.message-variant(@background; @header-color; @text-color; @icon-color) {
+.message-variant(@background; @header-color; @text-color; @icon-color; @border-color; @icon-border-color;) {
   background-color: #fff;
+
+  &.rs-message-bordered {
+    border: 1px solid @border-color;
+    border-left-width: 4px;
+
+    .rs-message-icon {
+      box-sizing: content-box;
+      border: 4px solid @icon-border-color;
+      border-radius: 50%;
+    }
+  }
 
   .rs-message-container {
     background-color: @background;
@@ -23,7 +34,7 @@
     font-size: 12px;
   }
 
-  .rs-message-icon-wrapper > .rs-icon,
+  .rs-message-icon > .rs-icon,
   .rs-btn-close {
     color: @icon-color;
   }

--- a/src/Message/test/MessageSpec.tsx
+++ b/src/Message/test/MessageSpec.tsx
@@ -27,6 +27,18 @@ describe('Message', () => {
     expect(screen.getByRole('alert')).to.text('description');
   });
 
+  it('Should be bordered', () => {
+    render(<Message bordered />);
+
+    expect(screen.getByRole('alert')).to.have.class('rs-message-bordered');
+  });
+
+  it('Should be centered', () => {
+    render(<Message centered />);
+
+    expect(screen.getByRole('alert')).to.have.class('rs-message-centered');
+  });
+
   it('Should have a type', () => {
     render(<Message type="info" />);
 

--- a/src/styles/color-modes/dark.less
+++ b/src/styles/color-modes/dark.less
@@ -134,18 +134,22 @@
   --rs-message-success-text: #fff;
   --rs-message-success-icon: #fff;
   --rs-message-success-bg: var(--rs-green-500);
+  --rs-message-success-border: var(--rs-green-800);
   --rs-message-info-header: #fff;
   --rs-message-info-text: #fff;
   --rs-message-info-icon: #fff;
   --rs-message-info-bg: var(--rs-blue-500);
+  --rs-message-info-border: var(--rs-blue-800);
   --rs-message-warning-header: var(--rs-gray-900);
   --rs-message-warning-text: var(--rs-gray-900);
   --rs-message-warning-icon: var(--rs-gray-900);
   --rs-message-warning-bg: var(--rs-yellow-500);
+  --rs-message-warning-border: var(--rs-yellow-800);
   --rs-message-error-header: #fff;
   --rs-message-error-text: #fff;
   --rs-message-error-icon: #fff;
   --rs-message-error-bg: var(--rs-red-500);
+  --rs-message-error-border: var(--rs-red-800);
 
   // Tooltip
   --rs-tooltip-bg: var(--rs-gray-500);

--- a/src/styles/color-modes/light.less
+++ b/src/styles/color-modes/light.less
@@ -140,19 +140,27 @@
   --rs-message-success-header: var(--rs-text-heading);
   --rs-message-success-text: var(--rs-text-primary);
   --rs-message-success-icon: var(--rs-color-green);
+  --rs-message-success-icon-border: var(--rs-green-200);
   --rs-message-success-bg: rgb(from var(--rs-green-100) r g b / 60%);
+  --rs-message-success-border: var(--rs-color-green);
   --rs-message-info-header: var(--rs-text-heading);
   --rs-message-info-text: var(--rs-text-primary);
   --rs-message-info-icon: var(--rs-color-blue);
+  --rs-message-info-icon-border: var(--rs-blue-200);
   --rs-message-info-bg: rgb(from var(--rs-blue-100) r g b / 60%);
+  --rs-message-info-border: var(--rs-color-blue);
   --rs-message-warning-header: var(--rs-text-heading);
   --rs-message-warning-text: var(--rs-text-primary);
   --rs-message-warning-icon: var(--rs-color-yellow);
+  --rs-message-warning-icon-border: var(--rs-yellow-200);
   --rs-message-warning-bg: rgb(from var(--rs-yellow-100) r g b / 60%);
+  --rs-message-warning-border: var(--rs-color-yellow);
   --rs-message-error-header: var(--rs-text-heading);
   --rs-message-error-text: var(--rs-text-primary);
   --rs-message-error-icon: var(--rs-color-red);
+  --rs-message-error-icon-border: var(--rs-red-200);
   --rs-message-error-bg: rgb(from var(--rs-red-100) r g b / 60%);
+  --rs-message-error-border: var(--rs-color-red);
 
   // Tooltip
   --rs-tooltip-bg: var(--rs-gray-900);

--- a/src/utils/statusIcons.tsx
+++ b/src/utils/statusIcons.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import Info from '@rsuite/icons/legacy/Info';
 import CheckCircle from '@rsuite/icons/legacy/CheckCircle';
 import CloseCircle from '@rsuite/icons/legacy/CloseCircle';
-import Remind from '@rsuite/icons/legacy/Remind';
 import Check from '@rsuite/icons/Check';
 import Close from '@rsuite/icons/Close';
+import RemindRoundIcon from '@rsuite/icons/RemindRound';
 
 export const MESSAGE_STATUS_ICONS = {
   info: <Info />,
   success: <CheckCircle />,
   error: <CloseCircle />,
-  warning: <Remind />
+  warning: <RemindRoundIcon />
 };
 
 export const PROGRESS_STATUS_ICON = {


### PR DESCRIPTION
![image](https://github.com/rsuite/rsuite/assets/1203827/a1fbd80d-4d23-4ce0-b23a-fa37811dfad2)

> https://rsuite-nextjs-git-feat-message-bordered-rsuite.vercel.app/components/message/#bordered