### PR TITLE
fix(nav): default appearance doesn't show an active background when focused

### DIFF
--- a/src/Nav/styles/index.less
+++ b/src/Nav/styles/index.less
@@ -156,8 +156,7 @@
   .rs-nav-item {
     border-radius: 6px;
 
-    &:hover,
-    &:focus {
+    &:hover {
       background: var(--rs-navs-bg-hover);
     }
   }


### PR DESCRIPTION
### before 


https://github.com/rsuite/rsuite/assets/53305259/e94b26aa-8a7a-4c13-8187-5f3acc7c42b7



### after


https://github.com/rsuite/rsuite/assets/53305259/2966443c-16a1-4e3e-896e-c5731495b59c

