### PR TITLE
feat(Checkbox): add support for `color` on `<Checkbox>`

### DIFF
--- a/docs/pages/components/checkbox/en-US/index.md
+++ b/docs/pages/components/checkbox/en-US/index.md
@@ -22,6 +22,10 @@ The `indeterminate` property sets the Checkbox to an indeterminate state, mainly
 
 <!--{include:`indeterminate.md`}-->
 
+### Colors
+
+<!--{include:`colors.md`}-->
+
 ### Checkbox Group
 
 <!--{include:`checkbox-group.md`}-->
@@ -47,18 +51,19 @@ WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#checkbox
 
 ### `<Checkbox>`
 
-| Property       | Type `(default)`                                           | Description                                                             |
-| -------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------- |
-| checked        | boolean                                                    | Specifies whether the checkbox is selected                              |
-| defaultChecked | boolean                                                    | Specifies the initial state: whether or not the checkbox is selected    |
-| disabled       | boolean                                                    | Whether disabled                                                        |
-| id             | ElementType                                                | Custom element type for the component                                   |
-| indeterminate  | boolean                                                    | When being a checkbox , setting styles after the child part is selected |
-| inputRef       | Ref                                                        | Ref of input element                                                    |
-| name           | string                                                     | Used for the name of the form                                           |
-| onChange       | (value: string \| number, checked: boolean, event) => void | Callback fired when checkbox is triggered and state changes             |
-| title          | string                                                     | HTML title                                                              |
-| value          | string \| number                                           | Correspond to the value of CheckboxGroup, determine whether to select   |
+| Property       | Type `(default)`                                           | Description                                                                                                     |
+| -------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| checked        | boolean                                                    | Specifies whether the checkbox is selected                                                                      |
+| color          | [Color](#code-ts-color-code)                               | The color of the checkbox when checked or indeterminate <br/>![](https://img.shields.io/badge/min-v5.56.0-blue) |
+| defaultChecked | boolean                                                    | Specifies the initial state: whether or not the checkbox is selected                                            |
+| disabled       | boolean                                                    | Whether disabled                                                                                                |
+| id             | ElementType                                                | Custom element type for the component                                                                           |
+| indeterminate  | boolean                                                    | When being a checkbox , setting styles after the child part is selected                                         |
+| inputRef       | Ref                                                        | Ref of input element                                                                                            |
+| name           | string                                                     | Used for the name of the form                                                                                   |
+| onChange       | (value: string \| number, checked: boolean, event) => void | Callback fired when checkbox is triggered and state changes                                                     |
+| title          | string                                                     | HTML title                                                                                                      |
+| value          | string \| number                                           | Correspond to the value of CheckboxGroup, determine whether to select                                           |
 
 ### `<CheckboxGroup>`
 
@@ -69,3 +74,5 @@ WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#checkbox
 | name         | string                                    | Used for the name of the form                               |
 | onChange     | (value:string \| number[], event) => void | Callback fired when checkbox is triggered and state changes |
 | value        | string[] \| number[]                      | Value of checked box (Controlled)                           |
+
+<!--{include:(_common/types/color.md)}-->

--- a/docs/pages/components/checkbox/en-US/index.md
+++ b/docs/pages/components/checkbox/en-US/index.md
@@ -53,11 +53,11 @@ WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#checkbox
 
 | Property       | Type `(default)`                                           | Description                                                                                                     |
 | -------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| as             | ElementType`(div)`                                         | Custom element type for the component                                                                           |
 | checked        | boolean                                                    | Specifies whether the checkbox is selected                                                                      |
 | color          | [Color](#code-ts-color-code)                               | The color of the checkbox when checked or indeterminate <br/>![](https://img.shields.io/badge/min-v5.56.0-blue) |
 | defaultChecked | boolean                                                    | Specifies the initial state: whether or not the checkbox is selected                                            |
 | disabled       | boolean                                                    | Whether disabled                                                                                                |
-| id             | ElementType                                                | Custom element type for the component                                                                           |
 | indeterminate  | boolean                                                    | When being a checkbox , setting styles after the child part is selected                                         |
 | inputRef       | Ref                                                        | Ref of input element                                                                                            |
 | name           | string                                                     | Used for the name of the form                                                                                   |
@@ -67,12 +67,12 @@ WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#checkbox
 
 ### `<CheckboxGroup>`
 
-| Property     | Type `(default)`                          | Description                                                 |
-| ------------ | ----------------------------------------- | ----------------------------------------------------------- |
-| defaultValue | string[] \| number[]                      | Default value                                               |
-| inline       | boolean                                   | Inline layout                                               |
-| name         | string                                    | Used for the name of the form                               |
-| onChange     | (value:string \| number[], event) => void | Callback fired when checkbox is triggered and state changes |
-| value        | string[] \| number[]                      | Value of checked box (Controlled)                           |
+| Property     | Type `(default)`                            | Description                                                 |
+| ------------ | ------------------------------------------- | ----------------------------------------------------------- |
+| defaultValue | string[] \| number[]                        | Default value                                               |
+| inline       | boolean                                     | Inline layout                                               |
+| name         | string                                      | Used for the name of the form                               |
+| onChange     | (value:string[] \| number[], event) => void | Callback fired when checkbox is triggered and state changes |
+| value        | string[] \| number[]                        | Value of checked box (Controlled)                           |
 
 <!--{include:(_common/types/color.md)}-->

--- a/docs/pages/components/checkbox/fragments/colors.md
+++ b/docs/pages/components/checkbox/fragments/colors.md
@@ -1,0 +1,34 @@
+<!--start-code-->
+
+```js
+import { Checkbox } from 'rsuite';
+
+const App = () => (
+  <>
+    <Checkbox defaultChecked color="red">
+      Red
+    </Checkbox>
+    <Checkbox defaultChecked color="orange">
+      Orange
+    </Checkbox>
+    <Checkbox defaultChecked color="yellow">
+      Yellow
+    </Checkbox>
+    <Checkbox defaultChecked color="green">
+      Green
+    </Checkbox>
+    <Checkbox defaultChecked color="cyan">
+      Cyan
+    </Checkbox>
+    <Checkbox defaultChecked color="blue">
+      Blue
+    </Checkbox>
+    <Checkbox defaultChecked color="violet">
+      Violet
+    </Checkbox>
+  </>
+);
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/checkbox/zh-CN/index.md
+++ b/docs/pages/components/checkbox/zh-CN/index.md
@@ -22,6 +22,10 @@
 
 <!--{include:`indeterminate.md`}-->
 
+### 颜色
+
+<!--{include:`colors.md`}-->
+
 ### 复选框分组
 
 <!--{include:`checkbox-group.md`}-->
@@ -51,18 +55,19 @@ type ValueType = string | number;
 
 ### `<Checkbox>`
 
-| 属性名称       | 类型 `(默认值)`                                            | 描述                                         |
-| -------------- | ---------------------------------------------------------- | -------------------------------------------- |
-| checked        | boolean                                                    | 被选择（受控）                               |
-| defaultChecked | boolean                                                    | 默认被选择                                   |
-| disabled       | boolean                                                    | 禁用                                         |
-| id             | ElementType                                                | 为组件自定义元素类型                         |
-| indeterminate  | boolean                                                    | 作为一个全选框时，子项部分被选择后的样式设置 |
-| inputRef       | Ref                                                        | HTML input 元素                              |
-| name           | string                                                     | 用于表单对应的名称                           |
-| onChange       | (value: string \| number, checked: boolean, event) => void | checked 状态发生改变的回调函数               |
-| title          | string                                                     | HTML title                                   |
-| value          | string \| number                                           | 值，对应 CheckboxGroup 的值，判断是否选中    |
+| 属性名称       | 类型 `(默认值)`                                            | 描述                                                                             |
+| -------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| checked        | boolean                                                    | 被选择（受控）                                                                   |
+| color          | [Color](#code-ts-color-code)                               | 选中或不确定状态时的颜色 <br/>![](https://img.shields.io/badge/min-v5.56.0-blue) |
+| defaultChecked | boolean                                                    | 默认被选择                                                                       |
+| disabled       | boolean                                                    | 禁用                                                                             |
+| id             | ElementType                                                | 为组件自定义元素类型                                                             |
+| indeterminate  | boolean                                                    | 作为一个全选框时，子项部分被选择后的样式设置                                     |
+| inputRef       | Ref                                                        | HTML input 元素                                                                  |
+| name           | string                                                     | 用于表单对应的名称                                                               |
+| onChange       | (value: string \| number, checked: boolean, event) => void | checked 状态发生改变的回调函数                                                   |
+| title          | string                                                     | HTML title                                                                       |
+| value          | string \| number                                           | 值，对应 CheckboxGroup 的值，判断是否选中                                        |
 
 ### `<CheckboxGroup>`
 
@@ -73,3 +78,5 @@ type ValueType = string | number;
 | name         | string                                    | 用于表单对应的名称 |
 | onChange     | (value:string \| number[], event) => void | 值改变后的回调函数 |
 | value        | string[] \| number[]                      | 值(受控)           |
+
+<!--{include:(_common/types/color.md)}-->

--- a/docs/pages/components/checkbox/zh-CN/index.md
+++ b/docs/pages/components/checkbox/zh-CN/index.md
@@ -57,11 +57,11 @@ type ValueType = string | number;
 
 | 属性名称       | 类型 `(默认值)`                                            | 描述                                                                             |
 | -------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| as             | ElementType`(div)`                                         | 为组件自定义元素类型                                                             |
 | checked        | boolean                                                    | 被选择（受控）                                                                   |
 | color          | [Color](#code-ts-color-code)                               | 选中或不确定状态时的颜色 <br/>![](https://img.shields.io/badge/min-v5.56.0-blue) |
 | defaultChecked | boolean                                                    | 默认被选择                                                                       |
 | disabled       | boolean                                                    | 禁用                                                                             |
-| id             | ElementType                                                | 为组件自定义元素类型                                                             |
 | indeterminate  | boolean                                                    | 作为一个全选框时，子项部分被选择后的样式设置                                     |
 | inputRef       | Ref                                                        | HTML input 元素                                                                  |
 | name           | string                                                     | 用于表单对应的名称                                                               |
@@ -71,12 +71,12 @@ type ValueType = string | number;
 
 ### `<CheckboxGroup>`
 
-| 属性名称     | 类型 `(默认值)`                           | 描述               |
-| ------------ | ----------------------------------------- | ------------------ |
-| defaultValue | string[] \| number[]                      | 默认值             |
-| inline       | boolean                                   | 内联布局           |
-| name         | string                                    | 用于表单对应的名称 |
-| onChange     | (value:string \| number[], event) => void | 值改变后的回调函数 |
-| value        | string[] \| number[]                      | 值(受控)           |
+| 属性名称     | 类型 `(默认值)`                             | 描述               |
+| ------------ | ------------------------------------------- | ------------------ |
+| defaultValue | string[] \| number[]                        | 默认值             |
+| inline       | boolean                                     | 内联布局           |
+| name         | string                                      | 用于表单对应的名称 |
+| onChange     | (value:string[] \| number[], event) => void | 值改变后的回调函数 |
+| value        | string[] \| number[]                        | 值(受控)           |
 
 <!--{include:(_common/types/color.md)}-->

--- a/src/Badge/test/BadgeSpec.tsx
+++ b/src/Badge/test/BadgeSpec.tsx
@@ -4,7 +4,9 @@ import Badge from '../Badge';
 import { render, screen } from '@testing-library/react';
 
 describe('Badge', () => {
-  testStandardProps(<Badge />);
+  testStandardProps(<Badge />, {
+    colors: ['red', 'orange', 'yellow', 'green', 'cyan', 'blue', 'violet']
+  });
 
   it('Should render independent', () => {
     const { container } = render(<Badge />);

--- a/src/Button/test/ButtonSpec.tsx
+++ b/src/Button/test/ButtonSpec.tsx
@@ -6,7 +6,10 @@ import { testStandardProps } from '@test/utils';
 import Button from '../Button';
 
 describe('Button', () => {
-  testStandardProps(<Button />, { sizes: ['lg', 'md', 'sm', 'xs'] });
+  testStandardProps(<Button />, {
+    sizes: ['lg', 'md', 'sm', 'xs'],
+    colors: ['red', 'orange', 'yellow', 'green', 'cyan', 'blue', 'violet']
+  });
 
   it('Should output a button', () => {
     render(<Button>Title</Button>);

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -17,7 +17,7 @@ export interface CheckboxProps<V = ValueType>
   extends WithAsProps,
     Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
   /**
-   * A badge can have different colors.
+   * The color of the checkbox when checked or indeterminate
    *
    * @version 5.56.0
    */
@@ -222,7 +222,7 @@ const Checkbox: RsRefForwardingComponent<'div', CheckboxProps> = React.forwardRe
       ) : null;
     }
 
-    const input = (
+    const control = (
       <span className={prefix`control`}>
         <input
           {...htmlInputProps}
@@ -248,7 +248,7 @@ const Checkbox: RsRefForwardingComponent<'div', CheckboxProps> = React.forwardRe
       <Component {...restProps} ref={ref} onClick={onClick} className={classes}>
         <div className={prefix`checker`}>
           <label title={title} onClick={handleLabelClick}>
-            {checkable ? input : null}
+            {checkable ? control : null}
             <span className={prefix`label`} id={labelId}>
               {children}
             </span>

--- a/src/Checkbox/stories/Checkbox.stories.tsx
+++ b/src/Checkbox/stories/Checkbox.stories.tsx
@@ -1,5 +1,6 @@
+import React from 'react';
 import type { StoryObj } from '@storybook/react';
-import Checkbox from '../Checkbox';
+import Checkbox, { CheckboxProps } from '../Checkbox';
 import { createMeta } from '@/storybook/utils';
 import '../styles/index.less';
 
@@ -48,5 +49,42 @@ export const Indeterminate: Story = {
     ...defaultArgs,
     children: 'Checkbox',
     indeterminate: true
+  }
+};
+
+const ColorTemplate = (CheckboxProps: CheckboxProps) => {
+  return (
+    <>
+      <Checkbox {...CheckboxProps} color="red">
+        Red
+      </Checkbox>
+      <Checkbox {...CheckboxProps} color="orange">
+        Orange
+      </Checkbox>
+      <Checkbox {...CheckboxProps} color="yellow">
+        Yellow
+      </Checkbox>
+      <Checkbox {...CheckboxProps} color="green">
+        Green
+      </Checkbox>
+      <Checkbox {...CheckboxProps} color="cyan">
+        Cyan
+      </Checkbox>
+      <Checkbox {...CheckboxProps} color="blue">
+        Blue
+      </Checkbox>
+      <Checkbox {...CheckboxProps} color="violet">
+        Violet
+      </Checkbox>
+    </>
+  );
+};
+
+export const Color: Story = {
+  render: ColorTemplate,
+  args: {
+    ...defaultArgs,
+    children: 'Checkbox',
+    defaultChecked: true
   }
 };

--- a/src/Checkbox/styles/index.less
+++ b/src/Checkbox/styles/index.less
@@ -150,3 +150,25 @@
     }
   }
 }
+
+each(@spectrum, .(@color) {
+  .rs-checkbox-@{color} {
+    .rs-checkbox-control::before{
+      border-color: var(~'--rs-@{color}-500');
+    }
+
+    label:hover{
+      .rs-checkbox-inner::before {
+        border-color: var(~'--rs-@{color}-500');
+      }
+    }
+
+    &.rs-checkbox-checked,
+    &.rs-checkbox-indeterminate  {
+      .rs-checkbox-inner::before{
+        border-color: var(~'--rs-@{color}-500');
+        background-color:var(~'--rs-@{color}-500');
+      }
+    }
+  }
+});

--- a/src/Checkbox/test/CheckboxSpec.tsx
+++ b/src/Checkbox/test/CheckboxSpec.tsx
@@ -5,7 +5,9 @@ import { testStandardProps } from '@test/utils';
 import Checkbox from '../Checkbox';
 
 describe('Checkbox', () => {
-  testStandardProps(<Checkbox />);
+  testStandardProps(<Checkbox />, {
+    colors: ['red', 'orange', 'yellow', 'green', 'cyan', 'blue', 'violet']
+  });
 
   it('Should render a checkbox', () => {
     render(<Checkbox>Test</Checkbox>);

--- a/src/Rate/test/RateSpec.tsx
+++ b/src/Rate/test/RateSpec.tsx
@@ -10,7 +10,9 @@ import Rate from '../Rate';
 import Sinon from 'sinon';
 
 describe('Rate', () => {
-  testStandardProps(<Rate />);
+  testStandardProps(<Rate />, {
+    colors: ['red', 'orange', 'yellow', 'green', 'cyan', 'blue', 'violet']
+  });
 
   it('Should render a default Rate', () => {
     render(<Rate />);

--- a/src/Tag/test/TagSpec.tsx
+++ b/src/Tag/test/TagSpec.tsx
@@ -6,7 +6,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 describe('Tag', () => {
   testStandardProps(<Tag />, {
-    sizes: ['lg', 'md', 'sm']
+    sizes: ['lg', 'md', 'sm'],
+    colors: ['red', 'orange', 'yellow', 'green', 'cyan', 'blue', 'violet']
   });
 
   it('Should output a Tag', () => {

--- a/test/utils/testStandardProps.ts
+++ b/test/utils/testStandardProps.ts
@@ -77,17 +77,36 @@ export function testSizeProp(
   });
 }
 
+export function testColorProp(
+  element,
+  colors: string[] = [],
+  renderOptions,
+  getUIElement = view => view.container.firstChild
+) {
+  colors.forEach(color => {
+    it(`Should be ${color} color`, () => {
+      const view = render(
+        React.cloneElement(element, { 'data-testid': 'element', color }),
+        renderOptions
+      );
+
+      expect(getUIElement(view)).to.have.class(new RegExp('^rs-[a-z-]+-' + color));
+    });
+  });
+}
+
 interface TestStandardPropsOptions {
   renderOptions?: any;
   customClassName?: string | boolean;
   sizes?: string[];
+  colors?: string[];
   getRootElement?: (view: any) => HTMLElement;
   getUIElement?: (view: any) => HTMLElement;
 }
 
 export function testStandardProps(element, options: TestStandardPropsOptions = {}) {
   const { displayName } = element.type;
-  const { renderOptions, customClassName, sizes, getRootElement, getUIElement } = options;
+  const { renderOptions, customClassName, sizes, colors, getRootElement, getUIElement } = options;
 
   describe(`${displayName} - Standard props`, () => {
     testTestIdProp(element, renderOptions);
@@ -104,6 +123,10 @@ export function testStandardProps(element, options: TestStandardPropsOptions = {
 
     if (sizes) {
       testSizeProp(element, sizes, renderOptions, getUIElement);
+    }
+
+    if (colors) {
+      testColorProp(element, colors, renderOptions, getUIElement);
     }
   });
 }


### PR DESCRIPTION
![image](https://github.com/rsuite/rsuite/assets/1203827/2d6ff772-4d4d-4436-b9eb-0ba47cf9b4d7)

https://rsuite-nextjs-git-feat-checkbox-rsuite.vercel.app/components/checkbox/#colors