### PR TITLE
fix(NavItem): fix NavItem cannot be used in Navbar and Sidenav

### DIFF
--- a/src/Nav/AdaptiveNavItem.tsx
+++ b/src/Nav/AdaptiveNavItem.tsx
@@ -1,0 +1,80 @@
+import React, { useContext, useEffect } from 'react';
+import NavItem, { NavItemProps } from './NavItem';
+import { useInternalId } from '@/internals/hooks';
+import { NavbarContext } from '../Navbar/Navbar';
+import { SidenavContext } from '../Sidenav/Sidenav';
+import NavContext from './NavContext';
+import { NavMenuActionType, NavMenuContext } from './NavMenu';
+import NavDropdownItem from './NavDropdownItem';
+import NavbarDropdownItem from '../Navbar/NavbarDropdownItem';
+import SidenavDropdownItem from '../Sidenav/SidenavDropdownItem';
+import NavbarItem from '../Navbar/NavbarItem';
+import SidenavItem from '../Sidenav/SidenavItem';
+
+/**
+ * The <Nav.Item> API
+ * When used as direct child of <Nav>, render the NavItem
+ * When used within a <Nav.Menu>, render the NavDropdownItem
+ */
+const AdaptiveNavItem = React.forwardRef((props: NavItemProps, ref: React.Ref<any>) => {
+  const nav = useContext(NavContext);
+
+  if (!nav) {
+    throw new Error('<Nav.Item> must be rendered within a <Nav> component.');
+  }
+
+  const parentNavMenu = useContext(NavMenuContext);
+  const navbar = useContext(NavbarContext);
+  const sidenav = useContext(SidenavContext);
+
+  const [, dispatch] = parentNavMenu ?? [];
+  const _id = useInternalId('Nav.Item');
+
+  useEffect(() => {
+    if (dispatch) {
+      dispatch({
+        type: NavMenuActionType.RegisterItem,
+        payload: {
+          _id,
+          eventKey: props.eventKey,
+          active: props.active ?? false
+        }
+      });
+
+      return () => {
+        dispatch({
+          type: NavMenuActionType.UnregisterItem,
+          payload: {
+            _id
+          }
+        });
+      };
+    }
+  }, [dispatch, _id, props.eventKey, props.active]);
+
+  if (parentNavMenu) {
+    if (navbar) {
+      return <NavbarDropdownItem ref={ref} {...props} />;
+    }
+
+    if (sidenav) {
+      return <SidenavDropdownItem ref={ref} {...props} />;
+    }
+
+    return <NavDropdownItem ref={ref} {...props} />;
+  }
+
+  if (navbar) {
+    return <NavbarItem ref={ref} {...props} />;
+  }
+
+  if (sidenav) {
+    return <SidenavItem ref={ref} {...props} />;
+  }
+
+  return <NavItem ref={ref} {...props} />;
+});
+
+AdaptiveNavItem.displayName = 'Nav.Item';
+
+export default AdaptiveNavItem;

--- a/src/Nav/Nav.tsx
+++ b/src/Nav/Nav.tsx
@@ -1,7 +1,7 @@
-import React, { useContext, useEffect, useMemo } from 'react';
+import React, { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import NavItem, { NavItemProps } from './NavItem';
-import { useClassNames, useEnsuredRef, useInternalId, useControlled } from '@/internals/hooks';
+import NavItem from './NavItem';
+import { useClassNames, useEnsuredRef, useControlled } from '@/internals/hooks';
 import { NavbarContext } from '../Navbar/Navbar';
 import { SidenavContext } from '../Sidenav/Sidenav';
 import { WithAsProps, RsRefForwardingComponent } from '@/internals/types';
@@ -10,13 +10,10 @@ import Menubar from '@/internals/Menu/Menubar';
 import { oneOf } from '@/internals/propTypes';
 import { deprecateComponent } from '@/internals/utils';
 import NavDropdown from './NavDropdown';
-import NavMenu, { NavMenuActionType, NavMenuContext } from './NavMenu';
+import NavMenu from './NavMenu';
 import NavDropdownItem from './NavDropdownItem';
 import NavDropdownMenu from './NavDropdownMenu';
-import NavbarDropdownItem from '../Navbar/NavbarDropdownItem';
-import SidenavDropdownItem from '../Sidenav/SidenavDropdownItem';
-import NavbarItem from '../Navbar/NavbarItem';
-import SidenavItem from '../Sidenav/SidenavItem';
+import AdaptiveNavItem from './AdaptiveNavItem';
 
 export interface NavProps<T = any>
   extends WithAsProps,
@@ -168,71 +165,7 @@ DeprecatedNavDropdown.Item = deprecateComponent(
 );
 
 Nav.Dropdown = DeprecatedNavDropdown;
-/**
- * The <Nav.Item> API
- * When used as direct child of <Nav>, render the NavItem
- * When used within a <Nav.Menu>, render the NavDropdownItem
- */
-Nav.Item = React.forwardRef((props: NavItemProps, ref: React.Ref<any>) => {
-  const nav = useContext(NavContext);
-
-  if (!nav) {
-    throw new Error('<Nav.Item> must be rendered within a <Nav> component.');
-  }
-
-  const parentNavMenu = useContext(NavMenuContext);
-  const navbar = useContext(NavbarContext);
-  const sidenav = useContext(SidenavContext);
-
-  const [, dispatch] = parentNavMenu ?? [];
-  const _id = useInternalId('Nav.Item');
-
-  useEffect(() => {
-    if (dispatch) {
-      dispatch({
-        type: NavMenuActionType.RegisterItem,
-        payload: {
-          _id,
-          eventKey: props.eventKey,
-          active: props.active ?? false
-        }
-      });
-
-      return () => {
-        dispatch({
-          type: NavMenuActionType.UnregisterItem,
-          payload: {
-            _id
-          }
-        });
-      };
-    }
-  }, [dispatch, _id, props.eventKey, props.active]);
-
-  if (parentNavMenu) {
-    if (navbar) {
-      return <NavbarDropdownItem ref={ref} {...props} />;
-    }
-
-    if (sidenav) {
-      return <SidenavDropdownItem ref={ref} {...props} />;
-    }
-
-    return <NavDropdownItem ref={ref} {...props} />;
-  }
-
-  if (navbar) {
-    return <NavbarItem ref={ref} {...props} />;
-  }
-
-  if (sidenav) {
-    return <SidenavItem ref={ref} {...props} />;
-  }
-
-  return <NavItem ref={ref} {...props} />;
-});
-Nav.Item.displayName = 'Nav.Item';
-
+Nav.Item = AdaptiveNavItem;
 Nav.Menu = NavMenu;
 
 Nav.displayName = 'Nav';

--- a/src/Nav/build.json
+++ b/src/Nav/build.json
@@ -1,6 +1,6 @@
 {
   "components": {
-    "NavItem": "Nav/NavItem",
+    "NavItem": "Nav/AdaptiveNavItem",
     "NavMenu": "Nav/NavMenu"
   }
 }

--- a/src/Nav/test/AdaptiveNavItemSpec.tsx
+++ b/src/Nav/test/AdaptiveNavItemSpec.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Nav from '../Nav';
+import NavMenu from '../NavMenu';
+import NavItem from '../AdaptiveNavItem';
+import Navbar from '../../Navbar';
+import Sidenav from '../../Sidenav';
+
+describe('<AdaptiveNavItem>', () => {
+  it('Should render a standard Nav Item', () => {
+    render(
+      <Nav>
+        <NavItem>Item</NavItem>
+      </Nav>
+    );
+
+    expect(screen.getByText('Item')).to.have.class('rs-nav-item');
+  });
+
+  it('Should render a standard Nav Dropdown Item', () => {
+    render(
+      <Nav>
+        <NavMenu>
+          <NavItem>Item</NavItem>
+        </NavMenu>
+      </Nav>
+    );
+
+    expect(screen.getByText('Item')).to.have.class('rs-dropdown-item');
+    expect(screen.getByText('Item')).to.have.attr('role', 'menuitem');
+  });
+
+  it('Should render a adaptive Navbar Item', () => {
+    render(
+      <Navbar>
+        <Nav>
+          <NavItem>Item</NavItem>
+        </Nav>
+      </Navbar>
+    );
+
+    expect(screen.getByText('Item')).to.have.class('rs-navbar-item');
+  });
+
+  it('Should render a adaptive Navbar Dropdown Item', () => {
+    render(
+      <Navbar>
+        <Nav>
+          <NavMenu>
+            <NavItem>Item</NavItem>
+          </NavMenu>
+        </Nav>
+      </Navbar>
+    );
+
+    expect(screen.getByText('Item')).to.have.class('rs-dropdown-item');
+  });
+
+  it('Should render a adaptive Sidenav Item', () => {
+    render(
+      <Sidenav>
+        <Nav>
+          <NavItem>Item</NavItem>
+        </Nav>
+      </Sidenav>
+    );
+
+    expect(screen.getByText('Item')).to.have.class('rs-sidenav-item');
+  });
+
+  it('Should render a adaptive Sidenav Dropdown Item', () => {
+    render(
+      <Sidenav>
+        <Nav>
+          <NavMenu>
+            <NavItem>Item</NavItem>
+          </NavMenu>
+        </Nav>
+      </Sidenav>
+    );
+
+    expect(screen.getByText('Item')).to.have.class('rs-dropdown-item');
+    expect(screen.getByText('Item')).to.have.attr('role', 'button');
+  });
+});


### PR DESCRIPTION
This PR solves the problem that the NavItem component imported in the following way cannot be used in Navbar and Sidenav.


```js
import NavItem from 'rsuite/NavItem';
```
