### PR TITLE
fix(Checkbox): listen for click events on the correct element

### DIFF
--- a/docs/pages/components/checkbox/en-US/index.md
+++ b/docs/pages/components/checkbox/en-US/index.md
@@ -16,9 +16,9 @@ Check boxes are usually used in groups. Allow users to select one or more values
 
 <!--{include:`disabled.md`}-->
 
-### Indeterminate State
+### Indeterminate
 
-the `indeterminate` property is mainly used on the select all or tree structure checkbox.
+The `indeterminate` property sets the Checkbox to an indeterminate state, mainly used in the select all or tree structure Checkbox.
 
 <!--{include:`indeterminate.md`}-->
 
@@ -32,7 +32,7 @@ the `indeterminate` property is mainly used on the select all or tree structure 
 
 ### Checkbox Group (Controlled)
 
-<!--{include:`checkbox-group-controller.md`}-->
+<!--{include:`checkbox-group-controlled.md`}-->
 
 ## Accessibility
 

--- a/docs/pages/components/checkbox/en-US/index.md
+++ b/docs/pages/components/checkbox/en-US/index.md
@@ -47,32 +47,25 @@ WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#checkbox
 
 ### `<Checkbox>`
 
-| Property       | Type `(default)`                                                                | Description                                                             |
-| -------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| checked        | boolean                                                                         | Specifies whether the checkbox is selected                              |
-| defaultChecked | boolean                                                                         | Specifies the initial state: whether or not the checkbox is selected    |
-| disabled       | boolean                                                                         | Whether disabled                                                        |
-| id             | ElementType                                                                     | Custom element type for the component                                   |
-| indeterminate  | boolean                                                                         | When being a checkbox , setting styles after the child part is selected |
-| inline         | boolean                                                                         | Inline layout                                                           |
-| inputRef       | Ref                                                                             | Ref of input element                                                    |
-| name           | string                                                                          | Used for the name of the form                                           |
-| onChange       | (value: [ValueType](#code-ts-value-type-code), checked: boolean, event) => void | Callback fired when checkbox is triggered and state changes             |
-| title          | string                                                                          | HTML title                                                              |
-| value          | [ValueType](#code-ts-value-type-code)                                           | Correspond to the value of CheckboxGroup, determine whether to select   |
+| Property       | Type `(default)`                                           | Description                                                             |
+| -------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------- |
+| checked        | boolean                                                    | Specifies whether the checkbox is selected                              |
+| defaultChecked | boolean                                                    | Specifies the initial state: whether or not the checkbox is selected    |
+| disabled       | boolean                                                    | Whether disabled                                                        |
+| id             | ElementType                                                | Custom element type for the component                                   |
+| indeterminate  | boolean                                                    | When being a checkbox , setting styles after the child part is selected |
+| inputRef       | Ref                                                        | Ref of input element                                                    |
+| name           | string                                                     | Used for the name of the form                                           |
+| onChange       | (value: string \| number, checked: boolean, event) => void | Callback fired when checkbox is triggered and state changes             |
+| title          | string                                                     | HTML title                                                              |
+| value          | string \| number                                           | Correspond to the value of CheckboxGroup, determine whether to select   |
 
 ### `<CheckboxGroup>`
 
-| Property     | Type `(default)`                                               | Description                                                 |
-| ------------ | -------------------------------------------------------------- | ----------------------------------------------------------- |
-| defaultValue | [ValueType](#code-ts-value-type-code)[]                        | Default value                                               |
-| inline       | boolean                                                        | Inline layout                                               |
-| name         | string                                                         | Used for the name of the form                               |
-| onChange     | (value:[ValueType](#code-ts-value-type-code)[], event) => void | Callback fired when checkbox is triggered and state changes |
-| value        | [ValueType](#code-ts-value-type-code)[]                        | Value of checked box (Controlled)                           |
-
-### `ts:ValueType`
-
-```ts
-type ValueType = string | number;
-```
+| Property     | Type `(default)`                          | Description                                                 |
+| ------------ | ----------------------------------------- | ----------------------------------------------------------- |
+| defaultValue | string[] \| number[]                      | Default value                                               |
+| inline       | boolean                                   | Inline layout                                               |
+| name         | string                                    | Used for the name of the form                               |
+| onChange     | (value:string \| number[], event) => void | Callback fired when checkbox is triggered and state changes |
+| value        | string[] \| number[]                      | Value of checked box (Controlled)                           |

--- a/docs/pages/components/checkbox/fragments/basic.md
+++ b/docs/pages/components/checkbox/fragments/basic.md
@@ -6,7 +6,7 @@ import { Checkbox } from 'rsuite';
 const App = () => (
   <>
     <Checkbox />
-    <Checkbox>Default</Checkbox>
+    <Checkbox>Label</Checkbox>
     <Checkbox defaultChecked>Checked</Checkbox>
   </>
 );

--- a/docs/pages/components/checkbox/fragments/basic.md
+++ b/docs/pages/components/checkbox/fragments/basic.md
@@ -6,8 +6,8 @@ import { Checkbox } from 'rsuite';
 const App = () => (
   <>
     <Checkbox />
-    <Checkbox> Default</Checkbox>
-    <Checkbox defaultChecked> Checked</Checkbox>
+    <Checkbox>Default</Checkbox>
+    <Checkbox defaultChecked>Checked</Checkbox>
   </>
 );
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/docs/pages/components/checkbox/fragments/checkbox-group-controlled.md
+++ b/docs/pages/components/checkbox/fragments/checkbox-group-controlled.md
@@ -7,20 +7,16 @@ const App = () => {
   const [value, setValue] = React.useState(['A', 'C']);
   return (
     <CheckboxGroup
-      inline
-      name="checkboxList"
+      name="checkbox-group"
       value={value}
       onChange={value => {
-        console.log(value, 'onChange');
         setValue(value);
       }}
     >
-      <Checkbox value="A">Item A</Checkbox>
-      <Checkbox value="B">Item B</Checkbox>
-      <Checkbox value="C">Item C</Checkbox>
-      <Checkbox value="D" disabled>
-        Item D
-      </Checkbox>
+      <Checkbox value="A">Checkbox A</Checkbox>
+      <Checkbox value="B">Checkbox B</Checkbox>
+      <Checkbox value="C">Checkbox C</Checkbox>
+      <Checkbox value="D">Checkbox D</Checkbox>
     </CheckboxGroup>
   );
 };

--- a/docs/pages/components/checkbox/fragments/checkbox-group.md
+++ b/docs/pages/components/checkbox/fragments/checkbox-group.md
@@ -4,15 +4,11 @@
 import { Checkbox, CheckboxGroup } from 'rsuite';
 
 const App = () => (
-  <CheckboxGroup name="checkboxList">
-    <p>Group1</p>
-    <Checkbox value="A">Item A</Checkbox>
-    <Checkbox value="B">Item B</Checkbox>
-    <p>Group2</p>
-    <Checkbox value="C">Item C</Checkbox>
-    <Checkbox value="D" disabled>
-      Item D
-    </Checkbox>
+  <CheckboxGroup name="checkbox-group">
+    <Checkbox value="A">Checkbox A</Checkbox>
+    <Checkbox value="B">Checkbox B</Checkbox>
+    <Checkbox value="C">Checkbox C</Checkbox>
+    <Checkbox value="D">Checkbox D</Checkbox>
   </CheckboxGroup>
 );
 

--- a/docs/pages/components/checkbox/fragments/checkbox-groupinline.md
+++ b/docs/pages/components/checkbox/fragments/checkbox-groupinline.md
@@ -4,13 +4,11 @@
 import { Checkbox, CheckboxGroup } from 'rsuite';
 
 const App = () => (
-  <CheckboxGroup inline name="checkboxList">
-    <Checkbox value="A">Item A</Checkbox>
-    <Checkbox value="B">Item B</Checkbox>
-    <Checkbox value="C">Item C</Checkbox>
-    <Checkbox value="D" disabled>
-      Item D
-    </Checkbox>
+  <CheckboxGroup inline name="checkbox-group">
+    <Checkbox value="A">Checkbox A</Checkbox>
+    <Checkbox value="B">Checkbox B</Checkbox>
+    <Checkbox value="C">Checkbox C</Checkbox>
+    <Checkbox value="D">Checkbox D</Checkbox>
   </CheckboxGroup>
 );
 

--- a/docs/pages/components/checkbox/fragments/disabled.md
+++ b/docs/pages/components/checkbox/fragments/disabled.md
@@ -5,25 +5,51 @@ import { Checkbox } from 'rsuite';
 
 const App = () => (
   <>
-    <label>Disabled: </label>
-    <Checkbox disabled> Default</Checkbox>
+    <Label>Disabled</Label>
+    <Checkbox disabled>Default</Checkbox>
     <Checkbox defaultChecked disabled>
       Checked
     </Checkbox>
+    <Checkbox indeterminate disabled>
+      Indeterminate
+    </Checkbox>
+
     <hr />
-    <label>Read only: </label>
-    <Checkbox readOnly> Default</Checkbox>
+    <Label>Read only</Label>
+    <Checkbox readOnly>Default</Checkbox>
     <Checkbox defaultChecked readOnly>
       Checked
     </Checkbox>
+    <Checkbox indeterminate readOnly>
+      Indeterminate
+    </Checkbox>
     <hr />
-    <label>Plaintext: </label>
-    <Checkbox plaintext> Default</Checkbox>
+    <Label>Plaintext</Label>
+    <Checkbox plaintext>Default</Checkbox>
     <Checkbox defaultChecked plaintext>
+      Checked
+    </Checkbox>
+    <Checkbox indeterminate plaintext>
       Checked
     </Checkbox>
   </>
 );
+
+function Label({ children }) {
+  return (
+    <label
+      style={{
+        verticalAlign: 'middle',
+        display: 'inline-block',
+        marginRight: 10,
+        width: 70,
+        color: 'var(--rs-text-secondary)'
+      }}
+    >
+      {children}
+    </label>
+  );
+}
 
 ReactDOM.render(<App />, document.getElementById('root'));
 ```

--- a/docs/pages/components/checkbox/fragments/indeterminate.md
+++ b/docs/pages/components/checkbox/fragments/indeterminate.md
@@ -12,7 +12,7 @@ const App = () => {
   const handleChange = value => setValue(value);
 
   return (
-    <div>
+    <>
       <Checkbox
         indeterminate={value.length > 0 && value.length < data.length}
         checked={value.length === data.length}
@@ -20,15 +20,20 @@ const App = () => {
       >
         Check all
       </Checkbox>
-      <hr />
-      <CheckboxGroup inline name="checkboxList" value={value} onChange={handleChange}>
+
+      <CheckboxGroup
+        name="checkboxList"
+        value={value}
+        onChange={handleChange}
+        style={{ marginLeft: 36 }}
+      >
         {data.map(item => (
           <Checkbox key={item} value={item}>
             Item {item}
           </Checkbox>
         ))}
       </CheckboxGroup>
-    </div>
+    </>
   );
 };
 

--- a/docs/pages/components/checkbox/fragments/indeterminate.md
+++ b/docs/pages/components/checkbox/fragments/indeterminate.md
@@ -3,10 +3,10 @@
 ```js
 import { Checkbox, CheckboxGroup } from 'rsuite';
 
-const data = ['A', 'B', 'C', 'D'];
+const data = ['A', 'B'];
 
 const App = () => {
-  const [value, setValue] = React.useState(['A', 'C']);
+  const [value, setValue] = React.useState(['A']);
 
   const handleCheckAll = (value, checked) => setValue(checked ? data : []);
   const handleChange = value => setValue(value);
@@ -18,7 +18,7 @@ const App = () => {
         checked={value.length === data.length}
         onChange={handleCheckAll}
       >
-        Check all
+        Parent Checkbox
       </Checkbox>
 
       <CheckboxGroup
@@ -29,7 +29,7 @@ const App = () => {
       >
         {data.map(item => (
           <Checkbox key={item} value={item}>
-            Item {item}
+            Child Checkbox {item}
           </Checkbox>
         ))}
       </CheckboxGroup>

--- a/docs/pages/components/checkbox/zh-CN/index.md
+++ b/docs/pages/components/checkbox/zh-CN/index.md
@@ -16,9 +16,9 @@
 
 <!--{include:`disabled.md`}-->
 
-### Indeterminate 状态
+### 不确定状态
 
-`indeterminate` 该状态主要在全选或者树形结构 Checkbox 上使用。
+使用 `indeterminate` 属性可以将 Checkbox 设置为不确定状态，主要用在全选或者树形结构 Checkbox 上。
 
 <!--{include:`indeterminate.md`}-->
 
@@ -32,7 +32,7 @@
 
 ### 受控的复选框组
 
-<!--{include:`checkbox-group-controller.md`}-->
+<!--{include:`checkbox-group-controlled.md`}-->
 
 ## 无障碍设计
 

--- a/docs/pages/components/checkbox/zh-CN/index.md
+++ b/docs/pages/components/checkbox/zh-CN/index.md
@@ -51,32 +51,25 @@ type ValueType = string | number;
 
 ### `<Checkbox>`
 
-| 属性名称       | 类型 `(默认值)`                                                                 | 描述                                         |
-| -------------- | ------------------------------------------------------------------------------- | -------------------------------------------- |
-| checked        | boolean                                                                         | 被选择（受控）                               |
-| defaultChecked | boolean                                                                         | 默认被选择                                   |
-| disabled       | boolean                                                                         | 禁用                                         |
-| id             | ElementType                                                                     | 为组件自定义元素类型                         |
-| indeterminate  | boolean                                                                         | 作为一个全选框时，子项部分被选择后的样式设置 |
-| inline         | boolean                                                                         | 内联布局                                     |
-| inputRef       | Ref                                                                             | HTML input 元素                              |
-| name           | string                                                                          | 用于表单对应的名称                           |
-| onChange       | (value: [ValueType](#code-ts-value-type-code), checked: boolean, event) => void | checked 状态发生改变的回调函数               |
-| title          | string                                                                          | HTML title                                   |
-| value          | [ValueType](#code-ts-value-type-code)                                           | 值，对应 CheckboxGroup 的值，判断是否选中    |
+| 属性名称       | 类型 `(默认值)`                                            | 描述                                         |
+| -------------- | ---------------------------------------------------------- | -------------------------------------------- |
+| checked        | boolean                                                    | 被选择（受控）                               |
+| defaultChecked | boolean                                                    | 默认被选择                                   |
+| disabled       | boolean                                                    | 禁用                                         |
+| id             | ElementType                                                | 为组件自定义元素类型                         |
+| indeterminate  | boolean                                                    | 作为一个全选框时，子项部分被选择后的样式设置 |
+| inputRef       | Ref                                                        | HTML input 元素                              |
+| name           | string                                                     | 用于表单对应的名称                           |
+| onChange       | (value: string \| number, checked: boolean, event) => void | checked 状态发生改变的回调函数               |
+| title          | string                                                     | HTML title                                   |
+| value          | string \| number                                           | 值，对应 CheckboxGroup 的值，判断是否选中    |
 
 ### `<CheckboxGroup>`
 
-| 属性名称     | 类型 `(默认值)`                                                | 描述               |
-| ------------ | -------------------------------------------------------------- | ------------------ |
-| defaultValue | [ValueType](#code-ts-value-type-code)[]                        | 默认值             |
-| inline       | boolean                                                        | 内联布局           |
-| name         | string                                                         | 用于表单对应的名称 |
-| onChange     | (value:[ValueType](#code-ts-value-type-code)[], event) => void | 值改变后的回调函数 |
-| value        | [ValueType](#code-ts-value-type-code)[]                        | 值(受控)           |
-
-### `ts:ValueType`
-
-```ts
-type ValueType = string | number;
-```
+| 属性名称     | 类型 `(默认值)`                           | 描述               |
+| ------------ | ----------------------------------------- | ------------------ |
+| defaultValue | string[] \| number[]                      | 默认值             |
+| inline       | boolean                                   | 内联布局           |
+| name         | string                                    | 用于表单对应的名称 |
+| onChange     | (value:string \| number[], event) => void | 值改变后的回调函数 |
+| value        | string[] \| number[]                      | 值(受控)           |

--- a/src/CheckPicker/styles/index.less
+++ b/src/CheckPicker/styles/index.less
@@ -21,7 +21,7 @@
       padding-left: 52px;
     }
 
-    .rs-check-item .rs-checkbox-checker .rs-checkbox-wrapper {
+    .rs-check-item .rs-checkbox-checker .rs-checkbox-control {
       left: 26px;
     }
   }

--- a/src/CheckTreePicker/styles/index.less
+++ b/src/CheckTreePicker/styles/index.less
@@ -25,7 +25,7 @@
         padding: 1px 0 1px 42px;
       }
 
-      .rs-checkbox-wrapper {
+      .rs-checkbox-control {
         left: (@checkbox-sense-width + 10px);
       }
 
@@ -54,7 +54,7 @@
     }
   }
 
-  .rs-checkbox-wrapper {
+  .rs-checkbox-control {
     left: 0;
   }
 }

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -12,12 +12,9 @@ import { WithAsProps, RsRefForwardingComponent } from '../@types/common';
 import { refType } from '../internals/propTypes';
 
 export type ValueType = string | number;
-export interface CheckboxProps<V = ValueType> extends WithAsProps {
-  /**
-   * HTML title
-   */
-  title?: string;
-
+export interface CheckboxProps<V = ValueType>
+  extends WithAsProps,
+    Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
   /**
    * Inline layout
    *
@@ -71,11 +68,6 @@ export interface CheckboxProps<V = ValueType> extends WithAsProps {
   value?: V;
 
   /**
-   * A checkbox can receive focus.
-   */
-  tabIndex?: number;
-
-  /**
    * Whether to show checkbox
    *
    * @private Used in MultiCascader
@@ -107,11 +99,6 @@ export interface CheckboxProps<V = ValueType> extends WithAsProps {
    * Called when the checkbox or label is clicked.
    */
   onClick?: (event: React.SyntheticEvent) => void;
-
-  /**
-   * Called when the user presses down a key.
-   */
-  onKeyDown?: (event: React.KeyboardEvent) => void;
 
   /**
    * Called when the checkbox is clicked.
@@ -269,8 +256,6 @@ Checkbox.propTypes = {
   indeterminate: PropTypes.bool,
   inputProps: PropTypes.any,
   inputRef: refType,
-  tabIndex: PropTypes.number,
-  title: PropTypes.string,
   value: PropTypes.any,
   onChange: PropTypes.func,
   onClick: PropTypes.func,

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -209,7 +209,7 @@ const Checkbox: RsRefForwardingComponent<'div', CheckboxProps> = React.forwardRe
     }
 
     const input = (
-      <span className={prefix`wrapper`}>
+      <span className={prefix`control`}>
         <input
           {...htmlInputProps}
           {...inputProps}

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -1,69 +1,124 @@
-import React, { useContext, useCallback, useMemo } from 'react';
+import React, { useContext, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { useControlled, partitionHTMLProps, useClassNames } from '../utils';
+import {
+  useControlled,
+  partitionHTMLProps,
+  useClassNames,
+  useEventCallback,
+  mergeRefs
+} from '../utils';
 import { CheckboxGroupContext } from '../CheckboxGroup';
 import { WithAsProps, RsRefForwardingComponent } from '../@types/common';
 import { refType } from '../internals/propTypes';
 
 export type ValueType = string | number;
 export interface CheckboxProps<V = ValueType> extends WithAsProps {
-  /** HTML title */
+  /**
+   * HTML title
+   */
   title?: string;
 
-  /** Inline layout */
+  /**
+   * Inline layout
+   *
+   * @private Used in CheckboxGroup
+   */
   inline?: boolean;
 
-  /** A checkbox can appear disabled and be unable to change states */
+  /**
+   * A checkbox can appear disabled and be unable to change states
+   */
   disabled?: boolean;
 
-  /** Make the control readonly */
+  /**
+   * Make the control readonly
+   */
   readOnly?: boolean;
 
-  /** Render the control as plain text */
+  /**
+   * Render the control as plain text
+   */
   plaintext?: boolean;
 
-  /** Whether or not checkbox is checked. */
+  /**
+   * Whether or not checkbox is checked.
+   */
   checked?: boolean;
 
-  /** The initial value of checked. */
+  /**
+   * The initial value of checked.
+   */
   defaultChecked?: boolean;
 
-  /** Whether or not checkbox is indeterminate. */
+  /**
+   * Whether or not checkbox is indeterminate.
+   */
   indeterminate?: boolean;
 
-  /** Attributes applied to the input element. */
+  /**
+   * Attributes applied to the input element.
+   */
   inputProps?: React.HTMLAttributes<HTMLInputElement>;
 
-  /** Pass a ref to the input element. */
+  /**
+   * Pass a ref to the input element.
+   */
   inputRef?: React.Ref<any>;
 
-  /** The HTML input value. */
+  /**
+   * The HTML input value.
+   */
   value?: V;
 
-  /** A checkbox can receive focus. */
+  /**
+   * A checkbox can receive focus.
+   */
   tabIndex?: number;
 
-  /** Whether to show checkbox */
+  /**
+   * Whether to show checkbox
+   *
+   * @private Used in MultiCascader
+   */
   checkable?: boolean;
 
-  /** Used for the name of the form */
+  /**
+   * Used for the name of the form
+   */
   name?: string;
 
-  /** Called when the user attempts to change the checked state. */
+  /**
+   * Whether the label is clickable
+   *
+   * @private Used in MultiCascader
+   */
+  labelClickable?: boolean;
+
+  /**
+   * Called when the user attempts to change the checked state.
+   */
   onChange?: (
     value: V | undefined,
     checked: boolean,
     event: React.ChangeEvent<HTMLInputElement>
   ) => void;
 
-  /** Called when the checkbox or label is clicked. */
+  /**
+   * Called when the checkbox or label is clicked.
+   */
   onClick?: (event: React.SyntheticEvent) => void;
 
-  /** Called when the checkbox is clicked. */
-  onCheckboxClick?: (event: React.SyntheticEvent) => void;
-
-  /** Called when the user presses down a key. */
+  /**
+   * Called when the user presses down a key.
+   */
   onKeyDown?: (event: React.KeyboardEvent) => void;
+
+  /**
+   * Called when the checkbox is clicked.
+   *
+   * @private Used in MultiCascader
+   */
+  onCheckboxClick?: (event: React.SyntheticEvent) => void;
 }
 
 /**
@@ -95,6 +150,7 @@ const Checkbox: RsRefForwardingComponent<'div', CheckboxProps> = React.forwardRe
       inputRef,
       inputProps,
       indeterminate,
+      labelClickable = true,
       tabIndex = 0,
       disabled = disabledContext,
       readOnly = readOnlyContext,
@@ -136,20 +192,26 @@ const Checkbox: RsRefForwardingComponent<'div', CheckboxProps> = React.forwardRe
       htmlInputProps[controlled ? 'checked' : 'defaultChecked'] = checked;
     }
 
-    const handleChange = useCallback(
-      (event: React.ChangeEvent<HTMLInputElement>) => {
-        const nextChecked = event.target.checked;
+    const checkboxRef = useRef<HTMLInputElement>(null);
 
-        if (disabled || readOnly) {
-          return;
-        }
+    const handleChange = useEventCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+      const nextChecked = event.target.checked;
 
-        setSelfChecked(nextChecked);
-        onChange?.(value, nextChecked, event);
-        onGroupChange?.(value, nextChecked, event);
-      },
-      [disabled, readOnly, setSelfChecked, onChange, value, onGroupChange]
-    );
+      if (disabled || readOnly) {
+        return;
+      }
+
+      setSelfChecked(nextChecked);
+      onChange?.(value, nextChecked, event);
+      onGroupChange?.(value, nextChecked, event);
+    });
+
+    const handleLabelClick = useEventCallback((event: React.SyntheticEvent) => {
+      // Prevent check when label is not clickable
+      if (!labelClickable && event.target !== checkboxRef.current) {
+        event.preventDefault();
+      }
+    });
 
     if (plaintext) {
       return checked ? (
@@ -160,20 +222,20 @@ const Checkbox: RsRefForwardingComponent<'div', CheckboxProps> = React.forwardRe
     }
 
     const input = (
-      <span className={prefix`wrapper`} onClick={onCheckboxClick} aria-disabled={disabled}>
+      <span className={prefix`wrapper`}>
         <input
           {...htmlInputProps}
           {...inputProps}
           name={name}
           value={value}
           type="checkbox"
-          ref={inputRef}
+          ref={mergeRefs(checkboxRef, inputRef)}
           tabIndex={tabIndex}
           readOnly={readOnly}
           disabled={disabled}
           aria-disabled={disabled}
           aria-checked={indeterminate ? 'mixed' : checked}
-          onClick={event => event.stopPropagation()}
+          onClick={onCheckboxClick}
           onChange={handleChange}
         />
         <span className={prefix`inner`} aria-hidden role="presentation" />
@@ -183,9 +245,9 @@ const Checkbox: RsRefForwardingComponent<'div', CheckboxProps> = React.forwardRe
     return (
       <Component {...restProps} ref={ref} onClick={onClick} className={classes}>
         <div className={prefix`checker`}>
-          <label title={title}>
+          <label title={title} onClick={handleLabelClick}>
             {checkable ? input : null}
-            {children}
+            <span className={prefix`label`}>{children}</span>
           </label>
         </div>
       </Component>
@@ -196,22 +258,22 @@ const Checkbox: RsRefForwardingComponent<'div', CheckboxProps> = React.forwardRe
 Checkbox.displayName = 'Checkbox';
 Checkbox.propTypes = {
   as: PropTypes.elementType,
-  title: PropTypes.string,
-  className: PropTypes.string,
-  inline: PropTypes.bool,
-  disabled: PropTypes.bool,
   checked: PropTypes.bool,
-  defaultChecked: PropTypes.bool,
-  indeterminate: PropTypes.bool,
-  onChange: PropTypes.func,
-  onClick: PropTypes.func,
-  inputProps: PropTypes.any,
-  inputRef: refType,
-  value: PropTypes.any,
+  checkable: PropTypes.bool,
+  className: PropTypes.string,
   children: PropTypes.node,
   classPrefix: PropTypes.string,
+  disabled: PropTypes.bool,
+  defaultChecked: PropTypes.bool,
+  inline: PropTypes.bool,
+  indeterminate: PropTypes.bool,
+  inputProps: PropTypes.any,
+  inputRef: refType,
   tabIndex: PropTypes.number,
-  checkable: PropTypes.bool,
+  title: PropTypes.string,
+  value: PropTypes.any,
+  onChange: PropTypes.func,
+  onClick: PropTypes.func,
   onCheckboxClick: PropTypes.func
 };
 

--- a/src/Checkbox/styles/index.less
+++ b/src/Checkbox/styles/index.less
@@ -19,7 +19,7 @@
 }
 
 /* rtl:begin:ignore */
-.rs-checkbox-wrapper {
+.rs-checkbox-control {
   &::before,
   .rs-checkbox-inner::before,
   .rs-checkbox-inner::after {
@@ -68,7 +68,7 @@
 /* rtl:end:ignore */
 
 /* stylelint-disable-next-line */ // For RTL Scope
-.rs-checkbox-wrapper {
+.rs-checkbox-control {
   position: absolute;
   width: @checkbox-width-height;
   height: @checkbox-width-height;

--- a/src/Checkbox/styles/index.less
+++ b/src/Checkbox/styles/index.less
@@ -21,7 +21,6 @@
 /* rtl:begin:ignore */
 .rs-checkbox-wrapper {
   &::before,
-  &::after,
   .rs-checkbox-inner::before,
   .rs-checkbox-inner::after {
     content: '';

--- a/src/Checkbox/styles/index.less
+++ b/src/Checkbox/styles/index.less
@@ -78,9 +78,15 @@
   top: @checkbox-sense-width;
 
   [type='checkbox'] {
-    width: 0;
-    height: 0;
+    position: absolute;
     opacity: 0;
+    z-index: 1;
+
+    // Sense area(Can be clicked)
+    top: -@checkbox-sense-width;
+    right: -@checkbox-sense-width;
+    bottom: -@checkbox-sense-width;
+    left: -@checkbox-sense-width;
   }
 
   &::before,
@@ -108,14 +114,6 @@
       opacity: 0;
       visibility: visible;
     }
-  }
-
-  // Sense area(Can be clicked)
-  &::after {
-    top: -@checkbox-sense-width;
-    right: -@checkbox-sense-width;
-    bottom: -@checkbox-sense-width;
-    left: -@checkbox-sense-width;
   }
 
   // Out border

--- a/src/Checkbox/test/CheckboxSpec.tsx
+++ b/src/Checkbox/test/CheckboxSpec.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
 import { render, fireEvent, screen } from '@testing-library/react';
 import sinon from 'sinon';
 import { testStandardProps } from '@test/utils';
@@ -11,14 +10,14 @@ describe('Checkbox', () => {
   it('Should render a checkbox', () => {
     render(<Checkbox>Test</Checkbox>);
 
+    expect(screen.getByRole('checkbox')).to.exist;
     expect(screen.getByLabelText('Test')).to.exist.and.to.have.attr('type', 'checkbox');
   });
 
-  it('Should add title', () => {
-    const title = 'Text';
-    const { container } = render(<Checkbox title={title}>Test</Checkbox>);
+  it('Should have a `title` attribute', () => {
+    const { container } = render(<Checkbox title="My title">Test</Checkbox>);
     // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
-    expect(container.querySelector('label')).to.have.attr('title', title);
+    expect(container.querySelector('label')).to.have.attr('title', 'My title');
   });
 
   it('Should have checkbox-inline class', () => {
@@ -29,14 +28,84 @@ describe('Checkbox', () => {
 
   it('Should be disabled', () => {
     const { container } = render(<Checkbox disabled>Test</Checkbox>);
-    expect(screen.getByLabelText('Test')).to.have.property('disabled', true);
+    expect(screen.getByRole('checkbox')).to.have.property('disabled', true);
     expect(container.firstChild).to.have.class('rs-checkbox-disabled');
+  });
+
+  it('Should be readOnly', () => {
+    render(<Checkbox readOnly>Test</Checkbox>);
+    expect(screen.getByRole('checkbox')).to.have.property('readOnly', true);
   });
 
   it('Should be checked', () => {
     const { container } = render(<Checkbox checked>Test</Checkbox>);
 
     expect(container.firstChild).to.have.class('rs-checkbox-checked');
+    expect(screen.getByRole('checkbox')).to.be.checked;
+  });
+
+  it('Should be uncheckable', () => {
+    const { rerender } = render(<Checkbox checkable={false}> checkable</Checkbox>);
+
+    expect(screen.queryByRole('checkbox')).to.not.exist;
+
+    rerender(<Checkbox checkable> checkable</Checkbox>);
+
+    expect(screen.queryByRole('checkbox')).to.exist;
+  });
+
+  it('Should be clickable on the label', () => {
+    const onChange = sinon.spy();
+    const onCheckboxClick = sinon.spy();
+
+    const { rerender } = render(
+      <Checkbox labelClickable={false} onChange={onChange} onCheckboxClick={onCheckboxClick}>
+        Label
+      </Checkbox>
+    );
+
+    fireEvent.click(screen.getByText('Label'));
+
+    expect(onChange).to.not.have.been.called;
+    expect(onCheckboxClick).to.not.have.been.called;
+
+    rerender(
+      <Checkbox onChange={onChange} onCheckboxClick={onCheckboxClick}>
+        Label
+      </Checkbox>
+    );
+
+    fireEvent.click(screen.getByText('Label'));
+
+    expect(onChange).to.have.been.calledOnce;
+    expect(onCheckboxClick).to.have.been.calledOnce;
+  });
+
+  it('Should be checked by default', () => {
+    const { container } = render(<Checkbox defaultChecked>Test</Checkbox>);
+
+    expect(container.firstChild).to.have.class('rs-checkbox-checked');
+    expect(screen.getByRole('checkbox')).to.be.checked;
+  });
+
+  it('Should be indeterminate', () => {
+    const { container } = render(<Checkbox indeterminate>Test</Checkbox>);
+
+    expect(container.firstChild).to.have.class('rs-checkbox-indeterminate');
+    expect(screen.getByRole('checkbox')).to.be.not.checked;
+    expect(screen.getByRole('checkbox')).to.have.attribute('aria-checked', 'mixed');
+  });
+
+  it('Should have a value', () => {
+    render(<Checkbox value="1">Test</Checkbox>);
+
+    expect(screen.getByRole('checkbox')).to.have.value('1');
+  });
+
+  it('Should have a name', () => {
+    render(<Checkbox name="1">Test</Checkbox>);
+
+    expect(screen.getByRole('checkbox')).to.have.property('name', '1');
   });
 
   it('Should have the underlying input checked', () => {
@@ -45,25 +114,10 @@ describe('Checkbox', () => {
     expect(screen.getByLabelText('Test')).to.be.checked;
   });
 
-  it('Should be defaultChecked', () => {
-    const { container } = render(<Checkbox defaultChecked>Test</Checkbox>);
-
-    expect(container.firstChild).to.have.class('rs-checkbox-checked');
-  });
-
   it('Should have the underlying input checked by default', () => {
     render(<Checkbox defaultChecked>Test</Checkbox>);
 
     expect(screen.getByLabelText('Test')).to.be.checked;
-  });
-
-  it('Should have a `Test` value', () => {
-    const value = 'Test';
-    // FIXME-@SevenOutman
-    // Is it reasonable to validate `defaultValue` for a checkbox?
-    render(<Checkbox defaultValue={value}>Test</Checkbox>);
-
-    expect(screen.getByLabelText('Test')).to.have.value(value);
   });
 
   it('Should support inputRef', () => {
@@ -100,15 +154,25 @@ describe('Checkbox', () => {
   it('Should call onClick callback', () => {
     const onClick = sinon.spy();
     const { container } = render(<Checkbox onClick={onClick}>Title</Checkbox>);
-    ReactTestUtils.Simulate.click(container.firstChild as HTMLElement);
+    fireEvent.click(container.firstChild as HTMLElement);
 
     expect(onClick).to.have.been.calledOnce;
+  });
+
+  it('Should call onCheckboxClick callback', () => {
+    const onCheckboxClick = sinon.spy();
+
+    render(<Checkbox onCheckboxClick={onCheckboxClick} />);
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(onCheckboxClick).to.have.been.calledOnce;
   });
 
   it('Should call onBlur callback', () => {
     const onBlur = sinon.spy();
     render(<Checkbox onBlur={onBlur} />);
-    ReactTestUtils.Simulate.blur(screen.getByRole('checkbox'));
+    fireEvent.blur(screen.getByRole('checkbox'));
 
     expect(onBlur).to.have.been.calledOnce;
   });
@@ -116,9 +180,15 @@ describe('Checkbox', () => {
   it('Should call onFocus callback', () => {
     const onFocus = sinon.spy();
     render(<Checkbox onFocus={onFocus} />);
-    ReactTestUtils.Simulate.focus(screen.getByRole('checkbox'));
+    fireEvent.focus(screen.getByRole('checkbox'));
 
     expect(onFocus).to.have.been.calledOnce;
+  });
+
+  it('Should inputProps be working', () => {
+    render(<Checkbox inputProps={{ className: 'my-checkbox' }} />);
+
+    expect(screen.getByRole('checkbox')).to.have.class('my-checkbox');
   });
 
   describe('Plain text', () => {

--- a/src/InputPicker/InputPicker.tsx
+++ b/src/InputPicker/InputPicker.tsx
@@ -173,7 +173,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
       ...rest
     } = props;
 
-    const { multi, tagProps, trigger, disabledOptions, onTagRemove, renderMenuItemCheckbox } =
+    const { multi, tagProps, trigger, disabledOptions, onTagRemove, renderCheckbox } =
       useContext(InputPickerContext);
 
     if (groupBy === valueKey || groupBy === labelKey) {
@@ -652,7 +652,7 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
           classPrefix={menuClassPrefix}
           listItemClassPrefix={multi ? undefined : `${menuClassPrefix}-item`}
           listItemAs={multi ? ListCheckItem : ListItem}
-          listItemProps={{ renderMenuItemCheckbox }}
+          listItemProps={{ renderCheckbox }}
           activeItemValues={multi ? value : [value]}
           focusItemValue={focusItemValue}
           maxHeight={menuMaxHeight}

--- a/src/InputPicker/InputPickerContext.tsx
+++ b/src/InputPicker/InputPickerContext.tsx
@@ -27,7 +27,7 @@ export interface InputPickerContextProps extends TagOnlyProps {
   disabledOptions?: boolean;
 
   /** Custom render checkbox on menu item */
-  renderMenuItemCheckbox?: (checkboxProps: CheckboxProps) => React.ReactNode;
+  renderCheckbox?: (checkboxProps: CheckboxProps) => React.ReactNode;
 }
 
 const InputPickerContext = React.createContext<InputPickerContextProps>({

--- a/src/MultiCascader/TreeView.tsx
+++ b/src/MultiCascader/TreeView.tsx
@@ -139,6 +139,7 @@ const TreeView: RsRefForwardingComponent<'div', TreeViewProps> = React.forwardRe
           onSelectItem={(_value, event) => handleSelect(layer, node, event)}
           onCheck={(_value, event, checked) => onCheck?.(node, event, checked)}
           checkable={!uncheckable}
+          labelClickable={false}
         >
           {renderMenuItem ? renderMenuItem(label, node) : label}
           {children ? <Icon className={prefix('caret')} spin={node.loading} /> : null}

--- a/src/MultiCascader/test/MultiCascaderSpec.tsx
+++ b/src/MultiCascader/test/MultiCascaderSpec.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import sinon from 'sinon';
 import {
-  getDOMNode,
   getInstance,
   testStandardProps,
   testFormControl,
@@ -34,9 +33,7 @@ describe('MultiCascader', () => {
     changedValue: ['3'],
     simulateEvent: {
       changeValue: (prevValue: any) => {
-        // TODO: Move click handler to correct element
-        const input = screen.getByText('3', { selector: 'label' }).firstChild as HTMLInputElement;
-        fireEvent.click(input);
+        fireEvent.click(screen.getByRole('checkbox', { name: '3' }));
         return { changedValue: [...prevValue, '3'] };
       }
     },
@@ -53,16 +50,16 @@ describe('MultiCascader', () => {
     getUIElement: () => screen.getByRole('combobox')
   });
 
-  it('Should output a dropdown', () => {
-    const instance = getDOMNode(<MultiCascader data={[]}>Title</MultiCascader>);
+  it('Should output a picker', () => {
+    const { container } = render(<MultiCascader data={[]}>Title</MultiCascader>);
 
-    expect(instance.className).to.contain('picker-cascader');
+    expect(container.firstChild).to.class('rs-picker-cascader');
   });
 
   it('Should have "default" appearance by default', () => {
-    const instance = getDOMNode(<MultiCascader data={[]} />);
+    const { container } = render(<MultiCascader data={[]} />);
 
-    expect(instance).to.have.class('rs-picker-default');
+    expect(container.firstChild).to.have.class('rs-picker-default');
   });
 
   it('Should display number of selected values', () => {
@@ -100,14 +97,6 @@ describe('MultiCascader', () => {
     render(<MultiCascader data={items} value={['3-1', '3-2']} uncheckableItemValues={['3']} />);
 
     expect(screen.getByRole('combobox')).to.have.text('3-1,3-22');
-  });
-
-  it('Should be inline', () => {
-    const { container } = render(<MultiCascader data={[]} inline />);
-
-    // eslint-disable-next-line testing-library/no-node-access
-    expect(container.firstChild).to.have.class('rs-picker-inline');
-    expect(screen.getByRole('tree')).to.exist;
   });
 
   it('Should output a placeholder', () => {
@@ -190,21 +179,20 @@ describe('MultiCascader', () => {
     expect(screen.getByRole('checkbox', { name: '2' })).to.be.checked;
   });
 
-  it('Should call `onSelect` callback ', () => {
-    const onSelectSpy = sinon.spy();
-    render(<MultiCascader data={items} defaultOpen onSelect={onSelectSpy} />);
+  it('Should call `onSelect` callback', () => {
+    const onSelect = sinon.spy();
+    render(<MultiCascader data={items} defaultOpen onSelect={onSelect} />);
 
-    fireEvent.click(screen.getByText('2', { selector: 'label' }));
-    expect(onSelectSpy).to.have.been.calledOnce;
+    fireEvent.click(screen.getByRole('checkbox', { name: '2' }));
+    expect(onSelect).to.have.been.calledOnce;
   });
 
-  it('Should call `onChange` callback ', () => {
-    const onChangeSpy = sinon.spy();
-    render(<MultiCascader data={items} defaultOpen onChange={onChangeSpy} />);
+  it('Should call `onChange` callback', () => {
+    const onChange = sinon.spy();
+    render(<MultiCascader data={items} defaultOpen onChange={onChange} />);
 
-    // TODO Move click handler to correct element
-    fireEvent.click(screen.getByText('1', { selector: 'label' }).firstChild as HTMLElement);
-    expect(onChangeSpy).to.have.been.calledWith(['1']);
+    fireEvent.click(screen.getByRole('checkbox', { name: '1' }));
+    expect(onChange).to.have.been.calledWith(['1']);
   });
 
   it('Should call `onClean` callback', () => {
@@ -216,25 +204,25 @@ describe('MultiCascader', () => {
   });
 
   it('Should call `onOpen` callback', () => {
-    const onOpenSpy = sinon.spy();
-    const picker = getInstance(<MultiCascader onOpen={onOpenSpy} data={items} />);
+    const onOpen = sinon.spy();
+    const picker = getInstance(<MultiCascader onOpen={onOpen} data={items} />);
 
     act(() => {
       picker.open();
     });
 
-    expect(onOpenSpy).to.be.calledOnce;
+    expect(onOpen).to.be.calledOnce;
   });
 
   it('Should call `onClose` callback', () => {
-    const onCloseSpy = sinon.spy();
-    const picker = getInstance(<MultiCascader defaultOpen onClose={onCloseSpy} data={items} />);
+    const onClose = sinon.spy();
+    const picker = getInstance(<MultiCascader defaultOpen onClose={onClose} data={items} />);
 
     act(() => {
       picker.close();
     });
 
-    expect(onCloseSpy).to.be.calledOnce;
+    expect(onClose).to.be.calledOnce;
   });
 
   it('Should clean selected default value', () => {
@@ -279,16 +267,16 @@ describe('MultiCascader', () => {
   });
 
   it('Should call onSelect callback with 3 params', () => {
-    const onSelectSpy = sinon.spy();
+    const onSelect = sinon.spy();
 
-    render(<MultiCascader defaultOpen data={items} onSelect={onSelectSpy} />);
+    render(<MultiCascader defaultOpen data={items} onSelect={onSelect} />);
     const checkbox = screen.getByText((_content, element) => element?.textContent === '2', {
       selector: '.rs-checkbox'
     });
 
     fireEvent.click(checkbox);
 
-    expect(onSelectSpy).to.have.been.calledWith(
+    expect(onSelect).to.have.been.calledWith(
       { label: '2', value: '2' },
       [{ label: '2', value: '2' }],
       sinon.match({ target: checkbox })
@@ -296,54 +284,41 @@ describe('MultiCascader', () => {
   });
 
   it('Should item able to stringfy', () => {
-    const onSelectSpy = sinon.spy();
-    const renderMenuItemSpy = sinon.spy();
+    const onSelect = sinon.spy();
+    const renderMenuItem = sinon.spy();
 
-    const instance = getInstance(
-      <MultiCascader
-        defaultOpen
-        data={items}
-        onSelect={onSelectSpy}
-        renderMenuItem={renderMenuItemSpy}
-      />
+    render(
+      <MultiCascader defaultOpen data={items} onSelect={onSelect} renderMenuItem={renderMenuItem} />
     );
     // eslint-disable-next-line testing-library/no-node-access
-    const checkbox = instance.overlay.querySelectorAll('.rs-checkbox')[2];
+    const checkbox = screen.getByRole('tree').querySelectorAll('.rs-checkbox')[2];
 
     fireEvent.click(checkbox);
 
-    expect(onSelectSpy).to.called;
-    expect(renderMenuItemSpy).to.called;
+    expect(onSelect).to.called;
+    expect(renderMenuItem).to.called;
     expect(() => JSON.stringify(items[2])).to.not.throw();
-    expect(() => JSON.stringify(onSelectSpy.firstCall.args[1])).to.not.throw();
-    expect(() => JSON.stringify(renderMenuItemSpy.lastCall.args[1])).to.not.throw();
+    expect(() => JSON.stringify(onSelect.firstCall.args[1])).to.not.throw();
+    expect(() => JSON.stringify(renderMenuItem.lastCall.args[1])).to.not.throw();
   });
 
-  it('Should call onCheck callback ', () => {
+  it('Should call onCheck callback', () => {
     const onCheckSpy = sinon.spy();
     render(<MultiCascader data={items} defaultOpen onCheck={onCheckSpy} />);
-    const checkbox = screen.getByText('1', { selector: 'label' }).firstChild as HTMLElement;
 
-    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByRole('checkbox', { name: '1' }));
 
-    expect(onCheckSpy).to.have.been.calledWith(
-      ['1'],
-      { label: '1', value: '1' },
-      true,
-      sinon.match({
-        target: checkbox
-      })
-    );
+    expect(onCheckSpy).to.have.been.calledWith(['1'], { label: '1', value: '1' }, true);
   });
 
   it('Should update columns', () => {
     const { rerender } = render(<MultiCascader data={[]} open />);
 
-    expect(screen.queryAllByRole('treeitem')).to.have.lengthOf(0);
+    expect(screen.queryAllByRole('treeitem')).to.have.length(0);
 
     rerender(<MultiCascader data={[{ label: 'test', value: 1 }]} open />);
 
-    expect(screen.getAllByRole('treeitem')).to.have.lengthOf(1);
+    expect(screen.getAllByRole('treeitem')).to.have.length(1);
     expect(screen.getAllByRole('treeitem')[0]).to.have.text('test');
   });
 
@@ -358,29 +333,7 @@ describe('MultiCascader', () => {
       />
     );
 
-    fireEvent.click(
-      // TODO Move click handler to "treeitem"
-      screen.getByText('1', { selector: 'label' })
-    );
-
-    expect(screen.getByRole('treeitem', { name: '2' })).to.exist;
-  });
-
-  it('Should children be loaded lazily in inline mode', () => {
-    render(
-      <MultiCascader
-        inline
-        data={[{ label: '1', value: '1', children: [] }]}
-        getChildren={() => {
-          return [{ label: '2', value: '2' }];
-        }}
-      />
-    );
-
-    fireEvent.click(
-      // TODO Move click handler to "treeitem"
-      screen.getByText('1', { selector: 'label' })
-    );
+    fireEvent.click(screen.getByRole('treeitem', { name: '1' }).firstChild as HTMLElement);
 
     expect(screen.getByRole('treeitem', { name: '2' })).to.exist;
   });
@@ -402,10 +355,7 @@ describe('MultiCascader', () => {
       />
     );
 
-    fireEvent.click(
-      // TODO Move click handler to "treeitem"
-      screen.getByText('1', { selector: 'label' })
-    );
+    fireEvent.click(screen.getByRole('treeitem', { name: '1' }).firstChild as HTMLElement);
 
     // eslint-disable-next-line testing-library/no-node-access
     expect(screen.getByRole('treeitem', { name: '1' }).querySelector('.rs-icon.rs-icon-spin')).to
@@ -413,15 +363,15 @@ describe('MultiCascader', () => {
   });
 
   it('Should call `onSearch` callback ', () => {
-    const onSearchSpy = sinon.spy();
-    render(<MultiCascader data={items} defaultOpen onSearch={onSearchSpy} />);
+    const onSearch = sinon.spy();
+    render(<MultiCascader data={items} defaultOpen onSearch={onSearch} />);
 
     const searchbox = screen.getByRole('searchbox');
 
     fireEvent.change(searchbox, { target: { value: '3' } });
 
-    expect(screen.getAllByRole('treeitem')).to.have.lengthOf(3);
-    expect(onSearchSpy).to.have.been.calledOnce;
+    expect(screen.getAllByRole('treeitem')).to.have.length(3);
+    expect(onSearch).to.have.been.calledOnce;
   });
 
   it('Should update the subcolumn when the leaf node is clicked', () => {
@@ -430,14 +380,13 @@ describe('MultiCascader', () => {
     expect(screen.queryByRole('tree')).to.be.exist;
 
     // Click on a node that has child nodes
-    // TODO Use "treeitem" role here
-    fireEvent.click(screen.getByText('3', { selector: 'label' }));
+    fireEvent.click(screen.getByRole('treeitem', { name: '3' }).firstChild as HTMLElement);
 
-    expect(screen.queryAllByRole('group')).to.have.lengthOf(2);
+    expect(screen.queryAllByRole('group')).to.have.length(2);
 
     // Click on the leaf node
-    fireEvent.click(screen.getByText('1', { selector: 'label' }));
+    fireEvent.click(screen.getByRole('treeitem', { name: '1' }).firstChild as HTMLElement);
 
-    expect(screen.queryAllByRole('group')).to.have.lengthOf(1);
+    expect(screen.queryAllByRole('group')).to.have.length(1);
   });
 });

--- a/src/TagPicker/index.tsx
+++ b/src/TagPicker/index.tsx
@@ -26,8 +26,15 @@ const TagPicker: PickerComponent<TagPickerProps> = React.forwardRef(
       renderMenuItemCheckbox,
       ...rest
     } = props;
+
     const contextValue = useMemo(
-      () => ({ multi: true, trigger, tagProps, onTagRemove, renderMenuItemCheckbox }),
+      () => ({
+        multi: true,
+        trigger,
+        tagProps,
+        onTagRemove,
+        renderCheckbox: renderMenuItemCheckbox
+      }),
       [onTagRemove, renderMenuItemCheckbox, tagProps, trigger]
     );
 

--- a/src/TagPicker/test/TagPickerSpec.tsx
+++ b/src/TagPicker/test/TagPickerSpec.tsx
@@ -159,7 +159,7 @@ describe('TagPicker', () => {
     expect(screen.getByRole('listbox')).to.have.text('foo-bar');
   });
 
-  it('Should renderMenuItemCheckbox render correct', () => {
+  it('Should renderCheckbox render correct', () => {
     render(
       <TagPicker
         data={data}

--- a/src/internals/Picker/ListCheckItem.tsx
+++ b/src/internals/Picker/ListCheckItem.tsx
@@ -4,22 +4,13 @@ import Checkbox, { CheckboxProps } from '../../Checkbox';
 import { WithAsProps, RsRefForwardingComponent } from '../../@types/common';
 import useCombobox from './hooks/useCombobox';
 
-export interface ListCheckItemProps extends WithAsProps {
+export interface ListCheckItemProps extends WithAsProps, CheckboxProps {
   active?: boolean;
   checkboxAs?: React.ElementType | string;
-  classPrefix?: string;
-  disabled?: boolean;
-  checkable?: boolean;
-  indeterminate?: boolean;
-  value?: string | number;
   focus?: boolean;
-  title?: string;
-  className?: string;
-  children?: React.ReactNode;
   onSelect?: (value: any, event: React.SyntheticEvent, checked: boolean) => void;
   onCheck?: (value: any, event: React.SyntheticEvent, checked: boolean) => void;
   onSelectItem?: (value: any, event: React.SyntheticEvent, checked: boolean) => void;
-  onKeyDown?: (event: React.KeyboardEvent) => void;
   renderMenuItemCheckbox?: (checkboxProps: CheckboxProps) => React.ReactNode;
 }
 
@@ -37,6 +28,7 @@ const ListCheckItem: RsRefForwardingComponent<'div', ListCheckItemProps> = React
       children,
       className,
       indeterminate,
+      labelClickable,
       onKeyDown,
       onSelect,
       onCheck,
@@ -68,13 +60,14 @@ const ListCheckItem: RsRefForwardingComponent<'div', ListCheckItemProps> = React
     const checkboxItemClasses = withClassPrefix({ focus });
 
     const checkboxProps: CheckboxProps = {
-      value,
-      disabled,
-      indeterminate,
       checkable,
       children,
       checked: active,
       className: checkboxItemClasses,
+      disabled,
+      value,
+      indeterminate,
+      labelClickable,
       onKeyDown: disabled ? undefined : onKeyDown,
       onChange: handleChange,
       onClick: handleSelectItem,

--- a/src/internals/Picker/ListCheckItem.tsx
+++ b/src/internals/Picker/ListCheckItem.tsx
@@ -4,14 +4,14 @@ import Checkbox, { CheckboxProps } from '../../Checkbox';
 import { WithAsProps, RsRefForwardingComponent } from '../../@types/common';
 import useCombobox from './hooks/useCombobox';
 
-export interface ListCheckItemProps extends WithAsProps, CheckboxProps {
+export interface ListCheckItemProps extends WithAsProps, Omit<CheckboxProps, 'onSelect'> {
   active?: boolean;
   checkboxAs?: React.ElementType | string;
   focus?: boolean;
   onSelect?: (value: any, event: React.SyntheticEvent, checked: boolean) => void;
   onCheck?: (value: any, event: React.SyntheticEvent, checked: boolean) => void;
   onSelectItem?: (value: any, event: React.SyntheticEvent, checked: boolean) => void;
-  renderMenuItemCheckbox?: (checkboxProps: CheckboxProps) => React.ReactNode;
+  renderCheckbox?: (checkboxProps: CheckboxProps) => React.ReactNode;
 }
 
 const ListCheckItem: RsRefForwardingComponent<'div', ListCheckItemProps> = React.forwardRef(
@@ -33,7 +33,7 @@ const ListCheckItem: RsRefForwardingComponent<'div', ListCheckItemProps> = React
       onSelect,
       onCheck,
       onSelectItem,
-      renderMenuItemCheckbox,
+      renderCheckbox,
       ...rest
     } = props;
 
@@ -86,8 +86,8 @@ const ListCheckItem: RsRefForwardingComponent<'div', ListCheckItemProps> = React
         className={merge(className, rootPrefix`picker-list-item`)}
         tabIndex={-1}
       >
-        {renderMenuItemCheckbox ? (
-          renderMenuItemCheckbox(checkboxProps)
+        {renderCheckbox ? (
+          renderCheckbox(checkboxProps)
         ) : (
           <CheckboxItem role="checkbox" {...checkboxProps} />
         )}

--- a/src/internals/Picker/styles/index.less
+++ b/src/internals/Picker/styles/index.less
@@ -397,7 +397,7 @@
       }
     }
 
-    .rs-checkbox-wrapper {
+    .rs-checkbox-control {
       left: @picker-item-content-padding-horizontal;
 
       .grouped &,

--- a/src/internals/Picker/test/ListCheckItemSpec.tsx
+++ b/src/internals/Picker/test/ListCheckItemSpec.tsx
@@ -51,8 +51,7 @@ describe('picker - ListCheckItem', () => {
 
     render(<ListCheckItem title="title" onCheck={onCheck} onSelectItem={onSelect} />);
 
-    // eslint-disable-next-line testing-library/no-node-access
-    fireEvent.click(screen.getByRole('checkbox').parentNode as HTMLElement);
+    fireEvent.click(screen.getByRole('checkbox'));
 
     expect(onCheck).to.have.been.calledOnce;
     expect(onSelect).to.have.been.calledOnce;
@@ -62,8 +61,7 @@ describe('picker - ListCheckItem', () => {
     const onSelectItem = sinon.spy();
     render(<ListCheckItem title="title" onSelectItem={onSelectItem} />);
 
-    // eslint-disable-next-line testing-library/no-node-access
-    fireEvent.click(screen.getByRole('checkbox').parentNode as HTMLElement);
+    fireEvent.click(screen.getByRole('checkbox'));
     expect(onSelectItem).to.have.been.calledOnce;
   });
 


### PR DESCRIPTION
- Listen for click events on the correct element.
- Adjusted some unreasonable css definitions.
- Affected components include: CheckPicker, CheckTreePicker, TagPicker, MultiCascader.