### PR TITLE
ci(mocha): fix test command error when release version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -215,7 +215,7 @@ function createPkgFile(done) {
   pkg.module = 'esm/index.js';
   pkg.typings = 'esm/index.d.ts';
   pkg.scripts = {
-    prepublishOnly: '../node_modules/mocha/bin/mocha ../test/validateBuilds.js'
+    prepublishOnly: '../node_modules/mocha/bin/_mocha ../test/validateBuilds.js'
   };
 
   writeFile(`${libRoot}/package.json`, JSON.stringify(pkg, null, 2) + '\n')


### PR DESCRIPTION
This pull request includes a small change to the `gulpfile.js` file. The change updates the script path for `prepublishOnly` to use `_mocha` instead of `mocha`.

* [`gulpfile.js`](diffhunk://#diff-25789e3ba4c2adf4a68996260eb693a441b4a834c38b76167a120f0b51b969f7L218-R218): Updated the `prepublishOnly` script path to use `_mocha` instead of `mocha`.