### PR TITLE
feat(useBreakpointValue): add a hook to get the value of the current breakpoint

### DIFF
--- a/docs/pages/components/use-breakpoint-value/en-US/index.md
+++ b/docs/pages/components/use-breakpoint-value/en-US/index.md
@@ -1,0 +1,32 @@
+# useBreakpointValue 🧪
+
+A React Hook that returns different values based on different screen sizes in responsive design.
+
+> ⚠️ This API is still in the experimental stage and may be subject to change.
+
+## Import
+
+<!--{include:<import-guide>}-->
+
+## Examples
+
+### Responsive avatar size
+
+<!--{include:`basic.md`}-->
+
+### Responsive stack direction
+
+<!--{include:`stack.md`}-->
+
+## API
+
+### `useBreakpointValue`
+
+```ts
+function useBreakpointValue<T>(
+  mediaQueries: Record<string | 'xxl' | 'xl' | 'lg' | 'md' | 'sm' | 'xs', T>,
+  options?: {
+    defaultValue?: T;
+  }
+): T;
+```

--- a/docs/pages/components/use-breakpoint-value/fragments/basic.md
+++ b/docs/pages/components/use-breakpoint-value/fragments/basic.md
@@ -1,0 +1,32 @@
+<!--start-code-->
+
+```js
+import { useBreakpointValue, Avatar } from 'rsuite';
+
+const App = () => {
+  const size = useBreakpointValue(
+    {
+      '(min-width: 1200px)': 'xxl',
+      '(min-width: 992px)': 'xl',
+      '(min-width: 768px)': 'lg',
+      '(min-width: 576px)': 'md'
+    },
+    { defaultValue: 'md' }
+  );
+
+  return (
+    <>
+      <p>
+        Resize your window to see avatar size change. Current size: <b>{size}</b>
+      </p>
+      <hr />
+
+      <Avatar size={size} circle src="https://i.pravatar.cc/150?u=1" />
+    </>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/use-breakpoint-value/fragments/stack.md
+++ b/docs/pages/components/use-breakpoint-value/fragments/stack.md
@@ -1,0 +1,32 @@
+<!--start-code-->
+
+```js
+import { useBreakpointValue, Button } from 'rsuite';
+
+const App = () => {
+  const direction = useBreakpointValue(
+    {
+      '(min-width: 992px)': 'row'
+    },
+    { defaultValue: 'column' }
+  );
+
+  return (
+    <>
+      <p>
+        Resize your window to see stack direction change. Current direction: <b>{direction}</b>
+      </p>
+      <hr />
+      <Stack direction={direction} spacing={10}>
+        <Button>Button 1</Button>
+        <Button>Button 2</Button>
+        <Button>Button 3</Button>
+      </Stack>
+    </>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/use-breakpoint-value/index.tsx
+++ b/docs/pages/components/use-breakpoint-value/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { Stack, useBreakpointValue, Avatar, Button } from 'rsuite';
+import DefaultPage from '@/components/Page';
+import ImportGuide from '@/components/ImportGuide';
+
+const inDocsComponents = {
+  'import-guide': () => <ImportGuide components={['useBreakpointValue']} hasCssComponents={[]} />
+};
+
+export default function Page() {
+  return (
+    <DefaultPage
+      inDocsComponents={inDocsComponents}
+      dependencies={{
+        useBreakpointValue,
+        Avatar,
+        Stack,
+        Button
+      }}
+    />
+  );
+}

--- a/docs/pages/components/use-breakpoint-value/zh-CN/index.md
+++ b/docs/pages/components/use-breakpoint-value/zh-CN/index.md
@@ -1,0 +1,32 @@
+# useBreakpointValue 🧪
+
+一个 React Hook，根据响应式设计中不同的屏幕尺寸返回不同的值。
+
+> ⚠️ 此 API 仍处于实验阶段，可能会发生变化。
+
+## 导入 Hook
+
+<!--{include:<import-guide>}-->
+
+## 示例
+
+### 响应式的改变头像大小
+
+<!--{include:`basic.md`}-->
+
+### 响应式的改变堆栈方向
+
+<!--{include:`stack.md`}-->
+
+## API
+
+### `useBreakpointValue`
+
+```ts
+function useBreakpointValue<T>(
+  mediaQueries: Record<string | 'xxl' | 'xl' | 'lg' | 'md' | 'sm' | 'xs', T>,
+  options?: {
+    defaultValue?: T;
+  }
+): T;
+```

--- a/docs/pages/components/use-media-query/en-US/index.md
+++ b/docs/pages/components/use-media-query/en-US/index.md
@@ -2,23 +2,11 @@
 
 Use useMediaQuery to easily retrieve media dimensions, combined with the component's size property for responsive UI.
 
-> ⚠️ Unstable API, may have breaking changes in future minor versions.
+> ⚠️ This API is still in the experimental stage and may be subject to change.
 
-## Usage
+## Import
 
-```js
-import { useMediaQuery } from 'rsuite';
-
-const App = () => {
-  const [isMobile, isDark, isLandscape] = useMediaQuery([
-    '(max-width: 700px)',
-    '(prefers-color-scheme: dark)',
-    '(orientation:landscape)'
-  ]);
-
-  return <div>{isMobile ? 'Mobile' : 'Desktop'}</div>;
-};
-```
+<!--{include:<import-guide>}-->
 
 ## Examples
 
@@ -36,23 +24,10 @@ The `Modal` component has a `size` prop that sets the size of the modal. We can 
 
 ## API
 
-### `useMediaQuery(query) => [...matches]`
+### `useMediaQuery`
 
-```tsx
+```ts
+type Query =  'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | string
 
- const mediaQuerySizeMap = {
-  xs: '(max-width: 575px)',
-  sm: '(min-width: 576px)',
-  md: '(min-width: 768px)',
-  lg: '(min-width: 992px)',
-  xl: '(min-width: 1200px)',
-  xxl: '(min-width: 1400px)'
-};
-
-
-useMediaQuery(
-  string
-  | keyof typeof mediaQuerySizeMap
-  | (string | keyof typeof mediaQuerySizeMap)[]
-) => boolean[]
+useMediaQuery(query: Query | Query[]) => boolean[]
 ```

--- a/docs/pages/components/use-media-query/index.tsx
+++ b/docs/pages/components/use-media-query/index.tsx
@@ -9,19 +9,18 @@ import {
   useMediaQuery
 } from 'rsuite';
 import { Icon } from '@rsuite/icons';
-import {
-  VscLock,
-  VscRepo,
-  VscWorkspaceTrusted,
-  VscNotebookTemplate,
-  VscRepoClone,
-  VscFile
-} from 'react-icons/vsc';
+import { VscRepo, VscNotebookTemplate, VscRepoClone, VscFile } from 'react-icons/vsc';
 import DefaultPage from '@/components/Page';
+import ImportGuide from '@/components/ImportGuide';
+
+const inDocsComponents = {
+  'import-guide': () => <ImportGuide components={['useMediaQuery']} hasCssComponents={[]} />
+};
 
 export default function Page() {
   return (
     <DefaultPage
+      inDocsComponents={inDocsComponents}
       dependencies={{
         useMediaQuery,
         Modal,
@@ -31,9 +30,7 @@ export default function Page() {
         Icon,
         RadioTile,
         RadioTileGroup,
-        VscLock,
         VscRepo,
-        VscWorkspaceTrusted,
         VscNotebookTemplate,
         VscRepoClone,
         VscFile

--- a/docs/pages/components/use-media-query/zh-CN/index.md
+++ b/docs/pages/components/use-media-query/zh-CN/index.md
@@ -2,23 +2,11 @@
 
 使用 useMediaQuery 轻松检索媒体尺寸，结合组件的大小属性可以实现响应式 UI 。
 
-> ⚠️ 不稳定的 API，可能会在未来的次要版本中进行重大更改。
+> ⚠️ 此 API 仍处于实验阶段，可能会发生变化。
 
-## 使用
+## 导入 Hook
 
-```js
-import { useMediaQuery } from 'rsuite';
-
-const App = () => {
-  const [isMobile, isDark, isLandscape] = useMediaQuery([
-    '(max-width: 700px)',
-    '(prefers-color-scheme: dark)',
-    '(orientation:landscape)'
-  ]);
-
-  return <div>{isMobile ? 'Mobile' : 'Desktop'}</div>;
-};
-```
+<!--{include:<import-guide>}-->
 
 ## 示例
 
@@ -37,24 +25,10 @@ const App = () => {
 
 ## API
 
-### `useMediaQuery(query) => [...matches]`
+### `useMediaQuery`
 
 ```ts
+type Query =  'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | string
 
- const mediaQuerySizeMap = {
-  xs: '(max-width: 575px)',
-  sm: '(min-width: 576px)',
-  md: '(min-width: 768px)',
-  lg: '(min-width: 992px)',
-  xl: '(min-width: 1200px)',
-  xxl: '(min-width: 1400px)'
-};
-
-
-useMediaQuery(
-  string
-  | keyof typeof mediaQuerySizeMap
-  | (string | keyof typeof mediaQuerySizeMap)[]
-) => boolean[]
-
+useMediaQuery(query: Query | Query[]) => boolean[]
 ```

--- a/docs/utils/component.config.json
+++ b/docs/utils/component.config.json
@@ -625,5 +625,14 @@
     "apis": ["useMediaQuery"],
     "tag": "Unstable 🧪",
     "tagColor": "orange"
+  },
+  {
+    "id": "use-breakpoint-value",
+    "name": "useBreakpointValue",
+    "title": "",
+    "apis": ["useBreakpointValue"],
+    "tag": "Unstable 🧪",
+    "tagColor": "orange",
+    "minVersion": "5.63.0"
   }
 ]

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -305,7 +305,7 @@ export type { DividerProps } from './Divider';
 export { default as Stack } from './Stack';
 export type { StackProps } from './Stack';
 
-// Utils and Hooks
+// Utils
 // --------------------------------------------------------
 export { default as Schema } from './Schema';
 
@@ -342,7 +342,11 @@ export type {
 } from './locales';
 
 export type { PickerHandle } from './internals/Picker';
+
+// Hooks
+
 export { default as useMediaQuery } from './useMediaQuery';
+export { default as useBreakpointValue } from './useBreakpointValue';
 
 // Disclosure
 // --------------------------------------------------------

--- a/src/useBreakpointValue/index.ts
+++ b/src/useBreakpointValue/index.ts
@@ -1,0 +1,3 @@
+import useBreakpointValue from './useBreakpointValue';
+
+export default useBreakpointValue;

--- a/src/useBreakpointValue/test/useBreakpointValueSpec.ts
+++ b/src/useBreakpointValue/test/useBreakpointValueSpec.ts
@@ -1,0 +1,51 @@
+import { renderHook } from '@test/utils';
+import { act } from '@testing-library/react';
+import MatchMediaMock from '@test/mocks/matchmedia-mock';
+import useBreakpointValue from '../useBreakpointValue';
+
+let matchMedia: MatchMediaMock;
+
+describe('useBreakpointValue', () => {
+  beforeEach(() => {
+    matchMedia = new MatchMediaMock();
+
+    window.resizeTo = function resizeTo(width, height) {
+      Object.assign(this, {
+        innerWidth: width,
+        innerHeight: height,
+        outerWidth: width,
+        outerHeight: height
+      }).dispatchEvent(new this.Event('resize'));
+    };
+  });
+
+  afterEach(() => {
+    matchMedia.clear();
+  });
+
+  it('Should return the default value', () => {
+    const { result } = renderHook(() => useBreakpointValue({}, { defaultValue: true }));
+
+    expect(result.current).to.be.equal(true);
+  });
+
+  it('Should return the value of the breakpoint', () => {
+    act(() => window.resizeTo(576, 1000));
+
+    const { result } = renderHook(() =>
+      useBreakpointValue({ sm: '14px' }, { defaultValue: '16px' })
+    );
+
+    expect(result.current).to.be.equal('14px');
+  });
+
+  it('Should return the media query value', () => {
+    act(() => window.resizeTo(400, 1000));
+
+    const { result } = renderHook(() =>
+      useBreakpointValue({ '(min-width: 400px)': '14px' }, { defaultValue: '16px' })
+    );
+
+    expect(result.current).to.be.equal('14px');
+  });
+});

--- a/src/useBreakpointValue/useBreakpointValue.ts
+++ b/src/useBreakpointValue/useBreakpointValue.ts
@@ -1,0 +1,37 @@
+import useMediaQuery, { Query } from '../useMediaQuery';
+
+interface UseBreakpointValueOptions<T = any> {
+  /**
+   * The default value to return if no screen size matches.
+   */
+  defaultValue: T;
+}
+
+/**
+ * A React Hook that returns different values based on different screen sizes in responsive design.
+ * @version 5.63.0
+ * @unstable Please note that this API is not stable and may change in the future.
+ * @see https://rsuitejs.com/components/use-breakpoint-value
+ *
+ * @example
+ * ```ts
+ * const fontSize = useBreakpointValue({ sm: "14px", lg: "24px" }, { defaultValue: "16px" });
+ * const direction = useBreakpointValue({ sm: 'row' }, { defaultValue:'column' });
+ * ```
+ *
+ */
+export function useBreakpointValue<T = any>(
+  breakpoints: Record<Query, T>,
+  options?: UseBreakpointValueOptions<T>
+) {
+  const { defaultValue } = options || {};
+  const keys = Object.keys(breakpoints);
+  const values = Object.values(breakpoints);
+  const matches = useMediaQuery(keys);
+
+  const index = matches.indexOf(true);
+
+  return index !== -1 ? values[index] : defaultValue;
+}
+
+export default useBreakpointValue;

--- a/src/useMediaQuery/index.ts
+++ b/src/useMediaQuery/index.ts
@@ -1,3 +1,4 @@
 import useMediaQuery from './useMediaQuery';
 
+export type { Query } from './useMediaQuery';
 export default useMediaQuery;

--- a/src/useMediaQuery/test/useMediaQuerySpec.ts
+++ b/src/useMediaQuery/test/useMediaQuerySpec.ts
@@ -1,9 +1,9 @@
 import { renderHook } from '@test/utils';
 import { act } from '@testing-library/react';
 import MatchMediaMock from '@test/mocks/matchmedia-mock';
+import useMediaQuery from '../useMediaQuery';
 
 let matchMedia: MatchMediaMock;
-import useMediaQuery from '../useMediaQuery';
 
 describe('useMediaQuery', () => {
   beforeEach(() => {

--- a/src/useMediaQuery/useMediaQuery.ts
+++ b/src/useMediaQuery/useMediaQuery.ts
@@ -19,7 +19,7 @@ interface MediaQuery {
 /**
  * The type of the query parameter.
  */
-type Query = string | keyof typeof mediaQuerySizeMap;
+export type Query = string | keyof typeof mediaQuerySizeMap;
 
 const matchMedia = (query: string) => {
   if (canUseDOM) {
@@ -34,11 +34,9 @@ const matchMedia = (query: string) => {
 
 /**
  * React hook that tracks state of a CSS media query.
- * @deprecated Use useMediaQuery instead.
- *
  * @see https://rsuitejs.com/components/use-media-query
  */
-export function useMediaQueryLegacy(query: Query | Query[]): boolean[] {
+export function useMediaQueryOld(query: Query | Query[]): boolean[] {
   const queries = Array.isArray(query) ? query : [query];
   const mediaQueries = queries.map(query => mediaQuerySizeMap[query] || query);
 
@@ -74,8 +72,8 @@ export function useMediaQueryLegacy(query: Query | Query[]): boolean[] {
 /**
  * React hook that tracks state of a CSS media query
  * @version 5.48.0
+ * @unstable Please note that this API is not stable and may change in the future.
  * @see https://rsuitejs.com/components/use-media-query
- *
  */
 export function useMediaQuery(query: Query | Query[]): boolean[] {
   const queries = Array.isArray(query) ? query : [query];
@@ -125,4 +123,4 @@ export function useMediaQuery(query: Query | Query[]): boolean[] {
 
 export default typeof React['useSyncExternalStore'] === 'function'
   ? useMediaQuery
-  : useMediaQueryLegacy;
+  : useMediaQueryOld;


### PR DESCRIPTION
### Usage

```tsx
 const fontSize = useBreakpointValue({ sm: "14px", lg: "24px" }, { defaultValue: "16px" });
 const direction = useBreakpointValue({ sm: 'row' }, { defaultValue:'column' });
```

### API
```ts
function useBreakpointValue<T>(
  mediaQueries: Record<string | 'xxl' | 'xl' | 'lg' | 'md' | 'sm' | 'xs', T>,
  options?: {
    defaultValue?: T;
  }
): T;
```