### PR TITLE
feat(useToaster): add support for `mouseReset` parameter in push method

### DIFF
--- a/docs/pages/components/toaster/en-US/index.md
+++ b/docs/pages/components/toaster/en-US/index.md
@@ -51,11 +51,12 @@ toaster.push(message: ReactNode, toastProps?: ToastProps): string;
 
 ##### ToastProps
 
-| Property  | Type`(Default)`                                                                                         | Description                                                                 |
-| --------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| placement | 'topCenter' \| 'topStart' \| 'topEnd' \| 'bottomCenter' \| 'bottomStart' \| 'bottomEnd' `('topCenter')` | Set the position of the message                                             |
-| container | HTMLElement \| (() => HTMLElement)                                                                      | Set the container where the message appears                                 |
-| duration  | number                                                                                                  | The number of milliseconds to wait before automatically closing the message |
+| Property   | Type`(Default)`                                                                                         | Description                                                                  |
+| ---------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| container  | HTMLElement \| (() => HTMLElement)                                                                      | Set the container where the message appears                                  |
+| duration   | number                                                                                                  | The number of milliseconds to wait before automatically closing the message  |
+| mouseReset | boolean `(true)`                                                                                        | Reset the auto-close timer when the mouse enters the message<br/>![][5.65.0] |
+| placement  | 'topCenter' \| 'topStart' \| 'topEnd' \| 'bottomCenter' \| 'bottomStart' \| 'bottomEnd' `('topCenter')` | Set the position of the message                                              |
 
 #### toaster.remove
 
@@ -72,3 +73,5 @@ Remove all messages.
 ```
 toaster.clear(): void;
 ```
+
+[5.65.0]: https://img.shields.io/badge/min-v5.65.0-blue

--- a/docs/pages/components/toaster/zh-CN/index.md
+++ b/docs/pages/components/toaster/zh-CN/index.md
@@ -51,11 +51,12 @@ toaster.push(message: ReactNode, toastProps?: ToastProps): string;
 
 ##### ToastProps
 
-| 属性      | 类型`(默认值)`                                                                                          | 说明                       |
-| --------- | ------------------------------------------------------------------------------------------------------- | -------------------------- |
-| placement | 'topCenter' \| 'topStart' \| 'topEnd' \| 'bottomCenter' \| 'bottomStart' \| 'bottomEnd' `('topCenter')` | 设置消息出现的位置         |
-| container | HTMLElement \| (() => HTMLElement)                                                                      | 设置消息出现在指定的容器中 |
-| duration  | number                                                                                                  | 自动关闭消息前等待的毫秒数 |
+| 属性       | 类型`(默认值)`                                                                                          | 说明                                             |
+| ---------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| container  | HTMLElement \| (() => HTMLElement)                                                                      | 设置消息出现在指定的容器中                       |
+| duration   | number                                                                                                  | 自动关闭消息前等待的毫秒数                       |
+| mouseReset | boolean `(true)`                                                                                        | 鼠标移入时是否重置自动关闭计时器<br/>![][5.65.0] |
+| placement  | 'topCenter' \| 'topStart' \| 'topEnd' \| 'bottomCenter' \| 'bottomStart' \| 'bottomEnd' `('topCenter')` | 设置消息出现的位置                               |
 
 #### toaster.remove
 
@@ -72,3 +73,5 @@ toaster.remove(toastId: string): void;
 ```ts
 toaster.clear(): void;
 ```
+
+[5.65.0]: https://img.shields.io/badge/min-v5.65.0-blue

--- a/src/internals/types/index.ts
+++ b/src/internals/types/index.ts
@@ -252,6 +252,7 @@ export declare namespace TypeAttributes {
 
   type Placement = Placement4 | Placement8 | PlacementAuto;
   type CheckTrigger = 'change' | 'blur' | 'none' | null;
+  type DisplayState = 'show' | 'hide' | 'hiding';
 }
 
 export interface SVGIcon {

--- a/src/toaster/ToastContext.ts
+++ b/src/toaster/ToastContext.ts
@@ -2,6 +2,8 @@ import React from 'react';
 
 export interface ToastContextProps {
   usedToaster?: boolean;
+  duration?: number;
+  mouseReset?: boolean;
 }
 
 const ToastContext = React.createContext<ToastContextProps>({ usedToaster: false });

--- a/src/toaster/hooks/useDelayedClosure.ts
+++ b/src/toaster/hooks/useDelayedClosure.ts
@@ -1,0 +1,58 @@
+import { useContext, useRef } from 'react';
+import on from 'dom-lib/on';
+import { useTimeout, useMount } from '@/internals/hooks';
+import ToastContext from '../ToastContext';
+
+interface UseDelayedClosureProps {
+  /**
+   * Callback function to be called when the closure is triggered.
+   */
+  onClose?: (event?: React.MouseEvent<HTMLButtonElement>) => void;
+
+  /**
+   * The duration (in milliseconds) after which the closure should be triggered.
+   */
+  duration: number;
+
+  /**
+   * Optional reference to the target element.
+   */
+  targetRef?: React.RefObject<HTMLElement>;
+
+  /**
+   * Reset the hide timer if the mouse moves over the target element.
+   */
+  mouseReset?: boolean;
+}
+
+/**
+ * A hook that delays the closure of the message box.
+ */
+function useDelayedClosure(props: UseDelayedClosureProps) {
+  const { onClose, duration: durationProp, targetRef } = props;
+  const { usedToaster, duration = durationProp, mouseReset } = useContext(ToastContext);
+  const mouseEnterRef = useRef<ReturnType<typeof on>>();
+  const mouseLeaveRef = useRef<ReturnType<typeof on>>();
+
+  const { clear, reset } = useTimeout(onClose, duration, usedToaster && duration > 0);
+
+  useMount(() => {
+    if (targetRef?.current && mouseReset) {
+      if (mouseEnterRef.current || mouseLeaveRef.current) {
+        return;
+      }
+
+      mouseEnterRef.current = on(targetRef.current, 'mouseenter', clear);
+      mouseLeaveRef.current = on(targetRef.current, 'mouseleave', reset);
+
+      return () => {
+        mouseEnterRef.current?.off();
+        mouseLeaveRef.current?.off();
+      };
+    }
+  });
+
+  return { clear, reset };
+}
+
+export default useDelayedClosure;


### PR DESCRIPTION
close: https://github.com/rsuite/rsuite/issues/1531

```tsx
import { useToaster } from 'rsuite';

return () => {
  const toaster = useToaster();

  const handleClick = () => {
    // Push the message to the toaster, the message will disappear after 2 seconds. 
    // But the message will not disappear when the mouse hovers over the message.
    toaster.push(<Message>message</Message>, { duration: 2000, mouseReset: true });
  };

  return <Button onClick={handleClick}>Push</Button>;
};
```