### PR TITLE
feat(InputNumber): add support for `decimalSeparator` prop

### DIFF
--- a/docs/pages/components/input-number/en-US/index.md
+++ b/docs/pages/components/input-number/en-US/index.md
@@ -20,6 +20,12 @@ An input component that can only enter numbers.
 
 <!--{include:`decimals.md`}-->
 
+### Decimal separator
+
+A decimal separator is a symbol that separates the integer part from the fractional part of a number written in decimal form (e.g., "." in 12.45). Different countries officially designate different symbols for use as the separator.
+
+<!--{include:`decimal-separator.md`}-->
+
 ### Formatter
 
 <!--{include:`formatter.md`}-->
@@ -52,18 +58,22 @@ limits: 10 - 100
 
 <!-- prettier-sort-markdown-table -->
 
-| Property     | Type `(Default)`                      | Description                                                                                               |
-| ------------ | ------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| classPrefix  | string `('input-number')`             | The prefix of the component CSS class.                                                                    |
-| defaultValue | number                                | Default value.                                                                                            |
-| disabled     | boolean                               | Disabled component.                                                                                       |
-| formatter    | (value: number) => string             | A format string used to display the number value. <br/>![](https://img.shields.io/badge/min-v5.55.0-blue) |
-| max          | number                                | Maximum value.                                                                                            |
-| min          | number                                | Minimum value.                                                                                            |
-| onChange     | (value: number , event) => void       | The callback function when value changes.                                                                 |
-| postfix      | ReactNode                             | Sets the element displayed on the right side of the component.                                            |
-| prefix       | ReactNode                             | Sets the element displayed to the left of the component.                                                  |
-| scrollable   | boolean `(true)`                      | Whether the value can be changed through the wheel event.                                                 |
-| size         | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')` | An input can have different sizes.                                                                        |
-| step         | number `(1)`                          | The value of each step. can be decimal.                                                                   |
-| value        | number                                | Value (Controlled).                                                                                       |
+| Property         | Type `(Default)`                      | Description                                                        |
+| ---------------- | ------------------------------------- | ------------------------------------------------------------------ |
+| classPrefix      | string `('input-number')`             | The prefix of the component CSS class.                             |
+| decimalSeparator | string                                | The decimal separator <br/>![][5.69.0]                             |
+| defaultValue     | number                                | Default value.                                                     |
+| disabled         | boolean                               | Disabled component.                                                |
+| formatter        | (value: number) => string             | A format string used to display the number value. <br/>![][5.55.0] |
+| max              | number                                | Maximum value.                                                     |
+| min              | number                                | Minimum value.                                                     |
+| onChange         | (value: number , event) => void       | The callback function when value changes.                          |
+| postfix          | ReactNode                             | Sets the element displayed on the right side of the component.     |
+| prefix           | ReactNode                             | Sets the element displayed to the left of the component.           |
+| scrollable       | boolean `(true)`                      | Whether the value can be changed through the wheel event.          |
+| size             | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')` | An input can have different sizes.                                 |
+| step             | number `(1)`                          | The value of each step. can be decimal.                            |
+| value            | number                                | Value (Controlled).                                                |
+
+[5.69.0]: https://img.shields.io/badge/min-v5.69.0-blue
+[5.55.0]: https://img.shields.io/badge/min-v5.55.0-blue

--- a/docs/pages/components/input-number/fragments/decimal-separator.md
+++ b/docs/pages/components/input-number/fragments/decimal-separator.md
@@ -1,0 +1,15 @@
+<!--start-code-->
+
+```js
+import { InputNumber, Stack } from 'rsuite';
+
+const App = () => (
+  <Stack>
+    <InputNumber defaultValue={3.14159} step={0.00001} decimalSeparator="," />
+  </Stack>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/input-number/zh-CN/index.md
+++ b/docs/pages/components/input-number/zh-CN/index.md
@@ -16,9 +16,15 @@
 
 <!--{include:`size.md`}-->
 
-### 浮点数
+### 小数
 
 <!--{include:`decimals.md`}-->
+
+### 小数点分隔符
+
+小数点分隔符是一个符号，用于将十进制形式的数字的整数部分与小数部分分开（例如，12.45 中的 "."）。不同的国家地区会指定不同的符号作为分隔符。
+
+<!--{include:`decimal-separator.md`}-->
 
 ### 格式化
 
@@ -52,18 +58,22 @@
 
 <!-- prettier-sort-markdown-table -->
 
-| 属性名称     | 类型 `(默认值)`                       | 描述                                                                     |
-| ------------ | ------------------------------------- | ------------------------------------------------------------------------ |
-| classPrefix  | string `('input-number')`             | 组件 CSS 类的前缀                                                        |
-| defaultValue | number                                | 设置默认值                                                               |
-| disabled     | boolean                               | 禁用                                                                     |
-| formatter    | (value: number) => string             | 格式化输入框的值 <br/>![](https://img.shields.io/badge/min-v5.55.0-blue) |
-| max          | number                                | 最大值                                                                   |
-| min          | number                                | 最小值                                                                   |
-| onChange     | (value: number, event) => void        | `value` 发生改变时的回调函数                                             |
-| postfix      | ReactNode                             | 后缀                                                                     |
-| prefix       | ReactNode                             | 前缀                                                                     |
-| scrollable   | boolean `(true)`                      | 是否可以通过鼠标滚动更新值                                               |
-| size         | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')` | 设置输入框尺寸                                                           |
-| step         | number `(1)`                          | 每次改变步数，可以为小数                                                 |
-| value        | number                                | 设置值 `受控`                                                            |
+| 属性名称         | 类型 `(默认值)`                       | 描述                             |
+| ---------------- | ------------------------------------- | -------------------------------- |
+| classPrefix      | string `('input-number')`             | 组件 CSS 类的前缀                |
+| decimalSeparator | string                                | 小数点分隔符<br/>![][5.69.0]     |
+| defaultValue     | number                                | 设置默认值                       |
+| disabled         | boolean                               | 禁用                             |
+| formatter        | (value: number) => string             | 格式化输入框的值<br/>![][5.55.0] |
+| max              | number                                | 最大值                           |
+| min              | number                                | 最小值                           |
+| onChange         | (value: number, event) => void        | `value` 发生改变时的回调函数     |
+| postfix          | ReactNode                             | 后缀                             |
+| prefix           | ReactNode                             | 前缀                             |
+| scrollable       | boolean `(true)`                      | 是否可以通过鼠标滚动更新值       |
+| size             | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')` | 设置输入框尺寸                   |
+| step             | number `(1)`                          | 每次改变步数，可以为小数         |
+| value            | number                                | 设置值 `受控`                    |
+
+[5.69.0]: https://img.shields.io/badge/min-v5.69.0-blue
+[5.55.0]: https://img.shields.io/badge/min-v5.55.0-blue

--- a/src/InputNumber/test/InputNumberSpec.tsx
+++ b/src/InputNumber/test/InputNumberSpec.tsx
@@ -310,4 +310,30 @@ describe('InputNumber', () => {
       });
     });
   });
+
+  describe('Decimal separator', () => {
+    it('Should render a decimal separator', () => {
+      render(<InputNumber value={0.1} />);
+
+      expect(screen.getByRole('textbox')).to.have.value('0.1');
+    });
+
+    it('Should render a decimal separator with a custom separator', () => {
+      render(<InputNumber value={0.1} decimalSeparator="," />);
+
+      expect(screen.getByRole('textbox')).to.have.value('0,1');
+    });
+
+    it('Should allow input of custom decimal separator', () => {
+      const onChange = sinon.spy();
+
+      render(<InputNumber decimalSeparator="," onChange={onChange} />);
+
+      userEvent.type(screen.getByRole('textbox'), '1,2');
+      fireEvent.blur(screen.getByRole('textbox'));
+
+      expect(screen.getByRole('textbox')).to.have.value('1,2');
+      expect(onChange.lastCall).to.have.been.calledWith('1.2');
+    });
+  });
 });


### PR DESCRIPTION
To solve this requirement  https://github.com/rsuite/rsuite/issues/3899


In other languages and cultures, the decimal point may not be a ".". The main decimal point symbols used in countries and regions using Arabic numerals are "," and ".". Chinese-speaking areas and most English-speaking areas use ".", but most other European countries and their former colonies use ",".


Add a `decimalSeparator` property to officially designate different symbols as separators for different countries/regions.
### Usage
```
<InputNumber decimalSeparator="," />
```