### PR TITLE
refactor: remove deprecated Less variables

### DIFF
--- a/src/Cascader/test/CascaderStylesSpec.tsx
+++ b/src/Cascader/test/CascaderStylesSpec.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import Cascader from '../index';
-import { itChrome } from '@test/utils';
+import { testPickerSize } from '@test/utils';
 import { mockTreeData } from '@test/mocks/data-mock';
+import Cascader from '../index';
 
 import '../styles/index.less';
 
 const data = mockTreeData([['node1', 'node-1-1', 'node-1-2']]);
 
 describe('Cascader styles', () => {
-  itChrome('Should render the correct caret', () => {
+  testPickerSize(Cascader);
+
+  it('Should render the correct caret', () => {
     render(<Cascader data={data} open />);
 
     const treeitem = screen.getByRole('treeitem').children[0];

--- a/src/CheckPicker/test/CheckPickerStylesSpec.tsx
+++ b/src/CheckPicker/test/CheckPickerStylesSpec.tsx
@@ -1,20 +1,23 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
-import CheckPicker from '../index';
-import { getStyle, inChrome } from '@test/utils';
+import { testPickerSize } from '@test/utils';
 import { mockGroupData } from '@test/mocks/data-mock';
-import getWidth from 'dom-lib/getWidth';
+import CheckPicker from '../index';
 import '../styles/index.less';
 
 const data = mockGroupData(['Eugenia', 'Kariane', 'Louisa'], { role: 'Master' });
 
 describe('CheckPicker styles', () => {
+  testPickerSize(CheckPicker);
+
   it('Should render the correct styles', () => {
     render(<CheckPicker data={data} open />);
-    const menuItemLabel = document.body.querySelector(
-      '.rs-picker-check-menu-items .rs-checkbox-checker label'
-    ) as HTMLElement;
-    inChrome && assert.equal(getStyle(menuItemLabel, 'padding'), '8px 12px 8px 38px');
+
+    const menuItemLabel = screen
+      .getByRole('listbox')
+      .querySelector('.rs-picker-check-menu-items .rs-checkbox-checker label');
+
+    expect(menuItemLabel).to.have.style('padding', '8px 12px 8px 38px');
   });
 
   it('Should change the width of the virtualized list', () => {
@@ -22,8 +25,9 @@ describe('CheckPicker styles', () => {
 
     fireEvent.click(screen.getByRole('combobox'));
 
-    expect(
-      getWidth((screen.getByRole('listbox').firstChild as HTMLElement).firstChild as HTMLElement)
-    ).to.equal(400);
+    expect(screen.getByRole('listbox').querySelector('.rs-virt-list')).to.have.style(
+      'width',
+      '400px'
+    );
   });
 });

--- a/src/CheckTreePicker/test/CheckTreePickerStylesSpec.tsx
+++ b/src/CheckTreePicker/test/CheckTreePickerStylesSpec.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import CheckTreePicker from '../index';
-import { itChrome } from '@test/utils';
+import { testPickerSize } from '@test/utils';
 import { mockTreeData } from '@test/mocks/data-mock';
-
+import CheckTreePicker from '../index';
 import '../styles/index.less';
 
 const data = mockTreeData([['Master', 'tester0', ['tester1', 'tester2']], 'disabled']);
 
 describe('CheckTreePicker styles', () => {
-  itChrome('Should render the correct styles', () => {
+  testPickerSize(CheckTreePicker, { data: [] });
+
+  it('Should render the correct styles', () => {
     render(<CheckTreePicker data={data} open />);
 
     expect(screen.getByRole('tree').querySelector('.rs-checkbox-checker label')).to.have.style(
@@ -18,7 +19,7 @@ describe('CheckTreePicker styles', () => {
     );
   });
 
-  itChrome('Should render the correct styles when data has only one level structure', () => {
+  it('Should render the correct styles when data has only one level structure', () => {
     render(<CheckTreePicker data={[{ value: 1, label: 1 }]} open />);
 
     expect(screen.getByRole('tree').querySelector('.rs-checkbox-checker label')).to.have.style(
@@ -27,7 +28,7 @@ describe('CheckTreePicker styles', () => {
     );
   });
 
-  itChrome('Should render the correct styles when first level data is unchecked', () => {
+  it('Should render the correct styles when first level data is unchecked', () => {
     render(
       <CheckTreePicker
         data={[

--- a/src/DatePicker/test/DatePickerStylesSpec.tsx
+++ b/src/DatePicker/test/DatePickerStylesSpec.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { testPickerSize } from '@test/utils';
 import DatePicker from '../index';
-
 import '../styles/index.less';
 
 describe('DatePicker styles', () => {
+  testPickerSize(DatePicker, { role: 'textbox', maxHeight: 40 });
+
   it('Should render the calendar icon', () => {
     render(<DatePicker />);
 

--- a/src/DateRangePicker/test/DateRangePickerStylesSpec.tsx
+++ b/src/DateRangePicker/test/DateRangePickerStylesSpec.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { testPickerSize } from '@test/utils';
 import DateRangePicker from '../index';
-import getWidth from 'dom-lib/getWidth';
-
 import '../styles/index.less';
 
 describe('DateRangePicker styles', () => {
+  testPickerSize(DateRangePicker, { role: 'textbox', maxHeight: 40 });
   it('Should render the correct styles', () => {
     render(<DateRangePicker open />);
 
@@ -16,7 +16,7 @@ describe('DateRangePicker styles', () => {
     const { container } = render(<DateRangePicker block defaultOpen />);
 
     expect(container.firstChild).to.have.class('rs-picker-block');
-    expect(getWidth(screen.getByRole('dialog'))).to.equal(264 * 2);
+    expect(screen.getByRole('dialog')).to.have.style('width', `${264 * 2}px`);
   });
 
   it('Should hava a padding of 0px', () => {

--- a/src/Form/styles/mixin.less
+++ b/src/Form/styles/mixin.less
@@ -82,7 +82,10 @@
 }
 
 .reset-input-group-addon-size(@size-name) {
-  @padding-horizontal-name: ~'padding-@{size-name}-horizontal';
+  @suffix: '';
+  .map-size(@size-name, @suffix);
+
+  @padding-horizontal-name: ~'padding-x@{suffix}';
 
   @width: (@@padding-horizontal-name * 2 - @input-border-width*2 + @font-size-base);
   @padding-horizontal: ((@width - @font-size-base)/2);
@@ -93,9 +96,12 @@
 }
 
 .reset-inside-input-group-btn-size(@size-name) {
+  @suffix: '';
+  .map-size(@size-name, @suffix);
+
   @height: ~'input-height-@{size-name}';
-  @vertical: ~'padding-@{size-name}-vertical';
-  @horizontal: ~'padding-@{size-name}-horizontal';
+  @vertical: ~'padding-y@{suffix}';
+  @horizontal: ~'padding-x@{suffix}';
   @font-size: ~'font-size-@{size-name}';
   @line-height: ~'line-height-@{size-name}';
 

--- a/src/Form/styles/mixin.less
+++ b/src/Form/styles/mixin.less
@@ -82,8 +82,8 @@
 }
 
 .reset-input-group-addon-size(@size-name) {
-  @suffix: '';
-  .map-size(@size-name, @suffix);
+ 
+  .map-size(@size-name);
 
   @padding-horizontal-name: ~'padding-x@{suffix}';
 
@@ -96,8 +96,8 @@
 }
 
 .reset-inside-input-group-btn-size(@size-name) {
-  @suffix: '';
-  .map-size(@size-name, @suffix);
+ 
+  .map-size(@size-name);
 
   @height: ~'input-height-@{size-name}';
   @vertical: ~'padding-y@{suffix}';

--- a/src/InputPicker/test/InputPickerStylesSpec.tsx
+++ b/src/InputPicker/test/InputPickerStylesSpec.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import InputPicker from '../index';
-import Button from '../../Button';
-import { toRGB } from '@test/utils';
+import { toRGB, testPickerSize } from '@test/utils';
 import { mockGroupData } from '@test/mocks/data-mock';
+import InputPicker from '../index';
 import '../styles/index.less';
 
 const data = mockGroupData(['Eugenia', 'Kariane', 'Louisa'], { role: 'Master' });
 
 describe('InputPicker styles', () => {
+  testPickerSize(InputPicker, { maxHeight: 40 });
   it('Should render correct toggle styles', () => {
     const { container } = render(<InputPicker data={data} />);
 
@@ -16,32 +16,6 @@ describe('InputPicker styles', () => {
     expect(container.firstChild).to.have.style('background-color', `${toRGB('#fff')}`);
     expect(screen.getByRole('combobox')).to.have.style('height', '34px');
     expect(screen.getByRole('textbox')).to.have.style('border-style', 'none');
-  });
-
-  it('Should render correct large size', () => {
-    render(<InputPicker toggleAs={Button} size="lg" data={data} />);
-    expect(screen.getByRole('combobox')).to.have.class('rs-btn-lg');
-    expect(screen.getByRole('combobox')).to.have.style('height', '40px');
-  });
-
-  it('Should render correct middle size ', () => {
-    render(<InputPicker toggleAs={Button} size="md" data={data} />);
-
-    expect(screen.getByRole('combobox')).to.have.class('rs-btn-md');
-    expect(screen.getByRole('combobox')).to.have.style('height', '34px');
-  });
-
-  it('Should render correct small size ', () => {
-    render(<InputPicker toggleAs={Button} size="sm" data={data} />);
-    expect(screen.getByRole('combobox')).to.have.class('rs-btn-sm');
-    expect(screen.getByRole('combobox')).to.have.style('height', '28px');
-  });
-
-  it('Should render correct xsmall size ', () => {
-    render(<InputPicker toggleAs={Button} size="xs" data={data} />);
-
-    expect(screen.getByRole('combobox')).to.have.class('rs-btn-xs');
-    expect(screen.getByRole('combobox')).to.have.style('height', '22px');
   });
 
   it('Should have correct height when disabled', () => {

--- a/src/MultiCascader/test/MultiCascaderStylesSpec.tsx
+++ b/src/MultiCascader/test/MultiCascaderStylesSpec.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import MultiCascader from '../index';
-import { itChrome } from '@test/utils';
+import { testPickerSize } from '@test/utils';
 import { mockTreeData } from '@test/mocks/data-mock';
-
+import MultiCascader from '../index';
 import '../styles/index.less';
 
-const data = mockTreeData([['abcde', ['vv-abc', 'vv-abcd']]]);
+const data = mockTreeData([['node-1', ['node-1', 'node-3']]]);
 
 describe('MultiCascader styles', () => {
-  itChrome('Should render the correct caret', () => {
+  testPickerSize(MultiCascader);
+
+  it('Should render the correct caret', () => {
     render(<MultiCascader data={data} open />);
 
     const tree = screen.getByRole('tree');

--- a/src/SelectPicker/styles/index.less
+++ b/src/SelectPicker/styles/index.less
@@ -1,6 +1,6 @@
 @import '../../styles/common';
 @import '../../styles/mixins/listbox';
-@import '../../internals/Picker/styles/index';
+@import '../../internals/Picker/styles/index.less';
 
 // Select Picker
 // ----------------------

--- a/src/SelectPicker/test/SelectPickerStylesSpec.tsx
+++ b/src/SelectPicker/test/SelectPickerStylesSpec.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import SelectPicker from '../index';
-import { toRGB, itChrome } from '@test/utils';
+import { toRGB, testPickerSize } from '@test/utils';
 import { mockGroupData } from '@test/mocks/data-mock';
+import SelectPicker from '../index';
 import '../styles/index.less';
 
 const data = mockGroupData(['Eugenia', 'Kariane', 'Louisa'], { role: 'Master' });
 
 describe('SelectPicker styles', () => {
+  testPickerSize(SelectPicker);
+
   it('Default select picker should render correct toggle styles', () => {
     render(<SelectPicker data={[]} open />);
 
@@ -26,38 +28,6 @@ describe('SelectPicker styles', () => {
     expect(screen.getByRole('combobox')).to.have.style('background-color', toRGB('#0000'));
     expect(screen.getByRole('combobox')).to.have.style('border-width', '0px');
     expect(screen.getByRole('combobox')).to.have.style('padding', '8px 32px 8px 12px');
-  });
-
-  itChrome('Select picker default toggle should render correct size', () => {
-    render(
-      <>
-        <SelectPicker size="lg" placeholder="Large" data={data} />
-        <SelectPicker size="md" placeholder="Medium" data={data} />
-        <SelectPicker size="sm" placeholder="Small" data={data} />
-        <SelectPicker size="xs" placeholder="Xsmall" data={data} />
-      </>
-    );
-
-    expect(screen.getAllByRole('combobox')[0]).to.have.style('padding', '9px 36px 9px 15px');
-    expect(screen.getAllByRole('combobox')[1]).to.have.style('padding', '7px 32px 7px 11px');
-    expect(screen.getAllByRole('combobox')[2]).to.have.style('padding', '4px 30px 4px 9px');
-    expect(screen.getAllByRole('combobox')[3]).to.have.style('padding', '1px 28px 1px 7px');
-  });
-
-  itChrome('Select picker subtle toggle should render correct size', () => {
-    render(
-      <>
-        <SelectPicker size="lg" appearance="subtle" placeholder="Large" data={data} />
-        <SelectPicker size="md" appearance="subtle" placeholder="Medium" data={data} />
-        <SelectPicker size="sm" appearance="subtle" placeholder="Small" data={data} />
-        <SelectPicker size="xs" appearance="subtle" placeholder="Xsmall" data={data} />
-      </>
-    );
-
-    expect(screen.getAllByRole('combobox')[0]).to.have.style('padding', '10px 36px 10px 16px');
-    expect(screen.getAllByRole('combobox')[1]).to.have.style('padding', '8px 32px 8px 12px');
-    expect(screen.getAllByRole('combobox')[2]).to.have.style('padding', '5px 30px 5px 10px');
-    expect(screen.getAllByRole('combobox')[3]).to.have.style('padding', '2px 28px 2px 8px');
   });
 
   it('Block select picker should render correct toggle styles', () => {

--- a/src/TagPicker/test/TagPickerStylesSpec.tsx
+++ b/src/TagPicker/test/TagPickerStylesSpec.tsx
@@ -1,19 +1,20 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import TagPicker from '../index';
-import { getStyle, inChrome } from '@test/utils';
+import { render, screen } from '@testing-library/react';
+import { testPickerSize } from '@test/utils';
 import { mockGroupData } from '@test/mocks/data-mock';
-
+import TagPicker from '../index';
 import '../styles/index.less';
 
 const data = mockGroupData(['Eugenia', 'Kariane', 'Louisa'], { role: 'Master' });
 
 describe('TagPicker styles', () => {
+  testPickerSize(TagPicker, { maxHeight: 40, subtle: false });
   it('Should render the correct styles', () => {
     render(<TagPicker data={data} open />);
-    const itemLabel = document.body.querySelector(
-      '.rs-picker-check-menu-items .rs-checkbox-checker label'
-    ) as HTMLElement;
-    inChrome && assert.equal(getStyle(itemLabel, 'padding'), '8px 12px 8px 38px');
+    const itemLabel = screen
+      .getByRole('listbox')
+      .querySelector('.rs-picker-check-menu-items .rs-checkbox-checker label');
+
+    expect(itemLabel).to.have.style('padding', '8px 12px 8px 38px');
   });
 });

--- a/src/Tree/styles/index.less
+++ b/src/Tree/styles/index.less
@@ -1,6 +1,6 @@
 @import '../../styles/common.less';
 @import '../../styles/mixins/listbox.less';
-@import '../../internals/Picker/styles/mixin.less';
+@import '../../internals/Picker/styles/index.less';
 @import './toggle.less';
 @import './indent-line.less';
 

--- a/src/TreePicker/test/TreePickerStylesSpec.tsx
+++ b/src/TreePicker/test/TreePickerStylesSpec.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import TreePicker from '../index';
-import { itChrome } from '@test/utils';
+import { testPickerSize } from '@test/utils';
 import { mockTreeData } from '@test/mocks/data-mock';
+import TreePicker from '../index';
+
 import '../styles/index.less';
 
 const data = mockTreeData([['Master', 'tester0', ['tester1', 'tester2']], 'disabled']);
 
 describe('TreePicker styles', () => {
-  itChrome('Should render the correct styles', () => {
+  testPickerSize(TreePicker, { data: [] });
+
+  it('Should render the correct styles', () => {
     render(<TreePicker data={data} open />);
 
     const treeNode = screen.queryAllByRole('treeitem')[0];

--- a/src/internals/Picker/styles/index.less
+++ b/src/internals/Picker/styles/index.less
@@ -198,16 +198,15 @@
 /* stylelint-disable-next-line */ // Custom button sizes
 .rs-picker-toggle.rs-btn {
   .picker-button-caret-md();
+  .picker-button-size(base);
   .date-picker-button-caret-md();
-  .date-picker-button-size(base);
 
   &-lg {
+    .button-size-lg();
     .picker-button-caret-lg();
+    .picker-button-size(large);
     .picker-default-button-reset-padding-left(large);
     .date-picker-button-caret-lg();
-    .date-picker-button-size(large);
-
-    .button-size-lg();
 
     .rs-picker-value-count {
       line-height: @line-height-large-computed;
@@ -216,27 +215,25 @@
 
   &-md {
     .picker-button-caret-md();
+    .picker-button-size(base);
     .picker-default-button-reset-padding-left(base);
     .date-picker-button-caret-md();
-    .date-picker-button-size(base);
   }
 
   &-sm {
     .button-size-sm();
-
     .picker-button-caret-sm();
+    .picker-button-size(small);
     .picker-default-button-reset-padding-left(small);
     .date-picker-button-caret-sm();
-    .date-picker-button-size(small);
   }
 
   &-xs {
     .button-size-xs();
-
     .picker-button-caret-xs();
+    .picker-button-size(extra-small);
     .picker-default-button-reset-padding-left(extra-small);
     .date-picker-button-caret-xs();
-    .date-picker-button-size(extra-small);
   }
 }
 

--- a/src/internals/Picker/styles/index.less
+++ b/src/internals/Picker/styles/index.less
@@ -4,11 +4,11 @@
 @import '../../../styles/mixins/combobox.less';
 @import '../../../Stack/styles/index.less';
 @import '../../../Form/styles/mixin.less';
-@import '../../CloseButton/styles/index.less';
 @import '../../../Loader/styles/index.less';
 @import '../../../Input/styles/index.less';
 @import '../../../InputGroup/styles/index.less';
 @import '../../../Highlight/styles/index.less';
+@import '../../CloseButton/styles/index.less';
 @import './mixin.less';
 
 //

--- a/src/internals/Picker/styles/mixin.less
+++ b/src/internals/Picker/styles/mixin.less
@@ -201,9 +201,9 @@
   }
 }
 
-.date-picker-button-size(@size) {
-  @suffix: '';
-  .map-size(@size, @suffix);
+.picker-button-size(@size) {
+  .map-size(@size);
+
   @padding-name: 'padding-y@{suffix}';
   @padding-vertical: @@padding-name;
 
@@ -213,8 +213,7 @@
 }
 
 .picker-default-button-reset-padding-left(@size) {
-  @suffix: '';
-  .map-size(@size, @suffix);
+  .map-size(@size);
   @padding-name: 'padding-x@{suffix}';
   @padding-horizontal: @@padding-name;
 

--- a/src/internals/Picker/styles/mixin.less
+++ b/src/internals/Picker/styles/mixin.less
@@ -202,7 +202,9 @@
 }
 
 .date-picker-button-size(@size) {
-  @padding-name: 'padding-@{size}-vertical';
+  @suffix: '';
+  .map-size(@size, @suffix);
+  @padding-name: 'padding-y@{suffix}';
   @padding-vertical: @@padding-name;
 
   .rs-picker-default & {
@@ -211,7 +213,9 @@
 }
 
 .picker-default-button-reset-padding-left(@size) {
-  @padding-name: 'padding-@{size}-horizontal';
+  @suffix: '';
+  .map-size(@size, @suffix);
+  @padding-name: 'padding-x@{suffix}';
   @padding-horizontal: @@padding-name;
 
   .rs-picker-default & {

--- a/src/styles/mixins/utilities.less
+++ b/src/styles/mixins/utilities.less
@@ -165,3 +165,23 @@
   box-shadow: none;
   outline: none;
 }
+
+.map-size(@size-name, @suffix) {
+  .map(base) {
+    @suffix: '';
+  }
+  .map(small) {
+    @suffix: '-sm';
+  }
+  .map(medium) {
+    @suffix: '-md';
+  }
+  .map(large) {
+    @suffix: '-lg';
+  }
+  .map(extra-small) {
+    @suffix: '-xs';
+  }
+
+  .map(@size-name);
+}

--- a/src/styles/mixins/utilities.less
+++ b/src/styles/mixins/utilities.less
@@ -166,7 +166,12 @@
   outline: none;
 }
 
-.map-size(@size-name, @suffix) {
+/**
+  * Map mixin
+  * @param {string} @size-name - The size name
+  * @param {string} @suffix - The suffix
+  */
+.map-size(@size-name) {
   .map(base) {
     @suffix: '';
   }

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -9,16 +9,13 @@
 // Controls
 
 // Polyfill for IE 11
-@ie-polyfill:           true; // @deprecated use @enable-ie-polyfill instead
-@enable-ie-polyfill:    @ie-polyfill;
+@enable-ie-polyfill:    true;
 
 // CSS Resets
-@reset-import:          true; // @deprecated use @enable-css-reset instead
-@enable-css-reset:      @reset-import;
+@enable-css-reset:      true;
 
 // Global button ripple switch
-@button-ripple:         true; // @deprecated use @enable-ripple-effect instead
-@enable-ripple-effect:  @button-ripple;
+@enable-ripple-effect:  true;
 
 // Whether include styles for dark mode
 @enable-dark-mode:      true;
@@ -84,7 +81,6 @@
 // Color system
 
 // Primary palette
-@base-color:      #3498ff; // @deprecated use @primary-color instead
 @primary-color:   #3498ff;
 
 // Secondary palette
@@ -164,42 +160,23 @@
 
 
 // Box shadows
-
-@default-box-shadow:  0 4px 4px rgba(0, 0, 0, 0.12), 0 0 10px rgba(0, 0, 0, 0.06); // @deprecated use @box-shadow instead
-@box-shadow:          @default-box-shadow;
+@box-shadow:          0 4px 4px rgba(0, 0, 0, 0.12), 0 0 10px rgba(0, 0, 0, 0.06);
 
 
 // Spacing
 // Define common padding and border radius sizes and more. Values based on 14px text and 1.428 line-height (~20px to start).
 
-@padding-base-vertical:           8px; // @deprecated use @padding-y instead
-@padding-base-horizontal:         12px; // @deprecated use @padding-x instead
-
-@padding-large-vertical:          10px; // @deprecated use @padding-y-lg instead
-@padding-large-horizontal:        16px; // @deprecated use @padding-x-lg instead
-
-@padding-small-vertical:          5px; // @deprecated use @padding-y-sm instead
-@padding-small-horizontal:        10px; // @deprecated use @padding-x-sm instead
-
-@padding-extra-small-vertical:    2px; // @deprecated use @padding-y-xs instead
-@padding-extra-small-horizontal:  8px; // @deprecated use @padding-x-xs instead
-
-@padding-y:         @padding-base-vertical;
-@padding-x:         @padding-base-horizontal;
-
-@padding-y-lg:      @padding-large-vertical;
-@padding-x-lg:      @padding-large-horizontal;
-
-@padding-y-sm:      @padding-small-vertical;
-@padding-x-sm:      @padding-small-horizontal;
-
-@padding-y-xs:      @padding-extra-small-vertical;
-@padding-x-xs:      @padding-extra-small-horizontal;
+@padding-y:         8px;
+@padding-x:         12px;
+@padding-y-lg:      10px;
+@padding-x-lg:      16px;
+@padding-y-sm:      5px;
+@padding-x-sm:      10px;
+@padding-y-xs:      2px;
+@padding-x-xs:      8px;
 
 // Border radius
-
-@border-radius-base:  6px;  // @deprecate use @border-radius instead
-@border-radius:       @border-radius-base;
+@border-radius:       6px;
 
 // Scaffolding
 // Settings for some of the most global styles.
@@ -214,21 +191,17 @@
 
 // Table
 
-@table-header-content-padding-vertical: 10px; // @deprecated use @table-header-padding-y instead
-@table-header-padding-y:                @table-header-content-padding-vertical;
+@table-header-padding-y:                10px;
 @table-header-padding-x:                10px;
 @table-header-font-size:                @font-size-small;
-@table-header-line-small:               @line-height-small; // @deprecated use @table-header-line-height instead
-@table-header-line-height:              @table-header-line-small;
+@table-header-line-height:              @line-height-small;
 @table-header-sort-wrapper-margin-left: 5px;
 
 @table-column-resize-spanner-width:                 3px;
 @table-column-resize-spanner-triangle-side-length:  3px;
 
-@table-body-content-padding-vertical:   13px; // @deprecated use @table-cell-padding-y instead
-@table-content-padding-horizontal:      10px; // @deprecated use @table-cell-padding-x instead
-@table-cell-padding-y:                  @table-body-content-padding-vertical;
-@table-cell-padding-x:                  @table-content-padding-horizontal;
+@table-cell-padding-y:                  13px;
+@table-cell-padding-x:                  10px;
 @table-cell-hover-color:                var(--rs-primary-500);
 
 @table-scrollbar-timing-duration:       0.1s;
@@ -242,12 +215,11 @@
 // Buttons
 
 @btn-font-weight:           normal;
-
-@btn-border-radius-base:    @border-radius; // @deprecated use @btn-border-radius instead
-@btn-border-radius:         @btn-border-radius-base;
+@btn-border-radius:         @border-radius;
 
 @btn-transition:            color 0.15s ease-out, background-color 0.15s ease-out;
 @btn-disabled-opacity:      0.3;
+
 
 // Ghost Button
 @btn-ghost-border-width:    1px;
@@ -262,13 +234,11 @@
 
 // Ripple
 
-@btn-ripple-background-color: rgba(0, 0, 0, 0.2); // @deprecated use @ripple-bg instead
-@ripple-bg:                   @btn-ripple-background-color;
+@ripple-bg: rgba(0, 0, 0, 0.2);
 
 // Badge
 
-@badge-dot-side-length: 8px; // @deprecated use @badge-dot-size instead
-@badge-dot-size:        @badge-dot-side-length;
+@badge-dot-size:        8px;
 
 // Avatar
 @avatar-size-xxl:         120px;
@@ -304,13 +274,11 @@
 @form-error-message-triangle-vertical:    4px;
 @form-error-message-translate-distance:   2px;
 
+
 // Input
 
-@padding-base-input-vertical:   @padding-y; // @deprecated use @input-padding-y instead
-@padding-base-input-horizontal: @padding-x; // @deprecated use @input-padding-x instead
-
-@input-padding-y:               @padding-base-input-vertical;
-@input-padding-x:               @padding-base-input-horizontal;
+@input-padding-y:               @padding-y;
+@input-padding-x:               @padding-x;
 @input-border-width:            1px;
 @input-transition:              border-color ease-in-out 0.15s;
 
@@ -322,14 +290,8 @@
 @input-height-small:        (@line-height-computed + (@padding-y-sm * 2));
 @input-height-extra-small:  (@line-height-computed + (@padding-y-xs * 2));
 
-// InputGroup padding for add-on
-@input-group-padding-for-add-on-large:        46px;
-@input-group-padding-for-add-on-base:         36px;
-@input-group-padding-for-add-on-small:        30px;
-@input-group-padding-for-add-on-extra-small:  26px;
 
 // Number input
-
 @number-input-touchspin-font-size: 12px;
 
 // Dropdowns
@@ -342,14 +304,12 @@
 @dropdown-divider-bg:         @divider-border-color;
 @dropdown-shadow:             0 0 10px rgba(0, 0, 0, 0.06), 0 4px 4px rgba(0, 0, 0, 0.12);
 
-@dropdown-menu-radius:              @border-radius;
-@dropdown-menu-padding-y:           @dropdown-menu-radius;
+@dropdown-menu-radius:        @border-radius;
+@dropdown-menu-padding-y:     @dropdown-menu-radius;
 
-@dropdown-item-padding-vertical:    8px; // @deprecated use @dropdown-item-padding-y instead
-@dropdown-item-padding-horizontal:  12px; // @deprecated use @dropdown-item-padding-x instead
 
-@dropdown-item-padding-y:           @dropdown-item-padding-vertical;
-@dropdown-item-padding-x:           @dropdown-item-padding-horizontal;
+@dropdown-item-padding-y:     8px;
+@dropdown-item-padding-x:     12px;
 
 // Dropdown item content submenu icon
 @dropdown-item-submenu-icon-angle-spacing:              10px;
@@ -405,11 +365,6 @@
 @nav-divider-margin-vertical:     6px;
 
 // Navbar
-
-@nav-bar-padding-vertical:        18px; // @deprecated use @navbar-item-padding-y instead
-@nav-bar-padding-horizontal:      16px; // @deprecated use @navbar-item-padding-x instead
-@nav-bar-height:                  (@nav-bar-padding-vertical * 2 + @line-height-computed); // @deprecated use @navbar-height instead
-
 @navbar-item-padding-y:           18px;
 @navbar-item-padding-x:           16px;
 @navbar-height:                   (@navbar-item-padding-y * 2 + @line-height-computed);

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,6 +1,6 @@
 export { testControlledUnControlled } from './testControlledUnControlled';
 export { testStandardProps } from './testStandardProps';
 export { testFormControl } from './testFormControl';
-export { testPickers } from './testPickers';
+export { testPickers, testPickerSize } from './testPickers';
 export { render } from './render';
 export * from './styles-test';

--- a/test/utils/testPickers.tsx
+++ b/test/utils/testPickers.tsx
@@ -254,40 +254,79 @@ export function testPickers(TestComponent: React.ComponentType<any>, options?: T
   });
 }
 
-export function testPickerSize(TestComponent: React.ComponentType<any>, pickerProps?: any) {
+interface TestPickerSizeOptions {
+  role?: 'combobox' | 'textbox';
+  maxHeight?: number;
+  heightStep?: number;
+  subtle?: boolean;
+  [key: string]: any;
+}
+
+export function testPickerSize(
+  TestComponent: React.ComponentType<any>,
+  pickerProps: TestPickerSizeOptions = {}
+) {
   const displayName = TestComponent.displayName;
+  const {
+    role = 'combobox',
+    maxHeight = 42,
+    heightStep = 6,
+    subtle = true,
+    ...restProps
+  } = pickerProps;
 
   describe(`${displayName} - Size`, () => {
     it('Should have different sizes', () => {
       render(
         <>
-          <TestComponent size="lg" placeholder="Large" {...pickerProps} />
-          <TestComponent size="md" placeholder="Medium" {...pickerProps} />
-          <TestComponent size="sm" placeholder="Small" {...pickerProps} />
-          <TestComponent size="xs" placeholder="Xsmall" {...pickerProps} />
+          <TestComponent size="lg" placeholder="Large" {...restProps} />
+          <TestComponent size="md" placeholder="Medium" {...restProps} />
+          <TestComponent size="sm" placeholder="Small" {...restProps} />
+          <TestComponent size="xs" placeholder="Xsmall" {...restProps} />
         </>
       );
 
-      expect(screen.getAllByRole('combobox')[0]).to.have.style('padding', '9px 36px 9px 15px');
-      expect(screen.getAllByRole('combobox')[1]).to.have.style('padding', '7px 32px 7px 11px');
-      expect(screen.getAllByRole('combobox')[2]).to.have.style('padding', '4px 30px 4px 9px');
-      expect(screen.getAllByRole('combobox')[3]).to.have.style('padding', '1px 28px 1px 7px');
+      const paddings = [
+        '9px 36px 9px 15px',
+        '7px 32px 7px 11px',
+        '4px 30px 4px 9px',
+        '1px 28px 1px 7px'
+      ];
+
+      screen.getAllByRole(role).forEach((picker, index) => {
+        if (role === 'combobox') {
+          expect(picker).to.have.style('padding', paddings[index]);
+        }
+
+        expect(picker).to.have.style('height', `${maxHeight - index * heightStep}px`);
+      });
     });
 
-    it('Should have different sizes with subtle appearance', () => {
-      render(
-        <>
-          <TestComponent size="lg" appearance="subtle" placeholder="Large" {...pickerProps} />
-          <TestComponent size="md" appearance="subtle" placeholder="Medium" {...pickerProps} />
-          <TestComponent size="sm" appearance="subtle" placeholder="Small" {...pickerProps} />
-          <TestComponent size="xs" appearance="subtle" placeholder="Xsmall" {...pickerProps} />
-        </>
-      );
+    if (subtle) {
+      it('Should have different sizes with subtle appearance', () => {
+        render(
+          <>
+            <TestComponent size="lg" appearance="subtle" placeholder="Large" {...restProps} />
+            <TestComponent size="md" appearance="subtle" placeholder="Medium" {...restProps} />
+            <TestComponent size="sm" appearance="subtle" placeholder="Small" {...restProps} />
+            <TestComponent size="xs" appearance="subtle" placeholder="Xsmall" {...restProps} />
+          </>
+        );
 
-      expect(screen.getAllByRole('combobox')[0]).to.have.style('padding', '10px 36px 10px 16px');
-      expect(screen.getAllByRole('combobox')[1]).to.have.style('padding', '8px 32px 8px 12px');
-      expect(screen.getAllByRole('combobox')[2]).to.have.style('padding', '5px 30px 5px 10px');
-      expect(screen.getAllByRole('combobox')[3]).to.have.style('padding', '2px 28px 2px 8px');
-    });
+        const paddings = [
+          '10px 36px 10px 16px',
+          '8px 32px 8px 12px',
+          '5px 30px 5px 10px',
+          '2px 28px 2px 8px'
+        ];
+
+        screen.getAllByRole(role).forEach((picker, index) => {
+          if (role === 'combobox') {
+            expect(picker).to.have.style('padding', paddings[index]);
+          }
+          expect(picker).to.have.style('height', `${maxHeight - index * heightStep}px`);
+        });
+      });
+    }
   });
 }

--- a/test/utils/testPickers.tsx
+++ b/test/utils/testPickers.tsx
@@ -253,3 +253,41 @@ export function testPickers(TestComponent: React.ComponentType<any>, options?: T
     });
   });
 }
+
+export function testPickerSize(TestComponent: React.ComponentType<any>, pickerProps?: any) {
+  const displayName = TestComponent.displayName;
+
+  describe(`${displayName} - Size`, () => {
+    it('Should have different sizes', () => {
+      render(
+        <>
+          <TestComponent size="lg" placeholder="Large" {...pickerProps} />
+          <TestComponent size="md" placeholder="Medium" {...pickerProps} />
+          <TestComponent size="sm" placeholder="Small" {...pickerProps} />
+          <TestComponent size="xs" placeholder="Xsmall" {...pickerProps} />
+        </>
+      );
+
+      expect(screen.getAllByRole('combobox')[0]).to.have.style('padding', '9px 36px 9px 15px');
+      expect(screen.getAllByRole('combobox')[1]).to.have.style('padding', '7px 32px 7px 11px');
+      expect(screen.getAllByRole('combobox')[2]).to.have.style('padding', '4px 30px 4px 9px');
+      expect(screen.getAllByRole('combobox')[3]).to.have.style('padding', '1px 28px 1px 7px');
+    });
+
+    it('Should have different sizes with subtle appearance', () => {
+      render(
+        <>
+          <TestComponent size="lg" appearance="subtle" placeholder="Large" {...pickerProps} />
+          <TestComponent size="md" appearance="subtle" placeholder="Medium" {...pickerProps} />
+          <TestComponent size="sm" appearance="subtle" placeholder="Small" {...pickerProps} />
+          <TestComponent size="xs" appearance="subtle" placeholder="Xsmall" {...pickerProps} />
+        </>
+      );
+
+      expect(screen.getAllByRole('combobox')[0]).to.have.style('padding', '10px 36px 10px 16px');
+      expect(screen.getAllByRole('combobox')[1]).to.have.style('padding', '8px 32px 8px 12px');
+      expect(screen.getAllByRole('combobox')[2]).to.have.style('padding', '5px 30px 5px 10px');
+      expect(screen.getAllByRole('combobox')[3]).to.have.style('padding', '2px 28px 2px 8px');
+    });
+  });
+}


### PR DESCRIPTION
This pull request includes several changes to improve the consistency and maintainability of the LESS stylesheets. The most important changes involve the introduction of a new mixin for mapping sizes, replacing deprecated variables, and updating import paths.

### Introduction of new mixin:

* [`src/styles/mixins/utilities.less`](diffhunk://#diff-2d1ecce75e5eca0a0a443e9ac3c610911902c26104d930351ff55bf75f0b03feR168-R192): Added `.map-size` mixin to map size names to suffixes, which helps in standardizing size-related variables.

### Replacement of deprecated variables:

* [`src/styles/variables.less`](diffhunk://#diff-4280652340dc0c8df16d261fba31010959b4bd152b4a219b487870b5e508142fL87): Removed deprecated variables and replaced them with their new equivalents, such as `@padding-base-vertical` with `@padding-y`, `@padding-large-vertical` with `@padding-y-lg`, and others. [[1]](diffhunk://#diff-4280652340dc0c8df16d261fba31010959b4bd152b4a219b487870b5e508142fL87) [[2]](diffhunk://#diff-4280652340dc0c8df16d261fba31010959b4bd152b4a219b487870b5e508142fL167-R179) [[3]](diffhunk://#diff-4280652340dc0c8df16d261fba31010959b4bd152b4a219b487870b5e508142fL217-R204) [[4]](diffhunk://#diff-4280652340dc0c8df16d261fba31010959b4bd152b4a219b487870b5e508142fL245-R223) [[5]](diffhunk://#diff-4280652340dc0c8df16d261fba31010959b4bd152b4a219b487870b5e508142fL265-R241) [[6]](diffhunk://#diff-4280652340dc0c8df16d261fba31010959b4bd152b4a219b487870b5e508142fL307-R281) [[7]](diffhunk://#diff-4280652340dc0c8df16d261fba31010959b4bd152b4a219b487870b5e508142fL325-L332) [[8]](diffhunk://#diff-4280652340dc0c8df16d261fba31010959b4bd152b4a219b487870b5e508142fL348-R312) [[9]](diffhunk://#diff-4280652340dc0c8df16d261fba31010959b4bd152b4a219b487870b5e508142fL408-L412)

### Updates to import paths:

* [`src/SelectPicker/styles/index.less`](diffhunk://#diff-ca880ea9ed79355ac3b63394157bfaf7c5919f0699439cd8f88e5b2ba9752756L3-R3): Changed the import path of the Picker styles to include the `.less` extension for consistency.

### Usage of new mixin in existing styles:

* [`src/Form/styles/mixin.less`](diffhunk://#diff-47d1b2bfbb4cc33db0c260c32b57e0f2b7b248add536b4d5313a9b33bb02ec99L85-R88): Updated the `.reset-input-group-addon-size` and `.reset-inside-input-group-btn-size` mixins to use the new `.map-size` mixin for padding variables. [[1]](diffhunk://#diff-47d1b2bfbb4cc33db0c260c32b57e0f2b7b248add536b4d5313a9b33bb02ec99L85-R88) [[2]](diffhunk://#diff-47d1b2bfbb4cc33db0c260c32b57e0f2b7b248add536b4d5313a9b33bb02ec99R99-R104)
* [`src/internals/Picker/styles/index.less`](diffhunk://#diff-39e60be854f6f35595816822070452a633398f2f4e4923a5c32ace4bcd07346bR201-L210): Replaced deprecated size-related mixins with the new `.picker-button-size` mixin. [[1]](diffhunk://#diff-39e60be854f6f35595816822070452a633398f2f4e4923a5c32ace4bcd07346bR201-L210) [[2]](diffhunk://#diff-39e60be854f6f35595816822070452a633398f2f4e4923a5c32ace4bcd07346bR218-L239)
* [`src/internals/Picker/styles/mixin.less`](diffhunk://#diff-25886cd3da7d92b531d02415dedfb90878a46e9614f6362b28571fecabbc74a2L204-R207): Added `.map-size` mixin to `.picker-button-size` and `.picker-default-button-reset-padding-left` for padding variables. [[1]](diffhunk://#diff-25886cd3da7d92b531d02415dedfb90878a46e9614f6362b28571fecabbc74a2L204-R207) [[2]](diffhunk://#diff-25886cd3da7d92b531d02415dedfb90878a46e9614f6362b28571fecabbc74a2L214-R217)