### PR TITLE
Test: (Container, Input, Navbar) removing get dom node

### DIFF
--- a/src/Container/test/ContainerStylesSpec.tsx
+++ b/src/Container/test/ContainerStylesSpec.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Container from '../index';
-import { getStyle } from '@test/utils';
-
 import '../styles/index.less';
 
 describe('Container styles', () => {
@@ -14,6 +12,6 @@ describe('Container styles', () => {
       </Container>
     );
     const dom = instanceRef.current as Element;
-    assert.equal(getStyle(dom, 'display'), 'flex');
+    expect(dom).to.have.style('display', 'flex');
   });
 });

--- a/src/Container/test/ContainerStylesSpec.tsx
+++ b/src/Container/test/ContainerStylesSpec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Container from '../index';
-import { getDOMNode, getStyle } from '@test/utils';
+import { getStyle } from '@test/utils';
 
 import '../styles/index.less';
 
@@ -13,6 +13,7 @@ describe('Container styles', () => {
         <span>Title</span>
       </Container>
     );
-    assert.equal(getStyle(getDOMNode(instanceRef.current), 'display'), 'flex');
+    const dom = instanceRef.current as Element;
+    assert.equal(getStyle(dom, 'display'), 'flex');
   });
 });

--- a/src/Input/test/InputStylesSpec.tsx
+++ b/src/Input/test/InputStylesSpec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Input from '../index';
-import { getStyle, toRGB, inChrome } from '@test/utils';
+import { toRGB, inChrome } from '@test/utils';
 
 import '../styles/index.less';
 
@@ -10,7 +10,6 @@ describe('Input styles', () => {
     const instanceRef = React.createRef<HTMLInputElement>();
     render(<Input ref={instanceRef} />);
     const dom = instanceRef.current as Element;
-    inChrome &&
-      assert.equal(getStyle(dom, 'border'), `1px solid ${toRGB('#e5e5ea')}`, 'Input border');
+    inChrome && expect(dom).to.have.style('border', `1px solid ${toRGB('#e5e5ea')}`);
   });
 });

--- a/src/Input/test/InputStylesSpec.tsx
+++ b/src/Input/test/InputStylesSpec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Input from '../index';
-import { getDOMNode, getStyle, toRGB, inChrome } from '@test/utils';
+import { getStyle, toRGB, inChrome } from '@test/utils';
 
 import '../styles/index.less';
 
@@ -9,7 +9,7 @@ describe('Input styles', () => {
   it('Input should render the correct styles', () => {
     const instanceRef = React.createRef<HTMLInputElement>();
     render(<Input ref={instanceRef} />);
-    const dom = getDOMNode(instanceRef.current);
+    const dom = instanceRef.current as Element;
     inChrome &&
       assert.equal(getStyle(dom, 'border'), `1px solid ${toRGB('#e5e5ea')}`, 'Input border');
   });

--- a/src/Navbar/test/NavbarStylesSpec.tsx
+++ b/src/Navbar/test/NavbarStylesSpec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { getDOMNode, getStyle, toRGB } from '@test/utils';
+import { getStyle, toRGB } from '@test/utils';
 import Nav from '../../Nav';
 import Navbar from '../Navbar';
 
@@ -10,7 +10,7 @@ describe('Navbar styles', () => {
   it('Should render the correct styles', () => {
     const instanceRef = React.createRef<HTMLDivElement>();
     render(<Navbar ref={instanceRef} />);
-    const dom = getDOMNode(instanceRef.current);
+    const dom = instanceRef.current as Element;
     assert.equal(getStyle(dom, 'backgroundColor'), toRGB('#f7f7fa'), 'NavBar background-color');
   });
 

--- a/src/Navbar/test/NavbarStylesSpec.tsx
+++ b/src/Navbar/test/NavbarStylesSpec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { getStyle, toRGB } from '@test/utils';
+import { toRGB } from '@test/utils';
 import Nav from '../../Nav';
 import Navbar from '../Navbar';
 
@@ -11,7 +11,7 @@ describe('Navbar styles', () => {
     const instanceRef = React.createRef<HTMLDivElement>();
     render(<Navbar ref={instanceRef} />);
     const dom = instanceRef.current as Element;
-    assert.equal(getStyle(dom, 'backgroundColor'), toRGB('#f7f7fa'), 'NavBar background-color');
+    expect(dom).to.have.style('background-color', toRGB('#f7f7fa'));
   });
 
   context('Navbar.Item', () => {


### PR DESCRIPTION
Why I am doing this: https://github.com/rsuite/rsuite/discussions/3200
What I did: removing the getDOMNode and using the render in @testing-library/react

This update involves 3 component changes: Container, Input, Navbar