### PR TITLE
build: bump schema-typed from 2.1.3 to 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react-use-set": "^1.0.0",
         "react-window": "^1.8.8",
         "rsuite-table": "^5.18.2",
-        "schema-typed": "^2.1.3"
+        "schema-typed": "^2.2.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.7.0",
@@ -17585,8 +17585,7 @@
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -17617,6 +17616,11 @@
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
       "dev": true
+    },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmmirror.com/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -21625,9 +21629,13 @@
       }
     },
     "node_modules/schema-typed": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.1.3.tgz",
-      "integrity": "sha512-Nk0LLOq0L64HaQsXQGAZ8Z176tDE4jewsxyWe+6QvidNiC33DMaWFg+LaLWJ85uPPBtqBBJlCq9W4c1KEA88WA=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmmirror.com/schema-typed/-/schema-typed-2.2.1.tgz",
+      "integrity": "sha512-looy+6hLbNAhPdorimnDZUFv4YIHLySjBdk9A/POJ3rjZ1XB9GcziCuOAUBAmYhMYe46gUSdiMpFqLRB1y2ptw==",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2"
+      }
     },
     "node_modules/schema-utils": {
       "version": "2.7.1",
@@ -39205,8 +39213,7 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.ismatch": {
       "version": "4.4.0",
@@ -39237,6 +39244,11 @@
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
       "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmmirror.com/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -42259,9 +42271,13 @@
       }
     },
     "schema-typed": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.1.3.tgz",
-      "integrity": "sha512-Nk0LLOq0L64HaQsXQGAZ8Z176tDE4jewsxyWe+6QvidNiC33DMaWFg+LaLWJ85uPPBtqBBJlCq9W4c1KEA88WA=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmmirror.com/schema-typed/-/schema-typed-2.2.1.tgz",
+      "integrity": "sha512-looy+6hLbNAhPdorimnDZUFv4YIHLySjBdk9A/POJ3rjZ1XB9GcziCuOAUBAmYhMYe46gUSdiMpFqLRB1y2ptw==",
+      "requires": {
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2"
+      }
     },
     "schema-utils": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-use-set": "^1.0.0",
     "react-window": "^1.8.8",
     "rsuite-table": "^5.18.2",
-    "schema-typed": "^2.1.3"
+    "schema-typed": "^2.2.1"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/src/Form/Form.tsx
+++ b/src/Form/Form.tsx
@@ -179,7 +179,7 @@ const Form: FormComponent = React.forwardRef((props: FormProps, ref: React.Ref<F
     let errorCount = 0;
     const model = getCombinedModel();
 
-    Object.keys(model.spec).forEach(key => {
+    Object.keys(model.getSchemaSpec()).forEach(key => {
       const checkResult = model.checkForField(key, formValue || {});
       if (checkResult.hasError === true) {
         errorCount += 1;
@@ -235,7 +235,7 @@ const Form: FormComponent = React.forwardRef((props: FormProps, ref: React.Ref<F
     const keys: string[] = [];
     const model = getCombinedModel();
 
-    Object.keys(model.spec).forEach(key => {
+    Object.keys(model.getSchemaSpec()).forEach(key => {
       keys.push(key);
       promises.push(model.checkForFieldAsync(key, formValue || {}));
     });

--- a/src/Form/test/FormSpec.tsx
+++ b/src/Form/test/FormSpec.tsx
@@ -251,17 +251,17 @@ describe('Form', () => {
     const values = {
       name: 'abc'
     };
-    const onErrorSpy = sinon.spy();
+    const onError = sinon.spy();
     render(
-      <Form formDefaultValue={values} onError={onErrorSpy} model={model}>
+      <Form formDefaultValue={values} onError={onError} model={model}>
         <FormControl name="name" />
       </Form>
     );
 
     userEvent.type(screen.getByRole('textbox'), 'd');
 
-    expect(onErrorSpy).to.be.called;
-    expect(onErrorSpy).to.be.calledWith({ name: checkEmail });
+    expect(onError).to.be.called;
+    expect(onError).to.be.calledWith({ name: checkEmail });
   });
 
   it('Should not call onError callback', () => {
@@ -269,9 +269,9 @@ describe('Form', () => {
       name: 'abc@ddd.com'
     };
 
-    const onErrorSpy = sinon.spy();
+    const onError = sinon.spy();
     render(
-      <Form formDefaultValue={values} onError={onErrorSpy} model={model}>
+      <Form formDefaultValue={values} onError={onError} model={model}>
         <FormControl name="name" />
       </Form>
     );
@@ -281,7 +281,7 @@ describe('Form', () => {
       initialSelectionEnd: 3
     });
 
-    expect(onErrorSpy).to.be.not.called;
+    expect(onError).to.be.not.called;
   });
 
   it('Should call onCheck callback', () => {
@@ -289,17 +289,17 @@ describe('Form', () => {
       name: 'abc'
     };
 
-    const onCheckSpy = sinon.spy();
+    const onCheck = sinon.spy();
     render(
-      <Form formDefaultValue={values} onCheck={onCheckSpy}>
+      <Form formDefaultValue={values} onCheck={onCheck}>
         <FormControl name="name" />
       </Form>
     );
 
     userEvent.type(screen.getByRole('textbox'), 'd');
 
-    expect(onCheckSpy).to.be.called;
-    expect(onCheckSpy).to.be.calledWith({});
+    expect(onCheck).to.be.called;
+    expect(onCheck).to.be.calledWith({});
   });
 
   it('Should call onCheck callback when blur', () => {
@@ -307,16 +307,16 @@ describe('Form', () => {
       name: 'abc'
     };
 
-    const onCheckSpy = sinon.spy();
+    const onCheck = sinon.spy();
     render(
-      <Form formDefaultValue={values} onCheck={onCheckSpy} checkTrigger="blur">
+      <Form formDefaultValue={values} onCheck={onCheck} checkTrigger="blur">
         <FormControl name="name" />
       </Form>
     );
     fireEvent.blur(screen.getByRole('textbox'));
 
-    expect(onCheckSpy).to.be.called;
-    expect(onCheckSpy).to.be.calledWith({});
+    expect(onCheck).to.be.called;
+    expect(onCheck).to.be.calledWith({});
   });
 
   it('Should not call onCheck callback when checkTrigger is null', () => {
@@ -324,19 +324,19 @@ describe('Form', () => {
       name: 'abc'
     };
 
-    const onCheckSpy = sinon.spy();
+    const onCheck = sinon.spy();
     render(
       // FIXME `checkTrigger` doesn't support `null` value
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      <Form formDefaultValue={values} onCheck={onCheckSpy} checkTrigger={null}>
+      <Form formDefaultValue={values} onCheck={onCheck} checkTrigger={null}>
         <FormControl name="name" />
       </Form>
     );
     fireEvent.blur(screen.getByRole('textbox'));
     userEvent.type(screen.getByRole('textbox'), 'd');
 
-    expect(onCheckSpy).to.be.not.called;
+    expect(onCheck).to.be.not.called;
   });
 
   it('Should call onCheck callback', () => {
@@ -344,11 +344,11 @@ describe('Form', () => {
       name: 'abc'
     };
 
-    const onCheckSpy = sinon.spy();
+    const onCheck = sinon.spy();
     render(
       <Form
         formDefaultValue={values}
-        onCheck={onCheckSpy}
+        onCheck={onCheck}
         formError={{
           email: 'email is null'
         }}
@@ -358,8 +358,8 @@ describe('Form', () => {
     );
     userEvent.type(screen.getByRole('textbox'), 'd');
 
-    expect(onCheckSpy).to.be.called;
-    expect(onCheckSpy).to.be.calledWith({ email: 'email is null' });
+    expect(onCheck).to.be.called;
+    expect(onCheck).to.be.calledWith({ email: 'email is null' });
   });
 
   it('Should call onError callback by checkAsync', async () => {
@@ -367,9 +367,9 @@ describe('Form', () => {
       name: 'abc'
     };
 
-    const onErrorSpy = sinon.spy();
+    const onError = sinon.spy();
     render(
-      <Form formDefaultValue={values} onError={onErrorSpy} model={modelAsync}>
+      <Form formDefaultValue={values} onError={onError} model={modelAsync}>
         <FormControl name="name" checkAsync />
       </Form>
     );
@@ -377,8 +377,8 @@ describe('Form', () => {
     userEvent.type(screen.getByRole('textbox'), 'd');
 
     await waitFor(() => {
-      expect(onErrorSpy).to.be.called;
-      expect(onErrorSpy).to.be.calledWith({ name: 'Duplicate name' });
+      expect(onError).to.be.called;
+      expect(onError).to.be.calledWith({ name: 'Duplicate name' });
     });
   });
 
@@ -414,8 +414,8 @@ describe('Form', () => {
     const model = Schema.Model({
       items: Schema.Types.ArrayType().of(
         Schema.Types.ObjectType().shape({
-          field1: Schema.Types.StringType().isRequired('error1'),
-          field2: Schema.Types.NumberType().isRequired('error2')
+          field1: Schema.Types.StringType().isRequired(),
+          field2: Schema.Types.NumberType().isRequired('field2 is required')
         })
       )
     });
@@ -431,25 +431,24 @@ describe('Form', () => {
       items: []
     };
 
-    const onErrorSpy = sinon.spy();
+    const onError = sinon.spy();
     render(
-      <Form formDefaultValue={values} onError={onErrorSpy} model={model}>
+      <Form formDefaultValue={values} onError={onError} model={model}>
         <FormControl name="items" accepter={Field} />
       </Form>
     );
 
     userEvent.type(screen.getByRole('textbox'), 'abcd');
 
-    expect(onErrorSpy).to.be.called;
-    expect(onErrorSpy).to.be.calledWith({
+    expect(onError).to.be.calledWith({
       items: {
         hasError: true,
         array: [
           {
             hasError: true,
             object: {
-              field1: { hasError: true, errorMessage: 'error1' },
-              field2: { hasError: true, errorMessage: 'error2' }
+              field1: { hasError: true, errorMessage: 'field1 is a required field' },
+              field2: { hasError: true, errorMessage: 'field2 is required' }
             }
           }
         ]
@@ -461,8 +460,8 @@ describe('Form', () => {
     const model = Schema.Model({
       items: Schema.Types.ArrayType().of(
         Schema.Types.ObjectType().shape({
-          field1: Schema.Types.StringType().isRequired('error1'),
-          field2: Schema.Types.NumberType().isRequired('error2')
+          field1: Schema.Types.StringType().isRequired(),
+          field2: Schema.Types.NumberType().isRequired('field2 is required')
         })
       )
     });
@@ -471,15 +470,13 @@ describe('Form', () => {
       return <input name="items" />;
     };
 
-    const values = {
-      items: [{ field1: '', field2: '' }]
-    };
+    const values = { items: [{ field1: '', field2: '' }] };
 
     const formRef = React.createRef<FormInstance>();
-    const onErrorSpy = sinon.spy();
+    const onError = sinon.spy();
 
     render(
-      <Form formDefaultValue={values} onError={onErrorSpy} model={model} ref={formRef}>
+      <Form formDefaultValue={values} onError={onError} model={model} ref={formRef}>
         <FormControl name="items" accepter={Field} />
       </Form>
     );
@@ -488,16 +485,15 @@ describe('Form', () => {
       (formRef.current as FormInstance).check();
     });
 
-    expect(onErrorSpy).to.be.called;
-    expect(onErrorSpy).to.be.calledWith({
+    expect(onError).to.be.calledWith({
       items: {
         hasError: true,
         array: [
           {
             hasError: true,
             object: {
-              field1: { hasError: true, errorMessage: 'error1' },
-              field2: { hasError: true, errorMessage: 'error2' }
+              field1: { hasError: true, errorMessage: 'field1 is a required field' },
+              field2: { hasError: true, errorMessage: 'field2 is required' }
             }
           }
         ]

--- a/src/Form/test/FormStylesSpec.tsx
+++ b/src/Form/test/FormStylesSpec.tsx
@@ -1,30 +1,22 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import Form, { FormInstance } from '../index';
+import { render, screen } from '@testing-library/react';
+import Form from '../index';
 import Button from '../../Button';
 import FormControlLabel from '../../FormControlLabel';
-import { getStyle } from '@test/utils';
 
 import '../styles/index.less';
 
 describe('Form styles', () => {
   it('Should render the correct styles', () => {
-    const instanceRef = React.createRef<FormInstance>();
     render(
-      <Form ref={instanceRef} layout="inline">
-        <Button>Text</Button>
-        <FormControlLabel>Text</FormControlLabel>
+      <Form layout="inline">
+        <Button>Button</Button>
+        <FormControlLabel>Label</FormControlLabel>
       </Form>
     );
-    const dom = (instanceRef.current as FormInstance).root as HTMLElement;
-    const buttonDom = dom.children[0];
-    const controlLabelDom = dom.children[1];
-    assert.equal(getStyle(buttonDom, 'verticalAlign'), 'top', 'Button vertical-align');
-    assert.equal(
-      getStyle(controlLabelDom, 'verticalAlign'),
-      'top',
-      'FormControlLabel vertical-align'
-    );
-    assert.equal(getStyle(controlLabelDom, 'marginTop'), '8px', 'FormControlLabel margin-top');
+
+    expect(screen.getByRole('button')).to.have.style('vertical-align', 'top');
+    expect(screen.getByText('Label')).to.have.style('vertical-align', 'top');
+    expect(screen.getByText('Label')).to.have.style('margin-top', '8px');
   });
 });

--- a/src/FormControl/FormControl.tsx
+++ b/src/FormControl/FormControl.tsx
@@ -268,7 +268,7 @@ const FormControl: FormControlComponent = React.forwardRef((props: FormControlPr
         id={controlId ? `${controlId}-error-message` : undefined}
         role="alert"
         aria-relevant="all"
-        show={!!messageNode}
+        show={fieldHasError}
         className={prefix`message-wrapper`}
         placement={errorPlacement}
       >

--- a/src/FormControl/test/FormControlStylesSpec.tsx
+++ b/src/FormControl/test/FormControlStylesSpec.tsx
@@ -1,24 +1,21 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import FormControl from '../index';
 import Form from '../../Form';
-import { getDOMNode, getStyle, toRGB, inChrome } from '@test/utils';
+import { toRGB, itChrome } from '@test/utils';
 
 import '../../Input/styles/index.less';
 import '../styles/index.less';
 
 describe('Form control styles', () => {
-  it('Should render the correct styles', () => {
-    const instanceRef = React.createRef();
+  itChrome('Should render the correct styles', () => {
     render(
       <Form>
-        <FormControl ref={instanceRef} name="name" />
+        <FormControl name="name" />
       </Form>
     );
-    const dom = getDOMNode(instanceRef.current);
-    const inputDom = dom.querySelector('.rs-input') as HTMLInputElement;
 
-    assert.equal(getStyle(dom, 'position'), 'relative');
-    inChrome && assert.equal(getStyle(inputDom, 'border'), `1px solid ${toRGB('#e5e5ea')}`);
+    expect(screen.getByTestId('form-control-wrapper')).to.have.style('position', 'relative');
+    expect(screen.getByRole('textbox')).to.have.style('border', `1px solid ${toRGB('#e5e5ea')}`);
   });
 });


### PR DESCRIPTION
## [2.2.1](https://github.com/rsuite/schema-typed/compare/2.2.0...2.2.1) (2024-04-12)


### Bug Fixes

* **ObjectType:** fix required message for properties not being replaced ([#79](https://github.com/rsuite/schema-typed/issues/79)) ([2aab276](https://github.com/rsuite/schema-typed/commit/2aab2768994b42d3572c2d90a926329912811c80))



# [2.2.0](https://github.com/rsuite/schema-typed/compare/2.1.3...2.2.0) (2024-04-11)


### Features

* add support for `equalTo` and `proxy` ([#78](https://github.com/rsuite/schema-typed/issues/78)) ([d9f0e55](https://github.com/rsuite/schema-typed/commit/d9f0e555cf532731839584b0c036648001fe0503))
* add support for `label` method ([#77](https://github.com/rsuite/schema-typed/issues/77)) ([9ff16c3](https://github.com/rsuite/schema-typed/commit/9ff16c346d6f13caabd4910a7d920c1c11eced18))
* **Schema:** support nested object check with `checkForField` and `checkForFieldAsync` ([#76](https://github.com/rsuite/schema-typed/issues/76)) ([e315aec](https://github.com/rsuite/schema-typed/commit/e315aec657ee230f2cf235861e05b37a7eedd274))
* **StringType:** add alllowMailto option to isURL rule ([#72](https://github.com/rsuite/schema-typed/issues/72)) ([349dc42](https://github.com/rsuite/schema-typed/commit/349dc429b51db89e7b261ed24aa006435c501685))

