### PR TITLE
fix(Form): fix `proxy` function in `schema-typed` not work in form

### DIFF
--- a/docs/pages/components/form-validation/en-US/index.md
+++ b/docs/pages/components/form-validation/en-US/index.md
@@ -119,6 +119,15 @@ There are `checkTrigger` properties on the `<Form>` and `<Form.Control>` compone
 
 <!--{include:`form-nested-fields.md`}-->
 
+
+
+### Proxy validation
+
+<!--{include:`form-check-proxy.md`}-->
+
+> Note: `proxy` isn't supported when `Form` enables `nestedField`
+
+
 ## Integration with other libraries
 
 - [With Formik Integration](/en/guide/form-formik/)

--- a/docs/pages/components/form-validation/fragments/form-check-proxy.md
+++ b/docs/pages/components/form-validation/fragments/form-check-proxy.md
@@ -1,0 +1,37 @@
+<!--start-code-->
+
+```js
+import { Form, Button, ButtonToolbar, Schema, Panel } from 'rsuite';
+
+const { StringType } = Schema.Types;
+const model = Schema.Model({
+  password: StringType().proxy(['confirmPassword']),
+  confirmPassword: StringType().equalTo('password')
+});
+
+function TextField(props) {
+  const { name, label, accepter, ...rest } = props;
+  return (
+    <Form.Group controlId={`${name}-3`}>
+      <Form.ControlLabel>{label} </Form.ControlLabel>
+      <Form.Control name={name} accepter={accepter} {...rest} />
+    </Form.Group>
+  );
+}
+function App() {
+  return (
+    <Form model={model}>
+      <TextField name="password" label="Password" />
+      <TextField name="confirmPassword" label="ConfirmPassword" />
+      <ButtonToolbar>
+        <Button appearance="primary" type="submit">
+          Submit
+        </Button>
+      </ButtonToolbar>
+    </Form>
+  );
+}
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/form-validation/zh-CN/index.md
+++ b/docs/pages/components/form-validation/zh-CN/index.md
@@ -121,6 +121,12 @@ return (
 
 <!--{include:`form-nested-fields.md`}-->
 
+### 代理校验
+
+<!--{include:`form-check-proxy.md`}-->
+
+ >注意：当 `Form` 启用`nestedField`时，不支持`proxy`。
+
 ## 与其他库集成
 
 - [与 Formik 集成](/zh/guide/form-formik/)

--- a/src/Form/Form.tsx
+++ b/src/Form/Form.tsx
@@ -1,7 +1,6 @@
 import React, { FormHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import { Schema, SchemaModel } from 'schema-typed';
-import type { CheckResult } from 'schema-typed';
 import { FormValueProvider, FormProvider } from './FormContext';
 import FormControl from '../FormControl';
 import FormControlLabel from '../FormControlLabel';
@@ -177,12 +176,13 @@ const Form: FormComponent = React.forwardRef((props: FormProps, ref: React.Ref<F
 
   const {
     formError,
-    setFieldError,
     onRemoveError,
     check,
     checkAsync,
     checkForField,
+    checkFieldForNextValue,
     checkForFieldAsync,
+    checkFieldAsyncForNextValue,
     cleanErrors,
     resetErrors,
     cleanErrorForField
@@ -257,14 +257,6 @@ const Form: FormComponent = React.forwardRef((props: FormProps, ref: React.Ref<F
     onRemoveError(name);
   });
 
-  const onFieldError = useEventCallback((name: string, checkResult: string | CheckResult) => {
-    setFieldError(name, checkResult);
-  });
-
-  const onFieldSuccess = useEventCallback((name: string) => {
-    removeFieldError(name);
-  });
-
   const onFieldChange = useEventCallback(
     (name: string, value: any, event: React.SyntheticEvent) => {
       const nextFormValue = setFieldValue(name, value);
@@ -281,13 +273,12 @@ const Form: FormComponent = React.forwardRef((props: FormProps, ref: React.Ref<F
     formError,
     nestedField,
     pushFieldRule,
-    getCombinedModel,
     removeFieldValue,
     removeFieldError,
     removeFieldRule,
-    onFieldSuccess,
     onFieldChange,
-    onFieldError
+    checkFieldForNextValue,
+    checkFieldAsyncForNextValue
   };
 
   return (

--- a/src/Form/FormContext.tsx
+++ b/src/Form/FormContext.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import { TypeAttributes } from '@/internals/types';
-import type { Schema, CheckResult } from 'schema-typed';
 import type { FieldRuleType } from './hooks/useSchemaModel';
 
 type RecordAny = Record<string, any>;
@@ -8,14 +7,20 @@ type RecordAny = Record<string, any>;
 interface TrulyFormContextValue<T = RecordAny, M = any, E = { [P in keyof T]?: M }> {
   formError: E;
   nestedField: boolean;
-  getCombinedModel: () => Schema;
   removeFieldValue: (name: string) => void;
   removeFieldError: (name: string) => void;
   removeFieldRule: (name: string) => void;
   pushFieldRule: (name: string, fieldRule: FieldRuleType) => void;
-  onFieldError: (name: string, fieldError: string | CheckResult) => void;
   onFieldChange: (name: string, value: any, event: React.SyntheticEvent) => void;
-  onFieldSuccess: (name: string) => void;
+  checkFieldForNextValue: (
+    name: string,
+    nextValue: Record<string, unknown>,
+    callback?: (checkResult: Record<string, unknown>) => void
+  ) => boolean;
+  checkFieldAsyncForNextValue: (
+    name: string,
+    nextValue: Record<string, unknown>
+  ) => Promise<Record<string, unknown>>;
 }
 
 type ExternalPropsContextValue = {

--- a/src/FormControl/FormControl.tsx
+++ b/src/FormControl/FormControl.tsx
@@ -92,10 +92,9 @@ const FormControl: FormControlComponent = React.forwardRef((props: FormControlPr
     removeFieldValue,
     removeFieldError,
     onFieldChange,
-    onFieldError,
-    onFieldSuccess,
-    getCombinedModel,
-    checkTrigger: contextCheckTrigger
+    checkTrigger: contextCheckTrigger,
+    checkFieldForNextValue,
+    checkFieldAsyncForNextValue
   } = useContext(FormContext);
 
   const {
@@ -171,29 +170,12 @@ const FormControl: FormControlComponent = React.forwardRef((props: FormControlPr
   });
 
   const handleFieldCheck = useEventCallback((value: any) => {
-    const callbackEvents = checkResult => {
-      if (checkResult.hasError) {
-        const { errorMessage } = checkResult;
-        const fieldError = nestedField ? checkResult : errorMessage || checkResult;
-
-        onFieldError?.(name, fieldError);
-      } else {
-        onFieldSuccess?.(name);
-      }
-
-      return checkResult;
-    };
-
     const nextFormValue = setFieldValue(name, value);
-    const model = getCombinedModel();
-    const checkOptions = { nestedObject: nestedField };
     if (checkAsync) {
-      return model
-        ?.checkForFieldAsync(name, nextFormValue, checkOptions)
-        .then(checkResult => callbackEvents(checkResult));
+      checkFieldAsyncForNextValue(name, nextFormValue);
+    } else {
+      checkFieldForNextValue(name, nextFormValue);
     }
-
-    return Promise.resolve(callbackEvents(model?.checkForField(name, nextFormValue, checkOptions)));
   });
 
   const fieldHasError = Boolean(fieldError);


### PR DESCRIPTION
[Schema-typed](https://github.com/rsuite/schema-typed/releases) added the `proxy` feature to support interdependent validation. However, it doesn't work in `rsuite`.

This PR solved this problem. But there are still two points to notice.

1. Although `checkForField ` or `checkForFieldAsync` use `getCheckResult` of `model` to get all results, they still return the result of `model.checkForField` or `model.checkForFieldAsync` to maintain stability.
2. When using `nestedField` and `proxy` together, I can't detect if it has any error in the result of `getCheckResult`. Therefore I didn't support `proxy` when using `nestedField` 
