### PR TITLE
Fix : Typo error on documentation, "From" to "Form" title

### DIFF
--- a/docs/utils/component.config.json
+++ b/docs/utils/component.config.json
@@ -241,7 +241,7 @@
   {
     "group": true,
     "id": "form-category",
-    "name": "From",
+    "name": "Form",
     "title": "表单"
   },
   {


### PR DESCRIPTION
<img width="772" alt="Screenshot 2024-04-03 at 15 24 08" src="https://github.com/rsuite/rsuite/assets/54962581/fce9bc4e-ab88-40d5-8c02-e4496fe2ed36">
To
<img width="864" alt="Screenshot 2024-04-03 at 15 24 18" src="https://github.com/rsuite/rsuite/assets/54962581/eb08b529-85d4-40fb-8299-1188ce6a9c12">
