### PR TITLE
docs(Calendar): fix missing imports for Compact example in CodeSandbox

### DIFF
--- a/docs/pages/components/calendar/fragments/compact.md
+++ b/docs/pages/components/calendar/fragments/compact.md
@@ -1,7 +1,7 @@
 <!--start-code-->
 
 ```js
-import { Calendar, Badge, List } from 'rsuite';
+import { Calendar, Badge, List, HStack } from 'rsuite';
 
 function getTodoList(date) {
   if (!date) {


### PR DESCRIPTION
fix: https://github.com/rsuite/rsuite/issues/4064