### PR TITLE
 Test: (Navbar, PanelGroup, Popover): Removing the getDOMNode and using render #3302 

### DIFF
--- a/src/Navbar/test/NavbarBodySpec.tsx
+++ b/src/Navbar/test/NavbarBodySpec.tsx
@@ -3,8 +3,10 @@ import sinon, { SinonStub } from 'sinon';
 
 import NavbarBody from '../NavbarBody';
 import { render } from '@testing-library/react';
+import { testStandardProps } from '@test/utils';
 
 describe('NavbarBody (deprecated)', () => {
+  testStandardProps(<NavbarBody />);
   beforeEach(() => {
     sinon.stub(console, 'warn').callsFake(() => null);
   });
@@ -18,24 +20,6 @@ describe('NavbarBody (deprecated)', () => {
     const { container } = render(<NavbarBody>{title}</NavbarBody>);
     expect(container.firstChild).to.have.class('rs-navbar-body');
     expect(container.firstChild?.textContent).to.equal(title);
-  });
-
-  it('Should have a custom className', () => {
-    const { container } = render(<NavbarBody className="custom" />);
-    expect(container.firstChild).to.have.class('custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const { container } = render(<NavbarBody style={{ fontSize }} />);
-    const instance = container.firstChild as HTMLElement;
-    expect(instance.style.fontSize).equal(fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const { container } = render(<NavbarBody classPrefix="custom-prefix" />);
-    const instance = container.firstChild as HTMLElement;
-    expect(instance.className).match(/\bcustom-prefix\b/);
   });
 
   it('Should warn deprecation message', () => {

--- a/src/Navbar/test/NavbarBodySpec.tsx
+++ b/src/Navbar/test/NavbarBodySpec.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import sinon, { SinonStub } from 'sinon';
-import { getDOMNode } from '@test/utils';
 
 import NavbarBody from '../NavbarBody';
+import { render } from '@testing-library/react';
 
 describe('NavbarBody (deprecated)', () => {
   beforeEach(() => {
@@ -15,29 +15,31 @@ describe('NavbarBody (deprecated)', () => {
 
   it('Should render a body', () => {
     const title = 'Test';
-    const instance = getDOMNode(<NavbarBody>{title}</NavbarBody>);
-    assert.equal(instance.className, 'rs-navbar-body');
-    assert.equal(instance.innerHTML, title);
+    const { container } = render(<NavbarBody>{title}</NavbarBody>);
+    expect(container.firstChild).to.have.class('rs-navbar-body');
+    expect(container.firstChild?.textContent).to.equal(title);
   });
 
   it('Should have a custom className', () => {
-    const instance = getDOMNode(<NavbarBody className="custom" />);
-    assert.include(instance.className, 'custom');
+    const { container } = render(<NavbarBody className="custom" />);
+    expect(container.firstChild).to.have.class('custom');
   });
 
   it('Should have a custom style', () => {
     const fontSize = '12px';
-    const instance = getDOMNode(<NavbarBody style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
+    const { container } = render(<NavbarBody style={{ fontSize }} />);
+    const instance = container.firstChild as HTMLElement;
+    expect(instance.style.fontSize).equal(fontSize);
   });
 
   it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<NavbarBody classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
+    const { container } = render(<NavbarBody classPrefix="custom-prefix" />);
+    const instance = container.firstChild as HTMLElement;
+    expect(instance.className).match(/\bcustom-prefix\b/);
   });
 
   it('Should warn deprecation message', () => {
-    getDOMNode(<NavbarBody />);
+    render(<NavbarBody />);
     assert.ok(/deprecated/i.test((console.warn as SinonStub).firstCall.args[0]));
   });
 });

--- a/src/Navbar/test/NavbarHeaderSpec.tsx
+++ b/src/Navbar/test/NavbarHeaderSpec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import sinon, { SinonStub } from 'sinon';
 import NavbarHeader from '../NavbarHeader';
-import { getDOMNode } from '@test/utils';
+import { render } from '@testing-library/react';
 
 describe('NavbarHeader (deprecated)', () => {
   beforeEach(() => {
@@ -14,30 +14,32 @@ describe('NavbarHeader (deprecated)', () => {
 
   it('Should render a header', () => {
     const title = 'Test';
-    const instance = getDOMNode(<NavbarHeader>{title}</NavbarHeader>);
-    assert.equal(instance.tagName, 'DIV');
-    assert.ok(instance.className.match(/\bnavbar-header\b/));
-    assert.equal(instance.textContent, title);
+    const { container } = render(<NavbarHeader>{title}</NavbarHeader>);
+    expect(container.firstChild).to.have.tagName('DIV');
+    expect(container.firstChild).to.have.class('rs-navbar-header');
+    expect(container.firstChild?.textContent).to.equal(title);
   });
 
   it('Should have a custom className', () => {
-    const instance = getDOMNode(<NavbarHeader className="custom" />);
-    assert.include(instance.className, 'custom');
+    const { container } = render(<NavbarHeader className="custom" />);
+    expect(container.firstChild).to.have.class('custom');
   });
 
   it('Should have a custom style', () => {
     const fontSize = '12px';
-    const instance = getDOMNode(<NavbarHeader style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
+    const { container } = render(<NavbarHeader style={{ fontSize }} />);
+    const instance = container.firstChild as HTMLElement;
+    expect(instance.style.fontSize).equal(fontSize);
   });
 
   it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(<NavbarHeader classPrefix="custom-prefix" />);
-    assert.ok(instance.className.match(/\bcustom-prefix\b/));
+    const { container } = render(<NavbarHeader classPrefix="custom-prefix" />);
+    const instance = container.firstChild as HTMLElement;
+    expect(instance.className).match(/\bcustom-prefix\b/);
   });
 
   it('Should warn deprecation message', () => {
-    getDOMNode(<NavbarHeader />);
+    render(<NavbarHeader />);
     assert.ok(/deprecated/i.test((console.warn as SinonStub).firstCall.args[0]));
   });
 });

--- a/src/Navbar/test/NavbarHeaderSpec.tsx
+++ b/src/Navbar/test/NavbarHeaderSpec.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import sinon, { SinonStub } from 'sinon';
 import NavbarHeader from '../NavbarHeader';
 import { render } from '@testing-library/react';
+import { testStandardProps } from '@test/utils';
 
 describe('NavbarHeader (deprecated)', () => {
+  testStandardProps(<NavbarHeader />);
   beforeEach(() => {
     sinon.stub(console, 'warn').callsFake(() => null);
   });
@@ -18,24 +20,6 @@ describe('NavbarHeader (deprecated)', () => {
     expect(container.firstChild).to.have.tagName('DIV');
     expect(container.firstChild).to.have.class('rs-navbar-header');
     expect(container.firstChild?.textContent).to.equal(title);
-  });
-
-  it('Should have a custom className', () => {
-    const { container } = render(<NavbarHeader className="custom" />);
-    expect(container.firstChild).to.have.class('custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const { container } = render(<NavbarHeader style={{ fontSize }} />);
-    const instance = container.firstChild as HTMLElement;
-    expect(instance.style.fontSize).equal(fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    const { container } = render(<NavbarHeader classPrefix="custom-prefix" />);
-    const instance = container.firstChild as HTMLElement;
-    expect(instance.className).match(/\bcustom-prefix\b/);
   });
 
   it('Should warn deprecation message', () => {

--- a/src/Navbar/test/NavbarSpec.tsx
+++ b/src/Navbar/test/NavbarSpec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import sinon from 'sinon';
-import { getDOMNode, testStandardProps } from '@test/utils';
+import { testStandardProps } from '@test/utils';
 import Navbar from '../Navbar';
 import Nav from '../../Nav';
 import Dropdown from '../../Dropdown';
@@ -17,8 +17,8 @@ describe('Navbar', () => {
   testStandardProps(<Navbar />);
 
   it('Should render a navbar', () => {
-    const instance = getDOMNode(<Navbar />);
-    assert.include(instance.className, 'rs-navbar');
+    const { container } = render(<Navbar />);
+    expect(container.firstChild).to.have.class('rs-navbar');
   });
 
   it('Should have a `navbar-nav` className in `nav`', () => {

--- a/src/PanelGroup/test/PanelGroupSpec.tsx
+++ b/src/PanelGroup/test/PanelGroupSpec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import sinon from 'sinon';
-import { getDOMNode, testStandardProps } from '@test/utils';
+import { testStandardProps } from '@test/utils';
 import PanelGroup from '../PanelGroup';
 import Panel from '../../Panel';
 
@@ -10,23 +10,22 @@ describe('PanelGroup', () => {
 
   it('Should render a PanelGroup', () => {
     const title = 'Test';
-    const instance = getDOMNode(<PanelGroup>{title}</PanelGroup>);
-    const instanceDom = instance;
+    const { container } = render(<PanelGroup>{title}</PanelGroup>);
 
-    assert.equal(instanceDom.tagName, 'DIV');
-    assert.ok(instanceDom.className.match(/\bpanel-group\b/));
-    assert.equal(instanceDom.textContent, title);
+    expect(container.firstChild).to.have.tagName('DIV');
+    expect(container.firstChild).to.have.class('rs-panel-group');
+    expect(container.firstChild?.textContent).to.equal(title);
   });
 
   it('Should render 2 Panels', () => {
-    const instance = getDOMNode(
+    render(
       <PanelGroup>
-        <Panel>111</Panel>
-        <Panel>222</Panel>
+        <Panel data-testid="panel">111</Panel>
+        <Panel data-testid="panel">222</Panel>
       </PanelGroup>
     );
-    // eslint-disable-next-line testing-library/no-node-access
-    assert.equal(instance.querySelectorAll('.rs-panel').length, 2);
+
+    expect(screen.getAllByTestId('panel')).to.have.length(2);
   });
 
   it('Should call onSelect callback', () => {

--- a/src/PanelGroup/test/PanelGroupStylesSpec.tsx
+++ b/src/PanelGroup/test/PanelGroupStylesSpec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import PanelGroup from '../index';
-import { getDOMNode, getStyle, itChrome } from '@test/utils';
+import { getStyle, itChrome } from '@test/utils';
 
 import '../styles/index.less';
 
@@ -9,7 +9,7 @@ describe('PanelGroup styles', () => {
   itChrome('Should render the correct styles', () => {
     const instanceRef = React.createRef();
     render(<PanelGroup ref={instanceRef} />);
-    const dom = getDOMNode(instanceRef.current);
+    const dom = instanceRef.current as Element;
     assert.equal(getStyle(dom, 'borderRadius'), '6px', 'Panel border-radius');
   });
 });

--- a/src/Popover/test/PopoverSpec.tsx
+++ b/src/Popover/test/PopoverSpec.tsx
@@ -1,31 +1,37 @@
 import React from 'react';
-import { getDOMNode, testStandardProps } from '@test/utils';
+import { testStandardProps } from '@test/utils';
 import Popover from '../Popover';
+import { render } from '@testing-library/react';
 
 describe('Popover', () => {
   testStandardProps(<Popover />);
 
   it('Should render a Popover', () => {
     const title = 'Test';
-    const instance = getDOMNode(<Popover>{title}</Popover>);
-    assert.equal(instance.tagName, 'DIV');
-    assert.equal(instance.className, 'rs-popover');
-    assert.equal(instance.textContent, title);
-    assert.equal(instance.querySelectorAll('.rs-popover-arrow').length, 1);
+    const { container } = render(<Popover>{title}</Popover>);
+
+    expect(container.firstChild).to.have.tagName('DIV');
+    expect(container.firstChild).to.have.class('rs-popover');
+    expect(container.firstChild?.textContent).to.equal(title);
+
+    //eslint-disable-next-line
+    expect(container.querySelectorAll('.rs-popover-arrow')).to.have.lengthOf(1);
   });
 
   it('Popover should without arrow', () => {
-    const instance = getDOMNode(<Popover arrow={false}>Test</Popover>);
-    assert.equal(instance.querySelectorAll('.rs-popover-arrow').length, 0);
+    const { container } = render(<Popover arrow={false}>Test</Popover>);
+
+    //eslint-disable-next-line
+    expect(container.querySelectorAll('.rs-popover-arrow')).to.have.lengthOf(0);
   });
 
   it('Should be full', () => {
-    const instance = getDOMNode(<Popover full>Test</Popover>);
-    assert.include(instance.className, 'rs-popover-full');
+    const { container } = render(<Popover full>Test</Popover>);
+    expect(container.firstChild).to.have.class('rs-popover-full');
   });
 
   it('Should have a id', () => {
-    const instance = getDOMNode(<Popover id="popover" />);
-    assert.equal(instance.id, 'popover');
+    const { container } = render(<Popover id="popover" />);
+    expect(container.firstChild).to.have.id('popover');
   });
 });


### PR DESCRIPTION
Why I am doing this: https://github.com/rsuite/rsuite/discussions/3200
What I did: removing the getDOMNode and using the render in @testing-library/react

This update involves 3 component changes: Navbar, PanelGroup, Popover