### PR TITLE
docs(Dropdown): fix the problem that the example cannot be displayed completely

### DIFF
--- a/docs/less/code-view.less
+++ b/docs/less/code-view.less
@@ -101,7 +101,6 @@ a code {
 
   .rcv-render {
     padding: 18px;
-    overflow-x: auto;
   }
 
   .rs-theme-dark &,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3edd7516-2ec2-46f1-a275-9bf4f67e1540)
