### PR TITLE
fix(locale): fix missing 'remove' and 'clear' keys in Hungarian locale under the common section

### DIFF
--- a/src/locales/hu_HU.ts
+++ b/src/locales/hu_HU.ts
@@ -30,7 +30,9 @@ export default {
   code: 'hu-HU',
   common: {
     loading: 'Betöltés...',
-    emptyMessage: 'Nem található adat'
+    emptyMessage: 'Nem található adat',
+    remove: 'eltávolít',
+    clear: 'töröl'
   },
   Plaintext: {
     unfilled: 'Kitöltetlen',


### PR DESCRIPTION
Other languages' locales have both 'remove' and 'clear' under the 'common' section, but the Hungarian locale did not. I have corrected this issue, and I kindly request that you review and merge the pull request.