### PR TITLE
fix(radio): disabled radio control hover cursor

### DIFF
--- a/src/Radio/styles/index.less
+++ b/src/Radio/styles/index.less
@@ -40,6 +40,10 @@
     right: -@radio-sense-width;
     bottom: -@radio-sense-width;
     left: -@radio-sense-width;
+
+    &:disabled {
+      cursor: @cursor-disabled;
+    }
   }
 
   &::before,


### PR DESCRIPTION
### Description
The cursor on the disabled Radio Control when hovered is incorrect.

### Current behavior

https://github.com/rsuite/rsuite/assets/8769408/d100f01a-b790-4636-863c-ba3a06af020e


### New behavior

https://github.com/rsuite/rsuite/assets/8769408/033f16d4-5448-49c2-a737-a80441ef88d7


### Additional Information
If the PR gets accepted please use my GitHub email-id (shrinidhiupadhyaya1195@gmail.com) instead of my other email-id for the Co-authored-by: message.