### PR TITLE
fix(TreePicker, CheckTreePicker): fix `locale` cannot override default localization configuration

### DIFF
--- a/src/CheckTree/CheckTreeView.tsx
+++ b/src/CheckTree/CheckTreeView.tsx
@@ -90,6 +90,11 @@ interface CheckTreeViewInnerProps<V = (string | number)[]>
   flattenedNodes?: TreeNodeMap;
 
   /**
+   * A collection of localized strings.
+   */
+  locale?: Record<string, string>;
+
+  /**
    * Callback function triggered when an item is focused.
    */
   onFocusItem?: (value?: TreeNode['value']) => void;

--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -235,6 +235,7 @@ const CheckTreePicker: PickerComponent<CheckTreePickerProps> = React.forwardRef(
         showIndentLine={showIndentLine}
         listProps={listProps}
         listRef={list}
+        locale={overrideLocale}
         searchBy={searchBy}
         searchable={searchable}
         searchKeyword={searchKeyword}

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.tsx
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.tsx
@@ -9,6 +9,7 @@ import CheckTreePicker from '../CheckTreePicker';
 import { KEY_VALUES } from '@/internals/constants';
 import { originMockData, changedMockData, controlledData } from './mocks';
 import { PickerHandle } from '@/internals/Picker';
+import CustomProvider from '@/CustomProvider';
 import {
   testStandardProps,
   testControlledUnControlled,
@@ -707,6 +708,69 @@ describe('CheckTreePicker', () => {
 
       expect(treeItem).to.have.attribute('aria-selected', 'true');
       expect(treeItem).to.have.contain('.rs-check-item-focus');
+    });
+  });
+
+  describe('Locale', () => {
+    it('Should render default locale', () => {
+      render(<CheckTreePicker defaultOpen data={data} />);
+
+      expect(screen.getByRole('combobox')).to.have.text('Select');
+      expect(screen.getByRole('searchbox')).to.have.attribute('placeholder', 'Search');
+
+      // Trigger search event
+      fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'not found value' } });
+      expect(screen.getByText('No results found')).to.exist;
+    });
+
+    it('Should render custom locale with `CustomProvider` component', () => {
+      const PickerZhCN = {
+        noResultsText: '无匹配选项',
+        searchPlaceholder: '搜索',
+        placeholder: '选择',
+        checkAll: '全部'
+      };
+
+      render(
+        <CustomProvider
+          locale={{
+            Picker: PickerZhCN
+          }}
+        >
+          <CheckTreePicker defaultOpen data={data} />
+        </CustomProvider>
+      );
+
+      expect(screen.getByRole('combobox')).to.have.text('选择');
+      expect(screen.getByRole('searchbox')).to.have.attribute('placeholder', '搜索');
+
+      // Trigger search event
+      fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'not found value' } });
+      expect(screen.getByText('无匹配选项')).to.exist;
+    });
+
+    it('Should override locale with `locale` property', () => {
+      render(
+        <CheckTreePicker
+          defaultOpen
+          data={data}
+          locale={{
+            searchPlaceholder: 'Custom Search Place Holder',
+            noResultsText: 'Custom No Results Message',
+            placeholder: 'Custom Place Holder'
+          }}
+        />
+      );
+
+      expect(screen.getByRole('combobox')).to.have.text('Custom Place Holder');
+      expect(screen.getByRole('searchbox')).to.have.attribute(
+        'placeholder',
+        'Custom Search Place Holder'
+      );
+
+      // Trigger search event
+      fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'not found value' } });
+      expect(screen.getByText('Custom No Results Message')).to.exist;
     });
   });
 });

--- a/src/Tree/TreeView.tsx
+++ b/src/Tree/TreeView.tsx
@@ -79,6 +79,11 @@ interface TreeViewInnerProps<V = string | number | null>
   loadingNodeValues?: V[];
 
   /**
+   * A collection of localized strings.
+   */
+  locale?: Record<string, string>;
+
+  /**
    * A map of flattened nodes.
    */
   flattenedNodes?: TreeNodeMap;

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -239,6 +239,7 @@ const TreePicker: PickerComponent<TreePickerProps> = React.forwardRef((props, re
         flattenedNodes={flattenedNodes}
         listProps={listProps}
         listRef={list}
+        locale={overrideLocale}
         height={treeHeight}
         onExpand={handleExpandTreeNode}
         onSearch={onSearch}

--- a/src/TreePicker/test/TreePickerSpec.tsx
+++ b/src/TreePicker/test/TreePickerSpec.tsx
@@ -14,6 +14,7 @@ import TreePicker, { TreePickerProps } from '../TreePicker';
 import { KEY_VALUES } from '@/internals/constants';
 import { PickerHandle } from '@/internals/Picker';
 import { ListHandle } from '@/internals/Windowing';
+import CustomProvider from '@/CustomProvider';
 
 const data = mockTreeData([['Master', 'tester0', ['tester1', 'tester2']], 'disabled']);
 
@@ -605,6 +606,69 @@ describe('TreePicker', () => {
       fireEvent.keyDown(screen.getByRole('tree'), { key: KEY_VALUES.RIGHT });
 
       expect(screen.getByRole('treeitem', { name: 'tester0' })).to.have.class('rs-tree-node-focus');
+    });
+  });
+
+  describe('Locale', () => {
+    it('Should render default locale', () => {
+      render(<TreePicker defaultOpen data={data} />);
+
+      expect(screen.getByRole('combobox')).to.have.text('Select');
+      expect(screen.getByRole('searchbox')).to.have.attribute('placeholder', 'Search');
+
+      // Trigger search event
+      fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'not found value' } });
+      expect(screen.getByText('No results found')).to.exist;
+    });
+
+    it('Should render custom locale with `CustomProvider` component', () => {
+      const PickerZhCN = {
+        noResultsText: '无匹配选项',
+        searchPlaceholder: '搜索',
+        placeholder: '选择',
+        checkAll: '全部'
+      };
+
+      render(
+        <CustomProvider
+          locale={{
+            Picker: PickerZhCN
+          }}
+        >
+          <TreePicker defaultOpen data={data} />
+        </CustomProvider>
+      );
+
+      expect(screen.getByRole('combobox')).to.have.text('选择');
+      expect(screen.getByRole('searchbox')).to.have.attribute('placeholder', '搜索');
+
+      // Trigger search event
+      fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'not found value' } });
+      expect(screen.getByText('无匹配选项')).to.exist;
+    });
+
+    it('Should override locale with `locale` property', () => {
+      render(
+        <TreePicker
+          defaultOpen
+          data={data}
+          locale={{
+            searchPlaceholder: 'Custom Search Place Holder',
+            noResultsText: 'Custom No Results Message',
+            placeholder: 'Custom Place Holder'
+          }}
+        />
+      );
+
+      expect(screen.getByRole('combobox')).to.have.text('Custom Place Holder');
+      expect(screen.getByRole('searchbox')).to.have.attribute(
+        'placeholder',
+        'Custom Search Place Holder'
+      );
+
+      // Trigger search event
+      fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'not found value' } });
+      expect(screen.getByText('Custom No Results Message')).to.exist;
     });
   });
 });


### PR DESCRIPTION
fix: https://github.com/rsuite/rsuite/issues/3872