### PR TITLE
feat(Loader): add `paused` value to the `speed` property to control the animation pause

### DIFF
--- a/docs/pages/components/loader/en-US/index.md
+++ b/docs/pages/components/loader/en-US/index.md
@@ -55,5 +55,5 @@ A component that provides state during data loading.
 | content     | ReactNode                                | Custom descriptive text                         |
 | inverse     | boolean                                  | An alternative dark visual style for the Loader |
 | size        | 'lg' \| 'md' \| 'sm' \| 'xs'`('md')`     | Sets the loader dimensions                      |
-| speed       | 'fast' \| 'normal' \| 'slow'`('normal')` | The speed at which the loader rotates           |
+| speed       | 'fast' \| 'normal' \| 'slow' \| 'paused'`('normal')` | The speed at which the loader rotates           |
 | vertical    | boolean                                  | The icon is displayed vertically with the text  |

--- a/docs/pages/components/loader/fragments/speed.md
+++ b/docs/pages/components/loader/fragments/speed.md
@@ -10,6 +10,8 @@ const App = () => (
     <Loader speed="normal" content="Normal" />
     <hr />
     <Loader speed="slow" content="Slow" />
+    <hr />
+    <Loader speed="paused" content="Paused" />
   </>
 );
 

--- a/docs/pages/components/loader/zh-CN/index.md
+++ b/docs/pages/components/loader/zh-CN/index.md
@@ -55,5 +55,5 @@
 | content     | ReactNode                                | 自定义描述文本     |
 | inverse     | boolean                                  | 翻转加载器颜色     |
 | size        | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`    | 设置加载器尺寸     |
-| speed       | 'fast' \| 'normal' \| 'slow'`('normal')` | 加载器旋转速度     |
+| speed       | 'fast' \| 'normal' \| 'slow' \| 'paused'`('normal')` | 加载器旋转速度     |
 | vertical    | boolean                                  | 图标与文字垂直显示 |

--- a/src/Loader/Loader.tsx
+++ b/src/Loader/Loader.tsx
@@ -20,11 +20,8 @@ export interface LoaderProps extends WithAsProps {
   /** Custom descriptive text */
   content?: React.ReactNode;
 
-  /** The state of the loader */
-  loaderPlayState?: 'paused' | 'running';
-
   /** The speed at which the loader rotates */
-  speed?: 'normal' | 'fast' | 'slow';
+  speed?: 'normal' | 'fast' | 'slow' | 'paused';
 
   /** A loader can have different sizes */
   size?: TypeAttributes.Size;
@@ -42,7 +39,6 @@ const Loader: RsRefForwardingComponent<'div', LoaderProps> = React.forwardRef(
       className,
       inverse,
       backdrop,
-      loaderPlayState = 'running',
       speed = 'normal',
       center,
       vertical,
@@ -56,7 +52,7 @@ const Loader: RsRefForwardingComponent<'div', LoaderProps> = React.forwardRef(
 
     const classes = merge(
       className,
-      prefix('wrapper', `speed-${speed}`, `play-state-${loaderPlayState}`, size, {
+      prefix('wrapper', `speed-${speed}`, size, {
         'backdrop-wrapper': backdrop,
         vertical,
         inverse,
@@ -97,7 +93,7 @@ Loader.propTypes = {
   vertical: PropTypes.bool,
   content: PropTypes.node,
   size: oneOf(['lg', 'md', 'sm', 'xs']),
-  speed: oneOf(['normal', 'fast', 'slow'])
+  speed: oneOf(['normal', 'fast', 'slow', 'paused'])
 };
 
 export default Loader;

--- a/src/Loader/Loader.tsx
+++ b/src/Loader/Loader.tsx
@@ -20,6 +20,9 @@ export interface LoaderProps extends WithAsProps {
   /** Custom descriptive text */
   content?: React.ReactNode;
 
+  /** The state of the loader */
+  loaderPlayState?: 'paused' | 'running';
+
   /** The speed at which the loader rotates */
   speed?: 'normal' | 'fast' | 'slow';
 
@@ -39,6 +42,7 @@ const Loader: RsRefForwardingComponent<'div', LoaderProps> = React.forwardRef(
       className,
       inverse,
       backdrop,
+      loaderPlayState = 'running',
       speed = 'normal',
       center,
       vertical,
@@ -52,7 +56,7 @@ const Loader: RsRefForwardingComponent<'div', LoaderProps> = React.forwardRef(
 
     const classes = merge(
       className,
-      prefix('wrapper', `speed-${speed}`, size, {
+      prefix('wrapper', `speed-${speed}`, `play-state-${loaderPlayState}`, size, {
         'backdrop-wrapper': backdrop,
         vertical,
         inverse,

--- a/src/Loader/styles/index.less
+++ b/src/Loader/styles/index.less
@@ -103,13 +103,8 @@
     animation-duration: @loader-duration-slow;
   }
 
-  // Loader animation-play-states
-  &-play-state-paused &-spin::after {
-    animation-play-state: @loader-play-state-paused;
-  }
-
-  &-play-state-running &-spin::after {
-    animation-play-state: @loader-play-state-running;
+  &-speed-paused &-spin::after {
+    animation-play-state: @loader-duration-paused;
   }
 
   // Position center

--- a/src/Loader/styles/index.less
+++ b/src/Loader/styles/index.less
@@ -103,6 +103,15 @@
     animation-duration: @loader-duration-slow;
   }
 
+  // Loader animation-play-states
+  &-play-state-paused &-spin::after {
+    animation-play-state: @loader-play-state-paused;
+  }
+
+  &-play-state-running &-spin::after {
+    animation-play-state: @loader-play-state-running;
+  }
+
   // Position center
   &-center,
   &-backdrop-wrapper {

--- a/src/Loader/test/LoaderSpec.tsx
+++ b/src/Loader/test/LoaderSpec.tsx
@@ -38,6 +38,11 @@ describe('Loader', () => {
     expect(screen.getByRole('status')).to.have.class('rs-loader-speed-fast');
   });
 
+  it('Should be paused', () => {
+    render(<Loader speed="paused" />);
+    expect(screen.getByRole('status')).to.have.class('rs-loader-speed-paused');
+  });
+
   describe('Accessibility', () => {
     it('Should have role status', () => {
       render(<Loader />);

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -617,6 +617,10 @@
 @loader-duration-normal:            0.6s;
 @loader-duration-slow:              0.8s;
 
+// spin play state
+@loader-play-state-paused:          paused;
+@loader-play-state-running:         running;
+
 // spacing
 @loader-content-spin-spacing-horizontal:    12px;
 @loader-content-spin-spacing-vertical:      10px;

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -616,10 +616,7 @@
 @loader-duration-fast:              0.4s;
 @loader-duration-normal:            0.6s;
 @loader-duration-slow:              0.8s;
-
-// spin play state
-@loader-play-state-paused:          paused;
-@loader-play-state-running:         running;
+@loader-duration-paused:          paused;
 
 // spacing
 @loader-content-spin-spacing-horizontal:    12px;


### PR DESCRIPTION
### Description
This PR introduces a new `loaderPlayState` prop for the Loader spinner component. The `loaderPlayState` prop accepts two values: `"running"` and `"paused"`, allowing users to control the play state of the loader animation.

### Use Cases
1. **Pause and Resume:** In applications with complex loading sequences, it might be necessary to pause the loader animation while certain conditions are being met and resume it afterward.
2. **Accessibility:** Users might want to pause animations to reduce distractions or for accessibility reasons.
3. **User Experience:** Provide better user experience by controlling the visibility and behavior of the loader based on user interactions.

### Implementation Details
- Added a new `loaderPlayState` prop to the Loader component, which defaults to `"running"`.
- Updated the CSS/JS to handle the `"running"` and `"paused"` states appropriately.
- Ensured backward compatibility by setting the default value to `"running"` so existing implementations are not affected.

### Code Example
```jsx
// Usage Example
<Loader loaderPlayState="paused" />
