### PR TITLE
build(deps): bump lunar-typescript from 1.7.5 to 1.7.6 in docs

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -29,7 +29,7 @@
         "date-fns": "^4.1.0",
         "dom-lib": "^3.1.2",
         "formik": "^2.4.5",
-        "lunar-typescript": "^1.7.5",
+        "lunar-typescript": "^1.7.6",
         "lz-string": "^1.4.4",
         "next": "^14.2.21",
         "nprogress": "^0.2.0",
@@ -7655,9 +7655,9 @@
       }
     },
     "node_modules/lunar-typescript": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmmirror.com/lunar-typescript/-/lunar-typescript-1.7.5.tgz",
-      "integrity": "sha512-AlOwYrxHRCR9Plba5TlZY0NVv6aFobmR1gxfiAE1KxjDzBXoDtT2KrsBYCVaErGokiL8qLMS1FNwGPiPRX2a4g=="
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/lunar-typescript/-/lunar-typescript-1.7.6.tgz",
+      "integrity": "sha512-vrNRgzJ6UgK++P81jaOykV7YBCLemC8l/XDbsXE7MinojXolOKiIHm6sOZg5wdDMbJxCWP1ERAaqcBV9mhw2Bg=="
     },
     "node_modules/lz-string": {
       "version": "1.5.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -36,7 +36,7 @@
     "date-fns": "^4.1.0",
     "dom-lib": "^3.1.2",
     "formik": "^2.4.5",
-    "lunar-typescript": "^1.7.5",
+    "lunar-typescript": "^1.7.6",
     "lz-string": "^1.4.4",
     "next": "^14.2.21",
     "nprogress": "^0.2.0",


### PR DESCRIPTION
This pull request includes updates to the `lunar-typescript` package version in the project dependencies. The changes involve updating the version from `1.7.5` to `1.7.6` in the `package.json` and `package-lock.json` files.

Dependency updates:

* [`docs/package.json`](diffhunk://#diff-adfa337ce44dc2902621da20152a048dac41878cf3716dfc4cc56d03aa212a56L39-R39): Updated `lunar-typescript` version from `1.7.5` to `1.7.6`.
* [`docs/package-lock.json`](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L32-R32): Updated `lunar-typescript` version from `1.7.5` to `1.7.6` and modified the resolved URL and integrity hash accordingly. [[1]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L32-R32) [[2]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L7658-R7660)