### PR TITLE
docs(MultiCascader, MultiCascadeTree): update incorrect props

### DIFF
--- a/docs/pages/components/multi-cascade-tree/en-US/index.md
+++ b/docs/pages/components/multi-cascade-tree/en-US/index.md
@@ -60,7 +60,7 @@ This tree allows the use of the `getChildren` option and the length of the child
 | columnHeight          | number                                                                             | Sets the height of the column                          |
 | columnWidth           | number                                                                             | Sets the width of the column                           |
 | data \*               | [ItemDataType][item][]                                                             | The data of component                                  |
-| defaultValue          | string                                                                             | Specifies the default value of the selected items      |
+| defaultValue          | string[]                                                                             | Specifies the default value of the selected items      |
 | disabledItemValues    | string[]                                                                           | Disabled items                                         |
 | getChildren           | (item: [ItemDataType][item]) => Promise&lt;[ItemDataType][item][]&gt;              | Asynchronously load the children of the tree node.     |
 | labelKey              | string `('label')`                                                                 | Set label key in data                                  |
@@ -71,7 +71,7 @@ This tree allows the use of the `getChildren` option and the length of the child
 | renderTreeNode        | (node: ReactNode, item: [ItemDataType][item]) => ReactNode                         | Custom render item                                     |
 | searchable            | boolean                                                                            | Whether to enable search                               |
 | uncheckableItemValues | string[]                                                                           | Set uncheckable items                                  |
-| value                 | string                                                                             | Specifies the values of the selected items(Controlled) |
+| value                 | string[]                                                                             | Specifies the values of the selected items(Controlled) |
 | valueKey              | string `('value')`                                                                 | Set value key in data                                  |
 
 <!--{include:(_common/types/item-data-type.md)}-->

--- a/docs/pages/components/multi-cascade-tree/zh-CN/index.md
+++ b/docs/pages/components/multi-cascade-tree/zh-CN/index.md
@@ -60,7 +60,7 @@ MultiCascadeTree 是一个按列显示树形结构数据的组件，支持多选
 | columnHeight          | number                                                                             | 设置列的高度                         |
 | columnWidth           | number                                                                             | 设置列的宽度                         |
 | data \*               | [ItemDataType][item][]                                                             | 组件数据                             |
-| defaultValue          | string                                                                             | 默认值                               |
+| defaultValue          | string[]                                                                             | 默认值                               |
 | disabledItemValues    | string[]                                                                           | 禁用选项                             |
 | getChildren           | (item: [ItemDataType][item]) => Promise&lt;[ItemDataType][item][]&gt;              | 异步加载树节点的子级                 |
 | labelKey              | string `('label')`                                                                 | 设置选项显示内容在 `data` 中的 `key` |
@@ -71,7 +71,7 @@ MultiCascadeTree 是一个按列显示树形结构数据的组件，支持多选
 | renderTreeNode        | (node: ReactNode, item: [ItemDataType][item]) => ReactNode                         | 自定义选项                           |
 | searchable            | boolean                                                                            | 是否启用搜索                         |
 | uncheckableItemValues | string[]                                                                           | 设置不可选中的选项                   |
-| value                 | string                                                                             | 设置值（受控）                       |
+| value                 | string[]                                                                             | 设置值（受控）                       |
 
 <!--{include:(_common/types/item-data-type.md)}-->
 

--- a/docs/pages/components/multi-cascade-tree/zh-CN/index.md
+++ b/docs/pages/components/multi-cascade-tree/zh-CN/index.md
@@ -72,6 +72,7 @@ MultiCascadeTree 是一个按列显示树形结构数据的组件，支持多选
 | searchable            | boolean                                                                            | 是否启用搜索                         |
 | uncheckableItemValues | string[]                                                                           | 设置不可选中的选项                   |
 | value                 | string[]                                                                             | 设置值（受控）                       |
+| valueKey              | string `('value')`                                                                 |  设置 `value` 在 `data` 的属性名称                                |
 
 <!--{include:(_common/types/item-data-type.md)}-->
 

--- a/docs/pages/components/multi-cascader/en-US/index.md
+++ b/docs/pages/components/multi-cascader/en-US/index.md
@@ -102,7 +102,7 @@ The `MultiCascader` component is used to select multiple values from cascading o
 | countable             | boolean `(true)`                                                                            | Can count selected options                                       |
 | data \*               | [ItemDataType][item][]                                                                      | The data of component                                            |
 | defaultOpen           | boolean                                                                                     | Default value of open property                                   |
-| defaultValue          | string                                                                                      | Default values of the selected items                             |
+| defaultValue          | string[]                                                                                      | Default values of the selected items                             |
 | disabled              | boolean                                                                                     | Disabled component                                               |
 | disabledItemValues    | string                                                                                      | Disabled items                                                   |
 | height                | number `(320)`                                                                              | The height of Dropdown                                           |
@@ -146,7 +146,7 @@ The `MultiCascader` component is used to select multiple values from cascading o
 | size                  | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')`                                           | A picker can have different sizes                                |
 | toggleAs              | ElementType `('a')`                                                                         | You can use a custom element for this component                  |
 | uncheckableItemValues | string                                                                                      | Set the option value for the check box not to be rendered        |
-| value                 | string                                                                                      | Specifies the values of the selected items(Controlled)           |
+| value                 | string[]                                                                                      | Specifies the values of the selected items(Controlled)           |
 | valueKey              | string `('value')`                                                                          | Set value key in data                                            |
 
 <!--{include:(_common/types/item-data-type.md)}-->

--- a/docs/pages/components/multi-cascader/zh-CN/index.md
+++ b/docs/pages/components/multi-cascader/zh-CN/index.md
@@ -104,7 +104,7 @@
 | countable             | boolean `(true)`                                                                                | 可以计数已选项                             |
 | data \*               | [ItemDataType][item][]                                                                          | 组件数据                                   |
 | defaultOpen           | boolean                                                                                         | 默认打开                                   |
-| defaultValue          | string                                                                                          | 设置默认值                                 |
+| defaultValue          | string[]                                                                                          | 设置默认值                                 |
 | disabled              | boolean                                                                                         | 禁用组件                                   |
 | disabledItemValues    | string                                                                                          | 禁用选项                                   |
 | height                | number `(320)`                                                                                  | 设置 Dropdown 的高度                       |
@@ -149,7 +149,7 @@
 | size                  | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')`                                               | 设置组件尺寸                               |
 | toggleAs              | ElementType `('a')`                                                                             | 为组件自定义元素类型                       |
 | uncheckableItemValues | string                                                                                          | 设置不显示复选框的选项值                   |
-| value                 | string                                                                                          | 设置值（受控）                             |
+| value                 | string[]                                                                                          | 设置值（受控）                             |
 | valueKey              | string `('value')`                                                                              | 设置选项值在 `data` 中的 `key`             |
 
 <!--{include:(_common/types/item-data-type.md)}-->


### PR DESCRIPTION
1. fix wrong value types in MultiCascadeTree and MultiCascader
2. add missing `valueKey` option in Chinese