### PR TITLE
fix(Calendar): fix the problem of displaying the first week of the year incorrectly

### DIFF
--- a/docs/pages/guide/i18n/fragments/example.md
+++ b/docs/pages/guide/i18n/fragments/example.md
@@ -1,48 +1,36 @@
 <!--start-code-->
 
 ```js
-import { CustomProvider, SelectPicker, DatePicker, Calendar, Pagination } from 'rsuite';
+import { CustomProvider, SelectPicker, DatePicker, Calendar, Stack, Divider } from 'rsuite';
 import * as locales from 'rsuite/locales';
 
 const data = Object.keys(locales).map(key => ({
-  key,
+  key: key.replace(/([a-z]{2})([A-Z]{2})/, '$1-$2'),
   value: locales[key]
 }));
 
 const App = () => {
-  const [localeKey, setLocaleKey] = React.useState('zhCN');
+  const [localeKey, setLocaleKey] = React.useState('ar-EG');
   const locale = data.find(item => item.key === localeKey);
   return (
     <CustomProvider locale={locale.value}>
-      <label id="change_locale">Change locale: </label>
-      <SelectPicker
-        aria-labelledby="change_locale"
-        cleanable={false}
-        data={data}
-        value={localeKey}
-        onChange={setLocaleKey}
-        labelKey="key"
-        valueKey="key"
-      />
-      <hr />
-      <DatePicker />
-      <div style={{ width: 280 }}>
-        <Calendar compact />
-      </div>
-      <hr />
-      <Pagination
-        prev
-        next
-        first
-        last
-        ellipsis
-        boundaryLinks
-        total={200}
-        limit={50}
-        limitOptions={[30, 50, 100]}
-        maxButtons={5}
-        layout={['total', '-', 'limit', '|', 'pager', 'skip']}
-      />
+      <Stack divider={<Divider vertical style={{ height: 400 }} />} spacing={40}>
+        <Stack direction="column" alignItems="flex-start" spacing={20}>
+          <DatePicker showWeekNumbers />
+          <Calendar showWeekNumbers compact style={{ width: 300 }} />
+        </Stack>
+        <Stack direction="column" alignItems="flex-start" spacing={30}>
+          <SelectPicker
+            label="Locale"
+            cleanable={false}
+            data={data}
+            value={localeKey}
+            onChange={setLocaleKey}
+            labelKey="key"
+            valueKey="key"
+          />
+        </Stack>
+      </Stack>
     </CustomProvider>
   );
 };

--- a/docs/pages/guide/i18n/index.tsx
+++ b/docs/pages/guide/i18n/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Calendar, SelectPicker, DatePicker, CustomProvider, Pagination } from 'rsuite';
+import { Calendar, SelectPicker, DatePicker, CustomProvider, Stack, Divider } from 'rsuite';
 import DefaultPage from '@/components/Page';
 import * as locales from 'rsuite/locales';
 
@@ -11,7 +11,8 @@ export default function Page() {
         Calendar,
         SelectPicker,
         DatePicker,
-        Pagination,
+        Stack,
+        Divider,
         locales
       }}
     />

--- a/src/Calendar/TableRow.tsx
+++ b/src/Calendar/TableRow.tsx
@@ -105,10 +105,13 @@ const TableRow: RsRefForwardingComponent<'div', TableRowProps> = React.forwardRe
     };
 
     const classes = merge(className, prefix('row'));
+    const { dateLocale } = locale;
+    const { firstWeekContainsDate, weekStartsOn } = dateLocale?.options ?? {};
+
     const week = format(weekendDate, isoWeek ? 'I' : 'w', {
-      locale: locale?.dateLocale,
-      firstWeekContainsDate: 4,
-      weekStartsOn: weekStart
+      locale: dateLocale,
+      firstWeekContainsDate,
+      weekStartsOn: weekStart || weekStartsOn
     });
 
     return (

--- a/src/Calendar/TableRow.tsx
+++ b/src/Calendar/TableRow.tsx
@@ -105,11 +105,10 @@ const TableRow: RsRefForwardingComponent<'div', TableRowProps> = React.forwardRe
     };
 
     const classes = merge(className, prefix('row'));
-    const { dateLocale } = locale;
-    const { firstWeekContainsDate, weekStartsOn } = dateLocale?.options ?? {};
+    const { firstWeekContainsDate, weekStartsOn } = locale?.dateLocale?.options ?? {};
 
     const week = format(weekendDate, isoWeek ? 'I' : 'w', {
-      locale: dateLocale,
+      locale: locale?.dateLocale,
       firstWeekContainsDate,
       weekStartsOn: weekStart || weekStartsOn
     });

--- a/src/Calendar/test/CalendarContainerSpec.tsx
+++ b/src/Calendar/test/CalendarContainerSpec.tsx
@@ -4,6 +4,7 @@ import { parseISO } from 'date-fns';
 import { testStandardProps } from '@test/utils';
 import sinon from 'sinon';
 import CalendarContainer from '../CalendarContainer';
+import { enGB, enUS } from '../../locales';
 
 describe('CalendarContainer', () => {
   testStandardProps(
@@ -92,5 +93,35 @@ describe('CalendarContainer', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Collapse time view' }));
 
     expect(screen.queryByRole('button', { name: 'Collapse month view' })).not.to.exist;
+  });
+
+  describe('Locale', () => {
+    it('Should render the first week of the year correctly when firstWeekContainsDate is 4', () => {
+      render(
+        <CalendarContainer
+          calendarDate={new Date('2025-01-01')}
+          format="yyyy-MM-dd"
+          showWeekNumbers
+          // enGB.Calendar.dateLocale.options.firstWeekContainsDate = 4;
+          locale={enGB.Calendar}
+        />
+      );
+
+      expect(screen.getAllByRole('rowheader')[0]).to.have.text('52');
+    });
+
+    it('Should render the first week of the year correctly when firstWeekContainsDate is 1', () => {
+      render(
+        <CalendarContainer
+          calendarDate={new Date('2025-01-01')}
+          format="yyyy-MM-dd"
+          showWeekNumbers
+          // enUS.Calendar.dateLocale.options.firstWeekContainsDate = 1;
+          locale={enUS.Calendar}
+        />
+      );
+
+      expect(screen.getAllByRole('rowheader')[0]).to.have.text('1');
+    });
   });
 });

--- a/src/CustomProvider/CustomProvider.tsx
+++ b/src/CustomProvider/CustomProvider.tsx
@@ -1,24 +1,77 @@
 import React from 'react';
 import { usePortal, useIsomorphicLayoutEffect } from '@/internals/hooks';
 import { getClassNamePrefix, prefix } from '@/internals/utils/prefix';
-import type { Locale as DateFnsLocale } from 'date-fns';
 import { Locale } from '../locales';
 import { addClass, removeClass, canUseDOM } from '../DOMHelper';
 import ToastContainer, { ToastContainerInstance, toastPlacements } from '../toaster/ToastContainer';
+import type { Locale as DateFnsLocale } from 'date-fns';
+import type { DateFns } from '@/internals/types';
 
 export interface FormatDateOptions {
+  /**
+   * The locale object that contains the language and formatting rules for the date.
+   */
   locale?: DateFnsLocale;
-  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-  firstWeekContainsDate?: number;
+
+  /**
+   * Defines which day of the week should be considered the start of the week.
+   *
+   * The value should be an integer from 0 to 6, where:
+   * - `0` represents Sunday,
+   * - `1` represents Monday,
+   * - `2` represents Tuesday,
+   * - `3` represents Wednesday,
+   * - `4` represents Thursday,
+   * - `5` represents Friday,
+   * - `6` represents Saturday.
+   *
+   * This option is important for functions that operate on weeks, such as calculating
+   * the start or end of a week, determining which week a date falls in, or generating
+   * calendar views. The default value varies depending on the locale, with Monday (`1`)
+   * being the default in most regions following ISO 8601, while Sunday (`0`) is often
+   * the default in regions like the United States.
+   */
+  weekStartsOn?: DateFns.Day;
+
+  /**
+   * `firstWeekContainsDate` is used to determine which week is considered the first week of the year.
+   *
+   * This option specifies the minimum day of January that must be included in the first week.
+   *
+   * The value can be set to:
+   * - `1`: The first week of the year must include January 1st.
+   * - `4`: The first week of the year must include January 4th, which is the default according to ISO 8601.
+   *
+   * The choice between `1` and `4` typically depends on the regional or business conventions for week numbering.
+   *
+   * Please note that this option only accepts `1` (Sunday) or `4` (Thursday), aligning with common international standards.
+   *
+   * For more detailed information, please refer to https://en.wikipedia.org/wiki/Week#Week_numbering.
+   */
+  firstWeekContainsDate?: DateFns.FirstWeekContainsDate;
+
+  /**
+   * If true, allows usage of the week-numbering year tokens `YY` and `YYYY`.
+   * See: https://date-fns.org/docs/Unicode-Tokens
+   **/
   useAdditionalWeekYearTokens?: boolean;
+
+  /**
+   * If true, allows usage of the day of year tokens `D` and `DD`.
+   * See: https://date-fns.org/docs/Unicode-Tokens
+   */
   useAdditionalDayOfYearTokens?: boolean;
 }
 
 export interface CustomValue<T = Locale> {
-  /** Language configuration */
+  /**
+   * The locale object that contains the language and formatting rules for the date.
+   */
   locale: T;
 
-  /** Support right-to-left */
+  /**
+   * Right-to-left text direction.
+   */
   rtl: boolean;
 
   /**
@@ -33,7 +86,7 @@ export interface CustomValue<T = Locale> {
    *    return format(date, formatStr, { locale: eo });
    *  }
    *
-   * */
+   */
   formatDate: (date: Date | number, format: string, options?: FormatDateOptions) => string;
 
   /**
@@ -48,7 +101,7 @@ export interface CustomValue<T = Locale> {
    *    return parse(date, formatStr, new Date(), { locale: eo });
    *  }
    *
-   * */
+   */
   parseDate: (
     dateString: string,
     formatString: string,
@@ -61,7 +114,10 @@ export interface CustomValue<T = Locale> {
    */
   toasters?: React.MutableRefObject<Map<string, ToastContainerInstance>>;
 
-  /** If true, the ripple effect is disabled. Affected components include: Button, Nav.Item, Pagination. */
+  /**
+   * If true, the ripple effect is disabled.
+   * Affected components include: Button, Nav.Item, Pagination.
+   */
   disableRipple?: boolean;
 }
 

--- a/src/DatePicker/test/DatePickerSpec.tsx
+++ b/src/DatePicker/test/DatePickerSpec.tsx
@@ -532,7 +532,7 @@ describe('DatePicker', () => {
   it('Should render week numbers given `showWeekNumbers=true`', () => {
     render(<DatePicker defaultOpen calendarDefaultDate={new Date('12/15/2021')} showWeekNumbers />);
 
-    [48, 49, 50, 51, 52, 1].forEach(weekOrder => {
+    [47, 48, 49, 50, 51, 52].forEach(weekOrder => {
       expect(screen.getByRole('grid', { name: 'Dec 2021' })).to.contain(
         screen.getByRole('rowheader', {
           name: `Week ${weekOrder}`

--- a/src/internals/types/index.ts
+++ b/src/internals/types/index.ts
@@ -286,3 +286,19 @@ export type CursorPosition = {
   clientTop: number;
   clientLeft: number;
 };
+
+export declare namespace DateFns {
+  /**
+   * FirstWeekContainsDate is used to determine which week is the first week of the year, based on what day the January, 1 is in that week.
+   * The day in that week can only be 1 (Monday) or 4 (Thursday).
+   * Please see https://en.wikipedia.org/wiki/Week#The_ISO_week_date_system for more information.
+   */
+  type FirstWeekContainsDate = 1 | 4;
+
+  /**
+   * The day of the week type alias.
+   * Unlike the date (the number of days since the beginning of the month), which begins with 1 and is dynamic (can go up to 28, 30, or 31), the day starts with 0 and static (always ends at 6).
+   * Look at it as an index in an array where Sunday is the first element and Saturday is the last.
+   */
+  type Day = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+}

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,4 +1,6 @@
 import defaultLocale from './default';
+import { Locale as DateFnsLocale } from 'date-fns';
+
 export { default as arEG } from './ar_EG';
 export { default as daDK } from './da_DK';
 export { default as deDE } from './de_DE';
@@ -31,7 +33,6 @@ type PickKeys<T> = {
 
 export type Locale = PickKeys<typeof defaultLocale>;
 export type CommonLocale = typeof defaultLocale.common;
-export type CalendarLocale = PickKeys<typeof defaultLocale.Calendar>;
 export type PlaintextLocale = PickKeys<typeof defaultLocale.Plaintext>;
 export type PaginationLocale = PickKeys<typeof defaultLocale.Pagination>;
 export type TableLocale = CommonLocale;
@@ -43,3 +44,7 @@ export type UploaderLocale = PickKeys<typeof defaultLocale.Uploader> & CommonLoc
 export type CloseButtonLocale = PickKeys<typeof defaultLocale.CloseButton>;
 export type BreadcrumbLocale = PickKeys<typeof defaultLocale.Breadcrumb>;
 export type ToggleLocale = PickKeys<typeof defaultLocale.Toggle>;
+
+export interface CalendarLocale extends PickKeys<typeof defaultLocale.Calendar> {
+  dateLocale?: DateFnsLocale;
+}


### PR DESCRIPTION
In date-fns, the value of `firstWeekContainsDate` defines which day of the year must be included in the first week. For example:

- If set to 1, the first week must include January 1st.
- If set to 4, the first week must include January 4th.

https://en.wikipedia.org/wiki/Week#The_ISO_week_date_system

This setting is mainly used to determine the first week of the year based on different cultural or business needs. Some countries or regions have different regulations; for instance, the ISO 8601 standard specifies that the first week of the year is the one that contains January 4th.

This PR will use the default value of firstWeekContainsDate from the locale in date-fns to determine the start of the first week for the current locale.