### PR TITLE
fix(uploader): background color on hover when disabled

### DIFF
--- a/src/Uploader/styles/index.less
+++ b/src/Uploader/styles/index.less
@@ -18,6 +18,10 @@
     opacity: 0.3;
     cursor: not-allowed;
 
+    &:hover {
+      background-color: transparent !important;
+    }
+
     .rs-uploader-picture & .rs-uploader-file-item-status {
       cursor: not-allowed;
     }


### PR DESCRIPTION
### Description
When `Uploader` component is disabled, the background color of the List component when hovered changes.

### Current behavior

https://github.com/rsuite/rsuite/assets/8769408/7821a1bc-68de-4197-9c39-1fa77cd2bd49

### New behavior
https://github.com/rsuite/rsuite/assets/8769408/13b02ed0-2ec1-4ab9-bb0a-2dd18bf4400a

### Additional Information
If the PR gets accepted please use my GitHub email-id (shrinidhiupadhyaya1195@gmail.com) instead of my other email-id for the Co-authored-by: message.


