### PR TITLE
fix(toggle): center align inner text/icon

### DIFF
--- a/src/Toggle/styles/index.less
+++ b/src/Toggle/styles/index.less
@@ -99,7 +99,8 @@
 
 // Label text inside the switch
 .rs-toggle-inner {
-  display: block;
+  display: flex;
+  align-items: center;
   transition: margin @toggle-transition;
 
   .high-contrast-mode({

--- a/src/Toggle/styles/index.less
+++ b/src/Toggle/styles/index.less
@@ -70,7 +70,7 @@
     background-color: var(--rs-toggle-disabled-bg);
     color: var(--rs-toggle-disabled-thumb);
     box-shadow: inset 0 0 0 1px var(--rs-toggle-disabled-thumb);
-    cursor: not-allowed;
+    pointer-events: none;
   }
 
   // checked state


### PR DESCRIPTION
### **Description**
The icon inside the toggle is not vertically centered.

### **Current behavior**

![image](https://github.com/rsuite/rsuite/assets/8769408/88e66ffe-ea6e-4d3e-bb9d-aeeb3a13da13)

### **New behavior**

![image](https://github.com/rsuite/rsuite/assets/8769408/0c0fc404-419d-4082-af49-fe86050f2908)

### **Additional Information**

If the PR gets accepted please use my GitHub email-id ([shrinidhiupadhyaya1195@gmail.com](mailto:shrinidhiupadhyaya1195@gmail.com)) instead of my other email-id for the Co-authored-by: message.