### PR TITLE
fix(TagGroup): fix css entry with nested children

### DIFF
--- a/src/TagGroup/styles/index.less
+++ b/src/TagGroup/styles/index.less
@@ -8,7 +8,7 @@
   margin: (-1 * @tag-gap) 0 0 (-1 * @tag-gap);
 }
 
-.rs-tag-group > & {
+.rs-tag-group > .rs-tag {
   margin-top: @tag-gap;
   margin-left: @tag-gap;
 }


### PR DESCRIPTION
I'm not a css expert but in my project when the rollup task tries to minify the styles it displays this error.

```text
warnings when minifying css:
▲ [WARNING] Unexpected "{" [css-syntax-error]

 .rs-tag-group>{margin-left:10px;margin-top:10px}
```

With the change the resultant css file (`lib/TagGroup/styles/index.css`) is:

 ```css
/* stylelint-disable */
*[class*='rs-'] {
  -webkit-box-sizing: border-box;
          box-sizing: border-box;
}
*[class*='rs-']::before,
*[class*='rs-']::after {
  -webkit-box-sizing: border-box;
          box-sizing: border-box;
}
.rs-tag-group {
  margin: -10px 0 0 -10px;
}
.rs-tag-group > .rs-tag {
  margin-top: 10px;
  margin-left: 10px;
}

/*# sourceMappingURL=index.css.map */
```

While now is:

```css
/* stylelint-disable */
*[class*='rs-'] {
  -webkit-box-sizing: border-box;
          box-sizing: border-box;
}
*[class*='rs-']::before,
*[class*='rs-']::after {
  -webkit-box-sizing: border-box;
          box-sizing: border-box;
}
.rs-tag-group {
  margin: -10px 0 0 -10px;
}
.rs-tag-group >  {
  margin-top: 10px;
  margin-left: 10px;
}

/*# sourceMappingURL=index.css.map */
```
