### PR TITLE
refactor(Breadcrumb): use a more reasonable DOM structure to improve accessibility

### DIFF
--- a/src/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/Breadcrumb/BreadcrumbItem.tsx
@@ -5,17 +5,35 @@ import { useClassNames } from '@/internals/hooks';
 import { WithAsProps, RsRefForwardingComponent } from '@/internals/types';
 
 export interface BreadcrumbItemProps extends WithAsProps<React.ElementType | string> {
-  // Style as the currently active section
+  /**
+   * The wrapper element of the BreadcrumbItem.
+   */
+  wrapperAs?: React.ElementType;
+
+  /**
+   * The active state of the BreadcrumbItem.
+   */
   active?: boolean;
 
-  // Render as an `a` tag instead of a `div` and adds the href attribute
+  /**
+   * The href attribute specifies the URL of the page the link goes to.
+   */
   href?: string;
 
-  // Display title.
+  /**
+   * The title attribute specifies extra information about an element.
+   */
   title?: string;
 
-  // The target attribute specifies where to open the linked document
+  /**
+   * The target attribute specifies where to open the linked document.
+   */
   target?: string;
+
+  /**
+   * The separator between each breadcrumb item.
+   */
+  separator?: React.ReactNode;
 }
 
 /**
@@ -25,8 +43,9 @@ export interface BreadcrumbItemProps extends WithAsProps<React.ElementType | str
 const BreadcrumbItem: RsRefForwardingComponent<'a', BreadcrumbItemProps> = React.forwardRef(
   (props: BreadcrumbItemProps, ref: React.Ref<any>) => {
     const {
-      as: Component = props.href ? SafeAnchor : 'span',
+      wrapperAs: WrapperComponent = 'li',
       href,
+      as: Component = href ? SafeAnchor : 'span',
       classPrefix = 'breadcrumb-item',
       title,
       target,
@@ -34,32 +53,24 @@ const BreadcrumbItem: RsRefForwardingComponent<'a', BreadcrumbItemProps> = React
       style,
       active,
       children,
+      separator,
       ...rest
     } = props;
 
     const { merge, withClassPrefix } = useClassNames(classPrefix);
     const classes = merge(className, withClassPrefix({ active }));
 
-    if (active) {
-      return (
-        <span ref={ref} {...rest} style={style} className={classes}>
-          {children}
-        </span>
-      );
-    }
-
     return (
-      <Component
-        {...rest}
-        href={href}
-        title={title}
-        target={target}
-        ref={ref}
-        style={style}
-        className={classes}
-      >
-        {children}
-      </Component>
+      <WrapperComponent style={style} className={classes} ref={ref} {...rest}>
+        {active ? (
+          <span>{children}</span>
+        ) : (
+          <Component href={href} title={title} target={target}>
+            {children}
+          </Component>
+        )}
+        {separator}
+      </WrapperComponent>
     );
   }
 );

--- a/src/Breadcrumb/styles/index.less
+++ b/src/Breadcrumb/styles/index.less
@@ -9,9 +9,19 @@
   font-size: @breadcrumb-font-size;
   color: var(--rs-text-secondary);
 
+  ol {
+    display: flex;
+    flex-wrap: wrap;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
   // If breadcrumbs has a ci
   &-item {
     transition: color 0.3s linear;
+    display: flex;
+    align-items: center;
 
     &:focus {
       .tab-focus();

--- a/src/Breadcrumb/test/BreadcrumbItemSpec.tsx
+++ b/src/Breadcrumb/test/BreadcrumbItemSpec.tsx
@@ -1,41 +1,41 @@
 import React from 'react';
+import sinon from 'sinon';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { testStandardProps } from '@test/utils';
 import Breadcrumb from '../Breadcrumb';
 import BreadcrumbItem from '../BreadcrumbItem';
-import Sinon from 'sinon';
-import { fireEvent, render, screen } from '@testing-library/react';
 
 describe('Breadcrumb.Item', () => {
   testStandardProps(<BreadcrumbItem />);
 
-  it('Should render `a` as inner element when is not active', () => {
+  it('Should render an anchor element when `href` is provided and `active` is false', () => {
     const { container } = render(<Breadcrumb.Item href="#">Crumb</Breadcrumb.Item>);
 
     expect(container.firstChild).to.not.have.class('rs-breadcrumb-item-active');
-    expect(container.firstChild).to.have.tagName('a');
+    expect(screen.getByText('Crumb')).to.have.tagName('A');
   });
 
-  it('Should render `span.active` with `active` attribute set.', () => {
-    const { container } = render(<Breadcrumb.Item active>Active Crumb</Breadcrumb.Item>);
+  it('Should render a span element with `active` class when `active` is true', () => {
+    const { container } = render(<Breadcrumb.Item active>Crumb</Breadcrumb.Item>);
 
     expect(container.firstChild).to.have.class('rs-breadcrumb-item-active');
-    expect(container.firstChild).to.have.tagName('SPAN');
+    expect(screen.getByText('Crumb')).to.have.tagName('SPAN');
   });
 
-  it('Should render `span.active` when active and has href', () => {
+  it('Should render a span element when `active` is true, even if `href` is provided', () => {
     const { container } = render(
       <Breadcrumb.Item href="#" active>
-        Active Crumb
+        Crumb
       </Breadcrumb.Item>
     );
 
     expect(container.firstChild).to.have.class('rs-breadcrumb-item-active');
-    expect(container.firstChild).to.have.tagName('SPAN');
-    expect(container.firstChild).to.not.have.attr('href');
+    expect(screen.getByText('Crumb')).to.have.tagName('SPAN');
+    expect(screen.getByText('Crumb')).to.not.have.attribute('href');
   });
 
-  it('Should spread additional props onto inner element', () => {
-    const onClick = Sinon.spy();
+  it('Should pass additional props to the inner element', () => {
+    const onClick = sinon.spy();
 
     render(
       <Breadcrumb.Item href="#" onClick={onClick}>
@@ -48,7 +48,7 @@ describe('Breadcrumb.Item', () => {
     expect(onClick).to.have.been.calledOnce;
   });
 
-  it('Should apply id onto the anchor', () => {
+  it('Should apply `id` to the anchor element', () => {
     const { container } = render(
       <Breadcrumb.Item href="#" id="test-link-id">
         Crumb
@@ -58,39 +58,59 @@ describe('Breadcrumb.Item', () => {
     expect(container.firstChild).to.have.id('test-link-id');
   });
 
-  it('Should apply `href` property onto `a` inner element', () => {
-    const { container } = render(
-      <Breadcrumb.Item href="http://rsuitejs.com/">Crumb</Breadcrumb.Item>
-    );
+  it('Should apply `href` attribute to the anchor element', () => {
+    render(<Breadcrumb.Item href="http://rsuitejs.com/">Crumb</Breadcrumb.Item>);
 
-    expect(container.firstChild).to.have.attribute('href', 'http://rsuitejs.com/');
+    expect(screen.getByText('Crumb')).to.have.attribute('href', 'http://rsuitejs.com/');
   });
 
-  it('Should apply `title` property onto `a` inner element', () => {
-    const { container } = render(
+  it('Should apply `title` attribute to the anchor element', () => {
+    render(
       <Breadcrumb.Item title="test-title" href="http://rsuitejs.com/">
         Crumb
       </Breadcrumb.Item>
     );
 
-    expect(container.firstChild).to.have.attribute('title', 'test-title');
+    expect(screen.getByText('Crumb')).to.have.attribute('title', 'test-title');
   });
 
-  it('Should set `target` attribute on `anchor`', () => {
-    const { container } = render(
+  it('Should apply `target` attribute to the anchor element', () => {
+    render(
       <Breadcrumb.Item target="_blank" href="http://rsuitejs.com/">
         Crumb
       </Breadcrumb.Item>
     );
 
-    expect(container.firstChild).to.have.attribute('target', '_blank');
+    expect(screen.getByText('Crumb')).to.have.attribute('target', '_blank');
   });
 
-  it('Should be rendered as an a element, only if the href prop is set', () => {
-    const { container, rerender } = render(<Breadcrumb.Item />);
-    expect(container.firstChild).to.have.tagName('SPAN');
+  it('Should render as an `a` element when `href` is set, otherwise as a `span`', () => {
+    const { rerender } = render(<Breadcrumb.Item>Crumb</Breadcrumb.Item>);
+    expect(screen.getByText('Crumb')).to.have.tagName('SPAN');
 
-    rerender(<Breadcrumb.Item href="#" />);
-    expect(container.firstChild).to.have.tagName('A');
+    rerender(<Breadcrumb.Item href="#">Crumb</Breadcrumb.Item>);
+    expect(screen.getByText('Crumb')).to.have.tagName('A');
+  });
+
+  it('Should render with a custom `as` element', () => {
+    render(
+      <Breadcrumb.Item as="div" href="#">
+        Crumb
+      </Breadcrumb.Item>
+    );
+
+    expect(screen.getByText('Crumb')).to.have.tagName('DIV');
+  });
+
+  it('Should render with a custom `wrapperAs` element', () => {
+    const { container } = render(<Breadcrumb.Item wrapperAs="span">Crumb</Breadcrumb.Item>);
+
+    expect(container.firstChild).to.have.tagName('SPAN');
+  });
+
+  it('Should render with a custom separator', () => {
+    render(<Breadcrumb.Item separator={<span>separator</span>}>Crumb</Breadcrumb.Item>);
+
+    expect(screen.getByText('separator')).to.exist;
   });
 });

--- a/src/Breadcrumb/test/BreadcrumbItemStylesSpec.tsx
+++ b/src/Breadcrumb/test/BreadcrumbItemStylesSpec.tsx
@@ -18,7 +18,7 @@ describe('BreadcrumbItem styles', () => {
     expect(screen.getByText('/')).to.have.style('margin', '0px 4px');
   });
 
-  it('Active item should render correct color', () => {
+  it('Should render active item with correct color', () => {
     render(
       <Breadcrumb>
         <Breadcrumb.Item active>item</Breadcrumb.Item>


### PR DESCRIPTION
https://rsuite-nextjs-git-refactor-breadcrumb-rsuite.vercel.app/components/breadcrumb/

### Before

<img width="636" alt="image" src="https://github.com/user-attachments/assets/1246e7fb-0108-4908-852f-abfedc09eaea">


### After

<img width="558" alt="image" src="https://github.com/user-attachments/assets/fefc2b53-48fb-491e-8d28-effdc8d2e83e">


> https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav