### PR TITLE
test(Modal): refactor test cases using `testStandardProps`

### DIFF
--- a/src/Modal/test/ModalBodySpec.tsx
+++ b/src/Modal/test/ModalBodySpec.tsx
@@ -1,27 +1,14 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import ModalBody from '../ModalBody';
+import { testStandardProps } from '@test/utils';
 
 const modalBodyText = 'Test';
 describe('ModalBody', () => {
+  testStandardProps(<ModalBody></ModalBody>);
+
   it('Should render a modal body', () => {
     render(<ModalBody>{modalBodyText}</ModalBody>);
     expect(screen.getByText(modalBodyText)).to.have.class('rs-modal-body');
-  });
-
-  it('Should have a custom className', () => {
-    render(<ModalBody className="custom">{modalBodyText}</ModalBody>);
-    expect(screen.getByText(modalBodyText)).to.have.class('custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    render(<ModalBody style={{ fontSize }}>{modalBodyText}</ModalBody>);
-    expect(screen.getByText(modalBodyText)).to.have.style('font-size', fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    render(<ModalBody classPrefix="custom-prefix">{modalBodyText}</ModalBody>);
-    expect(screen.getByText(modalBodyText).className).to.match(/\bcustom-prefix\b/);
   });
 });

--- a/src/Modal/test/ModalDialogSpec.tsx
+++ b/src/Modal/test/ModalDialogSpec.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import ModalDialog from '../ModalDialog';
+import { testStandardProps } from '@test/utils';
 
 describe('ModalDialog', () => {
+  testStandardProps(<ModalDialog></ModalDialog>);
+
   it('Should render a dialog', () => {
     const title = 'Test';
     render(<ModalDialog>{title}</ModalDialog>);
@@ -23,22 +26,6 @@ describe('ModalDialog', () => {
     const fontSize = '12px';
     render(<ModalDialog dialogStyle={{ fontSize }} />);
     expect(screen.getByRole('document')).to.have.style('font-size', fontSize);
-  });
-
-  it('Should have a custom className', () => {
-    render(<ModalDialog className="custom" />);
-    expect(screen.getByRole('dialog')).to.have.class('custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    render(<ModalDialog style={{ fontSize }} />);
-    expect(screen.getByRole('dialog')).to.have.style('font-size', fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    render(<ModalDialog classPrefix="custom-prefix" />);
-    expect(screen.getByRole('dialog').className).to.match(/\bcustom-prefix\b/);
   });
 
   describe('a11y', () => {

--- a/src/Modal/test/ModalFooterSpec.tsx
+++ b/src/Modal/test/ModalFooterSpec.tsx
@@ -2,28 +2,15 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import ModalFooter from '../ModalFooter';
+import { testStandardProps } from '@test/utils';
 
 const footerText = 'Test';
 
 describe('ModalFooter', () => {
+  testStandardProps(<ModalFooter></ModalFooter>);
+
   it('Should render a modal footer', () => {
     render(<ModalFooter>{footerText}</ModalFooter>);
     expect(screen.getByText(footerText)).to.have.class('rs-modal-footer');
-  });
-
-  it('Should have a custom className', () => {
-    render(<ModalFooter className="custom">{footerText}</ModalFooter>);
-    expect(screen.getByText(footerText)).to.have.class('custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    render(<ModalFooter style={{ fontSize }}>{footerText}</ModalFooter>);
-    expect(screen.getByText(footerText)).to.have.style('font-size', fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    render(<ModalFooter classPrefix="custom-prefix">{footerText}</ModalFooter>);
-    expect(screen.getByText(footerText).className).to.match(/\bcustom-prefix\b/);
   });
 });

--- a/src/Modal/test/ModalHeaderSpec.tsx
+++ b/src/Modal/test/ModalHeaderSpec.tsx
@@ -4,10 +4,12 @@ import { render, screen } from '@testing-library/react';
 import ModalHeader from '../ModalHeader';
 import Sinon from 'sinon';
 import userEvent from '@testing-library/user-event';
+import { testStandardProps } from '@test/utils';
 
 const headerText = 'Test';
 
 describe('ModalHeader', () => {
+  testStandardProps(<ModalHeader></ModalHeader>);
   it('Should render a modal header', () => {
     render(<ModalHeader>{headerText}</ModalHeader>);
     expect(screen.getByText(headerText)).to.have.class('rs-modal-header');
@@ -24,21 +26,5 @@ describe('ModalHeader', () => {
     userEvent.click(screen.getByRole('button'));
 
     expect(onClose).to.have.been.calledOnce;
-  });
-
-  it('Should have a custom className', () => {
-    render(<ModalHeader className="custom">{headerText}</ModalHeader>);
-    expect(screen.getByText(headerText)).to.have.class('custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    render(<ModalHeader style={{ fontSize }}>{headerText}</ModalHeader>);
-    expect(screen.getByText(headerText)).to.have.style('font-size', fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    render(<ModalHeader classPrefix="custom-prefix">{headerText}</ModalHeader>);
-    expect(screen.getByText(headerText).className).to.match(/\bcustom-prefix\b/);
   });
 });

--- a/src/Modal/test/ModalSpec.tsx
+++ b/src/Modal/test/ModalSpec.tsx
@@ -2,11 +2,14 @@ import React from 'react';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
-import { getDOMNode } from '@test/utils';
+import { getDOMNode, testStandardProps } from '@test/utils';
 import Modal from '../Modal';
 import SelectPicker from '../../SelectPicker';
 
 describe('Modal', () => {
+  testStandardProps(<Modal open></Modal>, {
+    getRootElement: () => screen.getByRole('dialog')
+  });
   it('Should render the modal content', () => {
     render(
       <Modal open>
@@ -88,22 +91,22 @@ describe('Modal', () => {
     });
   });
 
-  it('Should have a custom className', () => {
-    render(<Modal className="custom" open />);
-    expect(screen.getByRole('dialog')).to.have.class('custom');
-  });
+  // it('Should have a custom className', () => {
+  //   render(<Modal className="custom" open />);
+  //   expect(screen.getByRole('dialog')).to.have.class('custom');
+  // });
 
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    render(<Modal style={{ fontSize }} open size={200} />);
+  // it('Should have a custom style', () => {
+  //   const fontSize = '12px';
+  //   render(<Modal style={{ fontSize }} open size={200} />);
 
-    expect(screen.getByRole('dialog')).to.have.style('font-size', fontSize);
-  });
+  //   expect(screen.getByRole('dialog')).to.have.style('font-size', fontSize);
+  // });
 
-  it('Should have a custom className prefix', () => {
-    render(<Modal classPrefix="custom-prefix" open />);
-    expect(screen.getByRole('dialog').className).to.match(/\bcustom-prefix\b/);
-  });
+  // it('Should have a custom className prefix', () => {
+  //   render(<Modal classPrefix="custom-prefix" open />);
+  //   expect(screen.getByRole('dialog').className).to.match(/\bcustom-prefix\b/);
+  // });
 
   it('Should call onOpen callback', () => {
     const onOpenSpy = sinon.spy();

--- a/src/Modal/test/ModalSpec.tsx
+++ b/src/Modal/test/ModalSpec.tsx
@@ -91,23 +91,6 @@ describe('Modal', () => {
     });
   });
 
-  // it('Should have a custom className', () => {
-  //   render(<Modal className="custom" open />);
-  //   expect(screen.getByRole('dialog')).to.have.class('custom');
-  // });
-
-  // it('Should have a custom style', () => {
-  //   const fontSize = '12px';
-  //   render(<Modal style={{ fontSize }} open size={200} />);
-
-  //   expect(screen.getByRole('dialog')).to.have.style('font-size', fontSize);
-  // });
-
-  // it('Should have a custom className prefix', () => {
-  //   render(<Modal classPrefix="custom-prefix" open />);
-  //   expect(screen.getByRole('dialog').className).to.match(/\bcustom-prefix\b/);
-  // });
-
   it('Should call onOpen callback', () => {
     const onOpenSpy = sinon.spy();
     type AppInstance = {

--- a/src/Modal/test/ModalTitleSpec.tsx
+++ b/src/Modal/test/ModalTitleSpec.tsx
@@ -2,27 +2,13 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import ModalTitle from '../ModalTitle';
+import { testStandardProps } from '@test/utils';
 
 const titleText = 'Test';
 describe('ModalTitle', () => {
+  testStandardProps(<ModalTitle></ModalTitle>);
   it('Should render a modal title', () => {
     render(<ModalTitle>{titleText}</ModalTitle>);
     expect(screen.getByText(titleText)).to.have.class('rs-modal-title');
-  });
-
-  it('Should have a custom className', () => {
-    render(<ModalTitle className="custom">{titleText}</ModalTitle>);
-    expect(screen.getByText(titleText).className).to.match(/\bcustom\b/);
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    render(<ModalTitle style={{ fontSize }}>{titleText}</ModalTitle>);
-    expect(screen.getByText(titleText)).to.have.style('font-size', fontSize);
-  });
-
-  it('Should have a custom className prefix', () => {
-    render(<ModalTitle classPrefix="custom-prefix">{titleText}</ModalTitle>);
-    expect(screen.getByText(titleText).className).to.match(/\bcustom-prefix\b/);
   });
 });


### PR DESCRIPTION
Why I am doing this: https://github.com/rsuite/rsuite/discussions/3200
What I did: refactored some tests to use testStandardProps

This PR involves just one component: Modal

