### PR TITLE
fix(DatePicker): fix style error of the bottom button in the datePicker

### DIFF
--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -646,7 +646,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
               />
             )}
 
-            <>
+            <Stack.Item>
               <CalendarContainer
                 {...calendarProps}
                 targetId={id}
@@ -681,7 +681,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
                 onOk={handleOK}
                 hideOkBtn={oneTap}
               />
-            </>
+            </Stack.Item>
           </Stack>
         </PickerPopup>
       );


### PR DESCRIPTION
before
 
<img width="600" alt="image" src="https://github.com/rsuite/rsuite/assets/53305259/8cee90ea-d48d-48f6-ad71-995127f4df34">

after

<img width="630" alt="image" src="https://github.com/rsuite/rsuite/assets/53305259/35808b85-d469-4805-9bd9-bc9a4b0222c4">

caused by https://github.com/rsuite/rsuite/pull/3607

The reason is that the `Stack` component supported `Fragment` child, it will be spread. So we need to replace `Fragment` with the `Stack.Item`