### PR TITLE
fix(Deno): prevent ReferenceError in Deno environments

### DIFF
--- a/src/internals/hooks/useCustom.ts
+++ b/src/internals/hooks/useCustom.ts
@@ -10,7 +10,7 @@ const mergeObject = (list: any[]) =>
   }, {});
 
 const getDefaultRTL = () =>
-  typeof window !== 'undefined' && (document.body.getAttribute('dir') || document.dir) === 'rtl';
+  typeof document !== 'undefined' && (document.body.getAttribute('dir') || document.dir) === 'rtl';
 
 /**
  * A hook to get custom configuration of `<CustomProvider>`

--- a/src/internals/hooks/useIsomorphicLayoutEffect.ts
+++ b/src/internals/hooks/useIsomorphicLayoutEffect.ts
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect } from 'react';
 
 export const useIsomorphicLayoutEffect =
-  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+  typeof document !== 'undefined' ? useLayoutEffect : useEffect;
 
 export default useIsomorphicLayoutEffect;


### PR DESCRIPTION
This PR fixes isomorphism in Deno environments. `typeof window` turns out to be not sufficient in determining server/client in Deno, because `window` actually exists in Deno. The [workaround recommended by Remix](https://remix.run/docs/en/main/guides/gotchas#typeof-window-checks) is to replace `typeof window` with `typeof document`. 

Fixes #3864 