### PR TITLE
fix: overriding date format with local props locale

### DIFF
--- a/src/Calendar/Calendar.tsx
+++ b/src/Calendar/Calendar.tsx
@@ -141,7 +141,11 @@ const Calendar: RsRefForwardingComponent<typeof CalendarContainer, CalendarProps
     );
 
     const renderTitle = (date: Date) => (
-      <FormattedDate date={date} formatStr={locale?.formattedMonthPattern || 'MMMM  yyyy'} />
+      <FormattedDate
+        date={date}
+        formatStr={locale?.formattedMonthPattern || 'MMMM  yyyy'}
+        dateLocale={locale?.dateLocale}
+      />
     );
 
     const classes = merge(className, withClassPrefix('panel', { bordered, compact }));

--- a/src/Calendar/CalendarBody.tsx
+++ b/src/Calendar/CalendarBody.tsx
@@ -28,7 +28,9 @@ const CalendarBody: RsRefForwardingComponent<'div', CalendarBodyProps> = React.f
             weekStart,
             locale: locale?.dateLocale
           })}
-          aria-label={formatDate(thisMonthDate, locale.formattedMonthPattern)}
+          aria-label={formatDate(thisMonthDate, locale.formattedMonthPattern, {
+            locale: overrideLocale?.dateLocale
+          })}
         />
       </Component>
     );

--- a/src/Calendar/CalendarHeader.tsx
+++ b/src/Calendar/CalendarHeader.tsx
@@ -76,7 +76,10 @@ const CalendarHeader: RsRefForwardingComponent<'div', CalendarHeaderPrivateProps
 
     const renderTitle = () => {
       return (
-        renderTitleProp?.(date) ?? (date && <FormattedDate date={date} formatStr={dateFormat} />)
+        renderTitleProp?.(date) ??
+        (date && (
+          <FormattedDate date={date} formatStr={dateFormat} dateLocale={locale?.dateLocale} />
+        ))
       );
     };
 
@@ -97,7 +100,7 @@ const CalendarHeader: RsRefForwardingComponent<'div', CalendarHeaderPrivateProps
         />
         <Button
           {...btnProps}
-          aria-label="Select month"
+          aria-label="Select month 2222222222"
           id={targetId ? `${targetId}-grid-label` : undefined}
           className={dateTitleClasses}
           onClick={onToggleMonthDropdown}
@@ -135,7 +138,9 @@ const CalendarHeader: RsRefForwardingComponent<'div', CalendarHeaderPrivateProps
               onClick={onToggleTimeDropdown}
               disabled={disableSelectTime}
             >
-              {date && <FormattedDate date={date} formatStr={timeFormat} />}
+              {date && (
+                <FormattedDate date={date} formatStr={timeFormat} dateLocale={locale?.dateLocale} />
+              )}
             </Button>
           </div>
         )}

--- a/src/Calendar/Grid/GridCell.tsx
+++ b/src/Calendar/Grid/GridCell.tsx
@@ -46,7 +46,9 @@ const GridCell: RsRefForwardingComponent<'div', GridCellProps> = React.forwardRe
     const { formattedDayPattern, today } = getLocale('Calendar', overrideLocale);
 
     const formatStr = formattedDayPattern;
-    const ariaLabel = getAriaLabel(date, formatStr, formatDate);
+    const ariaLabel = getAriaLabel(date, formatStr, formatDate, {
+      locale: overrideLocale?.dateLocale
+    });
     const todayDate = new Date();
     const isToday = isSameDay(date, todayDate);
 

--- a/src/Calendar/MonthDropdown/MonthDropdownItem.tsx
+++ b/src/Calendar/MonthDropdown/MonthDropdownItem.tsx
@@ -51,7 +51,9 @@ const MonthDropdownItem: RsRefForwardingComponent<'div', MonthDropdownItemProps>
 
     const { prefix, merge, withClassPrefix } = useClassNames(classPrefix);
     const classes = merge(className, withClassPrefix({ active }), { disabled });
-    const ariaLabel = currentMonth ? getAriaLabel(currentMonth, formatStr, formatDate) : '';
+    const ariaLabel = currentMonth
+      ? getAriaLabel(currentMonth, formatStr, formatDate, { locale: overrideLocale?.dateLocale })
+      : '';
 
     return (
       <Component
@@ -66,7 +68,9 @@ const MonthDropdownItem: RsRefForwardingComponent<'div', MonthDropdownItemProps>
         onClick={handleClick}
         {...rest}
       >
-        <span className={prefix('content')}>{formatDate(currentMonth, 'MMM')}</span>
+        <span className={prefix('content')}>
+          {formatDate(currentMonth, 'MMM', { locale: overrideLocale?.dateLocale })}
+        </span>
       </Component>
     );
   }

--- a/src/Calendar/utils/getAriaLabel.ts
+++ b/src/Calendar/utils/getAriaLabel.ts
@@ -1,15 +1,18 @@
 import { format as formatDate } from '@/internals/utils/date';
+import { Locale } from '@/locales';
 
 /**
  * Get aria-label for the date.
  * @param date - The date.
  * @param formatStr - The format string.
  * @param format - The format function.
+ * @param options - The format options.
  */
 export function getAriaLabel(
   date: Date,
   formatStr: string,
-  format: (date: Date, formatStr: string) => string
+  format: (date: Date, formatStr: string, options) => string,
+  options: { locale?: Locale } = {}
 ) {
-  return format ? format(date, formatStr) : formatDate(date, formatStr);
+  return format ? format(date, formatStr, options) : formatDate(date, formatStr, options);
 }

--- a/src/CustomProvider/FormattedDate.tsx
+++ b/src/CustomProvider/FormattedDate.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { useCustom } from './useCustom';
+import { Locale } from '@/locales';
 
 interface FormattedDateProps {
   date: Date;
   formatStr: string;
+  // Custom locale object
+  dateLocale?: Locale;
 }
 
-export function FormattedDate({ date, formatStr }: FormattedDateProps) {
+export function FormattedDate({ date, formatStr, dateLocale }: FormattedDateProps) {
   const { formatDate } = useCustom('Calendar');
 
-  return <React.Fragment>{formatDate(date, formatStr)}</React.Fragment>;
+  return <React.Fragment>{formatDate(date, formatStr, { locale: dateLocale })}</React.Fragment>;
 }
 
 export default FormattedDate;

--- a/src/CustomProvider/test/FormattedDateSpec.tsx
+++ b/src/CustomProvider/test/FormattedDateSpec.tsx
@@ -4,6 +4,7 @@ import { format } from 'date-fns';
 import ru from 'date-fns/locale/ru';
 import CustomProvider from '../CustomProvider';
 import FormattedDate from '../FormattedDate';
+import ptBr from 'date-fns/locale/pt-BR';
 
 import ruRU from '../../locales/ru_RU';
 
@@ -50,5 +51,15 @@ describe('FormattedDate', () => {
     );
 
     expect(container.firstChild).to.have.text('Jan 01, 2020');
+  });
+
+  it('Should render default formatted date with custom locale', () => {
+    const { container } = render(
+      <div>
+        <FormattedDate date={new Date('2020-01-01')} formatStr="MMM dd, yyyy" dateLocale={ptBr} />
+      </div>
+    );
+
+    expect(container.firstChild).to.have.text('jan 01, 2020');
   });
 });

--- a/src/DatePicker/hooks/useFocus.ts
+++ b/src/DatePicker/hooks/useFocus.ts
@@ -33,7 +33,9 @@ function useFocus(props: UseFocusProps) {
    */
   const checkFocusable = (date: Date) => {
     const formatStr = showMonth ? formattedMonthPattern : formattedDayPattern;
-    const ariaLabel = getAriaLabel(date, formatStr as string, formatDate);
+    const ariaLabel = getAriaLabel(date, formatStr as string, formatDate, {
+      locale: localeProp?.dateLocale
+    });
     const container = getOverlayContainer();
 
     const dateElement = container?.querySelector(`[aria-label="${ariaLabel}"]`);


### PR DESCRIPTION
Issue:  https://github.com/rsuite/rsuite/issues/4051

Hi, what's up?
This is my first contribution to rsuite, so I must have forgotten or done something wrong, so let me know about points of improvement in the issue description, pull request, etc 🫶

This pull request includes several changes to the `Calendar` component and related files to support custom date locales. The most important changes include modifications to the `FormattedDate` component, updates to aria-label generation, and adjustments to various calendar components to utilize the new locale support.

### Support for custom date locales:

* [`src/CustomProvider/FormattedDate.tsx`](diffhunk://#diff-7f853ec19d870e3b54683bfd9d4e04f4d2143dbac94cb66656e027da6480f751R3-R15): Added a `dateLocale` prop to the `FormattedDate` component to allow passing a custom locale for date formatting.
* [`src/Calendar/utils/getAriaLabel.ts`](diffhunk://#diff-f6b23aa13003c5a3d45a57412ac62baa38b33ca7e3a8ab2b4bf4b97f2e90fe8aR2-R17): Updated the `getAriaLabel` function to accept an options object, including a custom locale for date formatting.

### Updates to aria-label generation:

* [`src/Calendar/Grid/GridCell.tsx`](diffhunk://#diff-690b9d52109f391bfb1cdb8e930c2c6e8c97ccd3ba8698a6d6d8e861d6aa3916L49-R51): Modified the `ariaLabel` generation to include the custom locale.
* [`src/DatePicker/hooks/useFocus.ts`](diffhunk://#diff-86ce63d5caecdfdfcaafe6a63b3c8d7ba14dcc66901ade089bc58e86a1e6c7c0L36-R38): Adjusted the `checkFocusable` function to generate `ariaLabel` with the custom locale.

### Adjustments to calendar components:

* `src/Calendar/Calendar.tsx`, `src/Calendar/CalendarBody.tsx`, `src/Calendar/CalendarHeader.tsx`, `src/Calendar/MonthDropdown/MonthDropdownItem.tsx`: Updated various components to pass the custom locale to the `FormattedDate` component and `getAriaLabel` function. [[1]](diffhunk://#diff-a0a9b476c1e0f78786b151ddcebfc22c858737db51261d9b373c0bd1f3842cd2L144-R148) [[2]](diffhunk://#diff-900039bbcb771737f9ff28ae4836044546f2f4d0a51bb7bbaed2894c456460e3L31-R33) [[3]](diffhunk://#diff-c77f4a29e13a634e01b16265ad190f80da75c030e5cb286c611a86d077719d49L79-R82) [[4]](diffhunk://#diff-c77f4a29e13a634e01b16265ad190f80da75c030e5cb286c611a86d077719d49L138-R143) [[5]](diffhunk://#diff-27a2dcb06c0017bd845304b7aac50de3030c6cf3ea6ef660a24509539c565636L69-R73)

### Tests:

* [`src/CustomProvider/test/FormattedDateSpec.tsx`](diffhunk://#diff-97ce9d8375bfceed6532136356d48c1bb3acc248ca49aa857a3d3ee1eab607baR55-R64): Added a test case to ensure the `FormattedDate` component correctly renders dates with a custom locale.

