### PR TITLE
fix(Message): fix the z-index issue of Message in full state

### DIFF
--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -848,6 +848,7 @@
 @zindex-date-range-picker-calendar-dropdown:  1;
 @zindex-date-range-picker-table-cell-content: 1;
 @zindex-badge-content:                        1;
+@zindex-message-full:                         3;
 @zindex-dropdown:                             5;
 @zindex-picker-toggle:                        5; // The same with zindex-dropdown
 @zindex-picker-input:                         (@zindex-picker-toggle + 1); // Greater than picker toggle
@@ -862,7 +863,6 @@
 @zindex-popover:                              1060;
 @zindex-tooltip:                              1070;
 @zindex-notification:                         1080;
-@zindex-message-full:                         1090;
 
 //#==== Uploader
 @zindex-uploader-picture-preview:         1;


### PR DESCRIPTION
In PR #3603, a z-index property was added to Message in full state, causing a breaking change.
![image](https://github.com/rsuite/rsuite/assets/1203827/c331bf7d-7b87-4207-9e32-32c5208e9c72)
