### PR TITLE
test(Calendar): refactor using fireEvent instead of Simulate

### DIFF
--- a/src/Calendar/test/CalendarHeaderSpec.tsx
+++ b/src/Calendar/test/CalendarHeaderSpec.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import ReactTestUtils from 'react-dom/test-utils';
-
+import sinon from 'sinon';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { testStandardProps } from '@test/utils';
 import Header from '../CalendarHeader';
 import CalendarContext from '../CalendarContext';
-import Sinon from 'sinon';
-import { testStandardProps } from '@test/utils';
 
 describe('Calendar-Header', () => {
   testStandardProps(<Header />);
@@ -17,48 +15,47 @@ describe('Calendar-Header', () => {
   });
 
   it('Should call `onMoveForward` callback', () => {
-    const onMoveForward = Sinon.spy();
+    const onMoveForward = sinon.spy();
 
     render(<Header showMonth onMoveForward={onMoveForward} />);
 
-    ReactTestUtils.Simulate.click(screen.getByRole('button', { name: 'Next month' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next month' }));
     expect(onMoveForward).to.have.been.calledOnce;
   });
 
   it('Should call `onMoveBackward` callback', () => {
-    const onMoveBackward = Sinon.spy();
+    const onMoveBackward = sinon.spy();
 
     render(<Header showMonth onMoveBackward={onMoveBackward} />);
 
-    ReactTestUtils.Simulate.click(screen.getByRole('button', { name: 'Previous month' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Previous month' }));
+
     expect(onMoveBackward).to.have.been.calledOnce;
   });
 
   it('Should call `onToggleMonthDropdown` callback', () => {
-    const onToggleMonthDropdown = Sinon.spy();
+    const onToggleMonthDropdown = sinon.spy();
 
     render(<Header showMonth onToggleMonthDropdown={onToggleMonthDropdown} />);
 
-    ReactTestUtils.Simulate.click(screen.getByRole('button', { name: 'Select month' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Select month' }));
+
     expect(onToggleMonthDropdown).to.have.been.calledOnce;
   });
 
   it('Should call `onToggleTimeDropdown` callback', () => {
-    const onToggleTimeDropdown = Sinon.spy();
-    const ref = React.createRef<HTMLDivElement>();
+    const onToggleTimeDropdown = sinon.spy();
 
     render(
       <CalendarContext.Provider
         value={{ date: new Date(), format: 'HH:mm:ss', locale: {}, isoWeek: false, weekStart: 0 }}
       >
-        <Header showTime onToggleTimeDropdown={onToggleTimeDropdown} ref={ref} />
+        <Header showTime onToggleTimeDropdown={onToggleTimeDropdown} />
       </CalendarContext.Provider>
     );
 
-    ReactTestUtils.Simulate.click(
-      // eslint-disable-next-line testing-library/no-node-access
-      (ref.current as HTMLDivElement).querySelector('.rs-calendar-header-title-time') as HTMLElement
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Select time' }));
+
     expect(onToggleTimeDropdown).to.have.been.calledOnce;
   });
 });

--- a/src/Calendar/test/CalendarTimeDropdownSpec.tsx
+++ b/src/Calendar/test/CalendarTimeDropdownSpec.tsx
@@ -7,12 +7,12 @@ import CalendarContext from '../CalendarContext';
 import en_US from '../../locales/en_US';
 
 describe('Calendar - TimeDropdown', () => {
-  testStandardProps(<TimeDropdown />);
+  testStandardProps(<TimeDropdown show />);
 
   it('Should render a div with `time-dropdown` class', () => {
     render(<TimeDropdown />);
 
-    expect(screen.getByRole('group')).to.have.class('rs-calendar-time-dropdown');
+    expect(screen.getByRole('group', { hidden: true })).to.have.class('rs-calendar-time-dropdown');
   });
 
   it('Should render hours, minutes and seconds', () => {
@@ -93,7 +93,7 @@ describe('Calendar - TimeDropdown', () => {
       </CalendarContext.Provider>
     );
 
-    fireEvent.click(screen.getByRole('option', { name: '1 hours' }));
+    fireEvent.click(screen.getByRole('option', { name: '1 hours', hidden: true }));
 
     expect(onChangeTime).to.have.been.calledOnce;
   });
@@ -117,7 +117,7 @@ describe('Calendar - TimeDropdown', () => {
       </CalendarContext.Provider>
     );
 
-    screen.getAllByRole('option').forEach((option, index) => {
+    screen.getAllByRole('option', { hidden: true }).forEach((option, index) => {
       expect(option).to.have.attribute('aria-disabled', index > 10 ? 'true' : 'false');
     });
   });
@@ -141,6 +141,6 @@ describe('Calendar - TimeDropdown', () => {
       </CalendarContext.Provider>
     );
 
-    expect(screen.getAllByRole('option')).to.have.length(11);
+    expect(screen.getAllByRole('option', { hidden: true })).to.have.length(11);
   });
 });


### PR DESCRIPTION
- Refactor using fireEvent instead of Simulate
- Use screen.getByText instead of querySelector
