### PR TITLE
fix(Table): fix the problem that the global locale configuration cannot be overridden

### DIFF
--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -23,8 +23,9 @@ export interface CellProps<Row extends RowDataType>
 }
 
 const CustomTable = React.forwardRef((props, ref) => {
-  const { propsWithDefaults, rtl } = useCustom('Table', props);
-  const { locale, loadAnimation = true, ...rest } = propsWithDefaults;
+  const { propsWithDefaults, rtl, getLocale } = useCustom('Table', props);
+  const { locale: overrideLocale, loadAnimation = true, ...rest } = propsWithDefaults;
+  const locale = getLocale('Calendar', overrideLocale);
 
   return <RsTable {...rest} rtl={rtl} ref={ref} locale={locale} loadAnimation={loadAnimation} />;
 }) as <Row extends RowDataType, Key extends RowKeyType>(

--- a/src/Table/test/TableSpec.tsx
+++ b/src/Table/test/TableSpec.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Table from '../Table';
+import CustomProvider from '../../CustomProvider';
+import zhCN from '../../locales/zh_CN';
+
+describe('Table', () => {
+  it('Should custom empty message', () => {
+    render(<Table locale={{ emptyMessage: 'No data' }} />);
+    expect(screen.getByText('No data')).to.exist;
+  });
+
+  it('Should custom loading message', () => {
+    render(<Table locale={{ loading: 'Loading...' }} loading />);
+    expect(screen.getByText('Loading...')).to.exist;
+  });
+
+  describe('CustomProvider', () => {
+    it('Should render empty message in CustomProvider', () => {
+      render(
+        <CustomProvider locale={zhCN}>
+          <Table />
+        </CustomProvider>
+      );
+
+      expect(screen.getByText('数据为空')).to.exist;
+    });
+
+    it('Should render loading message in CustomProvider', () => {
+      render(
+        <CustomProvider locale={zhCN}>
+          <Table loading />
+        </CustomProvider>
+      );
+
+      expect(screen.getByText('加载中...')).to.exist;
+    });
+
+    it('Should override empty message in CustomProvider', () => {
+      render(
+        <CustomProvider locale={zhCN}>
+          <Table locale={{ emptyMessage: 'No data' }} />
+        </CustomProvider>
+      );
+
+      expect(screen.getByText('No data')).to.exist;
+    });
+
+    it('Should override loading message in CustomProvider', () => {
+      render(
+        <CustomProvider locale={zhCN}>
+          <Table locale={{ loading: 'Loading...' }} loading />
+        </CustomProvider>
+      );
+
+      expect(screen.getByText('Loading...')).to.exist;
+    });
+  });
+});


### PR DESCRIPTION
fix the following code does not work
```tsx
<Table  locale={{ emptyMessage: 'No data' }} />
```

fix: https://github.com/rsuite/rsuite/issues/4042