### PR TITLE
build(deps): bump babel 7.26.*

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.76.0",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
+        "@babel/runtime": "^7.26.0",
         "@juggle/resize-observer": "^3.4.0",
         "@rsuite/icons": "^1.3.0",
         "@types/lodash": "^4.14.184",
@@ -24,8 +24,8 @@
         "schema-typed": "^2.2.2"
       },
       "devDependencies": {
-        "@babel/cli": "^7.25.9",
-        "@babel/core": "^7.25.9",
+        "@babel/cli": "^7.26.4",
+        "@babel/core": "^7.26.0",
         "@babel/plugin-proposal-export-default-from": "^7.25.9",
         "@babel/plugin-transform-class-properties": "^7.25.9",
         "@babel/plugin-transform-export-namespace-from": "^7.25.9",
@@ -33,7 +33,7 @@
         "@babel/plugin-transform-optional-chaining": "^7.25.9",
         "@babel/plugin-transform-runtime": "^7.25.9",
         "@babel/preset-env": "^7.26.0",
-        "@babel/preset-react": "^7.25.9",
+        "@babel/preset-react": "^7.26.3",
         "@babel/preset-typescript": "^7.26.0",
         "@commitlint/cli": "^19.6.1",
         "@commitlint/config-conventional": "^13.2.0",
@@ -154,9 +154,9 @@
       }
     },
     "node_modules/@babel/cli": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.25.9.tgz",
-      "integrity": "sha512-I+02IfrTiSanpxJBlZQYb18qCxB6c2Ih371cVpfgIrPQrjAYkf45XxomTJOG8JBWX5GY35/+TmhCMdJ4ZPkL8Q==",
+      "version": "7.26.4",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.26.4.tgz",
+      "integrity": "sha512-+mORf3ezU3p3qr+82WvJSnQNE1GAYeoCfEv4fik6B5/2cvKZ75AX8oawWQdXtM9MmndooQj15Jr9kelRFWsuRw==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -1784,9 +1784,9 @@
       }
     },
     "node_modules/@babel/preset-react": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.25.9.tgz",
-      "integrity": "sha512-D3to0uSPiWE7rBrdIICCd0tJSIGpLaaGptna2+w7Pft5xMqLpA1sz99DK5TZ1TjGbdQ/VI1eCSZ06dv3lT4JOw==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.26.3.tgz",
+      "integrity": "sha512-Nl03d6T9ky516DGK2YMxrTqvnpUW63TnJMOMonj+Zae0JiPC5BC9xPMSL6L8fiSpA5vP88qfygavVQvnLp+6Cw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1823,8 +1823,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.5",
-      "license": "MIT",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "url": "git@github.com:rsuite/rsuite.git"
   },
   "dependencies": {
-    "@babel/runtime": "^7.20.1",
+    "@babel/runtime": "^7.26.0",
     "@juggle/resize-observer": "^3.4.0",
     "@rsuite/icons": "^1.3.0",
     "@types/lodash": "^4.14.184",
@@ -82,8 +82,8 @@
     "lib"
   ],
   "devDependencies": {
-    "@babel/cli": "^7.25.9",
-    "@babel/core": "^7.25.9",
+    "@babel/cli": "^7.26.4",
+    "@babel/core": "^7.26.0",
     "@babel/plugin-proposal-export-default-from": "^7.25.9",
     "@babel/plugin-transform-class-properties": "^7.25.9",
     "@babel/plugin-transform-export-namespace-from": "^7.25.9",
@@ -91,7 +91,7 @@
     "@babel/plugin-transform-optional-chaining": "^7.25.9",
     "@babel/plugin-transform-runtime": "^7.25.9",
     "@babel/preset-env": "^7.26.0",
-    "@babel/preset-react": "^7.25.9",
+    "@babel/preset-react": "^7.26.3",
     "@babel/preset-typescript": "^7.26.0",
     "@commitlint/cli": "^19.6.1",
     "@commitlint/config-conventional": "^13.2.0",


### PR DESCRIPTION
This pull request updates several dependencies in the `package.json` file to their latest versions.

Dependency updates:

* Updated `@babel/runtime` from `^7.20.1` to `^7.26.0`
* Updated `@babel/cli` from `^7.25.9` to `^7.26.4`
* Updated `@babel/core` from `^7.25.9` to `^7.26.0`
* Updated `@babel/preset-react` from `^7.25.9` to `^7.26.3`