### PR TITLE
fix(steps): center align inner icon/text

### DIFF
--- a/src/Steps/styles/index.less
+++ b/src/Steps/styles/index.less
@@ -61,7 +61,8 @@
   // Icon content
   > .rs-steps-item-icon {
     width: 100%;
-    display: block;
+    display: flex;
+    justify-content: center;
     text-align: center;
     position: relative;
 


### PR DESCRIPTION
### **Description**

The icon inside steps is not vertically centered.

### **Current behavior**

![image](https://github.com/rsuite/rsuite/assets/8769408/85b40892-3651-4730-9bd3-8fb078b637a6)

### **New behavior**

![image](https://github.com/rsuite/rsuite/assets/8769408/3a6be498-a8c9-42c0-bf45-2525b8875902)

### **Additional Information**

If the PR gets accepted please use my GitHub email-id (shrinidhiupadhyaya1195@gmail.com) instead of my other email-id for the Co-authored-by: message.