### PR TITLE
feat(Form): add support for onSubmit and onReset

### DIFF
--- a/docs/pages/components/form-validation/en-US/index.md
+++ b/docs/pages/components/form-validation/en-US/index.md
@@ -128,15 +128,17 @@ There are `checkTrigger` properties on the `<Form>` and `<Form.Control>` compone
 
 ### Form ref
 
-| Name               | Type                                                                          | Description                                |
-| ------------------ | ----------------------------------------------------------------------------- | ------------------------------------------ |
-| check              | (callback?: (formError: E) => void) => boolean                                | Verify form data                           |
-| checkAsync         | () => Promise<CheckResult>                                                    | Asynchronously check form data             |
-| checkForField      | (fieldName: string, callback?: (checkResult: CheckResult) => void) => boolean | Checklist single field value               |
-| checkForFieldAsync | (fieldName: string) => Promise<CheckResult>                                   | Asynchronous check form single field value |
-| cleanErrors        | (callback: () => void) => void                                                | Clean error message                        |
-| cleanErrorForField | (fieldName: string, callback?: () => void) => void                            | Clear single field error message           |
-| resetErrors        | () => void                                                                    | Reset error message                        |
+| Name               | Type                                                                          | Description                                                   |
+| ------------------ | ----------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| check              | (callback?: (formError: E) => void) => boolean                                | Verify form data                                              |
+| checkAsync         | () => Promise<CheckResult>                                                    | Asynchronously check form data                                |
+| checkForField      | (fieldName: string, callback?: (checkResult: CheckResult) => void) => boolean | Checklist single field value                                  |
+| checkForFieldAsync | (fieldName: string) => Promise<CheckResult>                                   | Asynchronous check form single field value                    |
+| cleanErrorForField | (fieldName: string, callback?: () => void) => void                            | Clear single field error message                              |
+| cleanErrors        | (callback: () => void) => void                                                | Clean error message                                           |
+| reset              | () => void                                                                    | Reset form data to initial value and clear all error messages |
+| resetErrors        | () => void                                                                    | Reset error message                                           |
+| submit             | () => void                                                                    | Trigger form submission and verify data                       |
 
 ### Schema
 

--- a/docs/pages/components/form-validation/zh-CN/index.md
+++ b/docs/pages/components/form-validation/zh-CN/index.md
@@ -130,15 +130,17 @@ return (
 
 ### Form ref
 
-| 名称               | 类型                                                                          | 描述                   |
-| ------------------ | ----------------------------------------------------------------------------- | ---------------------- |
-| check              | (callback?: (formError: E) => void) => boolean                                | 检验表单数据           |
-| checkAsync         | () => Promise<CheckResult>                                                    | 异步检验表单数据       |
-| checkForField      | (fieldName: string, callback?: (checkResult: CheckResult) => void) => boolean | 校验表单单个字段值     |
-| checkForFieldAsync | (fieldName: string) => Promise<CheckResult>                                   | 异步校验表单单个字段值 |
-| cleanErrors        | (callback: () => void) => void                                                | 清除错误信息           |
-| cleanErrorForField | (fieldName: string, callback?: () => void) => void                            | 清除单个字段错误信息   |
-| resetErrors        | () => void                                                                    | 重置错误信息           |
+| 名称               | 类型                                                                          | 描述                                     |
+| ------------------ | ----------------------------------------------------------------------------- | ---------------------------------------- |
+| check              | (callback?: (formError: E) => void) => boolean                                | 检验表单数据                             |
+| checkAsync         | () => Promise<CheckResult>                                                    | 异步检验表单数据                         |
+| checkForField      | (fieldName: string, callback?: (checkResult: CheckResult) => void) => boolean | 校验表单单个字段值                       |
+| checkForFieldAsync | (fieldName: string) => Promise<CheckResult>                                   | 异步校验表单单个字段值                   |
+| cleanErrorForField | (fieldName: string, callback?: () => void) => void                            | 清除单个字段错误信息                     |
+| cleanErrors        | (callback: () => void) => void                                                | 清除错误信息                             |
+| reset              | () => void                                                                    | 重置表单数据为初始值，并清除所有错误信息 |
+| resetErrors        | () => void                                                                    | 重置错误信息                             |
+| submit             | () => void                                                                    | 触发表单提交并校验数据                   |
 
 ### Schema
 

--- a/docs/pages/components/form/en-US/index.md
+++ b/docs/pages/components/form/en-US/index.md
@@ -123,9 +123,10 @@ HTML:
 | onChange         | (formValue: object, event) => void                    | Callback fired when data changing                                                                          |
 | onCheck          | (formError: object) => void                           | Callback fired when data cheking                                                                           |
 | onError          | (formError: object) => void                           | Callback fired when error checking                                                                         |
+| onReset          | (formValue: object, event: FormEvent) => void         | Callback fired when form reset                                                                             |
+| onSubmit         | (formValue: object, event: FormEvent) => void         | Callback fired when form submit, only when the form data is validated will trigger                         |
 | plaintext        | boolean `(false)`                                     | Render the form as plain text                                                                              |
 | readOnly         | boolean `(false)`                                     | Make the form readonly                                                                                     |
-
 
 ### `<Form.Control>`
 

--- a/docs/pages/components/form/zh-CN/index.md
+++ b/docs/pages/components/form/zh-CN/index.md
@@ -122,6 +122,8 @@
 | onChange         | (formValue: object, event) => void                    | 数据改变后的回调函数                               |
 | onCheck          | (formError: object) => void                           | 数据校验的回调函数                                 |
 | onError          | (formError: object) => void                           | 校验出错的回调函数                                 |
+| onReset          | (formValue: object, event?: FormEvent) => void        | 表单重置的回调函数                                 |
+| onSubmit         | (formValue: object, event?: FormEvent) => void        | 表单提交的回调函数, 前提是表单数据校验通过后触发   |
 | plaintext        | boolean `(false)`                                     | 表单显示为纯文本                                   |
 | readOnly         | boolean `(false)`                                     | 只读表单                                           |
 

--- a/src/Form/FormContext.tsx
+++ b/src/Form/FormContext.tsx
@@ -5,11 +5,7 @@ import type { FieldRuleType } from './hooks/useSchemaModel';
 
 type RecordAny = Record<string, any>;
 
-interface TrulyFormContextValue<
-  T = RecordAny,
-  errorMsgType = any,
-  E = { [P in keyof T]?: errorMsgType }
-> {
+interface TrulyFormContextValue<T = RecordAny, M = any, E = { [P in keyof T]?: M }> {
   formError: E;
   nestedField: boolean;
   getCombinedModel: () => Schema;

--- a/src/Form/hooks/useFormRef.ts
+++ b/src/Form/hooks/useFormRef.ts
@@ -1,7 +1,4 @@
 import { useRef, useImperativeHandle } from 'react';
-import omit from 'lodash/omit';
-import useEventCallback from '../../utils/useEventCallback';
-import { nameToPath } from '../../FormControl/utils';
 import type { CheckResult } from 'schema-typed';
 
 export interface FormImperativeMethods<
@@ -43,6 +40,16 @@ export interface FormImperativeMethods<
    * All error messages are reset, and an initial value can be set
    */
   resetErrors: (formError?: E) => void;
+
+  /**
+   * Reset form data to initial value and clear all error messages
+   */
+  reset: () => void;
+
+  /**
+   * Submit form data and verify
+   */
+  submit: () => void;
 }
 
 export interface FormInstance<T = Record<string, any>, M = string, E = { [P in keyof T]?: M }>
@@ -54,50 +61,18 @@ export interface FormInstance<T = Record<string, any>, M = string, E = { [P in k
 }
 
 interface FormRefProps<T = Record<string, any>, M = string, E = { [P in keyof T]?: M }> {
-  formError: E;
-  nestedField?: boolean;
-  setFormError: (formError: E) => void;
-  check: (callback?: (formError: E) => void) => boolean;
-  checkForField: (fieldName: keyof T, callback?: (checkResult: CheckResult<M>) => void) => boolean;
-  checkAsync: () => Promise<any>;
-  checkForFieldAsync: (fieldName: keyof T) => Promise<CheckResult>;
+  imperativeMethods: FormImperativeMethods<T, M, E>;
 }
 
 export default function useFormRef(ref: React.Ref<FormInstance>, props: FormRefProps) {
   const rootRef = useRef<HTMLFormElement>(null);
 
-  const {
-    formError,
-    setFormError,
-    nestedField,
-    check,
-    checkForField,
-    checkAsync,
-    checkForFieldAsync
-  } = props;
-
-  const cleanErrors = useEventCallback(() => {
-    setFormError({});
-  });
-
-  const resetErrors = useEventCallback((formError: any = {}) => {
-    setFormError(formError);
-  });
-
-  const cleanErrorForField = useEventCallback((fieldName: string) => {
-    setFormError(omit(formError, [nestedField ? nameToPath(fieldName) : fieldName]));
-  });
+  const { imperativeMethods } = props;
 
   useImperativeHandle(ref, () => {
     return {
       root: rootRef.current,
-      check,
-      checkForField,
-      checkAsync,
-      checkForFieldAsync,
-      cleanErrors,
-      cleanErrorForField,
-      resetErrors
+      ...imperativeMethods
     };
   });
 

--- a/src/Form/hooks/useFormValidate.ts
+++ b/src/Form/hooks/useFormValidate.ts
@@ -5,10 +5,8 @@ import type { CheckResult } from 'schema-typed';
 import { useControlled } from '../../utils';
 import { nameToPath } from '../../FormControl/utils';
 import useEventCallback from '../../utils/useEventCallback';
-import useFormRef, { FormInstance } from './useFormRef';
 
 export interface FormErrorProps {
-  ref: React.Ref<FormInstance>;
   formValue: any;
   getCombinedModel: () => any;
   onCheck?: (formError: any) => void;
@@ -17,7 +15,7 @@ export interface FormErrorProps {
 }
 
 export default function useFormValidate(formError: any, props: FormErrorProps) {
-  const { ref, formValue, getCombinedModel, onCheck, onError, nestedField } = props;
+  const { formValue, getCombinedModel, onCheck, onError, nestedField } = props;
   const [realFormError, setFormError] = useControlled(formError, {});
 
   const realFormErrorRef = useRef(realFormError);
@@ -169,20 +167,27 @@ export default function useFormValidate(formError: any, props: FormErrorProps) {
     [formError, nestedField, onCheck, onError, setFormError]
   );
 
-  const formRef = useFormRef(ref, {
+  const cleanErrors = useEventCallback(() => {
+    setFormError({});
+  });
+
+  const resetErrors = useEventCallback((formError: any = {}) => {
+    setFormError(formError);
+  });
+
+  const cleanErrorForField = useEventCallback((fieldName: string) => {
+    setFormError(omit(formError, [nestedField ? nameToPath(fieldName) : fieldName]));
+  });
+
+  return {
+    formError: realFormError,
     check,
     checkForField,
     checkAsync,
     checkForFieldAsync,
-    formError,
-    setFormError,
-    nestedField
-  });
-
-  return {
-    formRef,
-    formError: realFormError,
-    check,
+    cleanErrors,
+    resetErrors,
+    cleanErrorForField,
     setFieldError,
     onRemoveError
   };

--- a/src/Form/hooks/useFormValue.ts
+++ b/src/Form/hooks/useFormValue.ts
@@ -3,7 +3,13 @@ import omit from 'lodash/omit';
 import set from 'lodash/set';
 import { useControlled } from '../../utils';
 
-export default function useFormValue(controlledValue, props) {
+type RecordAny = Record<string, any>;
+interface UseFormValueProps<V = RecordAny> {
+  formDefaultValue: V;
+  nestedField: boolean;
+}
+
+export default function useFormValue<V>(controlledValue, props: UseFormValueProps<V>) {
   const { formDefaultValue, nestedField } = props;
   const [formValue, setFormValue] = useControlled(controlledValue, formDefaultValue);
 
@@ -39,10 +45,21 @@ export default function useFormValue(controlledValue, props) {
     [setFormValue]
   );
 
+  const resetFormValue = useCallback(
+    (nextValue?: V) => {
+      const value = nextValue || formDefaultValue;
+      setFormValue(value);
+
+      return value;
+    },
+    [formDefaultValue, setFormValue]
+  );
+
   return {
     formValue,
     setFormValue,
     setFieldValue,
-    onRemoveValue
+    onRemoveValue,
+    resetFormValue
   };
 }

--- a/src/Form/test/Form.test.tsx
+++ b/src/Form/test/Form.test.tsx
@@ -13,3 +13,5 @@ formRef.current?.resetErrors();
 formRef.current?.checkForField('name');
 formRef.current?.checkAsync();
 formRef.current?.checkForFieldAsync('name');
+formRef.current?.reset();
+formRef.current?.submit();

--- a/src/Form/test/FormSpec.tsx
+++ b/src/Form/test/FormSpec.tsx
@@ -7,15 +7,10 @@ import { FormInstance } from '../hooks/useFormRef';
 import Form from '../Form';
 import FormControl from '../../FormControl';
 import Schema from '../../Schema';
-
-const checkEmail = 'Please input the correct email address';
+import Button from '../../Button';
 
 const model = Schema.Model({
-  name: Schema.Types.StringType().addRule(value => {
-    return /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(
-      value
-    );
-  }, checkEmail)
+  name: Schema.Types.StringType().isEmail('Email error')
 });
 
 const modelAsync = Schema.Model({
@@ -127,7 +122,7 @@ describe('Form', () => {
         model={model}
         formDefaultValue={values}
         onError={formError => {
-          expect(formError.name).to.equal(checkEmail);
+          expect(formError.name).to.equal('Email error');
         }}
       >
         <FormControl name="name" />
@@ -136,7 +131,7 @@ describe('Form', () => {
     const checkStatus = instance.checkForField('name', checkResult => {
       expect(checkResult).to.be.deep.equal({
         hasError: true,
-        errorMessage: checkEmail
+        errorMessage: 'Email error'
       });
     });
 
@@ -258,7 +253,7 @@ describe('Form', () => {
     userEvent.type(screen.getByRole('textbox'), 'd');
 
     expect(onError).to.be.called;
-    expect(onError).to.be.calledWith({ name: checkEmail });
+    expect(onError).to.be.calledWith({ name: 'Email error' });
   });
 
   it('Should not call onError callback', () => {
@@ -279,81 +274,6 @@ describe('Form', () => {
     });
 
     expect(onError).to.be.not.called;
-  });
-
-  it('Should call onCheck callback', () => {
-    const values = {
-      name: 'abc'
-    };
-
-    const onCheck = sinon.spy();
-    render(
-      <Form formDefaultValue={values} onCheck={onCheck}>
-        <FormControl name="name" />
-      </Form>
-    );
-
-    userEvent.type(screen.getByRole('textbox'), 'd');
-
-    expect(onCheck).to.be.called;
-    expect(onCheck).to.be.calledWith({});
-  });
-
-  it('Should call onCheck callback when blur', () => {
-    const values = {
-      name: 'abc'
-    };
-
-    const onCheck = sinon.spy();
-    render(
-      <Form formDefaultValue={values} onCheck={onCheck} checkTrigger="blur">
-        <FormControl name="name" />
-      </Form>
-    );
-    fireEvent.blur(screen.getByRole('textbox'));
-
-    expect(onCheck).to.be.called;
-    expect(onCheck).to.be.calledWith({});
-  });
-
-  it('Should not call onCheck callback when checkTrigger is null', () => {
-    const values = {
-      name: 'abc'
-    };
-
-    const onCheck = sinon.spy();
-    render(
-      <Form formDefaultValue={values} onCheck={onCheck} checkTrigger={null}>
-        <FormControl name="name" />
-      </Form>
-    );
-    fireEvent.blur(screen.getByRole('textbox'));
-    userEvent.type(screen.getByRole('textbox'), 'd');
-
-    expect(onCheck).to.be.not.called;
-  });
-
-  it('Should call onCheck callback', () => {
-    const values = {
-      name: 'abc'
-    };
-
-    const onCheck = sinon.spy();
-    render(
-      <Form
-        formDefaultValue={values}
-        onCheck={onCheck}
-        formError={{
-          email: 'email is null'
-        }}
-      >
-        <FormControl name="name" />
-      </Form>
-    );
-    userEvent.type(screen.getByRole('textbox'), 'd');
-
-    expect(onCheck).to.be.called;
-    expect(onCheck).to.be.calledWith({ email: 'email is null' });
   });
 
   it('Should call onError callback by checkAsync', async () => {
@@ -506,5 +426,301 @@ describe('Form', () => {
     expect(instance.cleanErrors).to.instanceOf(Function);
     expect(instance.cleanErrorForField).to.instanceOf(Function);
     expect(instance.resetErrors).to.instanceOf(Function);
+  });
+
+  describe('onCheck', () => {
+    it('Should call onCheck callback', () => {
+      const values = {
+        name: 'abc'
+      };
+
+      const onCheck = sinon.spy();
+      render(
+        <Form formDefaultValue={values} onCheck={onCheck}>
+          <FormControl name="name" />
+        </Form>
+      );
+
+      userEvent.type(screen.getByRole('textbox'), 'd');
+
+      expect(onCheck).to.be.called;
+      expect(onCheck).to.be.calledWith({});
+    });
+
+    it('Should call onCheck callback when blur', () => {
+      const values = {
+        name: 'abc'
+      };
+
+      const onCheck = sinon.spy();
+      render(
+        <Form formDefaultValue={values} onCheck={onCheck} checkTrigger="blur">
+          <FormControl name="name" />
+        </Form>
+      );
+      fireEvent.blur(screen.getByRole('textbox'));
+
+      expect(onCheck).to.be.called;
+      expect(onCheck).to.be.calledWith({});
+    });
+
+    it('Should not call onCheck callback when checkTrigger is null', () => {
+      const values = {
+        name: 'abc'
+      };
+
+      const onCheck = sinon.spy();
+      render(
+        <Form formDefaultValue={values} onCheck={onCheck} checkTrigger={null}>
+          <FormControl name="name" />
+        </Form>
+      );
+      fireEvent.blur(screen.getByRole('textbox'));
+      userEvent.type(screen.getByRole('textbox'), 'd');
+
+      expect(onCheck).to.be.not.called;
+    });
+
+    it('Should call onCheck callback', () => {
+      const values = {
+        name: 'abc'
+      };
+
+      const onCheck = sinon.spy();
+      render(
+        <Form
+          formDefaultValue={values}
+          onCheck={onCheck}
+          formError={{
+            email: 'email is null'
+          }}
+        >
+          <FormControl name="name" />
+        </Form>
+      );
+      userEvent.type(screen.getByRole('textbox'), 'd');
+
+      expect(onCheck).to.be.called;
+      expect(onCheck).to.be.calledWith({ email: 'email is null' });
+    });
+  });
+
+  describe('onSubmit', () => {
+    it('Should call onSubmit callback', () => {
+      const values = {
+        mail: 'foobar@gmail.com'
+      };
+
+      const onSubmit = sinon.spy();
+      const onError = sinon.spy();
+      const onCheck = sinon.spy();
+      render(
+        <Form
+          formDefaultValue={values}
+          model={model}
+          onSubmit={onSubmit}
+          onError={onError}
+          onCheck={onCheck}
+        >
+          <FormControl name="name" />
+          <Button type="submit">submit</Button>
+        </Form>
+      );
+
+      fireEvent.click(screen.getByRole('button'));
+
+      expect(onSubmit).to.be.calledWith(values);
+      expect(onCheck).to.be.calledWith({});
+      expect(onError).to.be.not.called;
+    });
+
+    it('Should call onSubmit callback by submit method', () => {
+      const values = {
+        mail: 'foobar@gmail.com'
+      };
+
+      const onSubmit = sinon.spy();
+      const onError = sinon.spy();
+      const onCheck = sinon.spy();
+      const formRef = React.createRef<FormInstance>();
+      render(
+        <Form
+          ref={formRef}
+          formDefaultValue={values}
+          model={model}
+          onSubmit={onSubmit}
+          onError={onError}
+          onCheck={onCheck}
+        >
+          <FormControl name="name" />
+        </Form>
+      );
+
+      formRef.current?.submit();
+
+      expect(onSubmit).to.be.calledWith(values);
+      expect(onCheck).to.be.calledWith({});
+      expect(onError).to.be.not.called;
+    });
+
+    it('Should not call onSubmit callback when check failed', () => {
+      const values = {
+        name: 'foobar'
+      };
+
+      const onSubmit = sinon.spy();
+      const onError = sinon.spy();
+      const onCheck = sinon.spy();
+      render(
+        <Form
+          formDefaultValue={values}
+          model={model}
+          onSubmit={onSubmit}
+          onError={onError}
+          onCheck={onCheck}
+        >
+          <FormControl name="name" />
+          <Button type="submit">submit</Button>
+        </Form>
+      );
+
+      fireEvent.click(screen.getByRole('button'));
+
+      expect(onSubmit).to.be.not.called;
+      expect(onCheck).to.be.calledWith({ name: 'Email error' });
+      expect(onError).to.be.calledWith({ name: 'Email error' });
+    });
+
+    it('Should not call onSubmit callback when form is disabled', () => {
+      const values = { name: 'foobar@gmail.com' };
+      const onSubmit = sinon.spy();
+      render(
+        <Form formDefaultValue={values} model={model} onSubmit={onSubmit} disabled>
+          <FormControl name="name" />
+          <Button type="submit">submit</Button>
+        </Form>
+      );
+
+      fireEvent.click(screen.getByRole('button'));
+      expect(onSubmit).to.be.not.called;
+    });
+
+    it('Should not call onSubmit callback when form is readOnly', () => {
+      const values = { name: 'foobar@gmail.com' };
+      const onSubmit = sinon.spy();
+      render(
+        <Form formDefaultValue={values} model={model} onSubmit={onSubmit} readOnly>
+          <FormControl name="name" />
+          <Button type="submit">submit</Button>
+        </Form>
+      );
+
+      fireEvent.click(screen.getByRole('button'));
+      expect(onSubmit).to.be.not.called;
+    });
+
+    it('Should not call onSubmit callback when form is plaintext', () => {
+      const values = { name: 'foobar@gmail.com' };
+      const onSubmit = sinon.spy();
+      render(
+        <Form formDefaultValue={values} model={model} onSubmit={onSubmit} plaintext>
+          <FormControl name="name" />
+          <Button type="submit">submit</Button>
+        </Form>
+      );
+
+      fireEvent.click(screen.getByRole('button'));
+      expect(onSubmit).to.be.not.called;
+    });
+  });
+
+  describe('onReset', () => {
+    it('Should call onReset callback', () => {
+      const values = { name: 'foobar@mail.com' };
+      const onReset = sinon.spy();
+
+      render(
+        <Form formDefaultValue={values} onReset={onReset} model={model}>
+          <FormControl name="name" />
+          <Button type="reset">reset</Button>
+        </Form>
+      );
+
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: '123' } });
+
+      expect(screen.getByRole('textbox')).to.have.value('123');
+      expect(screen.getByRole('alert')).to.have.text('Email error');
+
+      fireEvent.click(screen.getByRole('button'));
+
+      expect(screen.getByRole('textbox')).to.have.value('foobar@mail.com');
+      expect(screen.queryAllByRole('alert')).to.be.empty;
+      expect(onReset).to.be.calledWith(values);
+    });
+
+    it('Should call onReset callback by reset method', () => {
+      const values = { name: 'foobar@mail.com' };
+      const onReset = sinon.spy();
+      const formRef = React.createRef<FormInstance>();
+
+      render(
+        <Form formDefaultValue={values} onReset={onReset} model={model} ref={formRef}>
+          <FormControl name="name" />
+          <Button type="reset">reset</Button>
+        </Form>
+      );
+
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: '123' } });
+
+      expect(screen.getByRole('textbox')).to.have.value('123');
+      expect(screen.getByRole('alert')).to.have.text('Email error');
+
+      formRef.current?.reset();
+
+      expect(screen.getByRole('textbox')).to.have.value('foobar@mail.com');
+      expect(screen.queryAllByRole('alert')).to.be.empty;
+      expect(onReset).to.be.calledWith(values);
+    });
+
+    it('Should not call onReset callback when form is disabled', () => {
+      const values = { name: 'foobar@mail.com' };
+      const onReset = sinon.spy();
+      render(
+        <Form formDefaultValue={values} onReset={onReset} model={model} disabled>
+          <FormControl name="name" />
+          <Button type="reset">reset</Button>
+        </Form>
+      );
+
+      fireEvent.click(screen.getByRole('button'));
+      expect(onReset).to.be.not.called;
+    });
+
+    it('Should not call onReset callback when form is readOnly', () => {
+      const values = { name: 'foobar@mail.com' };
+      const onReset = sinon.spy();
+      render(
+        <Form formDefaultValue={values} onReset={onReset} model={model} readOnly>
+          <FormControl name="name" />
+          <Button type="reset">reset</Button>
+        </Form>
+      );
+
+      fireEvent.click(screen.getByRole('button'));
+      expect(onReset).to.be.not.called;
+    });
+    it('Should not call onReset callback when form is plaintext', () => {
+      const values = { name: 'foobar@mail.com' };
+      const onReset = sinon.spy();
+      render(
+        <Form formDefaultValue={values} onReset={onReset} model={model} plaintext>
+          <FormControl name="name" />
+          <Button type="reset">reset</Button>
+        </Form>
+      );
+
+      fireEvent.click(screen.getByRole('button'));
+      expect(onReset).to.be.not.called;
+    });
   });
 });


### PR DESCRIPTION

## Props

| Property         | Type `(default)`                                      | Description                                                                                                |
| ---------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
| onReset          | (formValue: object, event?: FormEvent) => void         | Callback fired when form reset                                                                             |
| onSubmit         | (formValue: object, event?: FormEvent) => void         | Callback fired when form submit, only when the form data is validated will trigger                         |

## Methods

| Name               | Type                                                                          | Description                                                   |
| ------------------ | ----------------------------------------------------------------------------- | ------------------------------------------------------------- |
| reset              | () => void                                                                    | Reset form data to initial value and clear all error messages |
| submit             | () => void                                                                    | Trigger form submission and verify data                       |

