### PR TITLE
fix(slider): block pointer events when disabled

### DIFF
--- a/src/Slider/styles/index.less
+++ b/src/Slider/styles/index.less
@@ -23,7 +23,7 @@
 
     .rs-slider-bar,
     .rs-slider-handle::before {
-      cursor: not-allowed;
+      pointer-events: none;
     }
   }
 

--- a/src/Toggle/styles/index.less
+++ b/src/Toggle/styles/index.less
@@ -99,8 +99,7 @@
 
 // Label text inside the switch
 .rs-toggle-inner {
-  display: flex;
-  align-items: center;
+  display: block;
   transition: margin @toggle-transition;
 
   .high-contrast-mode({

--- a/src/Toggle/styles/index.less
+++ b/src/Toggle/styles/index.less
@@ -99,7 +99,8 @@
 
 // Label text inside the switch
 .rs-toggle-inner {
-  display: block;
+  display: flex;
+  align-items: center;
   transition: margin @toggle-transition;
 
   .high-contrast-mode({

--- a/src/Toggle/styles/index.less
+++ b/src/Toggle/styles/index.less
@@ -70,7 +70,7 @@
     background-color: var(--rs-toggle-disabled-bg);
     color: var(--rs-toggle-disabled-thumb);
     box-shadow: inset 0 0 0 1px var(--rs-toggle-disabled-thumb);
-    cursor: not-allowed;
+    pointer-events: none;
   }
 
   // checked state


### PR DESCRIPTION
### **Description**

When the slider is disabled it is still accepting pointer events.

### **Current behavior**

`cursor: not-allowed;`

https://github.com/rsuite/rsuite/assets/8769408/59ebcaa2-3625-4e5a-a64f-e2c81f4eeb79

### **New behavior**

`pointer-events: none;`

https://github.com/rsuite/rsuite/assets/8769408/d7ee10d7-1e57-42d4-976f-325f655ba3ac

### **Additional Information**

If the PR gets accepted please use my GitHub email-id (shrinidhiupadhyaya1195@gmail.com) instead of my other email-id for the Co-authored-by: message.
