### PR TITLE
refactor: replaced `cursor: not-allowed` with `cursor: @cursor-disabled`

### DIFF
--- a/src/CheckTree/styles/index.less
+++ b/src/CheckTree/styles/index.less
@@ -103,7 +103,6 @@
 
     &.rs-checkbox-disabled {
       .rs-checkbox-label {
-        cursor: not-allowed;
         color: var(--rs-text-disabled);
         background: none;
       }

--- a/src/Checkbox/styles/mixin.less
+++ b/src/Checkbox/styles/mixin.less
@@ -29,7 +29,7 @@
   }
 
   &&-disabled label {
-    cursor: not-allowed;
+    cursor: @cursor-disabled;
   }
 
   // Disabled text styles.

--- a/src/RadioTile/styles/index.less
+++ b/src/RadioTile/styles/index.less
@@ -1,3 +1,5 @@
+@import '../../styles/common';
+
 .rs-radio-tile {
   border-radius: 6px;
   overflow: hidden;

--- a/src/RadioTile/styles/index.less
+++ b/src/RadioTile/styles/index.less
@@ -53,7 +53,7 @@
   &-disabled,
   &-disabled &-content {
     color: var(--rs-text-disabled);
-    cursor: not-allowed;
+    cursor: @cursor-disabled;
   }
 
   input {

--- a/src/Rate/styles/index.less
+++ b/src/Rate/styles/index.less
@@ -94,7 +94,7 @@
   }
 
   &-disabled &-character {
-    cursor: not-allowed;
+    cursor: @cursor-disabled;
   }
 
   &-readonly &-character {

--- a/src/Slider/styles/index.less
+++ b/src/Slider/styles/index.less
@@ -19,7 +19,7 @@
 
   &-disabled {
     opacity: 0.5;
-    cursor: not-allowed;
+    cursor: @cursor-disabled;
 
     .rs-slider-bar,
     .rs-slider-handle::before {

--- a/src/TagPicker/styles/index.less
+++ b/src/TagPicker/styles/index.less
@@ -13,8 +13,6 @@
   }
 
   &.rs-picker-disabled {
-    cursor: not-allowed;
-
     .rs-picker-toggle {
       position: absolute;
     }

--- a/src/Tree/styles/index.less
+++ b/src/Tree/styles/index.less
@@ -135,12 +135,6 @@
     }
   }
 
-  &-drag-disabled {
-    &.rs-tree-node-label {
-      cursor: not-allowed;
-    }
-  }
-
   &-disabled {
     .rs-tree-node-label {
       background: none;


### PR DESCRIPTION
Replaced `cursor: not-allowed` with `cursor: @cursor-disabled` across the following components to maintain code consistency
1. Checkbox
2. RadioTile
3. Rate
4. Slider

Also removed it in the following components as the cursor was already disabled.
1. CheckTree
2. TagPicker
3. Tree 

**Note:-** I have replaced it only in the components which i could test, `cursor: not-allowed` is still present in multiple components.
