### PR TITLE
Fix Nested objects and Arrays for Form Validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "react-use-set": "^1.0.0",
         "react-window": "^1.8.8",
         "rsuite-table": "^5.18.2",
-        "schema-typed": "^2.1.3"
+        "schema-typed": "^2.1.3",
+        "typescript": "^4.4.3"
       },
       "devDependencies": {
         "@babel/cli": "^7.7.0",
@@ -136,7 +137,6 @@
         "stylelint-config-standard": "^25.0.0",
         "tinycolor2": "^1.4.1",
         "ts-expect": "^1.3.0",
-        "typescript": "^4.6.4",
         "util": "^0.12.5",
         "webpack": "^5.11.0",
         "webpack-bundle-analyzer": "^4.3.0",
@@ -24256,10 +24256,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
-      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -44330,10 +44329,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
-      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
-      "dev": true
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA=="
     },
     "ua-parser-js": {
       "version": "0.7.33",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "react-use-set": "^1.0.0",
     "react-window": "^1.8.8",
     "rsuite-table": "^5.18.2",
-    "schema-typed": "^2.1.3"
+    "schema-typed": "^2.1.3",
+    "typescript": "^4.4.3"
   },
   "peerDependencies": {
     "react": ">=16.8.0",
@@ -189,7 +190,6 @@
     "stylelint-config-standard": "^25.0.0",
     "tinycolor2": "^1.4.1",
     "ts-expect": "^1.3.0",
-    "typescript": "^4.6.4",
     "util": "^0.12.5",
     "webpack": "^5.11.0",
     "webpack-bundle-analyzer": "^4.3.0",

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import PanelGroup, { type PanelGroupProps } from '../PanelGroup';
+import PanelGroup from '../PanelGroup';
+import type { PanelGroupProps } from '../PanelGroup';
 import Panel from '../Panel';
 import { RsRefForwardingComponent } from '../@types/common';
 

--- a/src/AutoComplete/Combobox.tsx
+++ b/src/AutoComplete/Combobox.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useCombobox } from '../internals/Picker';
-import Input, { type InputProps } from '../Input';
+import Input from '../Input';
+import type { InputProps } from '../Input';
 
 interface ComboboxProps extends InputProps {
   expanded?: boolean;

--- a/src/DateInput/utils.ts
+++ b/src/DateInput/utils.ts
@@ -1,4 +1,4 @@
-import { type Locale } from 'date-fns';
+import type { Locale } from 'date-fns';
 import { setYear, setMonth, setDate, setHours, setMinutes, setSeconds } from '../utils/dateUtils';
 import { safeSetSelection } from '../utils';
 

--- a/src/DateRangeInput/utils.ts
+++ b/src/DateRangeInput/utils.ts
@@ -1,4 +1,4 @@
-import { type Locale } from 'date-fns';
+import type { Locale } from 'date-fns';
 import { getSelectIndexGap, isCursorAfterMonth, getDatePattern } from '../DateInput';
 
 export enum DateType {

--- a/src/Form/Form.tsx
+++ b/src/Form/Form.tsx
@@ -254,7 +254,7 @@ const Form: FormComponent = React.forwardRef((props: FormProps, ref: React.Ref<F
       for (let i = 0; i < values.length; i++) {
         if (values[i].hasError) {
           errorCount += 1;
-          formError[keys[i]] = values[i].errorMessage;
+          formError[keys[i]] = values[i]?.errorMessage ?? values[i];
         }
       }
 

--- a/src/FormControl/FormControl.tsx
+++ b/src/FormControl/FormControl.tsx
@@ -163,7 +163,8 @@ const FormControl: FormControlComponent = React.forwardRef((props: FormControlPr
   const getFieldError = (fieldName: string) => {
     if (nestedField) {
       const name = /[\.\[\]]+/g.test(fieldName)
-        ? fieldName.replace(/\./g, '.object.').replace(/\[(.*)\]/g, '.array[$1]') + '.errorMessage'
+        ? fieldName.replace(/\./g, '.object.').replace(/\[([^\]]*)\]/g, '.array[$1]') +
+          '.errorMessage'
         : fieldName;
 
       return get(formError, name);

--- a/src/internals/Picker/hooks/useCombobox.ts
+++ b/src/internals/Picker/hooks/useCombobox.ts
@@ -1,5 +1,6 @@
 import { useContext } from 'react';
-import { ComboboxContextContext, type ComboboxContextProps } from '../PickerToggleTrigger';
+import { ComboboxContextContext } from '../PickerToggleTrigger';
+import type { ComboboxContextProps } from '../PickerToggleTrigger';
 
 function useCombobox() {
   const { id, hasLabel, popupType, multiple } =


### PR DESCRIPTION
- I fixed some errors that were coming up when running the "npm run lint" command, just to be able to commit.
- I made changes to the FormControl and Form components regarding how the "checkResult" object returned by the SchemaModel was parsed. It basically didn't take into account that there could be more than one level of nesting, and also didn't consider arrays.