### PR TITLE
fix(DatePicker,DateRangePicker): fix `renderValue` and `editable` can't coexist

### DIFF
--- a/docs/pages/components/date-picker/fragments/render-value.md
+++ b/docs/pages/components/date-picker/fragments/render-value.md
@@ -6,13 +6,23 @@ import format from 'date-fns/format';
 
 const App = () => {
   return (
-    <DatePicker
-      editable={false}
-      placeholder="Select Date"
-      renderValue={value => {
-        return format(value, 'EEE, d MMM');
-      }}
-    />
+    <>
+      <DatePicker
+        placeholder="Select Date"
+        renderValue={value => {
+          return format(value, 'EEE, d MMM');
+        }}
+      />
+      <hr />
+
+      <DatePicker
+        editable={false}
+        placeholder="Uneditable"
+        renderValue={value => {
+          return format(value, 'EEE, d MMM');
+        }}
+      />
+    </>
   );
 };
 

--- a/docs/pages/components/date-range-picker/fragments/render-value.md
+++ b/docs/pages/components/date-range-picker/fragments/render-value.md
@@ -6,13 +6,22 @@ import format from 'date-fns/format';
 
 const App = () => {
   return (
-    <DateRangePicker
-      editable={false}
-      placeholder="Select Date"
-      renderValue={([start, end]) => {
-        return format(start, 'EEE, d MMM') + ' - ' + format(end, 'EEE, d MMM');
-      }}
-    />
+    <>
+      <DateRangePicker
+        placeholder="Select Date"
+        renderValue={([start, end]) => {
+          return format(start, 'EEE, d MMM') + ' - ' + format(end, 'EEE, d MMM');
+        }}
+      />
+      <hr />
+      <DateRangePicker
+        editable={false}
+        placeholder="Uneditable"
+        renderValue={([start, end]) => {
+          return format(start, 'EEE, d MMM') + ' - ' + format(end, 'EEE, d MMM');
+        }}
+      />
+    </>
   );
 };
 

--- a/src/DateInput/test/testUtils.tsx
+++ b/src/DateInput/test/testUtils.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import sinon from 'sinon';
 import userEvent from '@testing-library/user-event';
 import isMatch from 'date-fns/isMatch';
 import formatDate from 'date-fns/format';
+import { keyPress } from '@test/utils/simulateEvent';
 
 export function keyPressTests(TestComponent: React.FC<any>) {
   function testKeyPress({
@@ -55,21 +56,7 @@ export function keyPressTests(TestComponent: React.FC<any>) {
 
     const input = screen.getByRole('textbox') as HTMLInputElement;
 
-    userEvent.click(input);
-
-    let timeout = 0;
-
-    const actions = keys.map(key => {
-      timeout += 100;
-      return new Promise<void>(resolve => {
-        setTimeout(() => {
-          fireEvent.keyDown(input, { key });
-          resolve();
-        }, timeout);
-      });
-    });
-
-    await Promise.all(actions);
+    await keyPress(input, keys);
 
     expect(input).to.value(expectedValue);
 

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -11,7 +11,7 @@ import Toolbar, { RangeType } from './Toolbar';
 import Stack from '../Stack';
 import PredefinedRanges from './PredefinedRanges';
 import { DatePickerLocale } from '../locales';
-import { mergeRefs, partitionHTMLProps } from '@/internals/utils';
+import { mergeRefs, partitionHTMLProps, createChainedFunction } from '@/internals/utils';
 import {
   useClassNames,
   useControlled,
@@ -45,12 +45,12 @@ import {
   onMenuKeyDown
 } from '@/internals/Picker';
 import { OverlayCloseCause } from '@/internals/Overlay/OverlayTrigger';
-import Input from '../Input';
 import DateInput from '../DateInput';
 import InputGroup from '../InputGroup';
 import { splitRanges, deprecatedPropTypes, getRestProps } from './utils';
 import useMonthView from './hooks/useMonthView';
 import useFocus from './hooks/useFocus';
+import useCustomizedInput from './hooks/useCustomizedInput';
 import type {
   FormControlBaseProps,
   PickerBaseProps,
@@ -232,8 +232,8 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
       onChange,
       onChangeCalendarDate,
       onClean,
-      onEntered,
-      onExited,
+      onEnter,
+      onExit,
       onNextMonth,
       onOk,
       onPrevMonth,
@@ -253,7 +253,6 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
     const id = useUniqueId('rs-', idProp);
     const { trigger, root, target, overlay } = usePickerRef(ref);
     const { locale } = useCustom<DatePickerLocale>('DatePicker', overrideLocale);
-
     const { merge, prefix } = useClassNames(classPrefix);
     const [value, setValue] = useControlled(valueProp, defaultValue);
     const { calendarDate, setCalendarDate, resetCalendarDate } = useCalendarDate(
@@ -619,20 +618,8 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
     const [ariaProps, rest] = partitionHTMLProps(restProps, { htmlProps: [], includeAria: true });
     const invalidValue = value && isErrorValue(value);
 
-    // Custom rendering of the selected value
-    let customValue: string | null = null;
-
-    // Input box is read-only when the component is uneditable or loading state
-    let inputReadOnly: boolean = readOnly || !editable || loading || false;
-
-    if (typeof renderValue === 'function' && value) {
-      customValue = renderValue(value, formatStr);
-
-      // If the custom rendering value, the input box is read-only
-      inputReadOnly = true;
-    }
-
-    const TargetInput = customValue ? Input : DateInput;
+    const customizedProps = { value, formatStr, renderValue, readOnly, editable, loading };
+    const { customValue, inputReadOnly, Input, events } = useCustomizedInput(customizedProps);
 
     return (
       <PickerToggleTrigger
@@ -641,8 +628,8 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
         ref={trigger}
         placement={placement}
         onClose={handleTriggerClose}
-        onEntered={onEntered}
-        onExited={onExited}
+        onEnter={createChainedFunction(events.onActive, onEnter)}
+        onExit={createChainedFunction(events.onInactive, onExit)}
         speaker={renderCalendarOverlay}
       >
         <Component
@@ -663,7 +650,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
               <PickerLabel className={prefix`label`} id={`${id}-label`}>
                 {label}
               </PickerLabel>
-              <TargetInput
+              <Input
                 aria-haspopup="dialog"
                 aria-invalid={invalidValue}
                 aria-labelledby={label ? `${id}-label` : undefined}
@@ -674,8 +661,8 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
                 format={formatStr}
                 placeholder={placeholder ? placeholder : formatStr}
                 disabled={disabled}
-                onChange={handleInputChange}
                 readOnly={inputReadOnly}
+                onChange={handleInputChange}
                 onKeyDown={handleInputKeyDown}
               />
 

--- a/src/DatePicker/hooks/useCustomizedInput.ts
+++ b/src/DatePicker/hooks/useCustomizedInput.ts
@@ -1,0 +1,52 @@
+import { useState, useCallback } from 'react';
+import { isValid } from '@/internals/utils/date';
+import Input from '../../Input';
+import DateInput from '../../DateInput';
+import DateRangeInput from '../../DateRangeInput';
+
+interface UseCustomizedInputProps<T> {
+  value?: T | null;
+  formatStr: string;
+  readOnly?: boolean;
+  editable?: boolean;
+  loading?: boolean;
+  mode?: 'date' | 'dateRange';
+  renderValue?: (value: T, format: string) => string;
+}
+
+function useCustomizedInput<T>(props: UseCustomizedInputProps<T>) {
+  const { value, formatStr, readOnly, editable, loading, mode = 'date', renderValue } = props;
+  const [active, setActive] = useState(false);
+
+  const onActive = useCallback(() => setActive(true), []);
+  const onInactive = useCallback(() => setActive(false), []);
+
+  // Custom rendering of the selected value
+  let customValue: string | null = null;
+
+  // Input box is read-only when the component is uneditable or loading state
+  let inputReadOnly: boolean = readOnly || !editable || loading || false;
+
+  // If the component is not active or editable, the custom rendering value is displayed
+  const customized = !active || !editable;
+
+  if (typeof renderValue === 'function' && value && customized) {
+    if (Array.isArray(value) ? value.every(isValid) : isValid(value)) {
+      customValue = renderValue(value, formatStr);
+
+      // If the custom rendering value, the input box is read-only
+      inputReadOnly = true;
+    }
+  }
+  const TargetInput = mode === 'dateRange' ? DateRangeInput : DateInput;
+  const CustomizedInput = customValue ? Input : TargetInput;
+
+  return {
+    customValue,
+    Input: CustomizedInput,
+    inputReadOnly,
+    events: { onActive, onInactive }
+  };
+}
+
+export default useCustomizedInput;

--- a/src/DatePicker/test/DatePickerSpec.tsx
+++ b/src/DatePicker/test/DatePickerSpec.tsx
@@ -8,6 +8,7 @@ import {
 } from '@test/utils';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { keyPress } from '@test/utils/simulateEvent';
 import Sinon from 'sinon';
 import enGB from 'date-fns/locale/en-GB';
 import { format, isSameDay, parseISO, isBefore, isValid } from 'date-fns';
@@ -80,17 +81,6 @@ describe('DatePicker', () => {
     render(<DatePicker defaultValue={parseISO('2017-08-14')} />);
 
     expect(screen.getByRole('textbox')).to.have.value('2017-08-14');
-  });
-
-  it('Should render a custom value', () => {
-    render(
-      <DatePicker
-        defaultValue={new Date('2024-05-13')}
-        renderValue={value => format(value, 'EEE, d MMM')}
-      />
-    );
-
-    expect(screen.getByRole('textbox')).to.have.value('Mon, 13 May');
   });
 
   it('Should open a dialog containing grid view of dates in a month', () => {
@@ -1203,6 +1193,34 @@ describe('DatePicker', () => {
       expect(container.firstChild).to.have.class('rs-picker-error');
       expect(screen.getByRole('textbox')).to.have.attribute('aria-invalid', 'true');
       expect(screen.getByRole('button', { name: 'OK' })).to.have.attribute('disabled');
+    });
+  });
+
+  describe('Customize value', () => {
+    it('Should render a custom value', () => {
+      render(
+        <DatePicker
+          defaultValue={new Date('2024-05-13')}
+          renderValue={value => format(value, 'EEE, d MMM')}
+        />
+      );
+
+      expect(screen.getByRole('textbox')).to.have.value('Mon, 13 May');
+    });
+
+    it('Should render a custom value when a value is entered via the keyboard', async () => {
+      render(
+        <>
+          <div data-testid="outside">Outside</div>
+          <DatePicker renderValue={value => format(value, 'EEE, d MMM')} />
+        </>
+      );
+
+      await keyPress(screen.getByRole('textbox'), '20240513');
+
+      userEvent.click(screen.getByTestId('outside'));
+
+      expect(screen.getByRole('textbox')).to.have.value('Mon, 13 May');
     });
   });
 });

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -64,10 +64,10 @@ import { getSafeCalendarDate, getMonthHoverRange, getWeekHoverRange, isSameRange
 import { deprecatePropTypeNew, oneOf } from '@/internals/propTypes';
 import DateRangePickerContext from './DateRangePickerContext';
 import DateRangeInput from '../DateRangeInput';
-import Input from '../Input';
 import InputGroup from '../InputGroup';
 import Header from './Header';
 import useDateDisabled from './hooks/useDateDisabled';
+import useCustomizedInput from '../DatePicker/hooks/useCustomizedInput';
 export interface DateRangePickerProps
   extends PickerBaseProps<DateRangePickerLocale>,
     FormControlBaseProps<DateRange | null> {
@@ -277,8 +277,7 @@ const DateRangePicker = React.forwardRef((props: DateRangePickerProps, ref) => {
     onChange,
     onClean,
     onEnter,
-    onEntered,
-    onExited,
+    onExit,
     onOk,
     onSelect,
     onShortcutClick,
@@ -679,7 +678,7 @@ const DateRangePicker = React.forwardRef((props: DateRangePickerProps, ref) => {
     }
   );
 
-  const handleOK = useEventCallback((event: React.SyntheticEvent) => {
+  const handleClickOK = useEventCallback((event: React.SyntheticEvent) => {
     setDateRange(event, selectedDates as DateRange);
     onOk?.(selectedDates as DateRange, event);
   });
@@ -705,12 +704,18 @@ const DateRangePicker = React.forwardRef((props: DateRangePickerProps, ref) => {
     setHoverDateRange(selectValue);
     setSelectedDates(selectValue);
     setCalendarDateRange({ dateRange: selectValue });
-    setDateRange(event, selectValue);
+    setDateRange(event, selectValue, false);
   });
 
+  /**
+   * Check if the date is disabled
+   */
   const isDateDisabled = useDateDisabled({ shouldDisableDate, DEPRECATED_disabledDate });
 
-  const disableByRange = (start: Date, end: Date, target: TARGET) => {
+  /**
+   * Check if a date range is disabled
+   */
+  const isRangeDisabled = (start: Date, end: Date, target: TARGET) => {
     if (isDateDisabled) {
       // If the date is between the start and the end the button is disabled
       while (isBefore(start, end) || isSameDay(start, end)) {
@@ -726,27 +731,33 @@ const DateRangePicker = React.forwardRef((props: DateRangePickerProps, ref) => {
     return false;
   };
 
-  const disableOkButton = () => {
-    const { open } = trigger.current?.getState() || {};
+  /**
+   * Check if the OK button is disabled
+   */
+  const isOkButtonDisabled = () => {
+    const [start, end] = selectedDates;
+    if (!start || !end || !isSelectedIdle) {
+      return true;
+    }
 
-    if (open) {
-      const [start, end] = selectedDates;
-      if (!start || !end || !isSelectedIdle) {
-        return true;
-      }
+    if (isErrorValue([start, end])) {
+      return true;
     }
 
     return false;
   };
 
-  const disableShortcut = (value: SelectedDatesState = []) => {
+  /**
+   * Check if the shortcut button is disabled
+   */
+  const isShortcutDisabled = (value: SelectedDatesState = []) => {
     const [start, end] = value;
 
     if (!start || !end) {
       return true;
     }
 
-    return disableByRange(start, end, TARGET.TOOLBAR_SHORTCUT);
+    return isRangeDisabled(start, end, TARGET.TOOLBAR_SHORTCUT);
   };
 
   const handleClose = useEventCallback(() => {
@@ -847,7 +858,7 @@ const DateRangePicker = React.forwardRef((props: DateRangePickerProps, ref) => {
                 ranges={sideRanges}
                 calendarDate={calendarDate}
                 locale={locale}
-                disableShortcut={disableShortcut}
+                disableShortcut={isShortcutDisabled}
                 onShortcutClick={handleShortcutPageDate}
                 data-testid="daterange-predefined-side"
               />
@@ -877,10 +888,10 @@ const DateRangePicker = React.forwardRef((props: DateRangePickerProps, ref) => {
               <Toolbar<SelectedDatesState, DateRange>
                 locale={locale}
                 calendarDate={selectedDates}
-                disableOkBtn={disableOkButton}
-                disableShortcut={disableShortcut}
+                disableOkBtn={isOkButtonDisabled}
+                disableShortcut={isShortcutDisabled}
                 hideOkBtn={oneTap}
-                onOk={handleOK}
+                onOk={handleClickOK}
                 onShortcutClick={handleShortcutPageDate}
                 ranges={bottomRanges}
               />
@@ -948,20 +959,15 @@ const DateRangePicker = React.forwardRef((props: DateRangePickerProps, ref) => {
   const showCleanButton = cleanable && hasValue && !readOnly;
   const invalidValue = value && isErrorValue(value);
 
-  // Custom rendering of the selected value
-  let customValue: string | null = null;
-
-  // Input box is read-only when the component is uneditable or loading state
-  let inputReadOnly: boolean = readOnly || !editable || loading || false;
-
-  if (typeof renderValue === 'function' && value) {
-    customValue = renderValue(value, formatStr);
-
-    // If the custom rendering value, the input box is read-only
-    inputReadOnly = true;
-  }
-
-  const TargetInput = customValue ? Input : DateRangeInput;
+  const { customValue, inputReadOnly, Input, events } = useCustomizedInput({
+    mode: 'dateRange',
+    value,
+    formatStr,
+    renderValue,
+    readOnly,
+    editable,
+    loading
+  });
 
   return (
     <PickerToggleTrigger
@@ -969,9 +975,8 @@ const DateRangePicker = React.forwardRef((props: DateRangePickerProps, ref) => {
       ref={trigger}
       pickerProps={pick(props, pickTriggerPropKeys)}
       placement={placement}
-      onEnter={createChainedFunction(handleEnter, onEnter)}
-      onEntered={onEntered}
-      onExited={onExited}
+      onEnter={createChainedFunction(events.onActive, handleEnter, onEnter)}
+      onExit={createChainedFunction(events.onInactive, onExit)}
       speaker={renderCalendarOverlay}
     >
       <Component
@@ -995,7 +1000,7 @@ const DateRangePicker = React.forwardRef((props: DateRangePickerProps, ref) => {
             <PickerLabel className={prefix`label`} id={`${id}-label`}>
               {label}
             </PickerLabel>
-            <TargetInput
+            <Input
               aria-haspopup="dialog"
               aria-invalid={invalidValue}
               aria-labelledby={label ? `${id}-label` : undefined}
@@ -1008,7 +1013,6 @@ const DateRangePicker = React.forwardRef((props: DateRangePickerProps, ref) => {
               placeholder={placeholder ? placeholder : rangeFormatStr}
               disabled={disabled}
               readOnly={inputReadOnly}
-              plaintext={plaintext}
               htmlSize={getInputHtmlSize()}
               onChange={handleInputChange}
               onKeyDown={handleInputKeyDown}

--- a/src/DateRangePicker/test/DateRangePickerSpec.tsx
+++ b/src/DateRangePicker/test/DateRangePickerSpec.tsx
@@ -10,6 +10,7 @@ import {
 } from '@test/utils';
 import sinon from 'sinon';
 import userEvent from '@testing-library/user-event';
+import { keyPress } from '@test/utils/simulateEvent';
 import {
   addDays,
   endOfMonth,
@@ -105,19 +106,6 @@ describe('DateRangePicker', () => {
     render(<DateRangePicker value={value} format={template} />);
 
     expect(screen.getByRole('textbox')).to.have.value('11/11/2019 01:00:00 ~ 11/12/2019 01:00:00');
-  });
-
-  it('Should render a custom value', () => {
-    render(
-      <DateRangePicker
-        defaultValue={[new Date('2024-05-13'), new Date('2024-05-14')]}
-        renderValue={([start, end]) => {
-          return format(start, 'EEE, d MMM') + ' ~ ' + format(end, 'EEE, d MMM');
-        }}
-      />
-    );
-
-    expect(screen.getByRole('textbox')).to.have.value('Mon, 13 May ~ Tue, 14 May');
   });
 
   it('Should select date time successfully', () => {
@@ -1244,5 +1232,39 @@ describe('DateRangePicker', () => {
     expect(times[1]).to.have.text('10');
     expect(input).to.have.value('07 ~ 10');
     expect(screen.getByTestId('daterange-header')).to.have.text('07 ~ 10');
+  });
+
+  describe('Customize value', () => {
+    it('Should render a custom value', () => {
+      render(
+        <DateRangePicker
+          defaultValue={[new Date('2024-05-13'), new Date('2024-05-14')]}
+          renderValue={([start, end]) => {
+            return format(start, 'EEE, d MMM') + ' ~ ' + format(end, 'EEE, d MMM');
+          }}
+        />
+      );
+
+      expect(screen.getByRole('textbox')).to.have.value('Mon, 13 May ~ Tue, 14 May');
+    });
+
+    it('Should render a custom value when a value is entered via the keyboard', async () => {
+      render(
+        <>
+          <div data-testid="outside">Outside</div>
+          <DateRangePicker
+            renderValue={([start, end]) => {
+              return format(start, 'EEE, d MMM') + ' ~ ' + format(end, 'EEE, d MMM');
+            }}
+          />
+        </>
+      );
+
+      await keyPress(screen.getByRole('textbox'), '2024051320240514');
+
+      userEvent.click(screen.getByTestId('outside'));
+
+      expect(screen.getByRole('textbox')).to.have.value('Mon, 13 May ~ Tue, 14 May');
+    });
   });
 });

--- a/test/utils/simulateEvent.ts
+++ b/test/utils/simulateEvent.ts
@@ -1,0 +1,24 @@
+import { fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+export async function keyPress(input: HTMLElement, keys: string | string[]) {
+  if (typeof keys === 'string') {
+    keys = keys.split('');
+  }
+
+  userEvent.click(input);
+
+  let timeout = 0;
+
+  const actions = keys.map(key => {
+    timeout += 100;
+    return new Promise<void>(resolve => {
+      setTimeout(() => {
+        fireEvent.keyDown(input, { key });
+        resolve();
+      }, timeout);
+    });
+  });
+
+  await Promise.all(actions);
+}


### PR DESCRIPTION
DatePicker
https://rsuite-nextjs-git-fix-date-range-picker-render-value-rsuite.vercel.app/components/date-picker/#custom-render-value

DateRangePicker
https://rsuite-nextjs-git-fix-date-range-picker-render-value-rsuite.vercel.app/components/date-range-picker/#custom-render-value