### PR TITLE
fix(progress): consistent spacing between label/icon & progress line (Vertical)

### DIFF
--- a/src/Progress/styles/index.less
+++ b/src/Progress/styles/index.less
@@ -161,6 +161,7 @@
   &&-vertical .rs-progress-info {
     flex-basis: auto;
     padding-left: 0;
+    padding-bottom: @progress-element-gap;
     width: auto;
   }
 


### PR DESCRIPTION
### Description
Horizontal Progress component has a `left-padding` of `12px`.
Vertical Progress component has `bottom-padding` of `8px`  but it needs to have a `bottom-padding` of `12px`, because it is vertically oriented.

### Current Behavior:-
![image](https://github.com/rsuite/rsuite/assets/8769408/77af8fde-9918-48a0-b37b-01b68d1da37c)

![image](https://github.com/rsuite/rsuite/assets/8769408/e3af7cd9-1716-4f4e-a881-dc831bcc0102)

### New behavior
![image](https://github.com/rsuite/rsuite/assets/8769408/c012c309-d5f4-4b35-9237-cfc6557de4e1)

### Additional Information
If the PR gets accepted please use my GitHub email-id (shrinidhiupadhyaya1195@gmail.com) instead of my other email-id for the Co-authored-by: message.