### PR TITLE
fix: supports Fragment children component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@babel/runtime-corejs2": "^7.8.4",
         "@commitlint/cli": "^13.2.1",
         "@commitlint/config-conventional": "^13.2.0",
+        "@faker-js/faker": "^8.4.0",
         "@npmcli/package-json": "^2.0.0",
         "@storybook/blocks": "^7.6.10",
         "@storybook/react": "^7.6.10",
@@ -3053,6 +3054,22 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.0.tgz",
+      "integrity": "sha512-htW87352wzUCdX1jyUQocUcmAaFqcR/w082EC8iP/gtkF0K+aKcBp0hR5Arb7dzR8tQ1TrhE9DNa5EbJELm84w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -28049,6 +28066,12 @@
           "dev": true
         }
       }
+    },
+    "@faker-js/faker": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.0.tgz",
+      "integrity": "sha512-htW87352wzUCdX1jyUQocUcmAaFqcR/w082EC8iP/gtkF0K+aKcBp0hR5Arb7dzR8tQ1TrhE9DNa5EbJELm84w==",
+      "dev": true
     },
     "@floating-ui/core": {
       "version": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@babel/runtime-corejs2": "^7.8.4",
     "@commitlint/cli": "^13.2.1",
     "@commitlint/config-conventional": "^13.2.0",
+    "@faker-js/faker": "^8.4.0",
     "@npmcli/package-json": "^2.0.0",
     "@storybook/blocks": "^7.6.10",
     "@storybook/react": "^7.6.10",

--- a/src/Carousel/Carousel.tsx
+++ b/src/Carousel/Carousel.tsx
@@ -131,7 +131,7 @@ const Carousel: RsRefForwardingComponent<'div', CarouselProps> = React.forwardRe
     );
 
     const uniqueId = useMemo(() => guid(), []);
-    const items = React.Children.map(
+    const items = ReactChildren.map(
       children as React.ReactElement[],
       (child: React.ReactElement, index) => {
         if (!child) {

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -801,7 +801,7 @@ const DateRangePicker = React.forwardRef((props: DateRangePickerProps, ref) => {
               />
             )}
 
-            <>
+            <Stack.Item>
               <div className={prefix('daterange-content')}>
                 {showHeader && (
                   <div className={prefix('daterange-header')} data-testid="daterange-header">
@@ -827,7 +827,7 @@ const DateRangePicker = React.forwardRef((props: DateRangePickerProps, ref) => {
                 onShortcutClick={handleShortcutPageDate}
                 ranges={bottomRanges}
               />
-            </>
+            </Stack.Item>
           </Stack>
         </div>
       </PickerPopup>

--- a/src/Stack/Stack.tsx
+++ b/src/Stack/Stack.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useClassNames, useCustom, isSupportFlexGap } from '../utils';
+import { useClassNames, useCustom, isSupportFlexGap, ReactChildren } from '../utils';
 import { oneOf } from '../internals/propTypes';
 import { RsRefForwardingComponent, WithAsProps } from '../@types/common';
 import StackItem from './StackItem';
@@ -90,11 +90,11 @@ const Stack = React.forwardRef((props: StackProps, ref: React.Ref<HTMLDivElement
    */
   const filterChildren = React.Children.toArray(children);
 
-  const count = filterChildren.length;
+  const count = ReactChildren.count(filterChildren as React.ReactElement[]);
 
   return (
     <Component {...rest} ref={ref} className={classes} style={styles}>
-      {React.Children.map(filterChildren as React.ReactElement[], (child, index) => {
+      {ReactChildren.map(filterChildren as React.ReactElement[], (child, index) => {
         const childNode =
           childrenRenderMode === 'wrap' && child.type !== StackItem ? (
             <StackItem

--- a/src/Stack/test/StackSpec.tsx
+++ b/src/Stack/test/StackSpec.tsx
@@ -93,4 +93,17 @@ describe('Stack', () => {
     expect(screen.getByTestId('test').firstChild).to.tagName('BUTTON');
     expect(screen.getByTestId('test').firstChild).to.have.class('rs-stack-item');
   });
+
+  it('Should render deep children, when direct child is a Fragment', () => {
+    render(
+      <Stack data-testid="test">
+        <>
+          <button>child one</button>
+          <button>child two</button>
+        </>
+      </Stack>
+    );
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(screen.getByTestId('test').children).to.have.length(2);
+  });
 });

--- a/src/Steps/Steps.tsx
+++ b/src/Steps/Steps.tsx
@@ -48,7 +48,7 @@ const Steps: StepsComponent = React.forwardRef((props: StepsProps, ref) => {
   const horizontal = !vertical;
   const classes = merge(className, withClassPrefix({ small, vertical, horizontal: !vertical }));
 
-  const count = React.Children.count(children);
+  const count = ReactChildren.count(children);
   const items = ReactChildren.mapCloneElement(children, (item, index) => {
     const itemStyles = {
       flexBasis: index < count - 1 ? `${100 / (count - 1)}%` : undefined,

--- a/src/Timeline/Timeline.tsx
+++ b/src/Timeline/Timeline.tsx
@@ -50,7 +50,7 @@ const Timeline: TimelineComponent = React.forwardRef((props: TimelineProps, ref)
   } = props;
 
   const { merge, withClassPrefix } = useClassNames(classPrefix);
-  const count = React.Children.count(children);
+  const count = ReactChildren.count(children);
   const withTime = some(React.Children.toArray(children), (item: any) => item?.props?.time);
 
   const classes = merge(

--- a/src/utils/ReactChildren.tsx
+++ b/src/utils/ReactChildren.tsx
@@ -10,15 +10,22 @@ function isFragment(children: React.ReactNode) {
   return React.Children.count(children) === 1 && typeOf(children) === Symbol.for('react.fragment');
 }
 
-function getChildren(children: React.ReactNode) {
-  return isFragment(children) ? (children as React.ReactElement).props?.children : children;
+function flatChildren(children: React.ReactNode) {
+  return React.Children.toArray(
+    React.Children.map(children as React.ReactElement[], child => {
+      if (isFragment(child)) {
+        return React.Children.toArray(child.props?.children || []);
+      }
+      return child;
+    })
+  );
 }
 
 export function find(children: React.ReactNode, func: any, context?: any) {
   let index = 0;
   let result: React.ReactNode;
 
-  React.Children.forEach(getChildren(children), child => {
+  React.Children.forEach(flatChildren(children), child => {
     if (result) {
       return;
     }
@@ -34,7 +41,7 @@ export function find(children: React.ReactNode, func: any, context?: any) {
 export function map(children: React.ReactNode, func: any, context?: any) {
   let index = 0;
 
-  return React.Children.map(getChildren(children), child => {
+  return React.Children.map(flatChildren(children), child => {
     if (!React.isValidElement(child)) {
       return child;
     }
@@ -57,14 +64,14 @@ export function mapCloneElement(children: React.ReactNode, func: any, context?: 
 }
 
 export function count(children: React.ReactNode) {
-  return React.Children.count(Array.isArray(children) ? children.filter(child => child) : children);
+  return React.Children.count(flatChildren(children));
 }
 
 function some(children: React.ReactNode, func: any, context?: any) {
   let index = 0;
   let result = false;
 
-  React.Children.forEach(getChildren(children), child => {
+  React.Children.forEach(flatChildren(children), child => {
     if (result) {
       return;
     }

--- a/src/utils/test/ReactChildrenSpec.tsx
+++ b/src/utils/test/ReactChildrenSpec.tsx
@@ -7,6 +7,37 @@ describe('[utils] ReactChildren', () => {
   it('Should count the number', () => {
     expect(ReactChildren.count(<div />)).to.equal(1);
     expect(ReactChildren.count([<div key="1" />, <div key="2" />])).to.equal(2);
+    expect(
+      ReactChildren.count([
+        <React.Fragment key="1">
+          <div key="1.1" />
+          <div key="1.2"></div>
+        </React.Fragment>,
+        <div key="2" />
+      ])
+    ).to.equal(3);
+    expect(
+      ReactChildren.count([
+        <React.Fragment key="1">
+          <div key="1.1" />
+          <div key="1.2"></div>
+        </React.Fragment>,
+        null,
+        undefined,
+        true,
+        <div key="2" />
+      ])
+    ).to.equal(3);
+    expect(
+      ReactChildren.count([
+        <React.Fragment key="1">
+          <div key="1.1" />
+          <div key="1.2"></div>
+        </React.Fragment>,
+        0,
+        <div key="2" />
+      ])
+    ).to.equal(4);
   });
 
   it('Should clone the element and add props', () => {
@@ -44,10 +75,13 @@ describe('[utils] ReactChildren', () => {
 
   it('Should clone the element and add props with React.Fragment', () => {
     const children = ReactChildren.mapCloneElement(
-      <React.Fragment>
-        <div key="1" role="button" />
+      [
+        <React.Fragment key="1">
+          <div key="1.1" role="button" />
+          <div key="1.2" role="button" />
+        </React.Fragment>,
         <div key="2" role="button" />
-      </React.Fragment>,
+      ],
       () => {
         return { className: 'foo' };
       }
@@ -72,13 +106,50 @@ describe('[utils] ReactChildren', () => {
     expect(children?.[0]).to.have.property('className', 'foo');
   });
 
+  it('Should map the element with React.Fragment', () => {
+    const children = ReactChildren.map(
+      [
+        <React.Fragment key="1">
+          <div key="1.1" role="listitem" />
+          <div key="1.2" role="listitem" />
+        </React.Fragment>,
+        <div key="2" role="listitem" />
+      ],
+      () => {
+        return { className: 'foo' };
+      }
+    );
+    expect(children).to.have.length(3);
+    expect(children?.[0]).to.have.property('className', 'foo');
+  });
+
   it('Should find the specified element', () => {
     const item = ReactChildren.find(
-      [<div key="1" className="foo" />, <div key="2" className="bar" />],
+      [
+        <div key="1" role="button" className="foo" />,
+        <div key="2" role="button" className="bar" />
+      ],
       child => child.props.className === 'bar'
     );
 
-    expect(item).to.have.property('key', '2');
+    render(<div>{item}</div>);
+    expect(screen.getByRole('button')).to.have.class('bar');
+  });
+
+  it('Should fine the specified element with React.Fragment', () => {
+    const item = ReactChildren.find(
+      [
+        <React.Fragment key="1">
+          <div key="1.1" role="button" className="foo" />
+          <div key="1.2" role="button" className="bar" />
+        </React.Fragment>,
+        <div key="2" role="button" className="header" />
+      ],
+      child => child.props.className === 'bar'
+    );
+
+    render(<div>{item}</div>);
+    expect(screen.getByRole('button')).to.have.class('bar');
   });
 
   it('Should check if the specified element exists', () => {
@@ -95,5 +166,19 @@ describe('[utils] ReactChildren', () => {
         child => child.props.className === 'bar2'
       )
     ).to.be.false;
+  });
+  it('Should check if the specified element exists with React.Fragment', () => {
+    expect(
+      ReactChildren.some(
+        [
+          <React.Fragment key="1">
+            <div key="1.1" className="foo" />
+            <div key="1.2" className="bar" />
+          </React.Fragment>,
+          <div key="2" className="header" />
+        ],
+        child => child.props.className === 'bar'
+      )
+    ).to.be.true;
   });
 });


### PR DESCRIPTION
#close #3606 

There are some other effects. 

## Row

#### before

<img width="700" alt="image" src="https://github.com/rsuite/rsuite/assets/53305259/cc2f05d6-c0b3-4075-af58-43b7e68d0d6b" >

#### after

<img width="700" alt="image" src="https://github.com/rsuite/rsuite/assets/53305259/d92d6cc6-ff8b-4126-a266-f02bcecf0293">


### Step

#### before

<img width="700" alt="image" src="https://github.com/rsuite/rsuite/assets/53305259/b0b16312-7733-42b2-a46f-c994b7c64ea8">

#### after

<img width="700" alt="image" src="https://github.com/rsuite/rsuite/assets/53305259/3c0f6d01-3fee-4bd4-9321-ab9323c81188">



### Carousel

#### before

<img width="700"  alt="image" src="https://github.com/rsuite/rsuite/assets/53305259/dad4f258-a157-48be-a6bc-a2d2298a617f">


#### after

<img width="700"  alt="image" src="https://github.com/rsuite/rsuite/assets/53305259/d628d1f0-9546-40e5-bb89-112e10e3d08d">


### Stack

#### before
<img width="700" alt="image" src="https://github.com/rsuite/rsuite/assets/53305259/7e4b74ff-22a8-4d9a-907f-c30351373b67">

#### after

<img width="700" alt="image" src="https://github.com/rsuite/rsuite/assets/53305259/a359c853-f28f-4950-870d-8000cc7728b4">



### Tabs

#### before

<img width="700" alt="image" src="https://github.com/rsuite/rsuite/assets/53305259/46cba19e-6674-4c69-88fb-6a2782b56e0d">

#### after

<img width="700" alt="image" src="https://github.com/rsuite/rsuite/assets/53305259/629db38f-d533-4247-84f9-16b8503928ed">


### TimeLine

There's no visible effect. But we need to replace `React.Children.count` with our own utility function  'ReactChildren.count'. 

