### PR TITLE
fix(cascader): typo in docs

### DIFF
--- a/docs/pages/components/cascader/en-US/index.md
+++ b/docs/pages/components/cascader/en-US/index.md
@@ -48,7 +48,7 @@ This tree allows the use of the `getChildren` option and the length of the child
 
 <!--{include:`async.md`}-->
 
-### Contorlled
+### Controlled
 
 <!--{include:`controlled.md`}-->
 


### PR DESCRIPTION
I noticed a small typo in the documentation at cascader documentation(https://rsuitejs.com/components/cascader/). This pull request fixes the typo by replacing 'Contorlled' with 'Controlled'. This change improves the readability and correctness of the documentation.