### PR TITLE
ci(test): pin React version to 18.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "release": "node scripts/release.js",
     "version": "npm run changelog && git add -A",
     "install:react-17": "npm i --no-save --legacy-peer-deps react@17 react-dom@17 ",
-    "install:react-18": "npm i --no-save --legacy-peer-deps react@18 react-dom@18 @testing-library/react@13 @testing-library/react-hooks@8 @testing-library/user-event@13"
+    "install:react-18": "npm i --no-save --legacy-peer-deps react@18.2.0 react-dom@18.2.0 @testing-library/react@13 @testing-library/react-hooks@8 @testing-library/user-event@13"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
React upgrade to 18.3.0 and later will not pass the test, so the version is temporarily locked to 18.2.0