### PR TITLE
fix(MultiCascadeTree,MultiCascader): fix parent node is not in a mixed state when searching

### DIFF
--- a/docs/pages/components/multi-cascade-tree/en-US/index.md
+++ b/docs/pages/components/multi-cascade-tree/en-US/index.md
@@ -53,26 +53,27 @@ This tree allows the use of the `getChildren` option and the length of the child
 
 <!-- prettier-sort-markdown-table -->
 
-| Property              | Type`(Default)`                                                                    | Description                                            |
-| --------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| childrenKey           | string `('children')`                                                              | Set children key in data                               |
-| classPrefix           | string `('multi-cascade-tree')`                                                    | The prefix of the component CSS class                  |
-| columnHeight          | number                                                                             | Sets the height of the column                          |
-| columnWidth           | number                                                                             | Sets the width of the column                           |
-| data \*               | [ItemDataType][item][]                                                             | The data of component                                  |
-| defaultValue          | string[]                                                                             | Specifies the default value of the selected items      |
-| disabledItemValues    | string[]                                                                           | Disabled items                                         |
-| getChildren           | (item: [ItemDataType][item]) => Promise&lt;[ItemDataType][item][]&gt;              | Asynchronously load the children of the tree node.     |
-| labelKey              | string `('label')`                                                                 | Set label key in data                                  |
-| onChange              | (value: string[], event) => void                                                   | Callback fired when value changes                      |
-| onSearch              | (value: string, event) => void                                                     | Callback fired when search value changes               |
-| onSelect              | (item: [ItemDataType][item], selectedPaths: [ItemDataType][item][], event) => void | Callback fired when item is selected                   |
-| renderColumn          | (childNodes: ReactNode, column: { items, parentItem, layer}) => ReactNode          | Custom render column                                   |
-| renderTreeNode        | (node: ReactNode, item: [ItemDataType][item]) => ReactNode                         | Custom render item                                     |
-| searchable            | boolean                                                                            | Whether to enable search                               |
-| uncheckableItemValues | string[]                                                                           | Set uncheckable items                                  |
-| value                 | string[]                                                                             | Specifies the values of the selected items(Controlled) |
-| valueKey              | string `('value')`                                                                 | Set value key in data                                  |
+| Property              | Type`(Default)`                                                                    | Description                                                                                      |
+| --------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| cascade               | boolean `(true)`                                                                   | Determines whether selection should cascade both from parent to child and child to parent nodes. |
+| childrenKey           | string `('children')`                                                              | Defines the key used to access child nodes in the data.                                          |
+| classPrefix           | string `('multi-cascade-tree')`                                                    | Sets the CSS class prefix for the component.                                                     |
+| columnHeight          | number                                                                             | Specifies the height of each column.                                                             |
+| columnWidth           | number                                                                             | Specifies the width of each column.                                                              |
+| data \*               | [ItemDataType][item][]                                                             | Defines the data structure used by the component.                                                |
+| defaultValue          | string[]                                                                           | Specifies the default selected values.                                                           |
+| disabledItemValues    | string[]                                                                           | Defines the items that should be disabled.                                                       |
+| getChildren           | (item: [ItemDataType][item]) => Promise&lt;[ItemDataType][item][]&gt;              | Asynchronously loads the children of a tree node.                                                |
+| labelKey              | string `('label')`                                                                 | Defines the key used to access labels in the data.                                               |
+| onChange              | (value: string[], event) => void                                                   | Callback triggered when the selected value changes.                                              |
+| onSearch              | (value: string, event) => void                                                     | Callback triggered when the search value changes.                                                |
+| onSelect              | (item: [ItemDataType][item], selectedPaths: [ItemDataType][item][], event) => void | Callback triggered when an item is selected.                                                     |
+| renderColumn          | (childNodes: ReactNode, column: { items, parentItem, layer}) => ReactNode          | Customizes the rendering of each column.                                                         |
+| renderTreeNode        | (node: ReactNode, item: [ItemDataType][item]) => ReactNode                         | Customizes the rendering of each tree node.                                                      |
+| searchable            | boolean                                                                            | Determines whether the search functionality is enabled.                                          |
+| uncheckableItemValues | string[]                                                                           | Specifies the items that cannot be checked.                                                      |
+| value                 | string[]                                                                           | Defines the currently selected values (controlled component).                                    |
+| valueKey              | string `('value')`                                                                 | Defines the key used to access values in the data.                                               |
 
 <!--{include:(_common/types/item-data-type.md)}-->
 

--- a/docs/pages/components/multi-cascade-tree/zh-CN/index.md
+++ b/docs/pages/components/multi-cascade-tree/zh-CN/index.md
@@ -53,26 +53,27 @@ MultiCascadeTree 是一个按列显示树形结构数据的组件，支持多选
 
 <!-- prettier-sort-markdown-table -->
 
-| 属性名称              | 类型`(默认值)`                                                                     | 描述                                 |
-| --------------------- | ---------------------------------------------------------------------------------- | ------------------------------------ |
-| childrenKey           | string `('children')`                                                              | 设置选项子节点在 `data` 中的 `key`   |
-| classPrefix           | string `('multi-cascade-tree')`                                                    | 组件 CSS 类的前缀                    |
-| columnHeight          | number                                                                             | 设置列的高度                         |
-| columnWidth           | number                                                                             | 设置列的宽度                         |
-| data \*               | [ItemDataType][item][]                                                             | 组件数据                             |
-| defaultValue          | string[]                                                                             | 默认值                               |
-| disabledItemValues    | string[]                                                                           | 禁用选项                             |
-| getChildren           | (item: [ItemDataType][item]) => Promise&lt;[ItemDataType][item][]&gt;              | 异步加载树节点的子级                 |
-| labelKey              | string `('label')`                                                                 | 设置选项显示内容在 `data` 中的 `key` |
-| onChange              | (value: string[], event) => void                                                   | 值变化后的回调函数                   |
-| onSearch              | (value: string, event) => void                                                     | 搜索值变化后的回调函数               |
-| onSelect              | (item: [ItemDataType][item], selectedPaths: [ItemDataType][item][], event) => void | 选项被点击选择后的回调函数           |
-| renderColumn          | (childNodes: ReactNode, column: { items, parentItem, layer}) => ReactNode          | 紫丁香渲染列                         |
-| renderTreeNode        | (node: ReactNode, item: [ItemDataType][item]) => ReactNode                         | 自定义选项                           |
-| searchable            | boolean                                                                            | 是否启用搜索                         |
-| uncheckableItemValues | string[]                                                                           | 设置不可选中的选项                   |
-| value                 | string[]                                                                             | 设置值（受控）                       |
-| valueKey              | string `('value')`                                                                 |  设置 `value` 在 `data` 的属性名称                                |
+| 属性                  | 类型`(默认值)`                                                                     | 描述                                       |
+| --------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------ |
+| cascade               | boolean `(true)`                                                                   | 确定选择是否在父节点与子节点之间双向级联。 |
+| childrenKey           | string `('children')`                                                              | 定义用于访问子节点的键。                   |
+| classPrefix           | string `('multi-cascade-tree')`                                                    | 设置组件的 CSS 类前缀。                    |
+| columnHeight          | number                                                                             | 指定每列的高度。                           |
+| columnWidth           | number                                                                             | 指定每列的宽度。                           |
+| data \*               | [ItemDataType][item][]                                                             | 定义组件使用的数据结构。                   |
+| defaultValue          | string[]                                                                           | 指定默认选中的值。                         |
+| disabledItemValues    | string[]                                                                           | 定义应禁用的项目。                         |
+| getChildren           | (item: [ItemDataType][item]) => Promise&lt;[ItemDataType][item][]&gt;              | 异步加载树节点的子节点。                   |
+| labelKey              | string `('label')`                                                                 | 定义用于访问标签的键。                     |
+| onChange              | (value: string[], event) => void                                                   | 当选中的值更改时触发的回调函数。           |
+| onSearch              | (value: string, event) => void                                                     | 当搜索值更改时触发的回调函数。             |
+| onSelect              | (item: [ItemDataType][item], selectedPaths: [ItemDataType][item][], event) => void | 当项目被选中时触发的回调函数。             |
+| renderColumn          | (childNodes: ReactNode, column: { items, parentItem, layer}) => ReactNode          | 自定义每列的渲染。                         |
+| renderTreeNode        | (node: ReactNode, item: [ItemDataType][item]) => ReactNode                         | 自定义每个树节点的渲染。                   |
+| searchable            | boolean                                                                            | 确定是否启用搜索功能。                     |
+| uncheckableItemValues | string[]                                                                           | 指定无法选中的项目。                       |
+| value                 | string[]                                                                           | 定义当前选中的值（受控组件）。             |
+| valueKey              | string `('value')`                                                                 | 定义用于访问值的键。                       |
 
 <!--{include:(_common/types/item-data-type.md)}-->
 

--- a/docs/pages/components/multi-cascader/en-US/index.md
+++ b/docs/pages/components/multi-cascader/en-US/index.md
@@ -87,72 +87,64 @@ The `MultiCascader` component is used to select multiple values from cascading o
 
 ### `<MultiCascader>`
 
-<!-- prettier-sort-markdown-table -->
-
-| Property              | Type`(Default)`                                                                             | Description                                                      |
-| --------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| appearance            | 'default' &#124; 'subtle' `('default')`                                                     | Set picker appearence                                            |
-| block                 | boolean                                                                                     | Blocking an entire row                                           |
-| caretAs               | ElementType                                                                                 | Custom component for the caret icon                              |
-| cascade               | boolean `(true)`                                                                            | whether cascade select                                           |
-| childrenKey           | string `('children')`                                                                       | Set children key in data                                         |
-| classPrefix           | string `('picker')`                                                                         | The prefix of the component CSS class                            |
-| cleanable             | boolean `(true)`                                                                            | Whether the selected value can be cleared                        |
-| container             | HTMLElement &#124; (() => HTMLElement)                                                      | Sets the rendering container                                     |
-| countable             | boolean `(true)`                                                                            | Can count selected options                                       |
-| data \*               | [ItemDataType][item][]                                                                      | The data of component                                            |
-| defaultOpen           | boolean                                                                                     | Default value of open property                                   |
-| defaultValue          | string[]                                                                                      | Default values of the selected items                             |
-| disabled              | boolean                                                                                     | Disabled component                                               |
-| disabledItemValues    | string                                                                                      | Disabled items                                                   |
-| height                | number `(320)`                                                                              | The height of Dropdown                                           |
-| inline                | boolean                                                                                     | The menu is displayed directly when the component is initialized |
-| ~inline~              | boolean                                                                                     | ⚠️`[Deprecated]` Use the `<MultiCascadeTree>` component instead  |
-| labelKey              | string `('label')`                                                                          | Set label key in data                                            |
-| loading               | boolean `(false)`                                                                           | Whether to display a loading state indicator                     |
-| locale                | [PickerLocaleType](/guide/i18n/#pickers)                                                    | Locale text                                                      |
-| ~menuClassName~       | string                                                                                      | ⚠️`[Deprecated]` Use `popupClassName` instead                    |
-| ~menuHeight~          | number                                                                                      | ⚠️`[Deprecated]` Use `columnHeight` instead                      |
-| ~menuStyle~           | CSSProperties                                                                               | ⚠️`[Deprecated]` Use `popupStyle` instead                        |
-| ~menuWidth~           | number                                                                                      | ⚠️`[Deprecated]` Use `columnWidth` instead                       |
-| onChange              | (value: string, event) => void                                                              | Callback fired when value change                                 |
-| onCheck               | (value: string, item: [ItemDataType][item], checked: boolean, event) => void;               | Called after the checkbox state changes                          |
-| onClean               | (event) => void                                                                             | Callback fired when value clean                                  |
-| onClose               | () => void                                                                                  | Callback fired when close component                              |
-| onEnter               | () => void                                                                                  | Callback fired before the overlay transitions in                 |
-| onEntered             | () => void                                                                                  | Callback fired after the overlay finishes transitioning in       |
-| onEntering            | () => void                                                                                  | Callback fired as the overlay begins to transition in            |
-| onExit                | () => void                                                                                  | Callback fired right before the overlay transitions out          |
-| onExited              | () => void                                                                                  | Callback fired after the overlay finishes transitioning out      |
-| onExiting             | () => void                                                                                  | Callback fired as the overlay begins to transition out           |
-| onOpen                | () => void                                                                                  | Callback fired when open component                               |
-| onSearch              | (searchKeyword:string, event) => void                                                       | callback function for Search                                     |
-| onSelect              | (item: [ItemDataType][item], selectedPaths: [ItemDataType][item][], event) => void          | Callback fired when item is selected                             |
-| open                  | boolean                                                                                     | Whether open the component                                       |
-| placeholder           | ReactNode `('Select')`                                                                      | Setting placeholders                                             |
-| placement             | [Placement](#code-ts-placement-code)`('bottomStart')`                                       | The placement of component                                       |
-| popupClassName        | string                                                                                      | Custom class name for the popup                                  |
-| popupStyle            | CSSProperties                                                                               | Custom style for the popup                                       |
-| preventOverflow       | boolean                                                                                     | Prevent floating element overflow                                |
-| ~rendeMenu~           | (node: ReactNode, column: { items, parentItem, layer}) => ReactNode                         | ⚠️`[Deprecated]` Use `renderColumn` instead                      |
-| renderColumn          | (childNodes: ReactNode, column: { items, parentItem, layer}) => ReactNode                   | Customizing the Rendering Menu list                              |
-| renderExtraFooter     | () => ReactNode                                                                             | custom render extra footer                                       |
-| ~renderMenu~          | (children: object[], menu:ReactNode, parentNode?: object, layer?: number) => ReactNode      | ⚠️`[Deprecated]` Use `renderColumn` instead                      |
-| ~renderMenuItem~      | (label:ReactNode, item: [ItemDataType][item]) => ReactNode                                  | ⚠️`[Deprecated]` Use `renderTreeNode` instead                    |
-| ~renderMenuItem~      | (node: ReactNode, item: [ItemDataType][item]) => ReactNode                                  | ⚠️`[Deprecated]` Use `renderTreeNode` instead                    |
-| renderTreeNode        | (node: ReactNode, item: [ItemDataType][item]) => ReactNode                                  | Custom render menu items                                         |
-| renderValue           | (value:string,selectedItems: [ItemDataType][item][],selectedElement:ReactNode) => ReactNode | Custom render selected items                                     |
-| searchable            | boolean `(true)`                                                                            | Whether you can search for options.                              |
-| size                  | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')`                                           | A picker can have different sizes                                |
-| toggleAs              | ElementType `('a')`                                                                         | You can use a custom element for this component                  |
-| uncheckableItemValues | string                                                                                      | Set the option value for the check box not to be rendered        |
-| value                 | string[]                                                                                      | Specifies the values of the selected items(Controlled)           |
-| valueKey              | string `('value')`                                                                          | Set value key in data                                            |
+| Property              | Type`(Default)`                                                                                 | Description                                                                                      |
+| --------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| appearance            | 'default' &#124; 'subtle' `('default')`                                                         | Sets the appearance of the picker.                                                               |
+| block                 | boolean                                                                                         | Blocks the entire row.                                                                           |
+| caretAs               | ElementType                                                                                     | Custom component for the caret icon.                                                             |
+| cascade               | boolean `(true)`                                                                                | Determines whether selection should cascade both from parent to child and child to parent nodes. |
+| childrenKey           | string `('children')`                                                                           | Defines the key used to access child nodes in the data.                                          |
+| classPrefix           | string `('picker')`                                                                             | Sets the CSS class prefix for the component.                                                     |
+| cleanable             | boolean `(true)`                                                                                | Determines whether the selected value can be cleared.                                            |
+| container             | HTMLElement &#124; (() => HTMLElement)                                                          | Sets the rendering container.                                                                    |
+| countable             | boolean `(true)`                                                                                | Enables counting of selected options.                                                            |
+| data \*               | [ItemDataType][item][]                                                                          | Defines the data structure used by the component.                                                |
+| defaultOpen           | boolean                                                                                         | Specifies whether the component is open by default.                                              |
+| defaultValue          | string[]                                                                                        | Specifies the default selected values.                                                           |
+| disabled              | boolean                                                                                         | Disables the component.                                                                          |
+| disabledItemValues    | string                                                                                          | Defines the values of items that should be disabled.                                             |
+| height                | number `(320)`                                                                                  | Specifies the height of the dropdown.                                                            |
+| inline                | boolean                                                                                         | Displays the menu directly when the component is initialized.                                    |
+| ~inline~              | boolean                                                                                         | ⚠️`[Deprecated]` Use the `<MultiCascadeTree>` component instead.                                 |
+| labelKey              | string `('label')`                                                                              | Defines the key used to access labels in the data.                                               |
+| loading               | boolean `(false)`                                                                               | Determines whether to display a loading state indicator.                                         |
+| locale                | [PickerLocaleType](/guide/i18n/#pickers)                                                        | Sets the locale text.                                                                            |
+| ~menuClassName~       | string                                                                                          | ⚠️`[Deprecated]` Use `popupClassName` instead.                                                   |
+| ~menuHeight~          | number                                                                                          | ⚠️`[Deprecated]` Use `columnHeight` instead.                                                     |
+| ~menuStyle~           | CSSProperties                                                                                   | ⚠️`[Deprecated]` Use `popupStyle` instead.                                                       |
+| ~menuWidth~           | number                                                                                          | ⚠️`[Deprecated]` Use `columnWidth` instead.                                                      |
+| onChange              | (value: string[], event) => void                                                                | Callback fired when the selected value changes.                                                  |
+| onCheck               | (value: string, item: [ItemDataType][item], checked: boolean, event) => void                    | Callback fired after the checkbox state changes.                                                 |
+| onClean               | (event) => void                                                                                 | Callback fired when the value is cleared.                                                        |
+| onClose               | () => void                                                                                      | Callback fired when the component is closed.                                                     |
+| onEnter               | () => void                                                                                      | Callback fired before the overlay transitions in.                                                |
+| onEntered             | () => void                                                                                      | Callback fired after the overlay finishes transitioning in.                                      |
+| onEntering            | () => void                                                                                      | Callback fired as the overlay begins to transition in.                                           |
+| onExit                | () => void                                                                                      | Callback fired right before the overlay transitions out.                                         |
+| onExited              | () => void                                                                                      | Callback fired after the overlay finishes transitioning out.                                     |
+| onExiting             | () => void                                                                                      | Callback fired as the overlay begins to transition out.                                          |
+| onOpen                | () => void                                                                                      | Callback fired when the component is opened.                                                     |
+| onSearch              | (searchKeyword: string, event) => void                                                          | Callback function for search.                                                                    |
+| onSelect              | (item: [ItemDataType][item], selectedPaths: [ItemDataType][item][], event) => void              | Callback fired when an item is selected.                                                         |
+| open                  | boolean                                                                                         | Determines whether the component is open.                                                        |
+| placeholder           | ReactNode `('Select')`                                                                          | Sets the placeholder text.                                                                       |
+| placement             | [Placement](#code-ts-placement-code)`('bottomStart')`                                           | Sets the placement of the component.                                                             |
+| popupClassName        | string                                                                                          | Custom class name for the popup.                                                                 |
+| popupStyle            | CSSProperties                                                                                   | Custom style for the popup.                                                                      |
+| preventOverflow       | boolean                                                                                         | Prevents the floating element from overflowing.                                                  |
+| ~renderMenu~          | (node: ReactNode, column: { items, parentItem, layer}) => ReactNode                             | ⚠️`[Deprecated]` Use `renderColumn` instead.                                                     |
+| renderColumn          | (childNodes: ReactNode, column: { items, parentItem, layer}) => ReactNode                       | Customizes the rendering of each column.                                                         |
+| renderExtraFooter     | () => ReactNode                                                                                 | Customizes the rendering of the extra footer.                                                    |
+| renderTreeNode        | (node: ReactNode, item: [ItemDataType][item]) => ReactNode                                      | Customizes the rendering of each tree node.                                                      |
+| renderValue           | (value: string, selectedItems: [ItemDataType][item][], selectedElement: ReactNode) => ReactNode | Customizes the rendering of the selected items.                                                  |
+| searchable            | boolean `(true)`                                                                                | Determines whether the search functionality is enabled.                                          |
+| size                  | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')`                                               | Sets the size of the picker.                                                                     |
+| toggleAs              | ElementType `('a')`                                                                             | Specifies a custom element for the component.                                                    |
+| uncheckableItemValues | string                                                                                          | Sets the values of items that cannot be checked.                                                 |
+| value                 | string[]                                                                                        | Specifies the values of the selected items (controlled).                                         |
+| valueKey              | string `('value')`                                                                              | Defines the key used to access values in the data.                                               |
 
 <!--{include:(_common/types/item-data-type.md)}-->
 <!--{include:(_common/types/placement-start.md)}-->
 
-\
-
 [item]: #code-ts-item-data-type-code
-[value]: #code-ts-value-type-code

--- a/docs/pages/components/multi-cascader/zh-CN/index.md
+++ b/docs/pages/components/multi-cascader/zh-CN/index.md
@@ -83,74 +83,64 @@
 
 ## Props
 
-<!--{include:(_common/types/item-data-type.md)}-->
-
 ### `<MultiCascader>`
 
-<!-- prettier-sort-markdown-table -->
-
-| 属性名称              | 类型`(默认值)`                                                                                  | 描述                                       |
-| --------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| appearance            | 'default' &#124; 'subtle' `('default')`                                                         | 设置外观                                   |
-| block                 | boolean                                                                                         | 堵塞整行                                   |
-| caretAs               | ElementType                                                                                     | 自定义右侧箭头图标的组件                   |
-| cascade               | boolean `(true)`                                                                                | 是否级联选择                               |
-| childrenKey           | string `('children')`                                                                           | 设置选项子节点在 `data` 中的 `key`         |
-| classPrefix           | string `('picker')`                                                                             | 组件 CSS 类的前缀                          |
-| cleanable             | boolean `(true)`                                                                                | 可以清除                                   |
-| columnHeight          | number                                                                                          | 设置菜单的高度                             |
-| columnWidth           | number                                                                                          | 设置菜单的宽度                             |
-| container             | HTMLElement &#124; (() => HTMLElement)                                                          | 设置渲染的容器                             |
-| countable             | boolean `(true)`                                                                                | 可以计数已选项                             |
-| data \*               | [ItemDataType][item][]                                                                          | 组件数据                                   |
-| defaultOpen           | boolean                                                                                         | 默认打开                                   |
-| defaultValue          | string[]                                                                                          | 设置默认值                                 |
-| disabled              | boolean                                                                                         | 禁用组件                                   |
-| disabledItemValues    | string                                                                                          | 禁用选项                                   |
-| height                | number `(320)`                                                                                  | 设置 Dropdown 的高度                       |
-| inline                | boolean                                                                                         | 在组件初始后直接展示菜单                   |
-| ~inline~              | boolean                                                                                         | ⚠️`[已弃用]` 使用 `<CascadeTree>` 组件代替 |
-| labelKey              | string `('label')`                                                                              | 设置选项显示内容在 `data` 中的 `key`       |
-| loading               | boolean `(false)`                                                                               | 是否显示一个加载中状态指示器               |
-| locale                | [PickerLocaleType](/zh/guide/i18n/#pickers)                                                     | 本地化的文本                               |
-| menuClassName         | string                                                                                          | 选项菜单的 className                       |
-| ~menuClassName~       | string                                                                                          | ⚠️`[已弃用]` 使用 `popupClassName` 代替    |
-| menuHeight            | number `(200)`                                                                                  | 设置菜单的高度                             |
-| ~menuHeight~          | number                                                                                          | ⚠️`[已弃用]` 使用 `columnHeight` 代替      |
-| ~menuStyle~           | CSSProperties                                                                                   | ⚠️`[已弃用]` 使用 `popupStyle` 代替        |
-| menuWidth             | number `(156)`                                                                                  | 设置菜单的宽度                             |
-| ~menuWidth~           | number                                                                                          | ⚠️`[已弃用]` 使用 `columnWidth` 代替       |
-| onChange              | (value: string, event) => void                                                                  | `value` 发生改变时的回调函数               |
-| onCheck               | (value: ValueType, item:[ItemDataType][item], checked:boolean, event) => void;                  | 复选框选中状态发生变化的回调函数           |
-| onClean               | (event) => void                                                                                 | 清空值时触发回调                           |
-| onClose               | () => void                                                                                      | 关闭回调函数                               |
-| onEnter               | () => void                                                                                      | 显示前动画过渡的回调函数                   |
-| onEntered             | () => void                                                                                      | 显示后动画过渡的回调函数                   |
-| onEntering            | () => void                                                                                      | 显示中动画过渡的回调函数                   |
-| onExit                | () => void                                                                                      | 退出前动画过渡的回调函数                   |
-| onExited              | () => void                                                                                      | 退出后动画过渡的回调函数                   |
-| onExiting             | () => void                                                                                      | 退出中动画过渡的回调函数                   |
-| onOpen                | () => void                                                                                      | 打开回调函数                               |
-| onSearch              | (searchKeyword:string, event) => void                                                           | 搜索的回调函数                             |
-| onSelect              | (item:[ItemDataType][item], selectedPaths: [ItemDataType][item][], event) => void               | 选项被点击选择后的回调函数                 |
-| open                  | boolean                                                                                         | 打开 (受控)                                |
-| placeholder           | ReactNode `('Select')`                                                                          | 占位符                                     |
-| placement             | [Placement](#code-ts-placement-code)`('bottomStart')`                                           | 打开位置                                   |
-| popupClassName        | string                                                                                          | 设置弹出层的 CSS 类名                      |
-| popupStyle            | CSSProperties                                                                                   | 设置弹出层的样式                           |
-| preventOverflow       | boolean                                                                                         | 防止浮动元素溢出                           |
-| renderColumn          | (childNodes: ReactNode, column: { items, parentItem, layer}) => ReactNode                       | 自定义渲染菜单列表                         |
-| renderExtraFooter     | () => ReactNode                                                                                 | 自定义页脚内容                             |
-| ~renderMenu~          | (children: object[], menu:ReactNode, parentNode?: object, layer?: number) => ReactNode          | ⚠️`[已弃用]` 使用 `renderColumn` 代替      |
-| ~renderMenuItem~      | (label:ReactNode, item: [ItemDataType][item] ) => ReactNode                                     | ⚠️`[已弃用]` 使用 `renderTreeNode` 代替    |
-| renderTreeNode        | (node: ReactNode, item: [ItemDataType][item]) => ReactNode                                      | 自定义选项                                 |
-| renderValue           | (value:string, selectedItems: [ItemDataType][item][], selectedElement: ReactNode ) => ReactNode | 自定义被选中的选项                         |
-| searchable            | boolean `(true)`                                                                                | 可以搜索                                   |
-| size                  | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')`                                               | 设置组件尺寸                               |
-| toggleAs              | ElementType `('a')`                                                                             | 为组件自定义元素类型                       |
-| uncheckableItemValues | string                                                                                          | 设置不显示复选框的选项值                   |
-| value                 | string[]                                                                                          | 设置值（受控）                             |
-| valueKey              | string `('value')`                                                                              | 设置选项值在 `data` 中的 `key`             |
+| 属性                  | 类型`(默认值)`                                                                                  | 描述                                            |
+| --------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| appearance            | 'default' &#124; 'subtle' `('default')`                                                         | 设置选择器的外观样式。                          |
+| block                 | boolean                                                                                         | 块级显示，占满整个行。                          |
+| caretAs               | ElementType                                                                                     | 自定义下拉箭头的组件。                          |
+| cascade               | boolean `(true)`                                                                                | 确定选择是否应该在父节点与子节点之间双向级联。  |
+| childrenKey           | string `('children')`                                                                           | 定义数据中用于访问子节点的键名。                |
+| classPrefix           | string `('picker')`                                                                             | 设置组件的 CSS 类前缀。                         |
+| cleanable             | boolean `(true)`                                                                                | 是否允许清除已选择的值。                        |
+| container             | HTMLElement &#124; (() => HTMLElement)                                                          | 设置渲染容器。                                  |
+| countable             | boolean `(true)`                                                                                | 启用已选项的计数显示。                          |
+| data \*               | [ItemDataType][item][]                                                                          | 定义组件使用的数据结构。                        |
+| defaultOpen           | boolean                                                                                         | 是否默认打开组件。                              |
+| defaultValue          | string[]                                                                                        | 指定默认选中的值。                              |
+| disabled              | boolean                                                                                         | 禁用组件。                                      |
+| disabledItemValues    | string                                                                                          | 定义应禁用的选项值。                            |
+| height                | number `(320)`                                                                                  | 指定下拉菜单的高度。                            |
+| inline                | boolean                                                                                         | 初始化时直接显示菜单。                          |
+| ~inline~              | boolean                                                                                         | ⚠️`[已弃用]` 请改用 `<MultiCascadeTree>` 组件。 |
+| labelKey              | string `('label')`                                                                              | 定义数据中用于访问标签的键名。                  |
+| loading               | boolean `(false)`                                                                               | 是否显示加载状态指示器。                        |
+| locale                | [PickerLocaleType](/guide/i18n/#pickers)                                                        | 设置本地化文本。                                |
+| ~menuClassName~       | string                                                                                          | ⚠️`[已弃用]` 请改用 `popupClassName`。          |
+| ~menuHeight~          | number                                                                                          | ⚠️`[已弃用]` 请改用 `columnHeight`。            |
+| ~menuStyle~           | CSSProperties                                                                                   | ⚠️`[已弃用]` 请改用 `popupStyle`。              |
+| ~menuWidth~           | number                                                                                          | ⚠️`[已弃用]` 请改用 `columnWidth`。             |
+| onChange              | (value: string[], event) => void                                                                | 当选择的值发生变化时触发的回调函数。            |
+| onCheck               | (value: string, item: [ItemDataType][item], checked: boolean, event) => void                    | 当复选框状态变化时触发的回调函数。              |
+| onClean               | (event) => void                                                                                 | 当清除值时触发的回调函数。                      |
+| onClose               | () => void                                                                                      | 当组件关闭时触发的回调函数。                    |
+| onEnter               | () => void                                                                                      | 在浮层过渡开始前触发的回调函数。                |
+| onEntered             | () => void                                                                                      | 在浮层完成过渡后触发的回调函数。                |
+| onEntering            | () => void                                                                                      | 在浮层开始过渡时触发的回调函数。                |
+| onExit                | () => void                                                                                      | 在浮层过渡结束前触发的回调函数。                |
+| onExited              | () => void                                                                                      | 在浮层完成过渡后触发的回调函数。                |
+| onExiting             | () => void                                                                                      | 在浮层开始过渡结束时触发的回调函数。            |
+| onOpen                | () => void                                                                                      | 当组件打开时触发的回调函数。                    |
+| onSearch              | (searchKeyword: string, event) => void                                                          | 搜索时触发的回调函数。                          |
+| onSelect              | (item: [ItemDataType][item], selectedPaths: [ItemDataType][item][], event) => void              | 当选中某个选项时触发的回调函数。                |
+| open                  | boolean                                                                                         | 是否打开组件。                                  |
+| placeholder           | ReactNode `('Select')`                                                                          | 设置占位符文本。                                |
+| placement             | [Placement](#code-ts-placement-code)`('bottomStart')`                                           | 设置组件的弹出位置。                            |
+| popupClassName        | string                                                                                          | 自定义弹出框的类名。                            |
+| popupStyle            | CSSProperties                                                                                   | 自定义弹出框的样式。                            |
+| preventOverflow       | boolean                                                                                         | 防止浮动元素溢出。                              |
+| ~renderMenu~          | (node: ReactNode, column: { items, parentItem, layer}) => ReactNode                             | ⚠️`[已弃用]` 请改用 `renderColumn`。            |
+| renderColumn          | (childNodes: ReactNode, column: { items, parentItem, layer}) => ReactNode                       | 自定义每一列的渲染方式。                        |
+| renderExtraFooter     | () => ReactNode                                                                                 | 自定义额外页脚的渲染方式。                      |
+| renderTreeNode        | (node: ReactNode, item: [ItemDataType][item]) => ReactNode                                      | 自定义树节点的渲染方式。                        |
+| renderValue           | (value: string, selectedItems: [ItemDataType][item][], selectedElement: ReactNode) => ReactNode | 自定义已选项的渲染方式。                        |
+| searchable            | boolean `(true)`                                                                                | 是否启用搜索功能。                              |
+| size                  | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')`                                               | 设置选择器的大小。                              |
+| toggleAs              | ElementType `('a')`                                                                             | 使用自定义元素作为组件。                        |
+| uncheckableItemValues | string                                                                                          | 设置无法勾选的选项值。                          |
+| value                 | string[]                                                                                        | 指定已选项的值（受控）。                        |
+| valueKey              | string `('value')`                                                                              | 定义数据中用于访问值的键名。                    |
 
 <!--{include:(_common/types/item-data-type.md)}-->
 <!--{include:(_common/types/placement-start.md)}-->

--- a/src/MultiCascadeTree/MultiCascadeTree.tsx
+++ b/src/MultiCascadeTree/MultiCascadeTree.tsx
@@ -78,6 +78,7 @@ const MultiCascadeTree = React.forwardRef(
       <Component ref={ref} className={classes} {...rest}>
         {searchable && (
           <SearchView
+            cascade={cascade}
             data={items}
             value={value}
             searchKeyword={searchKeyword}

--- a/src/MultiCascadeTree/test/MultiCascadeTreeSpec.tsx
+++ b/src/MultiCascadeTree/test/MultiCascadeTreeSpec.tsx
@@ -150,7 +150,7 @@ describe('MultiCascadeTree', () => {
 
     fireEvent.change(searchbox, { target: { value: '3' } });
 
-    expect(screen.getByRole('checkbox', { name: ['3', '3-1'].join('') })).to.be.checked;
+    expect(screen.getByRole('checkbox', { name: /3-1/ })).to.be.checked;
     expect(screen.getByRole('checkbox', { name: '3' })).to.have.attribute('aria-checked', 'mixed');
   });
 

--- a/src/MultiCascadeTree/test/MultiCascadeTreeSpec.tsx
+++ b/src/MultiCascadeTree/test/MultiCascadeTreeSpec.tsx
@@ -132,15 +132,26 @@ describe('MultiCascadeTree', () => {
   });
 
   it('Should call `onSearch` callback ', () => {
-    const onSearchSpy = sinon.spy();
-    render(<MultiCascadeTree data={items} onSearch={onSearchSpy} searchable />);
+    const onSearch = sinon.spy();
+    render(<MultiCascadeTree data={items} onSearch={onSearch} searchable />);
 
     const searchbox = screen.getByRole('searchbox');
 
     fireEvent.change(searchbox, { target: { value: '3' } });
 
     expect(screen.getAllByRole('treeitem')).to.have.length(3);
-    expect(onSearchSpy).to.have.been.calledOnce;
+    expect(onSearch).to.have.been.calledOnce;
+  });
+
+  it('Should cascade update the parent node when search', () => {
+    render(<MultiCascadeTree data={items} searchable defaultValue={['3-1']} />);
+
+    const searchbox = screen.getByRole('searchbox');
+
+    fireEvent.change(searchbox, { target: { value: '3' } });
+
+    expect(screen.getByRole('checkbox', { name: ['3', '3-1'].join('') })).to.be.checked;
+    expect(screen.getByRole('checkbox', { name: '3' })).to.have.attribute('aria-checked', 'mixed');
   });
 
   it('Should update the subcolumn when the leaf node is clicked', () => {

--- a/src/MultiCascader/MultiCascader.tsx
+++ b/src/MultiCascader/MultiCascader.tsx
@@ -355,6 +355,7 @@ const MultiCascader: PickerComponent<MultiCascaderProps<DataItemValue>> = React.
         >
           {searchable && (
             <SearchView
+              cascade={cascade}
               data={items}
               value={value}
               searchKeyword={searchKeyword}

--- a/src/MultiCascader/test/MultiCascaderSpec.tsx
+++ b/src/MultiCascader/test/MultiCascaderSpec.tsx
@@ -443,7 +443,7 @@ describe('MultiCascader', () => {
 
     fireEvent.change(searchbox, { target: { value: '3' } });
 
-    expect(screen.getByRole('checkbox', { name: ['3', '3-1'].join('') })).to.be.checked;
+    expect(screen.getByRole('checkbox', { name: /3-1/ })).to.be.checked;
     expect(screen.getByRole('checkbox', { name: '3' })).to.have.attribute('aria-checked', 'mixed');
   });
 

--- a/src/MultiCascader/test/MultiCascaderSpec.tsx
+++ b/src/MultiCascader/test/MultiCascaderSpec.tsx
@@ -436,6 +436,17 @@ describe('MultiCascader', () => {
     expect(onSearch).to.have.been.calledOnce;
   });
 
+  it('Should cascade update the parent node when search', () => {
+    render(<MultiCascader data={items} defaultOpen defaultValue={['3-1']} />);
+
+    const searchbox = screen.getByRole('searchbox');
+
+    fireEvent.change(searchbox, { target: { value: '3' } });
+
+    expect(screen.getByRole('checkbox', { name: ['3', '3-1'].join('') })).to.be.checked;
+    expect(screen.getByRole('checkbox', { name: '3' })).to.have.attribute('aria-checked', 'mixed');
+  });
+
   it('Should update the subcolumn when the leaf node is clicked', () => {
     render(<MultiCascader data={items} open />);
 


### PR DESCRIPTION
By default, when searching, if a keyword matches both the parent node and the child node at the same time, if the child node is selected, the parent node should be in a mixed state. Unless `cascade` is set to `false`, the selection status of the child node will not affect the selection status of the parent node.

close: https://github.com/rsuite/rsuite/pull/3922