### PR TITLE
Test: (InputNumber, IconButton, FormControl): Removing the getDOMNode and using render

### DIFF
--- a/src/FormControl/test/FormControlSpec.tsx
+++ b/src/FormControl/test/FormControlSpec.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
-import { getDOMNode } from '@test/utils';
 import Form, { FormInstance } from '../../Form';
 import FormControl from '../FormControl';
 import FormGroup from '../../FormGroup';
@@ -28,6 +27,29 @@ describe('FormControl', () => {
     );
 
     expect(screen.getByRole('textbox')).to.have.tagName('TEXTAREA');
+  });
+
+  it('Should have a custom style', () => {
+    render(
+      <Form>
+        <FormControl style={{ fontSize: 12 }} name="username" />
+      </Form>
+    );
+
+    expect(screen.getByRole('textbox')).to.have.style('font-size', '12px');
+  });
+
+  it('Should have a custom className prefix', () => {
+    const { container } = render(
+      <Form>
+        <FormControl classPrefix="custom-prefix" name="username" data-testid="control" />
+      </Form>
+    );
+
+    expect(
+      // eslint-disable-next-line
+      (container.querySelector('div') as HTMLDivElement).className
+    ).to.match(/\bcustom-prefix\b/);
   });
 
   it('Should call onChange callback', () => {
@@ -88,29 +110,6 @@ describe('FormControl', () => {
     );
 
     expect(screen.getByRole('textbox')).to.have.class('custom');
-  });
-
-  it('Should have a custom style', () => {
-    render(
-      <Form>
-        <FormControl style={{ fontSize: 12 }} name="username" />
-      </Form>
-    );
-
-    expect(screen.getByRole('textbox')).to.have.style('font-size', '12px');
-  });
-
-  it('Should have a custom className prefix', () => {
-    const instance = getDOMNode(
-      <Form>
-        <FormControl classPrefix="custom-prefix" name="username" data-testid="control" />
-      </Form>
-    );
-
-    assert.ok(
-      // eslint-disable-next-line testing-library/no-node-access
-      (instance.querySelector('div') as HTMLDivElement).className.match(/\bcustom-prefix\b/)
-    );
   });
 
   it('Should render correctly when form value was null', () => {

--- a/src/IconButton/test/IconButtonSpec.tsx
+++ b/src/IconButton/test/IconButtonSpec.tsx
@@ -8,15 +8,17 @@ describe('IconButton', () => {
   testStandardProps(<IconButton />);
 
   it('Should output a button', () => {
-    const { container } = render(<IconButton />);
+    render(<IconButton />);
+    const iconButton = screen.getByRole('button');
 
-    expect(screen.getByRole('button')).to.have.class('rs-btn-icon');
-    expect(container.firstChild).to.have.tagName('BUTTON');
+    expect(iconButton).to.have.class('rs-btn-icon');
+    expect(iconButton.tagName).to.be.equal('BUTTON');
   });
 
-  it('Should output a icon', () => {
-    const { container } = render(<IconButton icon={<User />} />);
-    //eslint-disable-next-line
-    expect(container.querySelector('.rs-icon')).to.exist;
+  it('Should output an icon', async () => {
+    render(<IconButton icon={<User />} />);
+    const icon = await screen.findByRole('button');
+
+    expect(icon).to.exist;
   });
 });

--- a/src/IconButton/test/IconButtonSpec.tsx
+++ b/src/IconButton/test/IconButtonSpec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { testStandardProps } from '@test/utils';
 import User from '@rsuite/icons/legacy/User';
 import IconButton from '../IconButton';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 describe('IconButton', () => {
   testStandardProps(<IconButton />);
@@ -10,7 +10,7 @@ describe('IconButton', () => {
   it('Should output a button', () => {
     const { container } = render(<IconButton />);
 
-    expect(container.firstChild).to.have.class('rs-btn-icon');
+    expect(screen.getByRole('button')).to.have.class('rs-btn-icon');
     expect(container.firstChild).to.have.tagName('BUTTON');
   });
 

--- a/src/IconButton/test/IconButtonSpec.tsx
+++ b/src/IconButton/test/IconButtonSpec.tsx
@@ -1,20 +1,22 @@
 import React from 'react';
-import { getDOMNode } from '@test/utils';
 import { testStandardProps } from '@test/utils';
 import User from '@rsuite/icons/legacy/User';
 import IconButton from '../IconButton';
+import { render } from '@testing-library/react';
 
 describe('IconButton', () => {
   testStandardProps(<IconButton />);
 
   it('Should output a button', () => {
-    const instance = getDOMNode(<IconButton />);
-    assert.include(instance.className, 'rs-btn-icon');
-    assert.equal(instance.nodeName, 'BUTTON');
+    const { container } = render(<IconButton />);
+
+    expect(container.firstChild).to.have.class('rs-btn-icon');
+    expect(container.firstChild).to.have.tagName('BUTTON');
   });
 
   it('Should output a icon', () => {
-    const instance = getDOMNode(<IconButton icon={<User />} />);
-    assert.ok(instance.querySelector('.rs-icon'));
+    const { container } = render(<IconButton icon={<User />} />);
+    //eslint-disable-next-line
+    expect(container.querySelector('.rs-icon')).to.exist;
   });
 });

--- a/src/IconButton/test/IconButtonStylesSpec.tsx
+++ b/src/IconButton/test/IconButtonStylesSpec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import IconButton from '../index';
 import { getStyle, inChrome } from '@test/utils';
 
@@ -9,14 +9,18 @@ describe('IconButton styles', () => {
   it('Should render the correct width and height', () => {
     const instanceRef = React.createRef<HTMLButtonElement>();
     render(<IconButton ref={instanceRef} />);
-    const { container } = render(<IconButton ref={instanceRef} />);
-    const dom = container.firstChild as HTMLElement;
-    expect(getStyle(dom, 'width')).to.equal(getStyle(dom, 'height'));
+    const iconButton = screen.getByRole('button');
+
+    expect(getStyle(iconButton as Element, 'width')).to.equal(
+      getStyle(iconButton as Element, 'height')
+    );
   });
 
   it('Should render the correct border-radius', () => {
     const instanceRef = React.createRef<HTMLButtonElement>();
-    const { container } = render(<IconButton circle ref={instanceRef} />);
-    inChrome && expect(getStyle(container.firstChild as Element, 'borderRadius')).to.equal('50%');
+    render(<IconButton circle ref={instanceRef} />);
+    const iconButton = screen.getByRole('button');
+
+    inChrome && expect(getStyle(iconButton as Element, 'borderRadius')).to.equal('50%');
   });
 });

--- a/src/IconButton/test/IconButtonStylesSpec.tsx
+++ b/src/IconButton/test/IconButtonStylesSpec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import IconButton from '../index';
-import { getDOMNode, getStyle, inChrome } from '@test/utils';
+import { getStyle, inChrome } from '@test/utils';
 
 import '../styles/index.less';
 
@@ -9,13 +9,14 @@ describe('IconButton styles', () => {
   it('Should render the correct width and height', () => {
     const instanceRef = React.createRef<HTMLButtonElement>();
     render(<IconButton ref={instanceRef} />);
-    const dom = getDOMNode(instanceRef.current);
-    assert.equal(getStyle(dom, 'width'), getStyle(dom, 'height'));
+    const { container } = render(<IconButton ref={instanceRef} />);
+    const dom = container.firstChild as HTMLElement;
+    expect(getStyle(dom, 'width')).to.equal(getStyle(dom, 'height'));
   });
 
-  it('Should render the correct border-raidus', () => {
+  it('Should render the correct border-radius', () => {
     const instanceRef = React.createRef<HTMLButtonElement>();
-    render(<IconButton circle ref={instanceRef} />);
-    inChrome && assert.equal(getStyle(getDOMNode(instanceRef.current), 'borderRadius'), '50%');
+    const { container } = render(<IconButton circle ref={instanceRef} />);
+    inChrome && expect(getStyle(container.firstChild as Element, 'borderRadius')).to.equal('50%');
   });
 });

--- a/src/InputNumber/test/InputNumberSpec.tsx
+++ b/src/InputNumber/test/InputNumberSpec.tsx
@@ -2,12 +2,7 @@ import React from 'react';
 import { render, fireEvent, act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
-import {
-  getDOMNode,
-  testStandardProps,
-  testControlledUnControlled,
-  testFormControl
-} from '@test/utils';
+import { testStandardProps, testControlledUnControlled, testFormControl } from '@test/utils';
 import InputNumber from '../InputNumber';
 
 describe('InputNumber', () => {
@@ -38,8 +33,8 @@ describe('InputNumber', () => {
   });
 
   it('Should render a input', () => {
-    const domNode = getDOMNode(<InputNumber />);
-    assert.include(domNode.className, 'rs-input-number');
+    const { container } = render(<InputNumber />);
+    expect(container.firstChild).to.have.class('rs-input-number');
   });
 
   it('Should output a subtle button', () => {

--- a/src/InputNumber/test/InputNumberStylesSpec.tsx
+++ b/src/InputNumber/test/InputNumberStylesSpec.tsx
@@ -1,22 +1,21 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import InputNumber from '../index';
-import { getDOMNode, getStyle, toRGB, inChrome } from '@test/utils';
+import { getStyle, toRGB, inChrome } from '@test/utils';
 
 import '../styles/index.less';
 
 describe('InputNumber styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef();
-    render(<InputNumber ref={instanceRef} />);
-    const dom = getDOMNode(instanceRef.current);
-    assert.equal(getStyle(dom, 'backgroundColor'), toRGB('#fff'), 'InputNumber background-color');
+
+    const { container } = render(<InputNumber ref={instanceRef} />);
+    expect(getStyle(container.firstChild as Element, 'backgroundColor')).to.equal(toRGB('#fff'));
     inChrome &&
-      assert.equal(
-        getStyle(dom, 'border'),
+      expect(getStyle(container.firstChild as Element, 'border')).to.equal(
         `1px solid ${toRGB('#e5e5ea')}`,
         'InputNumber border-color'
       );
-    assert.equal(getStyle(dom, 'height'), '36px', 'InputNumber height');
+    expect(getStyle(container.firstChild as Element, 'height')).to.equal('36px');
   });
 });


### PR DESCRIPTION
Why I am doing this: https://github.com/rsuite/rsuite/discussions/3200
What I did: removing the getDOMNode and using the render in @testing-library/react

This update involves 3 component changes: InputNumber, IconButton, FormControl

*I hope this time is ok