### PR TITLE
refactor(less): remove special handling code for IE11 support

### DIFF
--- a/docs/.browserslistrc
+++ b/docs/.browserslistrc
@@ -1,2 +1,1 @@
-> 1%
-last 2 versions
+>0.3%, defaults

--- a/docs/.browserslistrc
+++ b/docs/.browserslistrc
@@ -1,1 +1,1 @@
->0.3%, defaults
+defaults

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -77,11 +77,10 @@ module.exports = {
             sourceMap: true,
             postcssOptions: {
               plugins: [
-                require('autoprefixer'),
+                require('autoprefixer')
                 // Do not use postcss-rtl which generates a LTR+RTL css
                 // Use rtlcss-webpack-plugin which generates separate LTR css and RTL css
-                // require('postcss-rtl')({}),
-                require('postcss-custom-properties')()
+                // require('postcss-rtl')({})
               ]
             }
           }

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -71,7 +71,6 @@
         "markdown-loader": "2.0.2",
         "mini-css-extract-plugin": "^2.1.0",
         "postcss": "^8.4.31",
-        "postcss-custom-properties": "^12.0.0",
         "postcss-loader": "^4.2.0",
         "postcss-rtl": "^1.7.3",
         "rimraf": "^3.0.2",
@@ -8673,25 +8672,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss-custom-properties": {
-      "version": "12.1.11",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.11.tgz",
-      "integrity": "sha512-0IDJYhgU8xDv1KY6+VgUwuQkVtmYzRwu+dMjnmdMafXYv86SWqfxkc7qdDvWS38vsjaEtv8e0vGOUQrAiMBLpQ==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
       }
     },
     "node_modules/postcss-discard-comments": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -78,7 +78,6 @@
     "markdown-loader": "2.0.2",
     "mini-css-extract-plugin": "^2.1.0",
     "postcss": "^8.4.31",
-    "postcss-custom-properties": "^12.0.0",
     "postcss-loader": "^4.2.0",
     "postcss-rtl": "^1.7.3",
     "rimraf": "^3.0.2",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,6 @@ const del = require('del');
 const path = require('path');
 const less = require('gulp-less');
 const postcss = require('gulp-postcss');
-const postcssCustomProperties = require('postcss-custom-properties');
 const postcssPruneVar = require('postcss-prune-var');
 const postcssDiscardEmpty = require('postcss-discard-empty');
 const sourcemaps = require('gulp-sourcemaps');
@@ -122,7 +121,7 @@ function buildLess({
     gulp
       .src(src)
       .pipe(less(lessOptions))
-      .pipe(postcss([require('autoprefixer'), postcssCustomProperties(), ...postcssPlugins]))
+      .pipe(postcss([require('autoprefixer'), ...postcssPlugins]))
       .pipe(rename(outputFileName))
       .pipe(gulp.dest(dist));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,6 @@
         "minimist": "^1.2.8",
         "mocha": "^9.0.2",
         "picocolors": "^1.0.0",
-        "postcss-custom-properties": "^10.0.0",
         "postcss-discard-empty": "^6.0.1",
         "postcss-less": "^6.0.0",
         "postcss-prune-var": "^1.1.1",
@@ -15325,17 +15324,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-url-superb": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-utf8": {
       "version": "0.2.1",
       "dev": true,
@@ -19568,39 +19556,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/postcss-custom-properties": {
-      "version": "10.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.17",
-        "postcss-values-parser": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/postcss-custom-properties/node_modules/picocolors": {
-      "version": "0.2.1",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/postcss-custom-properties/node_modules/postcss": {
-      "version": "7.0.39",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
     "node_modules/postcss-discard-comments": {
       "version": "5.1.2",
       "dev": true,
@@ -20158,40 +20113,6 @@
       "version": "3.3.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/postcss-values-parser": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "color-name": "^1.1.4",
-        "is-url-superb": "^4.0.0",
-        "postcss": "^7.0.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/postcss-values-parser/node_modules/picocolors": {
-      "version": "0.2.1",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/postcss-values-parser/node_modules/postcss": {
-      "version": "7.0.39",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
     },
     "node_modules/postcss/node_modules/nanoid": {
       "version": "3.3.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "gulp-babel": "^8.0.0",
         "gulp-insert": "^0.5.0",
         "gulp-less": "^4.0.1",
-        "gulp-postcss": "^9.0.1",
+        "gulp-postcss": "^10.0.0",
         "gulp-rename": "^1.2.2",
         "gulp-rtlcss": "^1.4.0",
         "gulp-sourcemaps": "^2.6.4",
@@ -13829,20 +13829,57 @@
       }
     },
     "node_modules/gulp-postcss": {
-      "version": "9.0.1",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-10.0.0.tgz",
+      "integrity": "sha512-z1RF2RJEX/BvFsKN11PXai8lRmihZTiHnlJf7Zu8uHaA/Q7Om4IeN8z1NtMAW5OiLwUY02H0DIFl9tHl0CNSgA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "fancy-log": "^1.3.3",
-        "plugin-error": "^1.0.1",
-        "postcss-load-config": "^3.0.0",
+        "fancy-log": "^2.0.0",
+        "plugin-error": "^2.0.1",
+        "postcss-load-config": "^5.0.0",
         "vinyl-sourcemaps-apply": "^0.2.1"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14"
+        "node": ">=18"
       },
       "peerDependencies": {
         "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/gulp-postcss/node_modules/ansi-colors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-wrap": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gulp-postcss/node_modules/fancy-log": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-2.0.0.tgz",
+      "integrity": "sha512-9CzxZbACXMUXW13tS0tI8XsGGmxWzO2DmYrGuBJOJ8k8q2K7hwfJA5qHjuPPe8wtsco33YR9wc+Rlr5wYFvhSA==",
+      "dev": true,
+      "dependencies": {
+        "color-support": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/gulp-postcss/node_modules/plugin-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-2.0.1.tgz",
+      "integrity": "sha512-zMakqvIDyY40xHOvzXka0kUvf40nYIuwRE8dWhti2WtjQZ31xAgBZBhxsK7vK3QbRXS1Xms/LO7B5cuAsfB2Gg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/gulp-rename": {
@@ -19612,31 +19649,66 @@
       }
     },
     "node_modules/postcss-load-config": {
-      "version": "3.1.4",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-5.1.0.tgz",
+      "integrity": "sha512-G5AJ+IX0aD0dygOE0yFZQ/huFFMSNneyfp0e3/bT05a8OfPC5FUoZRPfGijUdGOJNMewJiwzcHJXFafFzeKFVA==",
       "dev": true,
-      "license": "MIT",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "dependencies": {
-        "lilconfig": "^2.0.5",
-        "yaml": "^1.10.2"
+        "lilconfig": "^3.1.1",
+        "yaml": "^2.4.2"
       },
       "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
+        "node": ">= 18"
       },
       "peerDependencies": {
+        "jiti": ">=1.21.0",
         "postcss": ">=8.0.9",
-        "ts-node": ">=9.0.0"
+        "tsx": "^4.8.1"
       },
       "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
         "postcss": {
           "optional": true
         },
-        "ts-node": {
+        "tsx": {
           "optional": true
         }
+      }
+    },
+    "node_modules/postcss-load-config/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/postcss-load-config/node_modules/yaml": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/postcss-media-query-parser": {

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "gulp-babel": "^8.0.0",
     "gulp-insert": "^0.5.0",
     "gulp-less": "^4.0.1",
-    "gulp-postcss": "^9.0.1",
+    "gulp-postcss": "^10.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-rtlcss": "^1.4.0",
     "gulp-sourcemaps": "^2.6.4",
@@ -199,7 +199,7 @@
     "aria-query@>5.1.3": "5.1.3"
   },
   "browserslist": [
-    ">0.3%, defaults"
+    "defaults"
   ],
   "sideEffects": [
     "cjs/**/styles/*",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,6 @@
     "minimist": "^1.2.8",
     "mocha": "^9.0.2",
     "picocolors": "^1.0.0",
-    "postcss-custom-properties": "^10.0.0",
     "postcss-discard-empty": "^6.0.1",
     "postcss-less": "^6.0.0",
     "postcss-prune-var": "^1.1.1",
@@ -200,9 +199,7 @@
     "aria-query@>5.1.3": "5.1.3"
   },
   "browserslist": [
-    "> 1%",
-    "last 2 versions",
-    "not ie <11"
+    ">0.3%, defaults"
   ],
   "sideEffects": [
     "cjs/**/styles/*",

--- a/src/Calendar/styles/index.less
+++ b/src/Calendar/styles/index.less
@@ -507,11 +507,6 @@
     margin: 1px;
     text-align: center;
     vertical-align: middle;
-
-    // In IE and Edge need more minus 1px. @see https://github.com/rsuite/rsuite/issues/585
-    .ie11-edge-width(
-      ~'calc((100% - @{calendar-table-cell-content-today-border-width} * 12 - 1px) / 6)'
-    );
   }
 
   &-cell-content {

--- a/src/Form/styles/mixin.less
+++ b/src/Form/styles/mixin.less
@@ -41,8 +41,6 @@
   padding: (@padding-vertical - @input-border-width) (@padding-horizontal - @input-border-width);
   font-size: @font-size;
   line-height: @line-height;
-  // You must declared height in IE
-  .ie11-height(@ie-height);
 
   textarea& {
     height: auto;
@@ -82,7 +80,7 @@
 }
 
 .reset-input-group-addon-size(@size-name) {
- 
+
   .map-size(@size-name);
 
   @padding-horizontal-name: ~'padding-x@{suffix}';
@@ -96,7 +94,7 @@
 }
 
 .reset-inside-input-group-btn-size(@size-name) {
- 
+
   .map-size(@size-name);
 
   @height: ~'input-height-@{size-name}';

--- a/src/Popover/styles/mixins.less
+++ b/src/Popover/styles/mixins.less
@@ -11,9 +11,6 @@
 
 .popover-arrow(top, @size, @color) {
   top: -@size;
-  // FIXED: The problem of the  1 pixel white border in Edge/IE11 browser .
-  .ie11-edge-direction(top, -(@size+1px));
-
   margin-left: -@size;
   border-width: 0 @size @size;
   border-bottom-color: @color;
@@ -21,9 +18,6 @@
 
 .popover-arrow(bottom, @size, @color) {
   bottom: -@size;
-  // FIXED: The problem of the  1 pixel white border in Edge/IE11 browser .
-  .ie11-edge-direction(bottom, -(@size+1px));
-
   margin-left: -@size;
   border-width: @size @size 0;
   border-top-color: @color;
@@ -32,9 +26,6 @@
 /* rtl:begin:ignore */
 .popover-arrow(right, @size, @color) {
   right: -@size;
-  // FIXED: The problem of the  1 pixel white border in Edge/IE11 browser .
-  .ie11-edge-direction(right, -(@size+1px));
-
   margin-top: -@size;
   border-width: @size 0 @size @size;
   border-left-color: @color;
@@ -42,9 +33,6 @@
 
 .popover-arrow(left, @size, @color) {
   left: -@size;
-  // FIXED: The problem of the  1 pixel white border in Edge/IE11 browser .
-  .ie11-edge-direction(left, -(@size+1px));
-
   margin-top: -@size;
   border-width: @size @size @size 0;
   border-right-color: @color;

--- a/src/Timeline/styles/index.less
+++ b/src/Timeline/styles/index.less
@@ -139,9 +139,6 @@
   &-with-time &-item-time,
   &-with-time &-item-content {
     flex: 1 0 50%;
-    // In IE flex item box-sizing is invalid .
-    // Reference https://github.com/philipwalton/flexbugs/issues/3
-    .ie11-max-width(50%);
   }
 
   &-align-alternate &-item:nth-child(2n),

--- a/src/Tooltip/styles/mixins.less
+++ b/src/Tooltip/styles/mixins.less
@@ -11,9 +11,6 @@
 
 .tooltip-arrow(top, @size, @color) {
   top: -@size;
-  // FIXED: The problem of the  1 pixel white border in Edge/IE11 browser .
-  .ie11-edge-direction(top, -(@size+1px));
-
   margin-left: -@size;
   border-width: 0 @size @size;
   border-bottom-color: @color;
@@ -21,9 +18,6 @@
 
 .tooltip-arrow(bottom, @size, @color) {
   bottom: -@size;
-  // FIXED: The problem of the  1 pixel white border in Edge/IE11 browser .
-  .ie11-edge-direction(bottom, -(@size+1px));
-
   margin-left: -@size;
   border-width: @size @size 0;
   border-top-color: @color;
@@ -32,9 +26,6 @@
 /* rtl:begin:ignore */
 .tooltip-arrow(right, @size, @color) {
   right: -@size;
-  // FIXED: The problem of the  1 pixel white border in Edge/IE11 browser .
-  .ie11-edge-direction(right, -(@size+1px));
-
   margin-top: -@size;
   border-width: @size 0 @size @size;
   border-left-color: @color;
@@ -42,9 +33,6 @@
 
 .tooltip-arrow(left, @size, @color) {
   left: -@size;
-  // FIXED: The problem of the  1 pixel white border in Edge/IE11 browser .
-  .ie11-edge-direction(left, -(@size+1px));
-
   margin-top: -@size;
   border-width: @size @size @size 0;
   border-right-color: @color;

--- a/src/internals/Picker/styles/index.less
+++ b/src/internals/Picker/styles/index.less
@@ -72,7 +72,6 @@
   &-value-list {
     flex: 0 1 auto;
     .ellipsis-basic();
-    .ie11-max-width(100%);
   }
 
   &-value-count {

--- a/src/styles/mixins/hacks.less
+++ b/src/styles/mixins/hacks.less
@@ -1,46 +1,5 @@
 // All hacks syntax for all kinds of browsers
 
-// IE 11
-// ---------------------
-.ie11-max-width(@value) when (@enable-ie-polyfill = true) {
-  // IE 11
-  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-    & {
-      max-width: @value;
-    }
-  }
-}
-
-.ie11-height(@value) when (@enable-ie-polyfill = true) {
-  // IE 11
-  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-    & {
-      height: @value;
-    }
-  }
-}
-
-.ie11-z-index(@value) when (@enable-ie-polyfill = true) {
-  // IE 11
-  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-    & {
-      z-index: @value;
-    }
-  }
-}
-
-.ie11-position(@value) when (@enable-ie-polyfill = true) {
-  // IE 11
-  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-    & {
-      position: @value;
-    }
-  }
-}
-
-.ie-box-shadow(@value) when (@enable-ie-polyfill = true) {
-  box-shadow: @value;
-}
 
 // Safari
 // ---------------------
@@ -68,38 +27,6 @@
   @media not all and (min-resolution: 0.001dpcm) {
     & {
       visibility: @value;
-    }
-  }
-}
-
-// IE && Edge
-// ---------------------
-.ie11-edge-width(@value) when (@enable-ie-polyfill = true) {
-  // IE 11
-  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-    & {
-      width: @value;
-    }
-  }
-
-  @supports (-ms-ime-align: auto) {
-    & {
-      width: @value;
-    }
-  }
-}
-
-.ie11-edge-direction(@direction ,@value) {
-  // IE 11
-  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-    & {
-      @{direction}: @value;
-    }
-  }
-  // edge
-  @supports (-ms-ime-align: auto) {
-    & {
-      @{direction}: @value;
     }
   }
 }

--- a/src/styles/mixins/utilities.less
+++ b/src/styles/mixins/utilities.less
@@ -40,9 +40,6 @@
 //drop-shadow
 .drop-shadow(@shadow) {
   filter: drop-shadow(@shadow);
-  // IE don't support `drop-shadow`,replace it with `box-shadow`.
-  // FIXME duplicated shadows
-  .ie-box-shadow(@shadow);
 }
 
 .set-translate-transition(@translateX:0,@translateY:0) {


### PR DESCRIPTION
This pull request involves significant changes to the codebase, primarily focusing on removing support for IE11 and Edge-specific hacks, and cleaning up dependencies related to `postcss-custom-properties`.

### Removal of IE11 and Edge-specific hacks:

* [`src/styles/mixins/hacks.less`](diffhunk://#diff-b69a3cdeba649dc598c95bb85b58142f2ebbf1e4f65c02cf222ee2dbf36a95dfL3-L43): Removed all IE11 and Edge-specific mixins, including `ie11-max-width`, `ie11-height`, `ie11-z-index`, `ie11-position`, `ie-box-shadow`, `ie11-edge-width`, and `ie11-edge-direction`. [[1]](diffhunk://#diff-b69a3cdeba649dc598c95bb85b58142f2ebbf1e4f65c02cf222ee2dbf36a95dfL3-L43) [[2]](diffhunk://#diff-b69a3cdeba649dc598c95bb85b58142f2ebbf1e4f65c02cf222ee2dbf36a95dfL74-L105)
* [`src/Calendar/styles/index.less`](diffhunk://#diff-351dc7887990f0c7ad6102c9a848b5fd24e8565deccd1c3627e589140f9ab0ccL510-L514): Removed IE11 and Edge-specific width adjustment mixin.
* [`src/Form/styles/mixin.less`](diffhunk://#diff-47d1b2bfbb4cc33db0c260c32b57e0f2b7b248add536b4d5313a9b33bb02ec99L44-L45): Removed IE11-specific height declaration.
* [`src/Popover/styles/mixins.less`](diffhunk://#diff-33852457cf1027493c3d0a86fbb211d008dff397319c2b6e8d80a5a315b0286cL14-L26): Removed IE11 and Edge-specific direction adjustments for popover arrows. [[1]](diffhunk://#diff-33852457cf1027493c3d0a86fbb211d008dff397319c2b6e8d80a5a315b0286cL14-L26) [[2]](diffhunk://#diff-33852457cf1027493c3d0a86fbb211d008dff397319c2b6e8d80a5a315b0286cL35-L47)
* [`src/Timeline/styles/index.less`](diffhunk://#diff-a5a70f7387a65e838a7cf16b363f61fd8861d76f2705fc3ec354de8cf7f0d436L142-L144): Removed IE11-specific max-width adjustment mixin.
* [`src/Tooltip/styles/mixins.less`](diffhunk://#diff-4fc24b43d19bf68f5a0748734cc7baca0315b6f15f2c1b02faf860a95def07b9L14-L26): Removed IE11 and Edge-specific direction adjustments for tooltip arrows. [[1]](diffhunk://#diff-4fc24b43d19bf68f5a0748734cc7baca0315b6f15f2c1b02faf860a95def07b9L14-L26) [[2]](diffhunk://#diff-4fc24b43d19bf68f5a0748734cc7baca0315b6f15f2c1b02faf860a95def07b9L35-L47)
* [`src/internals/Picker/styles/index.less`](diffhunk://#diff-39e60be854f6f35595816822070452a633398f2f4e4923a5c32ace4bcd07346bL75): Removed IE11-specific max-width adjustment mixin.
* [`src/styles/mixins/utilities.less`](diffhunk://#diff-2d1ecce75e5eca0a0a443e9ac3c610911902c26104d930351ff55bf75f0b03feL43-L45): Removed IE-specific box-shadow fallback for drop-shadow.

### Dependency cleanup:

* [`docs/package-lock.json`](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L74): Removed `postcss-custom-properties` dependency. [[1]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L74) [[2]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L8678-L8696)
* [`docs/package.json`](diffhunk://#diff-adfa337ce44dc2902621da20152a048dac41878cf3716dfc4cc56d03aa212a56L81): Removed `postcss-custom-properties` dependency.
* [`gulpfile.js`](diffhunk://#diff-25789e3ba4c2adf4a68996260eb693a441b4a834c38b76167a120f0b51b969f7L7): Removed usage of `postcss-custom-properties` in the build process. [[1]](diffhunk://#diff-25789e3ba4c2adf4a68996260eb693a441b4a834c38b76167a120f0b51b969f7L7) [[2]](diffhunk://#diff-25789e3ba4c2adf4a68996260eb693a441b4a834c38b76167a120f0b51b969f7L125-R124)
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L174): Removed `postcss-custom-properties` dependency.

### Configuration updates:

* [`docs/.browserslistrc`](diffhunk://#diff-78f2be41a853c2aa348389b889838e296834f9d3fe87b68ea1579abc703cf3efL1-R1): Updated browserlist configuration to ">0.3%, defaults" from "> 1%, last 2 versions".
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L203-R202): Updated browserlist configuration to ">0.3%, defaults" from "> 1%, last 2 versions, not ie <11".

### Build configuration:

* [`docs/next.config.js`](diffhunk://#diff-97081d4c5e67d7fb92c87085affbac02322e2b4c53c01c5e65f500fc3b67a402L80-R83): Cleaned up `postcssOptions` by removing the commented-out `postcss-rtl` and `postcss-custom-properties`.