### PR TITLE
fix(Button): fix the misalignment of icons and text in block buttons

### DIFF
--- a/docs/pages/components/button/fragments/block.md
+++ b/docs/pages/components/button/fragments/block.md
@@ -1,7 +1,8 @@
 <!--start-code-->
 
 ```js
-import { Button, ButtonToolbar } from 'rsuite';
+import { Button, IconButton, ButtonToolbar } from 'rsuite';
+import { FaGithub } from 'react-icons/fa';
 
 const App = () => (
   <ButtonToolbar>
@@ -10,6 +11,9 @@ const App = () => (
     </Button>
     <Button appearance="primary" block>
       Block
+    </Button>
+    <Button block startIcon={<FaGithub />}>
+      Github
     </Button>
   </ButtonToolbar>
 );

--- a/docs/pages/components/button/index.tsx
+++ b/docs/pages/components/button/index.tsx
@@ -3,7 +3,7 @@ import { Button, ButtonGroup, ButtonToolbar, IconButton, Whisper, Popover, Dropd
 import DefaultPage from '@/components/Page';
 import ArrowDownIcon from '@rsuite/icons/ArrowDown';
 import ImportGuide from '@/components/ImportGuide';
-import { FaFacebook, FaGooglePlus, FaTwitter, FaLinkedin } from 'react-icons/fa';
+import { FaFacebook, FaGooglePlus, FaTwitter, FaLinkedin, FaGithub } from 'react-icons/fa';
 import { SiWechat, SiSinaweibo } from 'react-icons/si';
 const inDocsComponents = {
   'import-guide': () => <ImportGuide components={['Button', 'ButtonGroup', 'ButtonToolbar']} />
@@ -25,6 +25,7 @@ export default function Page() {
         FaFacebook,
         FaGooglePlus,
         FaTwitter,
+        FaGithub,
         FaLinkedin,
         SiWechat,
         SiSinaweibo

--- a/src/Button/styles/index.less
+++ b/src/Button/styles/index.less
@@ -263,7 +263,6 @@ each(@spectrum, .(@color) {
 // --------------------------------------------------
 
 .rs-btn-block {
-  display: block;
   width: 100%;
 
   // Vertically space out multiple block buttons

--- a/src/Button/test/ButtonStylesSpec.tsx
+++ b/src/Button/test/ButtonStylesSpec.tsx
@@ -81,10 +81,11 @@ describe('Button styles', () => {
     });
   });
 
-  it('Button should render the correct display', () => {
-    render(<Button block>Tittle</Button>);
+  it('Should render the correct width when set block', () => {
+    const { container } = render(<Button block>Tittle</Button>);
 
-    expect(screen.getByRole('button')).to.have.style('display', 'block');
+    expect(screen.getByRole('button')).to.have.style('display', 'inline-flex');
+    expect(screen.getByRole('button')).to.have.style('width', getComputedStyle(container).width);
   });
 
   it('Disabled button should render the correct opacity', () => {


### PR DESCRIPTION
```tsx
<Button block startIcon={<FaGithub />}>Github</Button>
```

### Before

![image](https://github.com/user-attachments/assets/62918f49-19c8-4107-95a0-a8e170ab479b)

### After
![image](https://github.com/user-attachments/assets/afdb875e-e9e2-4daf-a0fb-d1776df40985)

