### PR TITLE
fix(toggle): block pointer events when disabled

### DIFF
--- a/src/Toggle/styles/index.less
+++ b/src/Toggle/styles/index.less
@@ -70,7 +70,7 @@
     background-color: var(--rs-toggle-disabled-bg);
     color: var(--rs-toggle-disabled-thumb);
     box-shadow: inset 0 0 0 1px var(--rs-toggle-disabled-thumb);
-    cursor: not-allowed;
+    pointer-events: none;
   }
 
   // checked state


### PR DESCRIPTION
### Description
When the toggle is disabled it is still accepting pointer events.

https://github.com/rsuite/rsuite/assets/8769408/ca752fbe-b18c-465d-b3bc-d1b039c4c595


### Current behavior
`cursor: not-allowed;`

### New behavior
`pointer-events: none;`


