### PR TITLE
fix: fix the color contrast of form controls in disabled state

### DIFF
--- a/docs/pages/components/form/fragments/status.md
+++ b/docs/pages/components/form/fragments/status.md
@@ -20,7 +20,8 @@ import {
   MultiCascader,
   Rate,
   Uploader,
-  Panel
+  Panel,
+  Toggle
 } from 'rsuite';
 
 import { mockTreeData } from './mock';
@@ -46,7 +47,8 @@ const defaultFormValue = {
   inputPicker: '',
   cascader: '',
   multiCascader: [],
-  rate: 0
+  rate: 0,
+  enable: false
 };
 
 const initFormValue = {
@@ -182,6 +184,16 @@ const App = () => {
         <Form.Group controlId="uploader">
           <Form.ControlLabel>Uploader:</Form.ControlLabel>
           <Form.Control name="uploader" accepter={Uploader} action="#" />
+        </Form.Group>
+
+        <Form.Group controlId="toggle">
+          <Form.ControlLabel>Toggle:</Form.ControlLabel>
+          <Form.Control
+            name="enable"
+            accepter={Toggle}
+            unCheckedChildren="Disabled"
+            checkedChildren="Enabled"
+          />
         </Form.Group>
       </Form>
     </Panel>

--- a/src/AutoComplete/test/AutoCompleteStylesSpec.tsx
+++ b/src/AutoComplete/test/AutoCompleteStylesSpec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import AutoComplete from '../index';
-import { toRGB } from '@test/utils';
+import { toRGB, inChrome } from '@test/utils';
 import '../styles/index.less';
 
 describe('AutoComplete styles', () => {
@@ -20,11 +20,11 @@ describe('AutoComplete styles', () => {
     const options = screen.getAllByRole('option');
 
     // Focused option
+    const focusedBgColor = inChrome
+      ? 'color(srgb 0.8 0.913725 1 / 0.5)'
+      : 'rgba(204, 233, 255, 0.5)';
     expect(options[0].firstChild).to.have.style('color', toRGB('#1675e0'));
-    expect(options[0].firstChild).to.have.style(
-      'background-color',
-      'color(srgb 0.8 0.913725 1 / 0.5)'
-    );
+    expect(options[0].firstChild).to.have.style('background-color', focusedBgColor);
 
     // Unfocused option
     expect(options[1].firstChild).to.have.style('color', toRGB('#575757'));

--- a/src/AutoComplete/test/AutoCompleteStylesSpec.tsx
+++ b/src/AutoComplete/test/AutoCompleteStylesSpec.tsx
@@ -1,55 +1,40 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import AutoComplete from '../index';
-import { getStyle, toRGB, inChrome } from '@test/utils';
-
+import { toRGB } from '@test/utils';
 import '../styles/index.less';
-import { PickerHandle } from '../../internals/Picker';
 
 describe('AutoComplete styles', () => {
-  it('Input should render the correct styles', () => {
-    const instanceRef = React.createRef<PickerHandle>();
-    render(<AutoComplete ref={instanceRef} data={[]} />);
-    const dom = ((instanceRef.current as PickerHandle).root as HTMLElement).querySelector(
-      'input'
-    ) as HTMLInputElement;
-    assert.equal(getStyle(dom, 'backgroundColor'), toRGB('#fff'), 'AutoComplete background-color');
-    // @description Can't get border-radius value in other browser except chrome
-    inChrome &&
-      assert.equal(getStyle(dom, 'border'), `1px solid ${toRGB('#e5e5ea')}`, 'AutoComplete border');
-    assert.equal(getStyle(dom, 'color'), toRGB('#575757'), 'AutoComplete font-color');
-    inChrome && assert.equal(getStyle(dom, 'borderRadius'), '6px', 'AutoComplete border-radius');
+  it('Should render the correct styles', () => {
+    render(<AutoComplete data={[]} />);
+
+    expect(screen.getByRole('combobox')).to.have.style('background-color', toRGB('#fff'));
+    expect(screen.getByRole('combobox')).to.have.style('color', toRGB('#575757'));
+    expect(screen.getByRole('combobox')).to.have.style('border', `1px solid ${toRGB('#e5e5ea')}`);
+    expect(screen.getByRole('combobox')).to.have.style('border-radius', '6px');
   });
 
-  it('Should the correct styles when set `open` and `defaultValue`', () => {
-    const instanceRef = React.createRef<PickerHandle>();
-    render(<AutoComplete ref={instanceRef} data={['a', 'b', 'ab']} open defaultValue="a" />);
-    const dom = ((instanceRef.current as PickerHandle).root as HTMLElement).querySelector(
-      'input'
-    ) as HTMLInputElement;
-    const unFocusItemDom = document.querySelector(
-      '.rs-auto-complete-item:not(.rs-auto-complete-item-focus)'
-    ) as HTMLElement;
+  it('Should render the correct styles when set `open`', () => {
+    render(<AutoComplete data={['a', 'b', 'ab']} open defaultValue="a" />);
 
-    assert.equal(getStyle(dom, 'color'), toRGB('#575757'), 'AutoComplete  focus item font-color');
-    assert.equal(
-      getStyle(unFocusItemDom, 'backgroundColor'),
-      toRGB('#0000'),
-      'AutoComplete unFocus item background-color'
+    const options = screen.getAllByRole('option');
+
+    // Focused option
+    expect(options[0].firstChild).to.have.style('color', toRGB('#1675e0'));
+    expect(options[0].firstChild).to.have.style(
+      'background-color',
+      'color(srgb 0.8 0.913725 1 / 0.5)'
     );
+
+    // Unfocused option
+    expect(options[1].firstChild).to.have.style('color', toRGB('#575757'));
+    expect(options[1].firstChild).to.have.style('background-color', toRGB('#0000'));
   });
 
-  it('Disabled should render the correct styles', () => {
-    const instanceRef = React.createRef<PickerHandle>();
-    render(<AutoComplete ref={instanceRef} data={[]} disabled />);
-    const dom = ((instanceRef.current as PickerHandle).root as HTMLElement).querySelector(
-      'input'
-    ) as HTMLInputElement;
-    assert.equal(
-      getStyle(dom, 'backgroundColor'),
-      toRGB('#f7f7fa'),
-      'Disabled autoComplete background-color'
-    );
-    assert.equal(getStyle(dom, 'color'), toRGB('#c5c6c7'), 'Disabled autoComplete color');
+  it('Should render the correct styles when set `disabled`', () => {
+    render(<AutoComplete data={[]} disabled />);
+
+    expect(screen.getByRole('combobox')).to.have.style('background-color', toRGB('#f7f7fa'));
+    expect(screen.getByRole('combobox')).to.have.style('color', toRGB('#8e8e93'));
   });
 });

--- a/src/Button/styles/mixin.less
+++ b/src/Button/styles/mixin.less
@@ -21,7 +21,7 @@
     @rules();
 
     .high-contrast-mode({
-      opacity: 0.5;
+      border-color: var(--rs-btn-default-disabled-boreder-color);
     });
   }
 }

--- a/src/Checkbox/styles/index.less
+++ b/src/Checkbox/styles/index.less
@@ -144,11 +144,7 @@
 
     .rs-checkbox-disabled.rs-checkbox-checked &,
     .rs-checkbox-disabled.rs-checkbox-indeterminate & {
-      opacity: 0.3;
-
-      .high-contrast-mode({
-        opacity: 0.5;
-      });
+      opacity: 0.5;
     }
   }
 }

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -658,6 +658,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
               {...getRestProps(rest, usedClassNamePropKeys)}
               inside
               size={size}
+              disabled={disabled}
               onClick={handleClick}
             >
               <PickerLabel className={prefix`label`} id={`${id}-label`}>

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -987,6 +987,7 @@ const DateRangePicker = React.forwardRef((props: DateRangePickerProps, ref) => {
               ...calendarOnlyProps
             ])}
             inside
+            disabled={disabled}
             size={size}
           >
             <PickerLabel className={prefix`label`} id={`${id}-label`}>

--- a/src/InputGroup/styles/index.less
+++ b/src/InputGroup/styles/index.less
@@ -191,7 +191,7 @@
   }
 }
 
-.rs-input-group-disabled {
+.rs-input-group.rs-input-group-disabled {
   background-color: var(--rs-input-disabled-bg);
   color: var(--rs-text-disabled);
   cursor: not-allowed;

--- a/src/Nav/test/NavItemStylesSpec.tsx
+++ b/src/Nav/test/NavItemStylesSpec.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import Nav from '../index';
 import { toRGB, getDefaultPalette } from '@test/utils';
-
 import '../styles/index.less';
 
 const { H700 } = getDefaultPalette();
@@ -40,7 +39,7 @@ describe('NavItem styles', () => {
 
     const navItemDisabled = screen.getByText('Disabled nav item');
 
-    expect(navItemDisabled).to.have.style('color', toRGB('#c5c6c7'));
+    expect(navItemDisabled).to.have.style('color', toRGB('#8e8e93'));
     expect(navItemDisabled).to.have.style('cursor', 'not-allowed');
   });
 });

--- a/src/Radio/styles/index.less
+++ b/src/Radio/styles/index.less
@@ -105,11 +105,7 @@
     }
 
     .rs-radio.rs-radio-disabled.rs-radio-checked & {
-      opacity: 0.3;
-
-      .high-contrast-mode({
-        opacity: 0.5;
-      });
+      opacity: 0.5;
     }
   }
 

--- a/src/Rate/styles/index.less
+++ b/src/Rate/styles/index.less
@@ -89,7 +89,7 @@
   }
 
   &-disabled {
-    opacity: 0.3;
+    opacity: 0.5;
     outline: none;
   }
 

--- a/src/SelectPicker/test/SelectPickerStylesSpec.tsx
+++ b/src/SelectPicker/test/SelectPickerStylesSpec.tsx
@@ -1,118 +1,69 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import SelectPicker from '../index';
-import { getStyle, toRGB, inChrome, itChrome } from '@test/utils';
+import { toRGB, itChrome } from '@test/utils';
 import { mockGroupData } from '@test/mocks/data-mock';
-import { PickerHandle } from '../../internals/Picker';
-
 import '../styles/index.less';
 
 const data = mockGroupData(['Eugenia', 'Kariane', 'Louisa'], { role: 'Master' });
 
 describe('SelectPicker styles', () => {
   it('Default select picker should render correct toggle styles', () => {
-    const instanceRef = React.createRef<PickerHandle>();
-    render(<SelectPicker data={[]} ref={instanceRef} open />);
+    render(<SelectPicker data={[]} open />);
 
-    const pickerNoneDom = document.body.querySelector('.rs-picker-none') as HTMLElement;
-    inChrome &&
-      assert.equal(
-        getStyle((instanceRef.current as PickerHandle).target as HTMLElement, 'border'),
-        `1px solid ${toRGB('#e5e5ea')}`
-      );
-    inChrome &&
-      assert.equal(
-        getStyle((instanceRef.current as PickerHandle).target as HTMLElement, 'padding'),
-        '7px 32px 7px 11px'
-      );
-    assert.equal(
-      getStyle((instanceRef.current as PickerHandle).target as HTMLElement, 'backgroundColor'),
-      toRGB('#fff')
+    expect(screen.getByRole('combobox')).to.have.style('background-color', toRGB('#fff'));
+    expect(screen.getByRole('combobox')).to.have.style('border', `1px solid ${toRGB('#e5e5ea')}`);
+    expect(screen.getByRole('combobox')).to.have.style('padding', '7px 32px 7px 11px');
+    expect(screen.getByTestId('picker-popup').querySelector('.rs-picker-none')).to.have.style(
+      'padding',
+      '6px 12px 12px'
     );
-    assert.equal(
-      (
-        ((instanceRef.current as PickerHandle).target as HTMLElement).querySelector(
-          '.rs-picker-caret-icon'
-        ) as HTMLElement
-      ).getAttribute('aria-label'),
-      'angle down'
-    );
-
-    inChrome && assert.equal(getStyle(pickerNoneDom, 'padding'), '6px 12px 12px');
   });
 
   it('Subtle select picker should render correct toggle styles', () => {
-    const instanceRef = React.createRef<PickerHandle>();
-    render(<SelectPicker data={[]} appearance="subtle" ref={instanceRef} />);
+    render(<SelectPicker data={[]} appearance="subtle" />);
 
-    inChrome &&
-      assert.equal(
-        getStyle((instanceRef.current as PickerHandle).target as HTMLElement, 'borderWidth'),
-        '0px',
-        'Toggle border'
-      );
-    inChrome &&
-      assert.equal(
-        getStyle((instanceRef.current as PickerHandle).target as HTMLElement, 'padding'),
-        '8px 32px 8px 12px',
-        'Toggle padding'
-      );
-    assert.equal(
-      getStyle((instanceRef.current as PickerHandle).target as HTMLElement, 'backgroundColor'),
-      toRGB('#0000'),
-      'Toggle background-color'
-    );
+    expect(screen.getByRole('combobox')).to.have.style('background-color', toRGB('#0000'));
+    expect(screen.getByRole('combobox')).to.have.style('border-width', '0px');
+    expect(screen.getByRole('combobox')).to.have.style('padding', '8px 32px 8px 12px');
   });
 
   itChrome('Select picker default toggle should render correct size', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    const instance = (
-      <div ref={instanceRef}>
+    render(
+      <>
         <SelectPicker size="lg" placeholder="Large" data={data} />
         <SelectPicker size="md" placeholder="Medium" data={data} />
         <SelectPicker size="sm" placeholder="Small" data={data} />
         <SelectPicker size="xs" placeholder="Xsmall" data={data} />
-      </div>
+      </>
     );
 
-    render(instance);
-    const pickerToggles = (instanceRef.current as HTMLElement).querySelectorAll(
-      '.rs-picker-toggle'
-    );
-    assert.equal(getStyle(pickerToggles[0], 'padding'), '9px 36px 9px 15px');
-    assert.equal(getStyle(pickerToggles[1], 'padding'), '7px 32px 7px 11px');
-    assert.equal(getStyle(pickerToggles[2], 'padding'), '4px 30px 4px 9px');
-    assert.equal(getStyle(pickerToggles[3], 'padding'), '1px 28px 1px 7px');
+    expect(screen.getAllByRole('combobox')[0]).to.have.style('padding', '9px 36px 9px 15px');
+    expect(screen.getAllByRole('combobox')[1]).to.have.style('padding', '7px 32px 7px 11px');
+    expect(screen.getAllByRole('combobox')[2]).to.have.style('padding', '4px 30px 4px 9px');
+    expect(screen.getAllByRole('combobox')[3]).to.have.style('padding', '1px 28px 1px 7px');
   });
 
   itChrome('Select picker subtle toggle should render correct size', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    const instance = (
-      <div ref={instanceRef}>
+    render(
+      <>
         <SelectPicker size="lg" appearance="subtle" placeholder="Large" data={data} />
         <SelectPicker size="md" appearance="subtle" placeholder="Medium" data={data} />
         <SelectPicker size="sm" appearance="subtle" placeholder="Small" data={data} />
         <SelectPicker size="xs" appearance="subtle" placeholder="Xsmall" data={data} />
-      </div>
+      </>
     );
 
-    render(instance);
-    const pickerToggles = (instanceRef.current as HTMLElement).querySelectorAll(
-      '.rs-picker-toggle'
-    );
-    assert.equal(getStyle(pickerToggles[0], 'padding'), '10px 36px 10px 16px');
-    assert.equal(getStyle(pickerToggles[1], 'padding'), '8px 32px 8px 12px');
-    assert.equal(getStyle(pickerToggles[2], 'padding'), '5px 30px 5px 10px');
-    assert.equal(getStyle(pickerToggles[3], 'padding'), '2px 28px 2px 8px');
+    expect(screen.getAllByRole('combobox')[0]).to.have.style('padding', '10px 36px 10px 16px');
+    expect(screen.getAllByRole('combobox')[1]).to.have.style('padding', '8px 32px 8px 12px');
+    expect(screen.getAllByRole('combobox')[2]).to.have.style('padding', '5px 30px 5px 10px');
+    expect(screen.getAllByRole('combobox')[3]).to.have.style('padding', '2px 28px 2px 8px');
   });
 
   it('Block select picker should render correct toggle styles', () => {
-    const instanceRef = React.createRef<PickerHandle>();
-    render(<SelectPicker ref={instanceRef} block data={data} />);
-    assert.equal(
-      getStyle((instanceRef.current as PickerHandle).root as HTMLElement, 'display'),
-      'block'
-    );
+    const { container } = render(<SelectPicker block data={data} />);
+
+    expect(container.firstChild).to.have.style('display', 'block');
   });
 
   it('Select picker group should render correct styles', () => {
@@ -134,40 +85,21 @@ describe('SelectPicker styles', () => {
       }
     ];
 
-    const ref = React.createRef<PickerHandle>();
-    render(
-      <SelectPicker ref={ref} groupBy="role" data={data} menuClassName="group-test-menu" open />
-    );
+    render(<SelectPicker groupBy="role" data={data} menuClassName="group-test-menu" open />);
 
-    const secondItemGroup = ((ref.current as PickerHandle).overlay as HTMLElement).querySelectorAll(
-      '.group-test-menu .rs-picker-menu-group'
-    )[1];
+    const groups = screen.getAllByRole('group');
 
-    inChrome &&
-      assert.equal(getStyle(secondItemGroup, 'borderTop'), `1px solid ${toRGB('#e5e5ea')}`);
-    assert.equal(getStyle(secondItemGroup, 'marginTop'), '6px');
+    expect(groups[1]).to.have.style('border-top', `1px solid ${toRGB('#e5e5ea')}`);
+    expect(groups[1]).to.have.style('margin-top', '6px');
   });
 
   it('Disabled select picker should render correct toggle styles', () => {
-    const ref = React.createRef<PickerHandle>();
-    render(<SelectPicker data={[]} disabled ref={ref} />);
-    const defaultDom = (ref.current as PickerHandle).root as HTMLElement;
-    assert.equal(getStyle(defaultDom, 'opacity'), '0.3');
-    assert.equal(
-      getStyle(defaultDom.querySelector('.rs-picker-toggle') as HTMLElement, 'backgroundColor'),
-      toRGB('#f7f7fa')
-    );
+    const { rerender } = render(<SelectPicker data={[]} disabled />);
 
-    const ref2 = React.createRef<PickerHandle>();
-    render(<SelectPicker data={[]} appearance="subtle" disabled ref={ref2} />);
-    assert.equal(
-      getStyle(
-        ((ref2.current as PickerHandle).root as HTMLElement).querySelector(
-          '.rs-picker-toggle'
-        ) as HTMLElement,
-        'backgroundColor'
-      ),
-      toRGB('#0000')
-    );
+    expect(screen.getByRole('combobox')).to.have.style('background-color', toRGB('#f7f7fa'));
+
+    rerender(<SelectPicker data={[]} appearance="subtle" disabled />);
+
+    expect(screen.getByRole('combobox')).to.have.style('background-color', toRGB('#0000'));
   });
 });

--- a/src/Slider/styles/index.less
+++ b/src/Slider/styles/index.less
@@ -18,7 +18,7 @@
   }
 
   &-disabled {
-    opacity: 0.3;
+    opacity: 0.5;
     cursor: not-allowed;
 
     .rs-slider-bar,

--- a/src/internals/Picker/PickerIndicator.tsx
+++ b/src/internals/Picker/PickerIndicator.tsx
@@ -10,6 +10,7 @@ interface PickerIndicatorProps {
   caretAs?: React.ElementType | null;
   onClose?: (event: React.MouseEvent<HTMLElement>) => void;
   showCleanButton?: boolean;
+  disabled?: boolean;
   as?: React.ElementType;
 }
 
@@ -18,7 +19,8 @@ const PickerIndicator = ({
   caretAs,
   onClose,
   showCleanButton,
-  as: Component = InputGroup.Addon
+  as: Component = InputGroup.Addon,
+  disabled
 }: PickerIndicatorProps) => {
   const { locale } = useCustom();
   const { prefix } = useClassNames('picker');
@@ -27,7 +29,7 @@ const PickerIndicator = ({
     if (loading) {
       return <Loader className={prefix('loader')} data-testid="spinner" />;
     }
-    if (showCleanButton) {
+    if (showCleanButton && !disabled) {
       return (
         <CloseButton
           className={prefix('clean')}
@@ -40,7 +42,9 @@ const PickerIndicator = ({
     return caretAs && <Icon as={caretAs} className={prefix('caret-icon')} />;
   };
 
-  return <Component>{addon()}</Component>;
+  const props = Component === InputGroup.Addon ? { disabled } : undefined;
+
+  return <Component {...props}>{addon()}</Component>;
 };
 
 export default PickerIndicator;

--- a/src/internals/Picker/styles/index.less
+++ b/src/internals/Picker/styles/index.less
@@ -35,8 +35,17 @@
   }
 
   &-disabled {
-    opacity: @btn-disabled-opacity;
     cursor: not-allowed;
+
+    .rs-picker-toggle-value,
+    .rs-picker-toggle-indicator,
+    .rs-picker-tag-list .rs-tag {
+      color: var(--rs-text-disabled) !important;
+    }
+
+    .rs-picker-value-count{
+      opacity: 0.5;
+    }
   }
 
   &-toggle &-toggle-placeholder {

--- a/src/styles/color-modes/dark.less
+++ b/src/styles/color-modes/dark.less
@@ -67,7 +67,7 @@
   --rs-text-inverse: var(--rs-gray-800);
   --rs-text-heading-inverse: var(--rs-gray-900);
   --rs-text-active: var(--rs-primary-500);
-  --rs-text-disabled: var(--rs-gray-500);
+  --rs-text-disabled: var(--rs-gray-400);
   --rs-border-primary: var(--rs-gray-600);
   --rs-border-secondary: var(--rs-gray-700);
   --rs-bg-card: var(--rs-gray-800);

--- a/src/styles/color-modes/high-contrast.less
+++ b/src/styles/color-modes/high-contrast.less
@@ -67,7 +67,7 @@
   --rs-text-inverse: var(--rs-gray-800);
   --rs-text-heading-inverse: var(--rs-gray-900);
   --rs-text-active: var(--rs-primary-500);
-  --rs-text-disabled: var(--rs-gray-500);
+  --rs-text-disabled: var(--rs-gray-400);
   --rs-border-primary: var(--rs-gray-100);
   --rs-border-secondary: var(--rs-gray-700);
   --rs-bg-card: var(--rs-gray-800);
@@ -92,7 +92,7 @@
   --rs-btn-default-active-bg: transparent;
   --rs-btn-default-active-text: var(--rs-primary-200);
   --rs-btn-default-disabled-bg: transparent;
-  --rs-btn-default-disabled-text: var(--rs-primary-500);
+  --rs-btn-default-disabled-text: var(--rs-primary-400);
   --rs-btn-primary-bg: var(--rs-primary-500);
   --rs-btn-primary-text: var(--rs-gray-900);
   --rs-btn-primary-hover-bg: var(--rs-primary-400);

--- a/src/styles/color-modes/high-contrast.less
+++ b/src/styles/color-modes/high-contrast.less
@@ -92,7 +92,8 @@
   --rs-btn-default-active-bg: transparent;
   --rs-btn-default-active-text: var(--rs-primary-200);
   --rs-btn-default-disabled-bg: transparent;
-  --rs-btn-default-disabled-text: var(--rs-primary-400);
+  --rs-btn-default-disabled-text: var(--rs-primary-900);
+  --rs-btn-default-disabled-boreder-color: var(--rs-gray-100);
   --rs-btn-primary-bg: var(--rs-primary-500);
   --rs-btn-primary-text: var(--rs-gray-900);
   --rs-btn-primary-hover-bg: var(--rs-primary-400);

--- a/src/styles/color-modes/light.less
+++ b/src/styles/color-modes/light.less
@@ -73,7 +73,7 @@
   --rs-text-inverse: var(--rs-gray-50);
   --rs-text-heading-inverse: var(--rs-gray-0);
   --rs-text-active: var(--rs-primary-700);
-  --rs-text-disabled: var(--rs-gray-400);
+  --rs-text-disabled: var(--rs-gray-600);
   --rs-text-error: var(--rs-color-red);
   --rs-text-weight-thin: 100;
   --rs-text-weight-light: 300;
@@ -103,7 +103,7 @@
   --rs-btn-default-active-bg: var(--rs-gray-300);
   --rs-btn-default-active-text: var(--rs-gray-900);
   --rs-btn-default-disabled-bg: var(--rs-gray-50);
-  --rs-btn-default-disabled-text: var(--rs-gray-400);
+  --rs-btn-default-disabled-text: var(--rs-gray-600);
   --rs-btn-primary-bg: var(--rs-primary-500);
   --rs-btn-primary-text: var(--rs-gray-0);
   --rs-btn-primary-hover-bg: var(--rs-primary-600);
@@ -288,7 +288,7 @@
   --rs-radio-tile-bg: var(--rs-gray-0);
   --rs-radio-tile-checked-color: var(--rs-primary-500);
   --rs-radio-tile-checked-mark-color: #fff;
-  --rs-radio-tile-checked-disabled-color: var(--rs-primary-100);
+  --rs-radio-tile-checked-disabled-color: var(--rs-primary-200);
   --rs-radio-tile-icon-size: 32px;
 
   // Rate
@@ -301,12 +301,12 @@
   --rs-toggle-loader-ring: rgb(from var(--rs-gray-50) r g b / 30%);
   --rs-toggle-loader-rotor: var(--rs-gray-0);
   --rs-toggle-hover-bg: var(--rs-gray-400);
-  --rs-toggle-disabled-bg: var(--rs-gray-50);
+  --rs-toggle-disabled-bg: var(--rs-gray-200);
   --rs-toggle-disabled-thumb: #fff;
   --rs-toggle-checked-bg: var(--rs-primary-500);
   --rs-toggle-checked-thumb: #fff;
   --rs-toggle-checked-hover-bg: var(--rs-primary-600);
-  --rs-toggle-checked-disabled-bg: var(--rs-primary-100);
+  --rs-toggle-checked-disabled-bg: var(--rs-primary-200);
   --rs-toggle-checked-disabled-thumb: #fff;
 
   // Slider


### PR DESCRIPTION
## Light 

| Before | After |
|---| ---|
| ![image](https://github.com/rsuite/rsuite/assets/1203827/d63dc66f-4bf5-48b5-bdbf-b4e2ff7a3141) | ![image](https://github.com/rsuite/rsuite/assets/1203827/250619a8-bf68-49c1-bb3a-11cd1b16e52a) |

## Dark

| Before | After |
|---| ---|
| ![image](https://github.com/rsuite/rsuite/assets/1203827/b36a10ad-0368-43be-8c14-cf83408c53ec) | ![image](https://github.com/rsuite/rsuite/assets/1203827/9bbc2b51-d1ef-46d2-aa64-589a1573f609) |



## High contrast

| Before | After |
|---| ---|
| ![image](https://github.com/rsuite/rsuite/assets/1203827/b6176d07-b7ec-4249-916f-d9fdc6994d81)| ![image](https://github.com/rsuite/rsuite/assets/1203827/00617b1c-7ecd-4e8b-97cf-3201ea6dd264)|










