### PR TITLE
perf(DateRangePicker): improve the performance when typing the date

### DIFF
--- a/src/DateRangePicker/hooks/useDateDisabled.ts
+++ b/src/DateRangePicker/hooks/useDateDisabled.ts
@@ -1,0 +1,43 @@
+import { useCallback } from 'react';
+import { DATERANGE_DISABLED_TARGET as TARGET } from '../../utils';
+import { DisabledDateFunction, SelectedDatesState } from '../types';
+
+interface UseDateDisabledProps {
+  shouldDisableDate?: DisabledDateFunction;
+  DEPRECATED_disabledDate?: DisabledDateFunction;
+}
+
+interface DateDisabledOptions {
+  selectDate?: SelectedDatesState;
+  selectedDone?: boolean;
+  target?: TARGET;
+}
+
+/**
+ * Returns a function that determines whether a date is disabled and is compatible with the deprecated `disabledDate` prop.
+ */
+function useDateDisabled(props: UseDateDisabledProps) {
+  const { shouldDisableDate, DEPRECATED_disabledDate } = props;
+
+  const isDateDisabled = useCallback(
+    (date: Date, options: DateDisabledOptions): boolean => {
+      const { selectDate, selectedDone, target } = options;
+      if (typeof shouldDisableDate === 'function') {
+        return shouldDisableDate(date, selectDate, selectedDone, target);
+      }
+      if (typeof DEPRECATED_disabledDate === 'function') {
+        return DEPRECATED_disabledDate(date, selectDate, selectedDone, target);
+      }
+      return false;
+    },
+    [shouldDisableDate, DEPRECATED_disabledDate]
+  );
+
+  if (shouldDisableDate || DEPRECATED_disabledDate) {
+    return isDateDisabled;
+  }
+
+  return undefined;
+}
+
+export default useDateDisabled;

--- a/src/DateRangePicker/types.ts
+++ b/src/DateRangePicker/types.ts
@@ -34,3 +34,5 @@ export type DisabledDateFunction = (
    */
   target?: DATERANGE_DISABLED_TARGET
 ) => boolean;
+
+export type SelectedDatesState = [] | [Date] | [Date, Date];


### PR DESCRIPTION
fix: https://github.com/rsuite/rsuite/issues/3764

The main reason for the performance problem is that the `isDateDisabled` method is called many times, and this method is called every time it is rendered. When a very large range of dates is entered in the input box, the `isDateDisabled` method is called many times, resulting in a performance problem. The improvement plan is to call the `isDateDisabled` method only when both of the following conditions are met:  
- The `shouldDisableDate` property is set.
- When the calendar panel popup is opened.

Also removed the logic of judging whether the Ok button is disabled through the `isDateDisabled` method. Because it is a redundant check, and the disabled date cannot be selected on the calendar panel.

