### PR TITLE
Test: (Timeline, Toaster, Tooltip): Removing the getDOMNode and using render

### DIFF
--- a/src/Timeline/test/TimelineItemSpec.tsx
+++ b/src/Timeline/test/TimelineItemSpec.tsx
@@ -1,42 +1,36 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { getDOMNode, testStandardProps } from '@test/utils';
+import { testStandardProps } from '@test/utils';
 import TimelineItem from '../TimelineItem';
 
 describe('TimelineItem', () => {
   testStandardProps(<TimelineItem />);
 
   it('Should output a TimelineItem', () => {
-    const instance = getDOMNode(<TimelineItem />);
-    assert.equal(instance.className, 'rs-timeline-item');
-    // eslint-disable-next-line testing-library/no-node-access
-    assert.ok(instance.querySelector('.rs-timeline-item-dot'));
-    // eslint-disable-next-line testing-library/no-node-access
-    assert.ok(instance.querySelector('.rs-timeline-item-tail'));
+    const { container } = render(<TimelineItem />);
+    expect(container.firstChild).to.have.class('rs-timeline-item');
+    // eslint-disable-next-line
+    expect(container.querySelector('.rs-timeline-item-dot')).to.have.class('rs-timeline-item-dot');
+    // eslint-disable-next-line
+    expect(container.querySelector('.rs-timeline-item-tail')).to.have.class(
+      'rs-timeline-item-tail'
+    );
   });
 
   it('Should render a dot', () => {
-    const instance = getDOMNode(<TimelineItem dot={<i>test</i>} />);
-    assert.equal(
-      // eslint-disable-next-line testing-library/no-node-access
-      (instance.querySelector('.rs-timeline-item-custom-dot') as HTMLElement).textContent,
-      'test'
-    );
+    const { container } = render(<TimelineItem dot={<i>test</i>} />);
+    expect(container.firstChild).to.have.text('test');
   });
 
   it('Should render a time', () => {
     const time = '2019-10-21';
-    const instance = getDOMNode(<TimelineItem time={time} />);
-    assert.equal(
-      // eslint-disable-next-line testing-library/no-node-access
-      (instance.querySelector('.rs-timeline-item-time') as HTMLElement).textContent,
-      time
-    );
+    const { container } = render(<TimelineItem time={time} />);
+    expect(container.firstChild).to.have.text(time);
   });
 
   it('Should output the last item', () => {
-    const instance = getDOMNode(<TimelineItem last />);
-    assert.ok(instance.className.match(/\brs-timeline-item-last\b/));
+    const { container } = render(<TimelineItem last />);
+    expect(container.firstChild).to.have.class('rs-timeline-item-last');
   });
 
   describe('Internal', () => {

--- a/src/Timeline/test/TimelineSpec.tsx
+++ b/src/Timeline/test/TimelineSpec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getDOMNode, testStandardProps } from '@test/utils';
+import { testStandardProps } from '@test/utils';
 import Timeline from '../Timeline';
 import { render, screen } from '@testing-library/react';
 
@@ -7,32 +7,32 @@ describe('Timeline', () => {
   testStandardProps(<Timeline />);
 
   it('Should output a Timeline', () => {
-    const instance = getDOMNode(<Timeline />);
-    assert.ok(instance.className.match(/\brs-timeline\b/));
+    const { container } = render(<Timeline />);
+    expect(container.firstChild).to.have.class('rs-timeline');
   });
 
   it('Should output a div', () => {
-    const instance = getDOMNode(<Timeline as={'div'} />);
-    assert.equal(instance.tagName, 'DIV');
+    const { container } = render(<Timeline as={'div'} />);
+    expect(container.firstChild).to.have.tagName('DIV');
   });
 
   it('Should be endless', () => {
-    const instance = getDOMNode(<Timeline endless />);
-    assert.ok(instance.className.match(/\bendless\b/));
+    const { container } = render(<Timeline endless />);
+    expect(container.firstChild).to.have.class('rs-timeline-endless');
   });
 
   it('Should have a with-time className', () => {
-    const instance = getDOMNode(
+    const { container } = render(
       <Timeline>
         <Timeline.Item time="2018-03-01 16:27:42" />
       </Timeline>
     );
-    assert.ok(instance.className.match(/\brs-timeline-with-time\b/));
+    expect(container.firstChild).to.have.class('rs-timeline-with-time');
   });
 
   it('Should have a custom align', () => {
-    const instance = getDOMNode(<Timeline align="left" />);
-    assert.ok(instance.className.match(/\brs-timeline-align-left\b/));
+    const { container } = render(<Timeline align="left" />);
+    expect(container.firstChild).to.have.class('rs-timeline-align-left');
   });
 
   describe('Active item', () => {

--- a/src/Timeline/test/TimelineStylesSpec.tsx
+++ b/src/Timeline/test/TimelineStylesSpec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Timeline from '../index';
-import { getDOMNode, getStyle } from '@test/utils';
+import { getStyle } from '@test/utils';
 
 import '../styles/index.less';
 
@@ -9,7 +9,7 @@ describe('Timeline styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef<HTMLDivElement>();
     render(<Timeline ref={instanceRef} />);
-    const dom = getDOMNode(instanceRef.current);
+    const dom = instanceRef.current as Element;
     assert.equal(getStyle(dom, 'listStyleType'), 'none', 'Timeline list-style');
   });
 });

--- a/src/Tooltip/test/TooltipSpec.tsx
+++ b/src/Tooltip/test/TooltipSpec.tsx
@@ -1,25 +1,27 @@
 import React from 'react';
-import { getDOMNode, testStandardProps } from '@test/utils';
+import { testStandardProps } from '@test/utils';
 import Tooltip from '../Tooltip';
+import { render } from '@testing-library/react';
 
 describe('Tooltip', () => {
   testStandardProps(<Tooltip />);
 
   it('Should render a Tooltip', () => {
     const title = 'Test';
-    const instance = getDOMNode(<Tooltip>{title}</Tooltip>);
-    assert.equal(instance.tagName, 'DIV');
-    assert.equal(instance.className, 'rs-tooltip rs-tooltip-arrow');
-    assert.equal(instance.textContent, title);
+    const { container } = render(<Tooltip>{title}</Tooltip>);
+    expect(container.firstChild).to.have.tagName('DIV');
+    expect(container.firstChild).to.have.class('rs-tooltip');
+    expect(container.firstChild).to.have.class('rs-tooltip-arrow');
+    expect(container.firstChild).to.have.text(title);
   });
 
   it('Tooltip should without arrow', () => {
-    const instance = getDOMNode(<Tooltip arrow={false}>Test</Tooltip>);
-    assert.equal(instance.className, 'rs-tooltip');
+    const { container } = render(<Tooltip arrow={false}>Test</Tooltip>);
+    expect(container.firstChild).to.have.class('rs-tooltip');
   });
 
   it('Should have a id', () => {
-    const instance = getDOMNode(<Tooltip id="tooltip" />);
-    assert.equal(instance.id, 'tooltip');
+    const { container } = render(<Tooltip id="tooltip" />);
+    expect(container.firstChild).to.have.id('tooltip');
   });
 });

--- a/src/toaster/test/ToastContainerSpec.tsx
+++ b/src/toaster/test/ToastContainerSpec.tsx
@@ -1,27 +1,18 @@
 import React from 'react';
 import ToastContainer from '../ToastContainer';
-import { getDOMNode } from '@test/utils';
+import { render } from '@testing-library/react';
+import { testStandardProps } from '@test/utils';
 
 describe('toaster - ToastContainer', () => {
-  it('Should output a container', () => {
-    const instance = getDOMNode(<ToastContainer />);
+  testStandardProps(<ToastContainer />);
 
-    assert.include(instance.className, 'rs-toast-container');
+  it('Should output a container', () => {
+    const { container } = render(<ToastContainer />);
+    expect(container.firstChild).to.have.class('rs-toast-container');
   });
 
   it('Should output a placement', () => {
-    const instance = getDOMNode(<ToastContainer placement="topStart" />);
-    assert.include(instance.className, 'rs-toast-container-top-start');
-  });
-
-  it('Should have a custom className', () => {
-    const instance = getDOMNode(<ToastContainer className="custom" />);
-    assert.include(instance.className, 'custom');
-  });
-
-  it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<ToastContainer style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
+    const { container } = render(<ToastContainer placement="topStart" />);
+    expect(container.firstChild).to.have.class('rs-toast-container-top-start');
   });
 });


### PR DESCRIPTION
Why I am doing this: https://github.com/rsuite/rsuite/discussions/3200
What I did: removing the getDOMNode and using the render in @testing-library/react

This update involves 3 component changes: Timeline, Toaster, Tooltip