### PR TITLE
test(Sidebar, Sidenav): refactor using render instead of getDOMNode

### DIFF
--- a/src/Sidebar/test/SidebarSpec.tsx
+++ b/src/Sidebar/test/SidebarSpec.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
-import { getDOMNode, testStandardProps } from '@test/utils';
+import { testStandardProps } from '@test/utils';
 import Sidebar from '../Sidebar';
+import { render } from '@testing-library/react';
 
 describe('Sidebar', () => {
   testStandardProps(<Sidebar />);
 
   it('Should render a Sidebar', () => {
     const title = 'Test';
-    const instance = getDOMNode(<Sidebar>{title}</Sidebar>);
-    assert.equal(instance.className, 'rs-sidebar');
-    assert.equal(instance.textContent, title);
+    const { container } = render(<Sidebar>{title}</Sidebar>);
+    expect(container.firstChild).to.have.class('rs-sidebar');
+    expect(container.firstChild).to.have.text(title);
   });
 });

--- a/src/Sidenav/test/SidenavBodySpec.tsx
+++ b/src/Sidenav/test/SidenavBodySpec.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
-import { getDOMNode, testStandardProps } from '@test/utils';
+import { testStandardProps } from '@test/utils';
 import SidenavBody from '../SidenavBody';
+import { render } from '@testing-library/react';
 
 describe('SidenavBody', () => {
   testStandardProps(<SidenavBody />);
 
   it('Should render a body', () => {
     const title = 'Test';
-    const instance = getDOMNode(<SidenavBody>{title}</SidenavBody>);
-    assert.equal(instance.className, 'rs-sidenav-body');
-    assert.equal(instance.innerHTML, title);
+    const { container } = render(<SidenavBody>{title}</SidenavBody>);
+    expect(container.firstChild).to.have.class('rs-sidenav-body');
+    expect(container.firstChild).to.have.text(title);
   });
 });

--- a/src/Sidenav/test/SidenavHeaderSpec.tsx
+++ b/src/Sidenav/test/SidenavHeaderSpec.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
-import { getDOMNode, testStandardProps } from '@test/utils';
+import { testStandardProps } from '@test/utils';
 import SidenavHeader from '../SidenavHeader';
+import { render } from '@testing-library/react';
 
 describe('SidenavHeader', () => {
   testStandardProps(<SidenavHeader />);
 
   it('Should render a header', () => {
     const title = 'Test';
-    const instance = getDOMNode(<SidenavHeader>{title}</SidenavHeader>);
-    assert.equal(instance.className, 'rs-sidenav-header');
-    assert.equal(instance.innerHTML, title);
+    const { container } = render(<SidenavHeader>{title}</SidenavHeader>);
+    expect(container.firstChild).to.have.class('rs-sidenav-header');
+    expect(container.firstChild).to.have.text(title);
   });
 });

--- a/src/Sidenav/test/SidenavSpec.tsx
+++ b/src/Sidenav/test/SidenavSpec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Simulate } from 'react-dom/test-utils';
 import { fireEvent, render, waitFor, screen, within } from '@testing-library/react';
 import sinon from 'sinon';
-import { getDOMNode, testStandardProps } from '@test/utils';
+import { testStandardProps } from '@test/utils';
 import Sidenav from '../Sidenav';
 import Nav from '../../Nav';
 import Dropdown from '../../Dropdown';
@@ -15,18 +15,18 @@ describe('<Sidenav>', () => {
   testStandardProps(<Sidenav />);
 
   it('Should render a navigation', () => {
-    const instance = getDOMNode(<Sidenav />);
-    assert.include(instance.className, 'rs-sidenav');
+    const { container } = render(<Sidenav />);
+    expect(container.firstChild).to.have.class('rs-sidenav');
   });
 
   it('Should apply appearance', () => {
-    const instance = getDOMNode(<Sidenav appearance="subtle" />);
-    assert.include(instance.className, 'rs-sidenav-subtle');
+    const { container } = render(<Sidenav appearance="subtle" />);
+    expect(container.firstChild).to.have.class('rs-sidenav-subtle');
   });
 
   it('Should be expanded', () => {
-    const instance = getDOMNode(<Sidenav expanded />);
-    assert.include(instance.className, 'rs-sidenav-collapse-in');
+    const { container } = render(<Sidenav expanded />);
+    expect(container.firstChild).to.have.class('rs-sidenav-collapse-in');
   });
 
   it('Should call onSelect callback', () => {


### PR DESCRIPTION
Why I am doing this: https://github.com/rsuite/rsuite/discussions/3200
What I did: removed use of getDOMNode

This PR involves the following components: Sidebar, Sidenav