### PR TITLE
test: use instead of getInstance

### DIFF
--- a/src/Animation/test/TransitionSpec.tsx
+++ b/src/Animation/test/TransitionSpec.tsx
@@ -31,7 +31,7 @@ describe('Animation', () => {
   });
 
   it('Should be transitionAppear', async () => {
-    const onEnteredSpy = sinon.spy();
+    const onEntered = sinon.spy();
     const { container } = render(
       <Transition
         transitionAppear
@@ -39,13 +39,17 @@ describe('Animation', () => {
         timeout={100}
         exitedClassName="class-out"
         enteredClassName="class-in"
-        onEntered={onEnteredSpy}
+        onEntered={onEntered}
       >
-        {props => <div {...props}>test</div>}
+        {(props, ref) => (
+          <div {...props} ref={ref}>
+            test
+          </div>
+        )}
       </Transition>
     );
 
-    expect(onEnteredSpy).to.not.be.called;
+    expect(onEntered).to.not.be.called;
 
     await waitFor(() => {
       expect(container.firstChild).to.have.class('class-in');
@@ -53,9 +57,9 @@ describe('Animation', () => {
   });
 
   it('Should call onEnter/onEntering/onEntered callback', async () => {
-    const onEnterSpy = sinon.spy();
-    const onEnteringSpy = sinon.spy();
-    const onEnteredSpy = sinon.spy();
+    const onEnter = sinon.spy();
+    const onEntering = sinon.spy();
+    const onEntered = sinon.spy();
 
     render(
       <Transition
@@ -64,25 +68,29 @@ describe('Animation', () => {
         timeout={100}
         exitedClassName="class-out"
         enteredClassName="class-in"
-        onEnter={onEnterSpy}
-        onEntering={onEnteringSpy}
-        onEntered={onEnteredSpy}
+        onEnter={onEnter}
+        onEntering={onEntering}
+        onEntered={onEntered}
       >
-        {props => <div {...props}>test</div>}
+        {(props, ref) => (
+          <div {...props} ref={ref}>
+            test
+          </div>
+        )}
       </Transition>
     );
 
     await waitFor(() => {
-      expect(onEnterSpy).to.be.called;
-      expect(onEnteringSpy).to.be.called;
-      expect(onEnteredSpy).to.be.called;
+      expect(onEnter).to.be.called;
+      expect(onEntering).to.be.called;
+      expect(onEntered).to.be.called;
     });
   });
 
   it('Should call onExit/onExiting/onExited callback', async () => {
-    const onExitSpy = sinon.spy();
-    const onExitingSpy = sinon.spy();
-    const onExitedSpy = sinon.spy();
+    const onExit = sinon.spy();
+    const onExiting = sinon.spy();
+    const onExited = sinon.spy();
 
     const transitionRef = React.createRef<Transition>();
     render(
@@ -91,11 +99,15 @@ describe('Animation', () => {
         timeout={100}
         exitedClassName="class-out"
         enteredClassName="class-in"
-        onExit={onExitSpy}
-        onExiting={onExitingSpy}
-        onExited={onExitedSpy}
+        onExit={onExit}
+        onExiting={onExiting}
+        onExited={onExited}
       >
-        {props => <div {...props}>test</div>}
+        {(props, ref) => (
+          <div {...props} ref={ref}>
+            test
+          </div>
+        )}
       </Transition>
     );
 
@@ -104,9 +116,9 @@ describe('Animation', () => {
     });
 
     await waitFor(() => {
-      expect(onExitSpy).to.be.called;
-      expect(onExitingSpy).to.be.called;
-      expect(onExitedSpy).to.be.called;
+      expect(onExit).to.be.called;
+      expect(onExiting).to.be.called;
+      expect(onExited).to.be.called;
     });
   });
 });

--- a/src/AutoComplete/test/AutoCompleteSpec.tsx
+++ b/src/AutoComplete/test/AutoCompleteSpec.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import AutoComplete from '../AutoComplete';
-import {
-  getInstance,
-  testStandardProps,
-  testControlledUnControlled,
-  testFormControl
-} from '@test/utils';
+import { testStandardProps, testControlledUnControlled, testFormControl } from '@test/utils';
 import { render, fireEvent, screen } from '@testing-library/react';
 import sinon from 'sinon';
 
@@ -45,8 +40,9 @@ describe('AutoComplete', () => {
   });
 
   it('Should be a `top-end` for placement', () => {
-    const instance = getInstance(<AutoComplete data={data} open placement="topEnd" />);
-    expect(instance.overlay.className).to.contain('placement-top-end');
+    render(<AutoComplete data={data} open placement="topEnd" />);
+
+    expect(screen.getByTestId('picker-popup')).to.have.class('placement-top-end');
   });
 
   it('Should call onSelect callback with correct args', () => {
@@ -59,14 +55,14 @@ describe('AutoComplete', () => {
   });
 
   it('Should call onChange callback', () => {
-    const onChangeSpy = sinon.spy();
+    const onChange = sinon.spy();
 
-    render(<AutoComplete data={data} onChange={onChangeSpy} />);
+    render(<AutoComplete data={data} onChange={onChange} />);
     const input = screen.getByRole('combobox');
 
     fireEvent.change(input, { target: { value: 'a' } });
-    expect(onChangeSpy).to.have.been.calledOnce;
-    expect(onChangeSpy).to.have.been.calledWith('a');
+    expect(onChange).to.have.been.calledOnce;
+    expect(onChange).to.have.been.calledWith('a');
   });
 
   it('Should call onFocus callback', () => {
@@ -87,67 +83,65 @@ describe('AutoComplete', () => {
   });
 
   it('Should call onKeyDown callback on input', () => {
-    const onKeyDownSpy = sinon.spy();
+    const onKeyDown = sinon.spy();
 
-    render(<AutoComplete onKeyDown={onKeyDownSpy} data={['a', 'b', 'ab']} open />);
+    render(<AutoComplete onKeyDown={onKeyDown} data={['a', 'b', 'ab']} open />);
     const input = screen.getByRole('combobox');
     fireEvent.keyDown(input);
-    expect(onKeyDownSpy).to.have.been.calledOnce;
+    expect(onKeyDown).to.have.been.calledOnce;
   });
 
   it('Should call onKeyDown callback on menu', () => {
-    const onKeyDownSpy = sinon.spy();
-    const instance = getInstance(
-      <AutoComplete defaultValue="a" onKeyDown={onKeyDownSpy} data={['a', 'b']} open />
-    );
-    fireEvent.keyDown(instance.overlay);
+    const onKeyDown = sinon.spy();
 
-    expect(onKeyDownSpy).to.be.calledOnce;
+    render(<AutoComplete defaultValue="a" onKeyDown={onKeyDown} data={['a', 'b']} open />);
+
+    fireEvent.keyDown(screen.getByTestId('picker-popup'));
+
+    expect(onKeyDown).to.be.calledOnce;
   });
 
   it('Should call onMenuFocus callback when key=ArrowDown', () => {
-    const onMenuFocusSpy = sinon.spy();
+    const onMenuFocus = sinon.spy();
 
-    const instance = getInstance(
-      <AutoComplete defaultValue="a" onMenuFocus={onMenuFocusSpy} data={['a', 'ab', 'ac']} open />
+    render(
+      <AutoComplete defaultValue="a" onMenuFocus={onMenuFocus} data={['a', 'ab', 'ac']} open />
     );
-    fireEvent.keyDown(instance.overlay, {
+
+    fireEvent.keyDown(screen.getByTestId('picker-popup'), {
       key: 'ArrowDown'
     });
 
-    expect(onMenuFocusSpy).to.be.calledOnce;
+    expect(onMenuFocus).to.be.calledOnce;
   });
 
   it('Should call onMenuFocus callback when key=ArrowUp', () => {
-    const onMenuFocusSpy = sinon.spy();
-    const instance = getInstance(
-      <AutoComplete defaultValue="a" onMenuFocus={onMenuFocusSpy} data={['a', 'ab', 'ac']} open />
+    const onMenuFocus = sinon.spy();
+    render(
+      <AutoComplete defaultValue="a" onMenuFocus={onMenuFocus} data={['a', 'ab', 'ac']} open />
     );
-    fireEvent.keyDown(instance.overlay, { key: 'ArrowDown' });
-    fireEvent.keyDown(instance.overlay, { key: 'ArrowUp' });
+    fireEvent.keyDown(screen.getByTestId('picker-popup'), { key: 'ArrowDown' });
+    fireEvent.keyDown(screen.getByTestId('picker-popup'), { key: 'ArrowUp' });
 
-    expect(onMenuFocusSpy).to.be.calledTwice;
+    expect(onMenuFocus).to.be.calledTwice;
   });
 
   it('Should call onChange callback when key=Enter', () => {
-    const onChangeSpy = sinon.spy();
-    const instance = getInstance(
-      <AutoComplete defaultValue="a" onChange={onChangeSpy} data={['a', 'ab', 'ac']} open />
-    );
+    const onChange = sinon.spy();
+    render(<AutoComplete defaultValue="a" onChange={onChange} data={['a', 'ab', 'ac']} open />);
 
-    fireEvent.keyDown(instance.overlay, { key: 'ArrowDown' });
-    fireEvent.keyDown(instance.overlay, { key: 'Enter' });
-    expect(onChangeSpy).to.be.calledOnce;
+    fireEvent.keyDown(screen.getByTestId('picker-popup'), { key: 'ArrowDown' });
+    fireEvent.keyDown(screen.getByTestId('picker-popup'), { key: 'Enter' });
+    expect(onChange).to.be.calledOnce;
   });
 
   it('Should call onSelect callback with selected item when key=Enter', () => {
     const onSelectSpy = sinon.spy();
 
-    const instance = getInstance(
-      <AutoComplete defaultValue="a" onSelect={onSelectSpy} data={['a', 'ab', 'ac']} open />
-    );
-    fireEvent.keyDown(instance.overlay, { key: 'ArrowDown' });
-    fireEvent.keyDown(instance.overlay, { key: 'Enter' });
+    render(<AutoComplete defaultValue="a" onSelect={onSelectSpy} data={['a', 'ab', 'ac']} open />);
+
+    fireEvent.keyDown(screen.getByTestId('picker-popup'), { key: 'ArrowDown' });
+    fireEvent.keyDown(screen.getByTestId('picker-popup'), { key: 'Enter' });
 
     expect(onSelectSpy).to.be.calledOnce;
     expect(onSelectSpy).to.be.calledWith('ab', { value: 'ab', label: 'ab' });
@@ -156,7 +150,7 @@ describe('AutoComplete', () => {
   it('Shouldn‘t call onSelect nor onChange callback on Enter pressed if selectOnEnter=false', () => {
     const onSelectSpy = sinon.spy();
 
-    const instance = getInstance(
+    render(
       <AutoComplete
         defaultValue="a"
         onSelect={onSelectSpy}
@@ -166,18 +160,16 @@ describe('AutoComplete', () => {
         open
       />
     );
-    fireEvent.keyDown(instance.overlay, { key: 'ArrowDown' });
-    fireEvent.keyDown(instance.overlay, { key: 'ArrowUp' });
+    fireEvent.keyDown(screen.getByTestId('picker-popup'), { key: 'ArrowDown' });
+    fireEvent.keyDown(screen.getByTestId('picker-popup'), { key: 'ArrowUp' });
 
     expect(onSelectSpy).to.be.not.called;
   });
 
   it('Should call onClose callback when key=Escape', () => {
     const onCloseSpy = sinon.spy();
-    const instance = getInstance(
-      <AutoComplete defaultValue="a" onClose={onCloseSpy} data={['a', 'ab', 'ac']} open />
-    );
-    fireEvent.keyDown(instance.overlay, { key: 'Escape' });
+    render(<AutoComplete defaultValue="a" onClose={onCloseSpy} data={['a', 'ab', 'ac']} open />);
+    fireEvent.keyDown(screen.getByTestId('picker-popup'), { key: 'Escape' });
     expect(onCloseSpy).to.be.calledOnce;
   });
 

--- a/src/Carousel/Carousel.tsx
+++ b/src/Carousel/Carousel.tsx
@@ -171,6 +171,7 @@ const Carousel: RsRefForwardingComponent<'div', CarouselProps> = React.forwardRe
       <Component {...rest} ref={mergeRefs(ref, rootRef)} className={classes}>
         <div className={prefix('content')}>
           <div
+            data-testid="carousel-slider"
             className={prefix('slider')}
             style={sliderStyles}
             onTransitionEnd={handleTransitionEnd}

--- a/src/Carousel/test/CarouselSpec.tsx
+++ b/src/Carousel/test/CarouselSpec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Simulate } from 'react-dom/test-utils';
 import sinon from 'sinon';
-import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { testStandardProps } from '@test/utils';
 import Carousel from '../Carousel';
 
@@ -39,12 +38,12 @@ describe('Carousel', () => {
 
   it('Should be autoplay', async () => {
     const style = { height: 20 };
-    const onSlideStartSpy = sinon.spy();
+    const onSlideStart = sinon.spy();
     render(
       <Carousel
         autoplay
         autoplayInterval={500}
-        onSlideStart={onSlideStartSpy}
+        onSlideStart={onSlideStart}
         style={{ width: 200, height: 20 }}
       >
         <div style={style}>1</div>
@@ -53,78 +52,61 @@ describe('Carousel', () => {
     );
 
     await waitFor(() => {
-      expect(onSlideStartSpy).to.called;
+      expect(onSlideStart).to.called;
     });
   });
 
   it('Should call `onSlideStart` callback', async () => {
-    const onSlideStartSpy = sinon.spy();
-    const { container } = render(
-      <Carousel onSlideStart={onSlideStartSpy}>
+    const onSlideStart = sinon.spy();
+    render(
+      <Carousel onSlideStart={onSlideStart}>
         <div>1</div>
         <div>2</div>
       </Carousel>
     );
 
-    // eslint-disable-next-line testing-library/no-container
-    const input = container
-      // eslint-disable-next-line testing-library/no-node-access
-      .querySelectorAll('.rs-carousel-label-wrapper')[1]
-      // eslint-disable-next-line testing-library/no-node-access
-      .querySelector('input') as HTMLInputElement;
-
-    fireEvent.click(input);
+    fireEvent.click(screen.getAllByRole('radio')[1]);
 
     await waitFor(() => {
-      expect(onSlideStartSpy).to.called;
+      expect(onSlideStart).to.called;
     });
   });
 
   it('Should call `onSelect` callback', async () => {
-    const onSelectSpy = sinon.spy();
-    const { container } = render(
-      <Carousel onSelect={onSelectSpy}>
+    const onSelect = sinon.spy();
+    render(
+      <Carousel onSelect={onSelect}>
         <div>1</div>
         <div>2</div>
       </Carousel>
     );
 
-    // eslint-disable-next-line testing-library/no-container
-    const input = container
-      // eslint-disable-next-line testing-library/no-node-access
-      .querySelectorAll('.rs-carousel-label-wrapper')[1]
-      // eslint-disable-next-line testing-library/no-node-access
-      .querySelector('input') as HTMLInputElement;
-
-    act(() => {
-      Simulate.change(input);
-    });
+    fireEvent.click(screen.getAllByRole('radio')[1]);
 
     await waitFor(() => {
-      expect(onSelectSpy).to.called;
+      expect(onSelect).to.called;
     });
   });
 
   it('Should call `onSlideEnd` callback', async () => {
-    const onSlideEndSpy = sinon.spy();
+    const onSlideEnd = sinon.spy();
 
-    const { container } = render(
-      <Carousel onSlideEnd={onSlideEndSpy}>
+    render(
+      <Carousel onSlideEnd={onSlideEnd}>
         <div>1</div>
         <div>2</div>
       </Carousel>
     );
 
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    Simulate.transitionEnd(container.querySelector('.rs-carousel-slider') as HTMLElement);
+    fireEvent.transitionEnd(screen.getByTestId('carousel-slider'));
 
     await waitFor(() => {
-      expect(onSlideEndSpy).to.called;
+      expect(onSlideEnd).to.called;
     });
   });
 
   it('Should initialize with the default index position', () => {
-    const { container } = render(
+    render(
       <Carousel defaultActiveIndex={2}>
         <div>1</div>
         <div>2</div>
@@ -132,10 +114,7 @@ describe('Carousel', () => {
         <div>4</div>
       </Carousel>
     );
-    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
-    expect((container.querySelector('[aria-hidden=false]') as HTMLElement).textContent).to.equal(
-      '3'
-    );
+    expect(screen.getByText('3')).to.have.attribute('aria-hidden', 'false');
   });
 
   it('Should handle active index dynamically', () => {

--- a/src/CheckTreePicker/test/CheckTreePickerSpec.tsx
+++ b/src/CheckTreePicker/test/CheckTreePickerSpec.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
-import { getInstance } from '@test/utils';
 import { mockTreeData } from '@test/mocks/data-mock';
 import CheckTreePicker from '../CheckTreePicker';
 import { KEY_VALUES } from '@/internals/constants';
@@ -412,22 +411,19 @@ describe('CheckTreePicker', () => {
   });
 
   it('Should to reset the option height', () => {
-    const instance = getInstance(
-      <CheckTreePicker open virtualized data={data} listProps={{ itemSize: () => 28 }} />
-    );
+    render(<CheckTreePicker open virtualized data={data} listProps={{ itemSize: () => 28 }} />);
 
-    // eslint-disable-next-line testing-library/no-node-access
-    const node = instance.overlay.querySelector('.rs-check-tree-node');
-    assert.equal(node.style.height, '28px');
+    const node = screen.getByTestId('picker-popup').querySelector('.rs-check-tree-node');
+
+    expect(node).to.have.style('height', '28px');
   });
 
   it('Should display indeterminate state when only one child node selected', () => {
-    const instance = getInstance(<CheckTreePicker open defaultExpandAll data={data} />);
+    render(<CheckTreePicker open defaultExpandAll data={data} />);
 
     fireEvent.click(screen.getByLabelText('tester2', { selector: 'input' }));
 
-    // eslint-disable-next-line testing-library/no-node-access
-    expect(instance.overlay.querySelectorAll('.rs-checkbox-indeterminate')).to.length(1);
+    expect(screen.getByRole('tree').querySelectorAll('.rs-checkbox-indeterminate')).to.length(1);
   });
 
   it('Should not has duplicated key when data changed', () => {
@@ -451,26 +447,26 @@ describe('CheckTreePicker', () => {
   });
 
   it('Should item able to stringify', () => {
-    const onSelectSpy = sinon.spy();
-    const renderTreeNodeSpy = sinon.spy();
+    const onSelect = sinon.spy();
+    const renderTreeNode = sinon.spy();
 
-    const instance = getInstance(
+    render(
       <CheckTreePicker
         defaultOpen
         data={data}
-        onSelect={onSelectSpy}
-        renderTreeNode={renderTreeNodeSpy}
+        onSelect={onSelect}
+        renderTreeNode={renderTreeNode}
       />
     );
 
-    // eslint-disable-next-line testing-library/no-node-access
-    fireEvent.click(instance.overlay.querySelector('div[data-key="String_Master"] input'));
+    expect(renderTreeNode).to.called;
 
-    expect(onSelectSpy).to.called;
-    expect(renderTreeNodeSpy).to.called;
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+
+    expect(onSelect).to.called;
     expect(() => JSON.stringify(data[0])).not.to.throw();
-    expect(() => JSON.stringify(onSelectSpy.firstCall.args[0])).not.to.throw();
-    expect(() => JSON.stringify(renderTreeNodeSpy.firstCall.args[0])).not.to.throw();
+    expect(() => JSON.stringify(onSelect.firstCall.args[0])).not.to.throw();
+    expect(() => JSON.stringify(renderTreeNode.firstCall.args[0])).not.to.throw();
   });
 
   it('Should children can be removed', () => {

--- a/src/DatePicker/test/DatePickerSpec.tsx
+++ b/src/DatePicker/test/DatePickerSpec.tsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import {
   testStandardProps,
-  getInstance,
   testControlledUnControlled,
   testFormControl,
   testPickers
@@ -152,11 +151,10 @@ describe('DatePicker', () => {
   it('Should call `onChange` callback when click shortcut', () => {
     const onChange = sinon.spy();
 
-    const instance = getInstance(<DatePicker onChange={onChange} defaultOpen />);
-    // eslint-disable-next-line testing-library/no-node-access
-    const today = instance.overlay.querySelector('.rs-picker-toolbar button');
+    render(<DatePicker onChange={onChange} defaultOpen />);
+    const today = screen.getByRole('dialog').querySelector('.rs-picker-toolbar button');
 
-    fireEvent.click(today);
+    fireEvent.click(today as Element);
 
     expect(onChange).to.calledOnce;
     expect(isSameDay(onChange.firstCall.firstArg, new Date())).to.true;

--- a/src/DateRangePicker/test/DateRangePickerSpec.tsx
+++ b/src/DateRangePicker/test/DateRangePickerSpec.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import { render, act, fireEvent, waitFor, screen, getByRole, within } from '@testing-library/react';
 import {
-  getInstance,
   testStandardProps,
   testFormControl,
   testControlledUnControlled,
@@ -232,10 +231,11 @@ describe('DateRangePicker', () => {
 
   it('Should call `onOpen` callback', async () => {
     const onOpen = sinon.spy();
-    const picker = getInstance(<DateRangePicker onOpen={onOpen} />);
+    const ref = React.createRef<any>();
+    render(<DateRangePicker onOpen={onOpen} ref={ref} />);
 
     act(() => {
-      picker.open();
+      ref.current.open();
     });
 
     await waitFor(() => {
@@ -245,10 +245,11 @@ describe('DateRangePicker', () => {
 
   it('Should call `onClose` callback', async () => {
     const onClose = sinon.spy();
-    const picker = getInstance(<DateRangePicker defaultOpen onClose={onClose} />);
+    const ref = React.createRef<any>();
+    render(<DateRangePicker defaultOpen onClose={onClose} ref={ref} />);
 
     act(() => {
-      picker.close();
+      ref.current.close();
     });
 
     await waitFor(() => {

--- a/src/DateRangePicker/test/DateRangePickerStylesSpec.tsx
+++ b/src/DateRangePicker/test/DateRangePickerStylesSpec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import DateRangePicker from '../index';
-import { getInstance } from '@test/utils';
 import getWidth from 'dom-lib/getWidth';
 
 import '../styles/index.less';
@@ -14,10 +13,10 @@ describe('DateRangePicker styles', () => {
   });
 
   it('Should keep size in `block` mode', function () {
-    const instance = getInstance(<DateRangePicker block defaultOpen />);
+    const { container } = render(<DateRangePicker block defaultOpen />);
 
-    expect(instance.root).to.have.class('rs-picker-block');
-    expect(getWidth(instance.overlay)).to.equal(264 * 2);
+    expect(container.firstChild).to.have.class('rs-picker-block');
+    expect(getWidth(screen.getByRole('dialog'))).to.equal(264 * 2);
   });
 
   it('Should hava a padding of 0px', () => {

--- a/src/Drawer/test/DrawerHeaderSpec.tsx
+++ b/src/Drawer/test/DrawerHeaderSpec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
 import sinon from 'sinon';
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { testStandardProps } from '@test/utils';
 
 import Drawer from '../Drawer';
@@ -10,26 +9,23 @@ describe('Drawer.Header', () => {
   testStandardProps(<Drawer.Header />);
 
   it('Should render a drawer header', () => {
-    const title = 'Test';
-    const { container } = render(<Drawer.Header>{title}</Drawer.Header>);
+    const { container } = render(<Drawer.Header>header</Drawer.Header>);
+
     expect(container.firstChild).to.have.class('rs-drawer-header');
-    expect(container.firstChild).to.have.text(title);
+    expect(container.firstChild).to.have.text('header');
   });
 
   it('Should hide close button', () => {
-    const title = 'Test';
-    const { container } = render(<Drawer.Header closeButton={false}>{title}</Drawer.Header>);
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    expect(container.querySelector('button')).to.not.exist;
+    render(<Drawer.Header closeButton={false}>header</Drawer.Header>);
+
+    expect(screen.queryByRole('button')).to.not.exist;
   });
 
   it('Should call onClose callback', () => {
-    const onCloseSpy = sinon.spy();
-    const { container } = render(<Drawer.Header onClose={onCloseSpy} />);
-    ReactTestUtils.Simulate.click(
-      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-      container.querySelector('.rs-drawer-header-close') as HTMLElement
-    );
-    expect(onCloseSpy).to.have.been.calledOnce;
+    const onClose = sinon.spy();
+    render(<Drawer.Header onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClose).to.have.been.calledOnce;
   });
 });

--- a/src/Form/test/FormValidationSpec.tsx
+++ b/src/Form/test/FormValidationSpec.tsx
@@ -1,8 +1,7 @@
 import React, { useRef } from 'react';
-import { render, fireEvent, act, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { render, fireEvent, act, waitFor, screen } from '@testing-library/react';
 import sinon from 'sinon';
-import { getInstance } from '@test/utils';
 import { FormInstance } from '../hooks/useFormRef';
 import Form from '../Form';
 import FormControl from '../../FormControl';
@@ -28,24 +27,23 @@ const modelAsync = Schema.Model({
 
 describe('Form Validation', () => {
   it('Should be `false` for check status', () => {
-    const values = {
-      name: 'abc'
-    };
-    const form = getInstance(
-      <Form model={model} formDefaultValue={values}>
+    const values = { name: 'abc' };
+    const ref = React.createRef<FormInstance>();
+    render(
+      <Form ref={ref} model={model} formDefaultValue={values}>
         <FormControl name="name" />
       </Form>
     );
 
-    expect(form.check()).to.be.false;
+    expect(ref.current?.check()).to.be.false;
   });
 
   it('Should be `false` for check status by checkForField', () => {
-    const values = {
-      name: 'abc'
-    };
-    const form = getInstance(
+    const values = { name: 'abc' };
+    const ref = React.createRef<FormInstance>();
+    render(
       <Form
+        ref={ref}
         model={model}
         formDefaultValue={values}
         onError={formError => {
@@ -55,7 +53,7 @@ describe('Form Validation', () => {
         <FormControl name="name" />
       </Form>
     );
-    const checkStatus = form.checkForField('name', checkResult => {
+    const checkStatus = ref.current?.checkForField('name', checkResult => {
       expect(checkResult).to.be.deep.equal({
         hasError: true,
         errorMessage: 'Email error'
@@ -69,24 +67,26 @@ describe('Form Validation', () => {
     const values = {
       name: 'abc@gmail.com'
     };
-    const form = getInstance(
-      <Form model={model} formDefaultValue={values}>
+    const ref = React.createRef<FormInstance>();
+    render(
+      <Form ref={ref} model={model} formDefaultValue={values}>
         <FormControl name="name" />
       </Form>
     );
-    expect(form.check()).to.be.true;
+    expect(ref.current?.check()).to.be.true;
   });
 
   it('Should be `true` for check status by checkForField', () => {
     const values = {
       name: 'abc@gmail.com'
     };
-    const form = getInstance(
-      <Form model={model} formDefaultValue={values}>
+    const ref = React.createRef<FormInstance>();
+    render(
+      <Form ref={ref} model={model} formDefaultValue={values}>
         <FormControl name="name" />
       </Form>
     );
-    const checkStatus = form.checkForField('name', checkResult => {
+    const checkStatus = ref.current?.checkForField('name', checkResult => {
       expect(checkResult).to.be.deep.equal({
         hasError: false
       });
@@ -96,18 +96,16 @@ describe('Form Validation', () => {
   });
 
   it('Should be {} for formError when call cleanErrors', () => {
-    const values = {
-      name: 'abc.com'
-    };
-
-    const form = getInstance(
-      <Form model={model} formDefaultValue={values}>
+    const values = { name: 'abc.com' };
+    const ref = React.createRef<any>();
+    render(
+      <Form ref={ref} model={model} formDefaultValue={values}>
         <FormControl name="name" />
       </Form>
     );
-    form.check();
-    form.cleanErrors(() => {
-      expect(form.state.formError).to.be.deep.equal({});
+    ref.current?.check();
+    ref.current?.cleanErrors(() => {
+      expect(ref.current?.state.formError).to.be.deep.equal({});
     });
   });
 
@@ -120,16 +118,16 @@ describe('Form Validation', () => {
       n1: Schema.Types.NumberType().min(2, 'error'),
       n2: Schema.Types.NumberType().min(2, 'error')
     });
-
-    const form = getInstance(
-      <Form model={model} formDefaultValue={values}>
+    const ref = React.createRef<any>();
+    render(
+      <Form ref={ref} model={model} formDefaultValue={values}>
         <FormControl name="n1" />
         <FormControl name="n2" />
       </Form>
     );
-    form.check();
-    form.cleanErrorForField('n2', () => {
-      expect(form.state.formError).to.be.deep.equal({ n1: 'error' });
+    ref.current.check();
+    ref.current.cleanErrorForField('n2', () => {
+      expect(ref.current.state.formError).to.be.deep.equal({ n1: 'error' });
     });
   });
 
@@ -137,13 +135,14 @@ describe('Form Validation', () => {
     const values = {
       name: 'abc.com'
     };
-    const form = getInstance(
-      <Form model={model} formDefaultValue={values}>
+    const ref = React.createRef<any>();
+    render(
+      <Form ref={ref} model={model} formDefaultValue={values}>
         <FormControl name="name" />
       </Form>
     );
-    form.resetErrors({ name: 'error' }, () => {
-      expect(form.state.formError).to.be.deep.equal({ name: 'error' });
+    ref.current.resetErrors({ name: 'error' }, () => {
+      expect(ref.current.state.formError).to.be.deep.equal({ name: 'error' });
     });
   });
 
@@ -227,12 +226,13 @@ describe('Form Validation', () => {
     const values = {
       name: 'abc'
     };
-    const form = getInstance(
-      <Form formDefaultValue={values} model={modelAsync}>
+    const ref = React.createRef<FormInstance>();
+    render(
+      <Form ref={ref} formDefaultValue={values} model={modelAsync}>
         <FormControl name="name" checkAsync />
       </Form>
     );
-    const result = await form.checkAsync();
+    const result = await ref.current?.checkAsync();
 
     expect(result.hasError).to.be.true;
   });
@@ -241,12 +241,13 @@ describe('Form Validation', () => {
     const values = {
       name: 'abc'
     };
-    const form = getInstance(
-      <Form formDefaultValue={values} model={modelAsync}>
+    const ref = React.createRef<any>();
+    render(
+      <Form ref={ref} formDefaultValue={values} model={modelAsync}>
         <FormControl name="name" checkAsync />
       </Form>
     );
-    const result = await form.checkForFieldAsync('name');
+    const result = await ref.current?.checkForFieldAsync('name');
 
     expect(result.hasError).to.be.true;
   });
@@ -343,16 +344,18 @@ describe('Form Validation', () => {
   });
 
   it('Should provide public objects and methods', () => {
-    const form = getInstance(<Form />);
+    const ref = React.createRef<FormInstance>();
 
-    expect(form.root).to.exist;
-    expect(form.check).to.instanceOf(Function);
-    expect(form.checkAsync).to.instanceOf(Function);
-    expect(form.checkForField).to.instanceOf(Function);
-    expect(form.checkForFieldAsync).to.instanceOf(Function);
-    expect(form.cleanErrors).to.instanceOf(Function);
-    expect(form.cleanErrorForField).to.instanceOf(Function);
-    expect(form.resetErrors).to.instanceOf(Function);
+    render(<Form ref={ref} />);
+
+    expect(ref.current?.root).to.exist;
+    expect(ref.current?.check).to.instanceOf(Function);
+    expect(ref.current?.checkAsync).to.instanceOf(Function);
+    expect(ref.current?.checkForField).to.instanceOf(Function);
+    expect(ref.current?.checkForFieldAsync).to.instanceOf(Function);
+    expect(ref.current?.cleanErrors).to.instanceOf(Function);
+    expect(ref.current?.cleanErrorForField).to.instanceOf(Function);
+    expect(ref.current?.resetErrors).to.instanceOf(Function);
   });
 
   describe('The onCheck callback', () => {

--- a/src/InputPicker/test/InputPickerSpec.tsx
+++ b/src/InputPicker/test/InputPickerSpec.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render, fireEvent, screen, within } from '@testing-library/react';
 import sinon from 'sinon';
 import {
-  getInstance,
   testStandardProps,
   testControlledUnControlled,
   testFormControl,
@@ -78,17 +77,17 @@ describe('InputPicker', () => {
   });
 
   it('Should be plaintext', () => {
-    const instance1 = getInstance(<InputPicker plaintext data={data} value={'Eugenia'} />);
-    const instance2 = getInstance(<InputPicker plaintext data={data} />);
-    const instance3 = getInstance(<InputPicker plaintext data={data} placeholder="-" />);
-    const instance4 = getInstance(
-      <InputPicker plaintext data={data} placeholder="-" value={'Eugenia'} />
-    );
+    const { rerender } = render(<InputPicker plaintext data={data} value={'Eugenia'} />);
+    expect(screen.getByText('Eugenia')).to.exist;
 
-    expect(instance1.target).to.text('Eugenia');
-    expect(instance2.target).to.text('Not selected');
-    expect(instance3.target).to.text('-');
-    expect(instance4.target).to.text('Eugenia');
+    rerender(<InputPicker plaintext data={data} />);
+    expect(screen.getByText('Not selected')).to.exist;
+
+    rerender(<InputPicker plaintext data={data} placeholder="-" />);
+    expect(screen.getByText('-')).to.exist;
+
+    rerender(<InputPicker plaintext data={data} placeholder="-" value={'Eugenia'} />);
+    expect(screen.getByText('Eugenia')).to.exist;
   });
 
   it('Should be readOnly', () => {
@@ -227,42 +226,38 @@ describe('InputPicker', () => {
   });
 
   it('Should call `onChange` callback with correct value', () => {
-    const onChangeSpy = sinon.spy();
-    render(<InputPicker defaultOpen onChange={onChangeSpy} data={data} />);
+    const onChange = sinon.spy();
+    render(<InputPicker defaultOpen onChange={onChange} data={data} />);
 
     fireEvent.click(screen.getByRole('option', { name: 'Eugenia' }));
 
-    expect(onChangeSpy).to.have.been.calledWith('Eugenia');
+    expect(onChange).to.have.been.calledWith('Eugenia');
   });
 
   it('Should call `onClean` callback', () => {
-    const onCleanSpy = sinon.spy();
-    render(<InputPicker data={data} defaultValue={'Eugenia'} onClean={onCleanSpy} />);
+    const onClean = sinon.spy();
+    render(<InputPicker data={data} defaultValue={'Eugenia'} onClean={onClean} />);
     fireEvent.click(screen.getByRole('button', { name: /clear/i }));
 
-    expect(onCleanSpy).to.calledOnce;
+    expect(onClean).to.calledOnce;
   });
 
   it('Should call `onClean` callback by keyDown', () => {
-    const onCleanSpy = sinon.spy();
-    const instance = getInstance(
-      <InputPicker data={data} defaultOpen defaultValue={'Eugenia'} onClean={onCleanSpy} />
-    );
-    fireEvent.keyDown(instance.target, { key: 'Backspace' });
+    const onClean = sinon.spy();
+    render(<InputPicker data={data} defaultOpen defaultValue={'Eugenia'} onClean={onClean} />);
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Backspace' });
 
-    expect(onCleanSpy).to.calledOnce;
+    expect(onClean).to.calledOnce;
   });
 
   it('Should call `onSelect` with correct args by key=Enter ', () => {
-    const onSelectSpy = sinon.spy();
-    const instance = getInstance(
-      <InputPicker defaultOpen data={data} onSelect={onSelectSpy} defaultValue={'Kariane'} />
-    );
+    const onSelect = sinon.spy();
+    render(<InputPicker defaultOpen data={data} onSelect={onSelect} defaultValue={'Kariane'} />);
 
-    fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
-    fireEvent.keyDown(instance.target, { key: 'Enter' });
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'ArrowDown' });
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
 
-    expect(onSelectSpy).to.have.been.calledWith('Louisa');
+    expect(onSelect).to.have.been.calledWith('Louisa');
   });
 
   it('Should output a clean button', () => {
@@ -272,20 +267,20 @@ describe('InputPicker', () => {
   });
 
   it('Should call `onSearch` callback with correct search keyword', () => {
-    const onSearchSpy = sinon.spy();
-    render(<InputPicker data={[]} defaultOpen onSearch={onSearchSpy} />);
+    const onSearch = sinon.spy();
+    render(<InputPicker data={[]} defaultOpen onSearch={onSearch} />);
 
     const input = screen.getByRole('textbox');
 
     fireEvent.change(input, { target: { value: 'a' } });
 
-    expect(onSearchSpy).to.have.been.calledOnce;
-    expect(onSearchSpy).to.have.been.calledWith('a');
+    expect(onSearch).to.have.been.calledOnce;
+    expect(onSearch).to.have.been.calledWith('a');
   });
 
   it('Should focus item by key=ArrowDown ', () => {
-    const instance = getInstance(<InputPicker defaultOpen data={data} defaultValue={'Eugenia'} />);
-    fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
+    render(<InputPicker defaultOpen data={data} defaultValue={'Eugenia'} />);
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'ArrowDown' });
 
     expect(screen.getByRole('option', { name: 'Kariane' }).firstChild).to.have.class(
       'rs-picker-select-menu-item-focus'
@@ -293,8 +288,8 @@ describe('InputPicker', () => {
   });
 
   it('Should focus item by key=ArrowUp ', () => {
-    const instance = getInstance(<InputPicker defaultOpen data={data} defaultValue={'Kariane'} />);
-    fireEvent.keyDown(instance.target, { key: 'ArrowUp' });
+    render(<InputPicker defaultOpen data={data} defaultValue={'Kariane'} />);
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'ArrowUp' });
 
     expect(screen.getByRole('option', { name: 'Eugenia' }).firstChild).to.have.class(
       'rs-picker-select-menu-item-focus'
@@ -302,30 +297,28 @@ describe('InputPicker', () => {
   });
 
   it('Should call `onChange` by key=Enter ', () => {
-    const onChangeSpy = sinon.spy();
-    const instance = getInstance(
-      <InputPicker defaultOpen data={data} onChange={onChangeSpy} defaultValue={'Kariane'} />
-    );
+    const onChange = sinon.spy();
+    render(<InputPicker defaultOpen data={data} onChange={onChange} defaultValue={'Kariane'} />);
 
-    fireEvent.keyDown(instance.target, { key: 'Enter' });
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
 
-    expect(onChangeSpy).to.calledOnce;
+    expect(onChange).to.calledOnce;
   });
 
   it('Should call onBlur callback', () => {
-    const onBlurSpy = sinon.spy();
-    render(<InputPicker data={[]} onBlur={onBlurSpy} />);
+    const onBlur = sinon.spy();
+    render(<InputPicker data={[]} onBlur={onBlur} />);
     fireEvent.blur(screen.getByRole('textbox'));
 
-    expect(onBlurSpy).to.calledOnce;
+    expect(onBlur).to.calledOnce;
   });
 
   it('Should call onFocus callback', () => {
-    const onFocusSpy = sinon.spy();
-    render(<InputPicker data={[]} onFocus={onFocusSpy} />);
+    const onFocus = sinon.spy();
+    render(<InputPicker data={[]} onFocus={onFocus} />);
     fireEvent.focus(screen.getByRole('textbox'));
 
-    expect(onFocusSpy).to.called;
+    expect(onFocus).to.called;
   });
 
   it('Should render a button by toggleAs={Button}', () => {

--- a/src/InputPicker/test/InputSearchSpec.tsx
+++ b/src/InputPicker/test/InputSearchSpec.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
-
+import sinon from 'sinon';
+import { render, screen, fireEvent } from '@testing-library/react';
 import InputAutosize from '../InputAutosize';
 import InputSearch from '../InputSearch';
-import Sinon from 'sinon';
-import { render } from '@testing-library/react';
 import { testStandardProps } from '@test/utils';
 
 describe('InputPicker - InputSearch', () => {
@@ -18,10 +16,9 @@ describe('InputPicker - InputSearch', () => {
   });
 
   it('Should render a input', () => {
-    const { container } = render(<InputSearch />);
+    render(<InputSearch />);
 
-    //eslint-disable-next-line
-    expect(container.querySelectorAll('.rs-picker-search-input')).to.have.lengthOf(1);
+    expect(screen.getByRole('textbox')).to.exist;
   });
 
   it('Should have a InputAutosize', () => {
@@ -34,11 +31,10 @@ describe('InputPicker - InputSearch', () => {
   });
 
   it('Should call onChange callback', () => {
-    const onChange = Sinon.spy();
-    const { container } = render(<InputSearch onChange={onChange} />);
-    //eslint-disable-next-line
-    ReactTestUtils.Simulate.change(container.querySelector('input') as HTMLInputElement);
+    const onChange = sinon.spy();
+    render(<InputSearch onChange={onChange} />);
 
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'a' } });
     expect(onChange).to.have.been.calledOnce;
   });
 });

--- a/src/MaskedInput/test/MaskedInputSpec.tsx
+++ b/src/MaskedInput/test/MaskedInputSpec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
 import sinon from 'sinon';
-import { render, act, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import MaskedInput from '../MaskedInput';
 
@@ -9,40 +8,33 @@ describe('MaskedInput', () => {
   it('Should render a input', () => {
     render(
       <MaskedInput
-        data-testid="test"
         mask={['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
       />
     );
-    expect(screen.getByTestId('test').className).to.equal('rs-input');
+    expect(screen.getByRole('textbox')).to.have.class('rs-input');
   });
 
   it('Should render default value', () => {
     render(
       <MaskedInput
-        data-testid="test"
         defaultValue="12345"
         mask={['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
       />
     );
-    expect((screen.getByTestId('test') as HTMLInputElement).value).to.equal('(123) 45_-____');
+    expect(screen.getByRole('textbox')).to.have.value('(123) 45_-____');
   });
 
   it('Should call onChange callback', () => {
-    const onChangeSpy = sinon.spy();
+    const onChange = sinon.spy();
     render(
       <MaskedInput
-        data-testid="test"
-        onChange={onChangeSpy}
+        onChange={onChange}
         mask={['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
       />
     );
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '12345' } });
 
-    act(() => {
-      (screen.getByTestId('test') as HTMLInputElement).value = '12345';
-      ReactTestUtils.Simulate.change(screen.getByTestId('test'));
-    });
-
-    expect(onChangeSpy.calledOnce).to.true;
-    expect(onChangeSpy.firstCall.firstArg).to.equal('(123) 45_-____');
+    expect(onChange.calledOnce).to.true;
+    expect(onChange).to.be.calledWithMatch('(123) 45_-____');
   });
 });

--- a/src/MaskedInput/test/TextMaskSpec.tsx
+++ b/src/MaskedInput/test/TextMaskSpec.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
-import { render, act, screen } from '@testing-library/react';
+import { render, act, screen, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
 import { mergeRefs } from '@/internals/utils';
 import TextMask, { TextMaskProps } from '../TextMask';
@@ -152,9 +151,8 @@ describe('TextMask', () => {
 
     expect((inputRef.current as TextMastTestInstance).input.value).to.equal('');
 
-    act(() => {
-      (inputRef.current as TextMastTestInstance).input.value = '12345';
-      ReactTestUtils.Simulate.change((inputRef.current as TextMastTestInstance).input);
+    fireEvent.change((inputRef.current as TextMastTestInstance).input, {
+      target: { value: '12345' }
     });
 
     expect((inputRef.current as TextMastTestInstance).input.value).to.equal('(123) 45_-____');
@@ -242,39 +240,41 @@ describe('TextMask', () => {
   });
 
   it('calls `onChange` when a change event is received', () => {
-    const onChangeSpy = sinon.spy(event => {
-      expect(event.target.value).to.equal('123');
-    });
-    render(
-      <TextMask
-        data-testid="test"
-        value="123"
-        onChange={onChangeSpy}
-        mask={['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
-        guide={true}
-      />
-    );
-    ReactTestUtils.Simulate.change(screen.getByTestId('test'), {
-      target: { value: '123' } as any
-    });
-    expect(onChangeSpy.callCount).to.equal(1);
-  });
-
-  it('calls props.onBlur when a change event is received', () => {
-    const onBlurSpy = sinon.spy(event => {
+    const onChange = sinon.spy(event => {
       expect(event.target.value).to.equal('(123) ___-____');
     });
     render(
       <TextMask
         data-testid="test"
         value="123"
-        onBlur={onBlurSpy}
+        onChange={onChange}
         mask={['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
         guide={true}
       />
     );
-    ReactTestUtils.Simulate.blur(screen.getByTestId('test'));
-    expect(onBlurSpy.callCount).to.equal(1);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '123' }
+    });
+
+    expect(onChange).to.be.calledOnce;
+  });
+
+  it('calls props.onBlur when a change event is received', () => {
+    const onBlur = sinon.spy(event => {
+      expect(event.target.value).to.equal('(123) ___-____');
+    });
+    render(
+      <TextMask
+        data-testid="test"
+        value="123"
+        onBlur={onBlur}
+        mask={['(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
+        guide={true}
+      />
+    );
+    fireEvent.blur(screen.getByTestId('test'));
+    expect(onBlur.callCount).to.equal(1);
   });
 
   // test fix for issues #230, #483, #778 etc.
@@ -297,7 +297,7 @@ describe('TextMask', () => {
     (inputRef.current as TextMastTestInstance).input.value = '(123';
 
     // Simulate onChange event with current value "(123"
-    ReactTestUtils.Simulate.change((inputRef.current as TextMastTestInstance).input, {
+    fireEvent.change((inputRef.current as TextMastTestInstance).input, {
       target: { value: '(123' } as any
     });
 

--- a/src/MultiCascader/test/MultiCascaderSpec.tsx
+++ b/src/MultiCascader/test/MultiCascaderSpec.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
 import {
-  getInstance,
   testStandardProps,
   testFormControl,
   testControlledUnControlled,
@@ -257,19 +256,20 @@ describe('MultiCascader', () => {
   });
 
   it('Should call `onClean` callback', () => {
-    const onCleanSpy = sinon.spy();
-    render(<MultiCascader data={items} defaultValue={['1']} onClean={onCleanSpy} />);
+    const onClean = sinon.spy();
+    render(<MultiCascader data={items} defaultValue={['1']} onClean={onClean} />);
 
     fireEvent.click(screen.getByRole('button', { name: /clear/i }));
-    expect(onCleanSpy).to.have.been.calledOnce;
+    expect(onClean).to.have.been.calledOnce;
   });
 
   it('Should call `onOpen` callback', () => {
     const onOpen = sinon.spy();
-    const picker = getInstance(<MultiCascader onOpen={onOpen} data={items} />);
+    const ref = React.createRef<any>();
+    render(<MultiCascader ref={ref} onOpen={onOpen} data={items} />);
 
     act(() => {
-      picker.open();
+      ref.current.open();
     });
 
     expect(onOpen).to.be.calledOnce;
@@ -277,10 +277,11 @@ describe('MultiCascader', () => {
 
   it('Should call `onClose` callback', async () => {
     const onClose = sinon.spy();
-    const picker = getInstance(<MultiCascader defaultOpen onClose={onClose} data={items} />);
+    const ref = React.createRef<any>();
+    render(<MultiCascader ref={ref} defaultOpen onClose={onClose} data={items} />);
 
     act(() => {
-      picker.close();
+      ref.current.close();
     });
 
     await waitFor(() => {
@@ -366,12 +367,12 @@ describe('MultiCascader', () => {
   });
 
   it('Should call onCheck callback', () => {
-    const onCheckSpy = sinon.spy();
-    render(<MultiCascader data={items} defaultOpen onCheck={onCheckSpy} />);
+    const onCheck = sinon.spy();
+    render(<MultiCascader data={items} defaultOpen onCheck={onCheck} />);
 
     fireEvent.click(screen.getByRole('checkbox', { name: '1' }));
 
-    expect(onCheckSpy).to.have.been.calledWith(['1'], { label: '1', value: '1' }, true);
+    expect(onCheck).to.have.been.calledWith(['1'], { label: '1', value: '1' }, true);
   });
 
   it('Should update columns', () => {

--- a/src/SafeAnchor/test/SafeAnchorSpec.tsx
+++ b/src/SafeAnchor/test/SafeAnchorSpec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
 import sinon from 'sinon';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import SafeAnchor from '../SafeAnchor';
 
 describe('SafeAnchor', () => {
@@ -16,18 +15,20 @@ describe('SafeAnchor', () => {
   it('Should call onClick callback', () => {
     const onClick = sinon.spy();
     render(<SafeAnchor onClick={onClick}>Title</SafeAnchor>);
-    ReactTestUtils.Simulate.click(screen.getByText('Title'));
+
+    fireEvent.click(screen.getByText('Title'));
+
     expect(onClick).to.have.been.calledOnce;
   });
 
   it('Should call onClick callback', () => {
     const onClick = sinon.spy();
     render(
-      <SafeAnchor onClick={onClick} href="http://a.com">
+      <SafeAnchor onClick={onClick} href="#">
         Title
       </SafeAnchor>
     );
-    ReactTestUtils.Simulate.click(screen.getByText('Title'));
+    fireEvent.click(screen.getByText('Title'));
 
     expect(onClick).to.have.been.calledOnce;
   });
@@ -39,7 +40,7 @@ describe('SafeAnchor', () => {
         Title
       </SafeAnchor>
     );
-    ReactTestUtils.Simulate.click(screen.getByText('Title'));
+    fireEvent.click(screen.getByText('Title'));
 
     expect(handleClick).to.have.been.calledOnce;
     expect(handleClick.getCall(0).args[0].isDefaultPrevented()).to.be.false;
@@ -52,7 +53,7 @@ describe('SafeAnchor', () => {
         Title
       </SafeAnchor>
     );
-    ReactTestUtils.Simulate.click(screen.getByText('Title'));
+    fireEvent.click(screen.getByText('Title'));
 
     expect(handleClick).to.not.have.been.calledOnce;
     expect(container.firstChild).to.have.attr('tabindex', '-1');

--- a/src/SelectPicker/test/SelectPickerSpec.tsx
+++ b/src/SelectPicker/test/SelectPickerSpec.tsx
@@ -3,7 +3,6 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 import {
-  getInstance,
   testStandardProps,
   testControlledUnControlled,
   testFormControl,
@@ -121,10 +120,9 @@ describe('SelectPicker', () => {
   });
 
   it('Should render a group', () => {
-    const instance = getInstance(<SelectPicker defaultOpen groupBy="role" data={data} />);
+    render(<SelectPicker defaultOpen groupBy="role" data={data} />);
 
-    // eslint-disable-next-line testing-library/no-node-access
-    expect(instance.overlay.querySelector('.rs-picker-menu-group')).to.exist;
+    expect(screen.getByRole('group')).to.exist;
   });
 
   it('Should toggle expansion of a group by clicking on the group title', () => {
@@ -207,12 +205,12 @@ describe('SelectPicker', () => {
   });
 
   it('Should call `onChange` callback with correct value', () => {
-    const onChangeSpy = sinon.spy();
-    render(<SelectPicker defaultOpen onChange={onChangeSpy} data={data} />);
+    const onChange = sinon.spy();
+    render(<SelectPicker defaultOpen onChange={onChange} data={data} />);
 
     fireEvent.click(screen.getByRole('option', { name: 'Eugenia' }));
 
-    expect(onChangeSpy).to.have.been.calledWith('Eugenia');
+    expect(onChange).to.have.been.calledWith('Eugenia');
   });
 
   it('Should call `onClean` callback', () => {
@@ -248,15 +246,13 @@ describe('SelectPicker', () => {
   });
 
   it('Should call `onSelect` with correct args by key=Enter ', () => {
-    const onSelectSpy = sinon.spy();
-    const instance = getInstance(
-      <SelectPicker defaultOpen data={data} onSelect={onSelectSpy} defaultValue={'Kariane'} />
-    );
+    const onSelect = sinon.spy();
+    render(<SelectPicker defaultOpen data={data} onSelect={onSelect} defaultValue={'Kariane'} />);
 
-    fireEvent.keyDown(instance.target, { key: 'ArrowDown' });
-    fireEvent.keyDown(instance.target, { key: 'Enter' });
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'ArrowDown' });
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' });
 
-    expect(onSelectSpy).to.have.been.calledWith('Louisa');
+    expect(onSelect).to.have.been.calledWith('Louisa');
   });
 
   it('Should focus item by key=ArrowDown ', () => {
@@ -278,40 +274,34 @@ describe('SelectPicker', () => {
   });
 
   it('Should call `onChange` by key=Enter ', () => {
-    const onChangeSpy = sinon.spy();
-    const instance = getInstance(
-      <SelectPicker defaultOpen data={data} onChange={onChangeSpy} defaultValue={'Kariane'} />
-    );
+    const onChange = sinon.spy();
+    render(<SelectPicker defaultOpen data={data} onChange={onChange} defaultValue={'Kariane'} />);
 
-    fireEvent.keyDown(instance.target, { key: 'Enter' });
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' });
 
-    expect(onChangeSpy).to.calledOnce;
+    expect(onChange).to.calledOnce;
   });
 
   it('Should call onBlur callback', async () => {
-    const onBlurSpy = sinon.spy();
-    // FIXME SelectPicker does not have `onBlur` prop
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const instance = getInstance(<SelectPicker defaultOpen data={data} onBlur={onBlurSpy} />);
+    const onBlur = sinon.spy();
 
-    fireEvent.blur(instance.target);
+    render(<SelectPicker defaultOpen data={data} onBlur={onBlur} />);
+
+    fireEvent.blur(screen.getByRole('combobox'));
 
     await waitFor(() => {
-      expect(onBlurSpy).to.calledOnce;
+      expect(onBlur).to.calledOnce;
     });
   });
 
   it('Should call onFocus callback', () => {
-    const onFocusSpy = sinon.spy();
-    // FIXME SelectPicker does not have `onFocus` prop
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const instance = getInstance(<SelectPicker defaultOpen data={data} onFocus={onFocusSpy} />);
+    const onFocus = sinon.spy();
 
-    fireEvent.focus(instance.target);
+    render(<SelectPicker defaultOpen data={data} onFocus={onFocus} />);
 
-    expect(onFocusSpy).to.calledOnce;
+    fireEvent.focus(screen.getByRole('combobox'));
+
+    expect(onFocus).to.calledOnce;
   });
 
   it('Should render a button by toggleAs={Button}', () => {

--- a/src/Uploader/test/UploadTriggerSpec.tsx
+++ b/src/Uploader/test/UploadTriggerSpec.tsx
@@ -1,9 +1,10 @@
+/* eslint-disable testing-library/no-node-access */
+/* eslint-disable testing-library/no-container */
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
 import sinon from 'sinon';
 
 import UploadTrigger from '../UploadTrigger';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 describe('UploadTrigger', () => {
   it('Should output a UploadTrigger', () => {
@@ -18,35 +19,34 @@ describe('UploadTrigger', () => {
 
   it('Should be multipled', () => {
     const { container } = render(<UploadTrigger multiple />);
-    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
-    assert.ok(container.querySelector('input[multiple]'));
+
+    expect(container.querySelector('input[multiple]')).to.exist;
   });
 
   it('Should have a accept', () => {
     const { container } = render(<UploadTrigger accept=".jpg" />);
-    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
-    assert.ok(container.querySelector('input[accept=".jpg"]'));
+
+    expect(container.querySelector('input[accept=".jpg"]')).to.exist;
   });
 
   it('Should render custom component', () => {
     const { container } = render(<UploadTrigger as={'a'} />);
-    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
-    assert.equal((container.querySelector('.rs-uploader-trigger-btn') as HTMLElement).tagName, 'A');
+    expect(container.querySelector('.rs-uploader-trigger-btn')).to.has.tagName('A');
   });
 
   it('Should call onChange callback', () => {
     const onChange = sinon.spy();
     const { container } = render(<UploadTrigger onChange={onChange} />);
-    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
-    ReactTestUtils.Simulate.change(container.querySelector('input') as HTMLElement);
+
+    fireEvent.change(container.querySelector('input') as HTMLElement);
 
     expect(onChange).to.have.been.calledOnce;
   });
 
   it('Should have a name', () => {
     const { container } = render(<UploadTrigger name="file" />);
-    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
-    assert.ok(container.querySelector('input[name="file"]'));
+
+    expect(container.querySelector('input[name="file"]')).to.exist;
   });
 
   it('Should have a custom className', () => {
@@ -55,10 +55,9 @@ describe('UploadTrigger', () => {
   });
 
   it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const { container } = render(<UploadTrigger style={{ fontSize }} />);
-    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
-    assert.equal((container.querySelector('button') as HTMLElement).style.fontSize, fontSize);
+    const { container } = render(<UploadTrigger style={{ fontSize: 12 }} />);
+
+    expect(container.querySelector('button')).to.have.style('font-size', '12px');
   });
 
   it('Should have a custom className prefix', () => {
@@ -67,32 +66,29 @@ describe('UploadTrigger', () => {
   });
 
   it('Should call `onDragEnter` callback', () => {
-    const onDragEnterSpy = sinon.spy();
-    const { container } = render(<UploadTrigger draggable onDragEnter={onDragEnterSpy} />);
-    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    const onDragEnter = sinon.spy();
+    const { container } = render(<UploadTrigger draggable onDragEnter={onDragEnter} />);
     const button = container.querySelector('button') as HTMLElement;
 
-    ReactTestUtils.Simulate.dragEnter(button);
-    assert.ok(onDragEnterSpy.calledOnce);
+    fireEvent.dragEnter(button);
+    expect(onDragEnter).to.have.been.calledOnce;
   });
 
   it('Should call `onDragOver` callback', () => {
-    const onDragOverSpy = sinon.spy();
-    const { container } = render(<UploadTrigger draggable onDragOver={onDragOverSpy} />);
-    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    const onDragOver = sinon.spy();
+    const { container } = render(<UploadTrigger draggable onDragOver={onDragOver} />);
     const button = container.querySelector('button') as HTMLElement;
 
-    ReactTestUtils.Simulate.dragOver(button);
-    assert.ok(onDragOverSpy.calledOnce);
+    fireEvent.dragOver(button);
+    expect(onDragOver).to.have.been.calledOnce;
   });
 
   it('Should call `onDragLeave` callback', () => {
-    const onDragLeaveSpy = sinon.spy();
-    const { container } = render(<UploadTrigger draggable onDragLeave={onDragLeaveSpy} />);
-    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    const onDragLeave = sinon.spy();
+    const { container } = render(<UploadTrigger draggable onDragLeave={onDragLeave} />);
     const button = container.querySelector('button') as HTMLElement;
 
-    ReactTestUtils.Simulate.dragLeave(button);
-    assert.ok(onDragLeaveSpy.calledOnce);
+    fireEvent.dragLeave(button);
+    expect(onDragLeave).to.have.been.calledOnce;
   });
 });

--- a/src/Uploader/test/UploaderSpec.tsx
+++ b/src/Uploader/test/UploaderSpec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
 import sinon from 'sinon';
-import { getInstance, testStandardProps } from '@test/utils';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { testStandardProps } from '@test/utils';
 
 import Uploader from '../Uploader';
 import Button from '../../Button';
@@ -62,8 +62,11 @@ describe('Uploader', () => {
       blobFile: new File(['foo'], 'foo.txt', { type: 'text/plain' })
     };
 
-    const instance = getInstance(<Uploader name="file" action="" onUpload={onUpload} />);
-    instance.start(file);
+    const ref = React.createRef<any>();
+
+    render(<Uploader ref={ref} name="file" action="" onUpload={onUpload} />);
+
+    ref.current.start(file);
 
     expect(onUpload.args[0][1] instanceof FormData).to.equal(true);
     expect(onUpload).to.been.calledOnce;
@@ -72,9 +75,10 @@ describe('Uploader', () => {
   it('Should call `onUpload` callback', () => {
     const onUpload = sinon.spy();
     const file = { blobFile: new File(['foo'], 'foo.txt') };
+    const ref = React.createRef<any>();
 
-    const instance = getInstance(<Uploader name="file" action="" onUpload={onUpload} />);
-    instance.start(file);
+    render(<Uploader ref={ref} name="file" action="" onUpload={onUpload} />);
+    ref.current.start(file);
 
     expect(onUpload).to.been.calledOnce;
   });
@@ -82,9 +86,11 @@ describe('Uploader', () => {
   it('Should upload a FormData', () => {
     const onUpload = sinon.spy();
     const file = { blobFile: new File(['foo'], 'foo.txt') };
+    const ref = React.createRef<any>();
 
-    const instance = getInstance(<Uploader name="file" action="" onUpload={onUpload} />);
-    instance.start(file);
+    render(<Uploader ref={ref} name="file" action="" onUpload={onUpload} />);
+
+    ref.current.start(file);
 
     expect(onUpload.args[0][1] instanceof FormData).to.equal(true);
   });
@@ -92,11 +98,11 @@ describe('Uploader', () => {
   it('Should upload a File', () => {
     const onUpload = sinon.spy();
     const file = { blobFile: new File(['foo'], 'foo.txt') };
+    const ref = React.createRef<any>();
 
-    const instance = getInstance(
-      <Uploader name="file" action="" onUpload={onUpload} disableMultipart />
-    );
-    instance.start(file);
+    render(<Uploader ref={ref} name="file" action="" onUpload={onUpload} disableMultipart />);
+
+    ref.current.start(file);
 
     expect(onUpload.args[0][1] instanceof File).to.equal(true);
   });
@@ -119,18 +125,18 @@ describe('Uploader', () => {
   });
 
   it('Should call `onRemove` callback', () => {
-    const onRemoveSpy = sinon.spy();
+    const onRemove = sinon.spy();
     const file = {
       blobFile: new File(['foo'], 'foo.txt'),
       status: 'finished',
       name: 'foo.txt'
     } as const;
 
-    render(<Uploader name="file" action="" onRemove={onRemoveSpy} defaultFileList={[file]} />);
+    render(<Uploader name="file" action="" onRemove={onRemove} defaultFileList={[file]} />);
 
     userEvent.click(screen.getByRole('button', { name: 'Remove file: foo.txt' }));
 
-    expect(onRemoveSpy).to.have.been.calledOnce;
+    expect(onRemove).to.have.been.calledOnce;
   });
 
   it('Should apply appearance', () => {

--- a/src/Whisper/test/WhisperSpec.tsx
+++ b/src/Whisper/test/WhisperSpec.tsx
@@ -1,8 +1,6 @@
 import React, { CSSProperties, Ref } from 'react';
-import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import sinon from 'sinon';
-import { getInstance } from '@test/utils';
-
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import Whisper, { WhisperInstance } from '../Whisper';
 import Tooltip from '../../Tooltip';
 
@@ -83,13 +81,14 @@ describe('Whisper', () => {
 
   it('Should call onOpen callback by open()', async () => {
     const onOpen = sinon.spy();
-    const instance = getInstance(
-      <Whisper onOpen={onOpen} trigger="none" speaker={<Tooltip />}>
+    const ref = React.createRef<WhisperInstance>();
+    render(
+      <Whisper ref={ref} onOpen={onOpen} trigger="none" speaker={<Tooltip />}>
         <button>button</button>
       </Whisper>
     );
 
-    instance.open();
+    ref.current?.open();
     await waitFor(() => {
       expect(onOpen).to.have.been.calledOnce;
     });

--- a/src/internals/utils/getDOMNode.ts
+++ b/src/internals/utils/getDOMNode.ts
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 function safeFindDOMNode(componentOrElement: React.Component | Element | null | undefined) {
   if (componentOrElement && 'setState' in componentOrElement) {
     // eslint-disable-next-line react/no-find-dom-node
-    return ReactDOM.findDOMNode(componentOrElement);
+    return ReactDOM.findDOMNode?.(componentOrElement);
   }
   return (componentOrElement ?? null) as Element | Text | null;
 }

--- a/test/utils/getDOMNode.tsx
+++ b/test/utils/getDOMNode.tsx
@@ -1,8 +1,4 @@
-/* eslint-disable react/no-find-dom-node */
-
 import React from 'react';
-import { findDOMNode } from 'react-dom';
-import * as ReactTestUtils from 'react-dom/test-utils';
 import { render as testRender } from '@testing-library/react';
 import { guid } from '@/internals/utils';
 
@@ -38,10 +34,6 @@ export function getDOMNode(children) {
 
   if (isDOMElement(children.child)) {
     return children.child;
-  }
-
-  if (ReactTestUtils.isCompositeComponent(children)) {
-    return findDOMNode(children);
   }
 
   return getTestDOMNode(children);

--- a/test/utils/testPickers.tsx
+++ b/test/utils/testPickers.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
-import Sinon from 'sinon';
-import { getInstance } from './getInstance';
+import sinon from 'sinon';
 
 interface TestPickerOptions {
   data?: any;
@@ -48,15 +47,15 @@ export function testPickers(TestComponent: React.ComponentType<any>, options?: T
     });
 
     it('Should have a custom menuStyle', () => {
-      const instance = getInstance(<TestComponent open menuStyle={{ fontSize: 12 }} data={data} />);
+      render(<TestComponent open menuStyle={{ fontSize: 12 }} data={data} />);
 
-      expect(instance.overlay).to.have.style('font-size', '12px');
+      expect(screen.getByTestId('picker-popup')).to.have.style('font-size', '12px');
     });
 
     it('Should have a custom menuClassName', () => {
-      const instance = getInstance(<TestComponent open menuClassName="custom-class" data={data} />);
+      render(<TestComponent open menuClassName="custom-class" data={data} />);
 
-      expect(instance.overlay).to.have.class('custom-class');
+      expect(screen.getByTestId('picker-popup')).to.have.class('custom-class');
     });
 
     if (popupAutoWidth) {
@@ -122,21 +121,25 @@ export function testPickers(TestComponent: React.ComponentType<any>, options?: T
 
     describe('ref testing', () => {
       it('Should call `onOpen` callback', async () => {
-        const onOpenSpy = Sinon.spy();
-        const instance = getInstance(<TestComponent onOpen={onOpenSpy} data={data} />);
+        const onOpen = sinon.spy();
+        const ref = React.createRef<any>();
 
-        act(() => instance.open());
+        render(<TestComponent onOpen={onOpen} data={data} ref={ref} />);
+
+        act(() => ref.current.open());
         await waitFor(() => {
-          expect(onOpenSpy).to.have.been.calledOnce;
+          expect(onOpen).to.have.been.calledOnce;
         });
       });
 
       it('Should call `onClose` callback', async () => {
-        const onCloseSpy = Sinon.spy();
-        const instance = getInstance(<TestComponent onClose={onCloseSpy} data={data} />);
+        const onCloseSpy = sinon.spy();
+        const ref = React.createRef<any>();
 
-        act(() => instance.open());
-        act(() => instance.close());
+        render(<TestComponent onClose={onCloseSpy} data={data} ref={ref} />);
+
+        act(() => ref.current.open());
+        act(() => ref.current.close());
 
         await waitFor(() => {
           expect(onCloseSpy).to.have.been.calledOnce;
@@ -144,24 +147,25 @@ export function testPickers(TestComponent: React.ComponentType<any>, options?: T
       });
 
       it('Should provide public objects and methods', () => {
-        const instance = getInstance(<TestComponent data={data} open virtualized={virtualized} />);
+        const ref = React.createRef<any>();
+        render(<TestComponent data={data} open virtualized={virtualized} ref={ref} />);
 
-        expect(instance.root).to.exist;
-        expect(instance.target).to.exist;
-        expect(instance.updatePosition).to.instanceOf(Function);
-        expect(instance.open).to.instanceOf(Function);
-        expect(instance.close).to.instanceOf(Function);
-        expect(instance.overlay).to.exist;
+        expect(ref.current.root).to.exist;
+        expect(ref.current.target).to.exist;
+        expect(ref.current.updatePosition).to.instanceOf(Function);
+        expect(ref.current.open).to.instanceOf(Function);
+        expect(ref.current.close).to.instanceOf(Function);
+        expect(ref.current.overlay).to.exist;
 
         if (virtualized) {
-          expect(instance.list).to.exist;
+          expect(ref.current.list).to.exist;
         }
       });
     });
 
     describe('Open state', () => {
       it('Should open the popup on click', () => {
-        const onOpen = Sinon.spy();
+        const onOpen = sinon.spy();
 
         render(<TestComponent data={data} onOpen={onOpen} />);
 
@@ -174,7 +178,7 @@ export function testPickers(TestComponent: React.ComponentType<any>, options?: T
       });
 
       it('Should open the popup on Enter key', () => {
-        const onOpen = Sinon.spy();
+        const onOpen = sinon.spy();
 
         render(<TestComponent data={data} onOpen={onOpen} />);
 
@@ -187,7 +191,7 @@ export function testPickers(TestComponent: React.ComponentType<any>, options?: T
       });
 
       it('Should close the popup on outside click', () => {
-        const onClose = Sinon.spy();
+        const onClose = sinon.spy();
 
         render(<TestComponent data={data} defaultOpen onClose={onClose} />);
 
@@ -197,7 +201,7 @@ export function testPickers(TestComponent: React.ComponentType<any>, options?: T
       });
 
       it('Should close the popup on Escape key', () => {
-        const onClose = Sinon.spy();
+        const onClose = sinon.spy();
 
         render(<TestComponent data={data} defaultOpen onClose={onClose} />);
 
@@ -210,7 +214,7 @@ export function testPickers(TestComponent: React.ComponentType<any>, options?: T
       });
 
       it('Should close the popup on Tab key', () => {
-        const onClose = Sinon.spy();
+        const onClose = sinon.spy();
 
         render(<TestComponent data={data} defaultOpen onClose={onClose} />);
 


### PR DESCRIPTION
Remove the use of getInstance in the test so that the test can run normally in React 19.