### PR TITLE
fix(Drawer): remove the `max-height` that should not exist in Drawer.Body

### DIFF
--- a/docs/pages/components/drawer/fragments/basic.md
+++ b/docs/pages/components/drawer/fragments/basic.md
@@ -31,7 +31,7 @@ const App = () => {
           </Drawer.Actions>
         </Drawer.Header>
         <Drawer.Body>
-          <Placeholder.Paragraph />
+          <Placeholder.Paragraph rows={20} />
         </Drawer.Body>
       </Drawer>
     </>

--- a/src/Drawer/Drawer.tsx
+++ b/src/Drawer/Drawer.tsx
@@ -58,6 +58,7 @@ const Drawer: DrawerComponent = React.forwardRef((props: DrawerProps, ref) => {
       <Modal
         {...rest}
         ref={ref}
+        overflow={false}
         classPrefix={classPrefix}
         className={classes}
         animation={animation}

--- a/src/Drawer/test/DrawerSpec.tsx
+++ b/src/Drawer/test/DrawerSpec.tsx
@@ -103,6 +103,17 @@ describe('Drawer', () => {
     expect(screen.getByTestId('drawer-wrapper')).to.have.class('rs-drawer-no-backdrop');
   });
 
+  it('Should not have max-height in the body', () => {
+    render(
+      <Drawer open>
+        <Drawer.Header />
+        <Drawer.Body>Body</Drawer.Body>
+      </Drawer>
+    );
+
+    expect(screen.getByText('Body').style.maxHeight).to.equal('');
+  });
+
   describe('Focused state', () => {
     let focusableContainer: HTMLElement | null = null;
 


### PR DESCRIPTION
<img width="1365" alt="image" src="https://github.com/rsuite/rsuite/assets/1203827/11d77204-9b97-42fb-9a74-e2cfbef36ac7">
