### PR TITLE
feat(Badge): add support for `compact`, `invisible`, `outline`, `placement`, `shape`, `offset` props

### DIFF
--- a/docs/less/code-view.less
+++ b/docs/less/code-view.less
@@ -113,10 +113,6 @@ a code {
   }
 }
 
-.rcv-render .rs-badge ~ .rs-badge {
-  margin-left: 20px;
-}
-
 .rcv-render .notification-container {
   display: flex;
   flex-direction: column;

--- a/docs/pages/_common/types/placement-corners.md
+++ b/docs/pages/_common/types/placement-corners.md
@@ -1,0 +1,5 @@
+### `ts:PlacementCorners`
+
+```ts
+type PlacementCorners =  'topStart' | 'topEnd' | 'bottomStart' | 'bottomEnd' |
+```

--- a/docs/pages/components/badge/en-US/index.md
+++ b/docs/pages/components/badge/en-US/index.md
@@ -1,6 +1,6 @@
 # Badge
 
-Used for buttons, numbers or status markers next to icons.
+Used to display the number of unread messages or status on icons or other components.
 
 ## Usage
 
@@ -16,17 +16,31 @@ Used for buttons, numbers or status markers next to icons.
 
 <!--{include:`content.md`}-->
 
+### Placement
+
+<!--{include:`placement.md`}-->
+
+### Shapes
+
+If the wrapped element is a circle, you can use the `shape` property `circle` to make the Badge position more reasonable.
+
+<!--{include:`shape.md`}-->
+
+### Offset
+
+If the Badge position is not reasonable, you can use the `offset` property to make fine adjustments.
+
+<!--{include:`offset.md`}-->
+
 ### Invisible
 
 <!--{include:`invisible.md`}-->
 
-### Independent Use
+### Badge without children
 
 <!--{include:`independent.md`}-->
 
-### Colorful indicator
-
-`color` attribute sets the indicator style, options include: 'red', 'orange', 'yellow', 'green', 'cyan', 'blue', 'violet'.
+### Colors
 
 <!--{include:`color.md`}-->
 
@@ -34,12 +48,21 @@ Used for buttons, numbers or status markers next to icons.
 
 ### `<Badge>`
 
-| Property    | Type`(Default)`              | Description                                                |
-| ----------- | ---------------------------- | ---------------------------------------------------------- |
-| children    | ReactNode                    | Be wrapped component                                       |
-| classPrefix | string `('badge')`           | The prefix of the component CSS class                      |
-| content     | ReactNode                    | Content info                                               |
-| color       | [Color](#code-ts-color-code) | A indicator can have different colors                      |
-| maxCount    | number`(99)`                 | Max count number（Only valid if `content` is type number） |
+| Property    | Type`(Default)`                                     | Description                                                                                            |
+| ----------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| children    | ReactNode                                           | The wrapped component                                                                                  |
+| classPrefix | string `('badge')`                                  | The prefix of the component CSS class                                                                  |
+| color       | [Color](#code-ts-color-code) \| string              | Set the color of the badge                                                                             |
+| compact     | boolean                                             | Whether to use compact mode<br/>![][6.0.0]                                                             |
+| content     | number \| ReactNode                                 | The content of the badge                                                                               |
+| invisible   | boolean                                             | Whether the badge is invisible<br/>![][6.0.0]                                                          |
+| maxCount    | number`(99)`                                        | Max count number（Only valid if `content` is type number）                                             |
+| offset      | [number,number] \| [string, string]                 | Define the horizontal and vertical offset of the badge relative to its wrapped element <br/>![][6.0.0] |
+| outline     | boolean`(true)`                                     | Whether to use outline mode<br/>![][6.0.0]                                                             |
+| placement   | [PlacementCorners](#code-ts-placement-corners-code) | Set the position of the badge in the wrapped element<br/>![][6.0.0]                                    |
+| shape       | 'rectangle' \| 'circle'                             | The shape of the wrapped element<br/>![][6.0.0]                                                        |
 
 <!--{include:(_common/types/color.md)}-->
+<!--{include:(_common/types/placement-corners.md)}-->
+
+[6.0.0]: https://img.shields.io/badge/>=-v6.0.0-blue

--- a/docs/pages/components/badge/fragments/basic.md
+++ b/docs/pages/components/badge/fragments/basic.md
@@ -1,11 +1,11 @@
 <!--start-code-->
 
 ```js
-import { Badge, Button } from 'rsuite';
+import { Avatar, Badge } from 'rsuite';
 
 const App = () => (
-  <Badge>
-    <Button>New Message</Button>
+  <Badge content={6}>
+    <Avatar src="https://i.pravatar.cc/150?u=1" />
   </Badge>
 );
 

--- a/docs/pages/components/badge/fragments/color.md
+++ b/docs/pages/components/badge/fragments/color.md
@@ -1,27 +1,47 @@
 <!--start-code-->
 
 ```js
-import { Badge } from 'rsuite';
+import { Badge, Avatar, HStack } from 'rsuite';
 
 const App = () => (
   <>
-    <Badge color="red">Red</Badge>
-    <Badge color="orange">Orange</Badge>
-    <Badge color="yellow">Yellow</Badge>
-    <Badge color="green">Green</Badge>
-    <Badge color="cyan">Cyan</Badge>
-    <Badge color="blue">Blue</Badge>
-    <Badge color="violet">Violet</Badge>
+    <HStack spacing={10}>
+      <Badge color="red" content={6}>
+        <Avatar />
+      </Badge>
+      <Badge color="orange" content={6}>
+        <Avatar />
+      </Badge>
+      <Badge color="yellow" content={6}>
+        <Avatar />
+      </Badge>
+      <Badge color="green" content={6}>
+        <Avatar />
+      </Badge>
+      <Badge color="cyan" content={6}>
+        <Avatar />
+      </Badge>
+      <Badge color="blue" content={6}>
+        <Avatar />
+      </Badge>
+      <Badge color="violet" content={6}>
+        <Avatar />
+      </Badge>
+      <Badge color="#000000" content={6} content="Custom">
+        <Avatar />
+      </Badge>
+    </HStack>
     <hr />
-    <Badge color="red" />
-    <Badge color="orange" />
-    <Badge color="yellow" />
-    <Badge color="green" />
-    <Badge color="cyan" />
-    <Badge color="blue" />
-    <Badge color="violet" />
-    <Badge color="blue" content="99+" />
-    <Badge color="violet" content="NEW" />
+    <HStack spacing={10}>
+      <Badge color="red" content="red" />
+      <Badge color="orange" content="orange" />
+      <Badge color="yellow" content="yellow" />
+      <Badge color="green" content="green" />
+      <Badge color="cyan" content="cyan" />
+      <Badge color="blue" content="blue" />
+      <Badge color="violet" content="violet" />
+      <Badge color="#000000" content={6} content="custom" />
+    </HStack>
   </>
 );
 

--- a/docs/pages/components/badge/fragments/content.md
+++ b/docs/pages/components/badge/fragments/content.md
@@ -1,18 +1,35 @@
 <!--start-code-->
 
 ```js
-import { Badge, Button } from 'rsuite';
+import { Badge, Avatar, HStack } from 'rsuite';
+import { MdCheck, MdNotifications, MdError } from 'react-icons/md';
 
 const App = () => (
-  <>
-    <Badge content={999}>
-      <Button>New Message</Button>
+  <HStack spacing={10}>
+    <Badge content={6}>
+      <Avatar src="https://i.pravatar.cc/150?u=1" />
     </Badge>
 
-    <Badge content="NEW">
-      <Button>New Message</Button>
+    <Badge content="new" color="yellow">
+      <Avatar src="https://i.pravatar.cc/150?u=2" />
     </Badge>
-  </>
+
+    <Badge color="green" placement="bottomEnd">
+      <Avatar src="https://i.pravatar.cc/150?u=3" />
+    </Badge>
+
+    <Badge compact color="green" placement="bottomEnd" content={<MdCheck size={12} />}>
+      <Avatar src="https://i.pravatar.cc/150?u=4" />
+    </Badge>
+
+    <Badge compact content={<MdNotifications size={12} />}>
+      <Avatar src="https://i.pravatar.cc/150?u=6" />
+    </Badge>
+
+    <Badge compact content={<MdError size={12} />}>
+      <Avatar />
+    </Badge>
+  </HStack>
 );
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/docs/pages/components/badge/fragments/independent.md
+++ b/docs/pages/components/badge/fragments/independent.md
@@ -1,14 +1,30 @@
 <!--start-code-->
 
 ```js
-import { Badge } from 'rsuite';
+import { Badge, HStack } from 'rsuite';
+import { MdCheck, MdNotifications, MdError } from 'react-icons/md';
 
 const App = () => (
   <>
-    <Badge />
-    <Badge style={{ background: '#4caf50' }} />
-    <Badge content="99+" />
-    <Badge content="NEW" />
+    <HStack>
+      <Badge />
+      <Badge style={{ background: '#4caf50' }} />
+      <Badge compact color="green" content={<MdCheck size={12} />} />
+      <Badge compact content={<MdNotifications />} />
+
+      <Badge content="99+" />
+      <Badge content="new" color="yellow" />
+    </HStack>
+    <hr />
+    <HStack>
+      <Badge compact color="green" content={<MdCheck size={12} />} />
+      <Text>Ready</Text>
+    </HStack>
+    <hr />
+    <HStack>
+      <Badge compact color="red" content={<MdError size={12} />} />
+      <Text>Error</Text>
+    </HStack>
   </>
 );
 

--- a/docs/pages/components/badge/fragments/invisible.md
+++ b/docs/pages/components/badge/fragments/invisible.md
@@ -1,18 +1,24 @@
 <!--start-code-->
 
 ```js
-import { Badge, Button, Toggle } from 'rsuite';
+import { Badge, Avatar, Toggle, HStack } from 'rsuite';
 
 const App = () => {
-  const [content, setContent] = React.useState(true);
+  const [show, setShow] = React.useState(true);
 
   return (
     <>
-      <Badge content={content}>
-        <Button>新消息</Button>
-      </Badge>
+      <HStack spacing={20}>
+        <Badge content={6} invisible={!show}>
+          <Avatar src="https://i.pravatar.cc/150?u=1" />
+        </Badge>
+
+        <Badge content={'New'} invisible={!show} />
+      </HStack>
       <hr />
-      <Toggle checked={content} onChange={setContent} />
+      <Toggle checked={show} onChange={setShow} >
+        Show Badge
+      </Toggle>
     </>
   );
 };

--- a/docs/pages/components/badge/fragments/offset.md
+++ b/docs/pages/components/badge/fragments/offset.md
@@ -1,0 +1,16 @@
+<!--start-code-->
+
+```js
+import { Avatar, Badge, HStack, IconButton } from 'rsuite';
+import { MdNotifications } from 'react-icons/md';
+
+const App = () => (
+  <Badge content={6} shape="circle" offset={[5, 5]}>
+    <IconButton icon={<MdNotifications size={20} />} circle appearance="subtle" />
+  </Badge>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/badge/fragments/placement.md
+++ b/docs/pages/components/badge/fragments/placement.md
@@ -1,0 +1,29 @@
+<!--start-code-->
+
+```js
+import { Avatar, Badge, HStack } from 'rsuite';
+
+const App = () => (
+  <HStack spacing={10}>
+    <Badge content={6} placement="topStart">
+      <Avatar src="https://i.pravatar.cc/150?u=1" />
+    </Badge>
+
+    <Badge content={6} placement="topEnd">
+      <Avatar src="https://i.pravatar.cc/150?u=1" />
+    </Badge>
+
+    <Badge content={6} placement="bottomStart">
+      <Avatar src="https://i.pravatar.cc/150?u=1" />
+    </Badge>
+
+    <Badge content={6} placement="bottomEnd">
+      <Avatar src="https://i.pravatar.cc/150?u=1" />
+    </Badge>
+  </HStack>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/badge/fragments/shape.md
+++ b/docs/pages/components/badge/fragments/shape.md
@@ -1,0 +1,34 @@
+<!--start-code-->
+
+```js
+import { Avatar, Badge, HStack, IconButton } from 'rsuite';
+import { MdNotifications } from 'react-icons/md';
+
+const App = () => (
+  <>
+    <HStack spacing={10}>
+      <Badge content={6} shape="rectangle">
+        <Avatar src="https://i.pravatar.cc/150?u=1" />
+      </Badge>
+
+      <Badge content={6} shape="circle">
+        <Avatar src="https://i.pravatar.cc/150?u=2" circle />
+      </Badge>
+    </HStack>
+    <hr />
+    <HStack spacing={10}>
+      <Badge content={6} shape="rectangle">
+        <IconButton icon={<MdNotifications size={20} />} size="sm" />
+      </Badge>
+
+      <Badge content={6} shape="circle">
+        <IconButton icon={<MdNotifications size={20} />} circle size="sm" />
+      </Badge>
+    </HStack>
+  </>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/badge/index.tsx
+++ b/docs/pages/components/badge/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Badge, Button, Toggle } from 'rsuite';
 import DefaultPage from '@/components/Page';
 import ImportGuide from '@/components/ImportGuide';
+import { Badge, Button, Toggle, Avatar, HStack, Text, IconButton } from 'rsuite';
+import { MdCheck, MdNotifications, MdError } from 'react-icons/md';
 
 const inDocsComponents = {
   'import-guide': () => <ImportGuide components={['Badge']} />
@@ -9,6 +10,20 @@ const inDocsComponents = {
 
 export default function Page() {
   return (
-    <DefaultPage inDocsComponents={inDocsComponents} dependencies={{ Badge, Button, Toggle }} />
+    <DefaultPage
+      inDocsComponents={inDocsComponents}
+      dependencies={{
+        Avatar,
+        Badge,
+        Button,
+        Toggle,
+        HStack,
+        Text,
+        IconButton,
+        MdCheck,
+        MdNotifications,
+        MdError
+      }}
+    />
   );
 }

--- a/docs/pages/components/badge/zh-CN/index.md
+++ b/docs/pages/components/badge/zh-CN/index.md
@@ -1,6 +1,6 @@
 # Badge 标记
 
-用于按钮、图标旁的数字或状态标记。
+用于在图标或者其他组件上显示未读消息数量或者状态。
 
 ## 获取组件
 
@@ -12,21 +12,35 @@
 
 <!--{include:`basic.md`}-->
 
-### 附加内容
+### 带内容
 
 <!--{include:`content.md`}-->
+
+### 位置
+
+<!--{include:`placement.md`}-->
+
+### 形状
+
+如果包裹元素为圆形时, 为了让 Badge 的位置更加合理, 可以使用 `shape` 属性 `circle`。
+
+<!--{include:`shape.md`}-->
+
+### 偏移
+
+如果 Badge 的位置不合理, 可以使用 `offset` 属性进行微调。
+
+<!--{include:`offset.md`}-->
 
 ### 不可见的
 
 <!--{include:`invisible.md`}-->
 
-### 独立使用
+### 没有 children 的 Badge
 
 <!--{include:`independent.md`}-->
 
-### 彩色指示器
-
-`color` 属性设置徽标提示点样式，选项包括: 'red', 'orange', 'yellow', 'green', 'cyan', 'blue', 'violet'。
+### 颜色
 
 <!--{include:`color.md`}-->
 
@@ -34,12 +48,21 @@
 
 ### `<Badge>`
 
-| 属性名称    | 类型`(默认值)`               | 描述                                            |
-| ----------- | ---------------------------- | ----------------------------------------------- |
-| children    | ReactNode                    | 包裹的组件                                      |
-| classPrefix | string `('badge')`           | 组件 CSS 类的前缀                               |
-| content     | ReactNode                    | 内容                                            |
-| color       | [Color](#code-ts-color-code) | 设置颜色                                        |
-| maxCount    | number`(99)`                 | 最大计数（仅当 `content` 为 number 类型时有效） |
+| 属性名称    | 类型`(默认值)`                                      | 描述                                                      |
+| ----------- | --------------------------------------------------- | --------------------------------------------------------- |
+| children    | ReactNode                                           | 包裹的组件                                                |
+| classPrefix | string `('badge')`                                  | 组件 CSS 类名的前缀                                       |
+| color       | [Color](#code-ts-color-code) \| string              | 设置标记的颜色                                            |
+| compact     | boolean                                             | 是否为紧凑模式<br/>![][6.0.0]                             |
+| content     | number \| ReactNode                                 | 标记内容                                                  |
+| invisible   | boolean                                             | 标记是否不可见<br/>![][6.0.0]                             |
+| maxCount    | number`(99)`                                        | 最大计数（仅当 `content` 为 number 类型时有效）           |
+| offset      | [number,number] \| [string, string]                 | 定义标记相对于其被包裹元素的水平和垂直偏移<br/>![][6.0.0] |
+| outline     | boolean`(true)`                                     | 是否为轮廓模式<br/>![][6.0.0]                             |
+| placement   | [PlacementCorners](#code-ts-placement-corners-code) | 设置标记在被包裹元素的位置<br/>![][6.0.0]                 |
+| shape       | 'rectangle' \| 'circle'                             | 被包裹元素的形状<br/>![][6.0.0]                           |
 
 <!--{include:(_common/types/color.md)}-->
+<!--{include:(_common/types/placement-corners.md)}-->
+
+[6.0.0]: https://img.shields.io/badge/>=-v6.0.0-blue

--- a/src/AutoComplete/AutoComplete.tsx
+++ b/src/AutoComplete/AutoComplete.tsx
@@ -20,6 +20,7 @@ import {
   WithAsProps,
   FormControlPickerProps,
   TypeAttributes,
+  Placement,
   ItemDataType
 } from '@/internals/types';
 import { transformData, shouldDisplay } from './utils';
@@ -33,7 +34,7 @@ export interface AutoCompleteProps<T = string>
   menuClassName?: string;
 
   /** The placement of component */
-  placement?: TypeAttributes.Placement;
+  placement?: Placement;
 
   /** When set to false, the Enter key selection function is invalid */
   selectOnEnter?: boolean;

--- a/src/Badge/Badge.tsx
+++ b/src/Badge/Badge.tsx
@@ -1,69 +1,139 @@
 import React from 'react';
+import kebabCase from 'lodash/kebabCase';
 import { useClassNames } from '@/internals/hooks';
-import { WithAsProps, RsRefForwardingComponent, TypeAttributes } from '@/internals/types';
+import { getCssValue } from '@/internals/utils';
 import { useCustom } from '../CustomProvider';
+import {
+  Color,
+  isPresetColor,
+  WithAsProps,
+  PlacementCorners,
+  RsRefForwardingComponent
+} from '@/internals/types';
 
 export interface BadgeProps extends WithAsProps {
-  /** Main content */
+  /**
+   * The content of the badge
+   */
   content?: React.ReactNode;
 
-  /** Max count */
+  /**
+   * The maximum value of the badge
+   */
   maxCount?: number;
 
-  /** A badge can have different colors */
-  color?: TypeAttributes.Color;
+  /**
+   * A badge can have different colors
+   */
+  color?: Color | string;
+
+  /**
+   * The badge will have an outline
+   * @version 6.0.0
+   */
+  outline?: boolean;
+
+  /**
+   * The placement of the badge
+   * @version 6.0.0
+   */
+  placement?: PlacementCorners;
+
+  /**
+   * If true, the Badge will have no padding, making it appear more compact and rounded.
+   */
+  compact?: boolean;
+
+  /**
+   * The shape of the wrapped element
+   * @version 6.0.0
+   */
+  shape?: 'rectangle' | 'circle';
+
+  /**
+   * Define the horizontal and vertical offset of the badge relative to its wrapped element
+   * @version 6.0.0
+   */
+  offset?: [number, number] | [string, string];
+
+  /**
+   * The badge will be hidden
+   * @version 6.0.0
+   */
+  invisible?: boolean;
 }
 
 /**
  * The Badge component is usually used to mark or highlight the status or quantity of an object.
  * @see https://rsuitejs.com/components/badge
  */
-const Badge: RsRefForwardingComponent<'div', BadgeProps> = React.forwardRef(
-  (props: BadgeProps, ref) => {
-    const { propsWithDefaults } = useCustom('Badge', props);
-    const {
-      as: Component = 'div',
-      content: contentText,
-      color,
-      className,
-      classPrefix = 'badge',
-      children,
-      maxCount = 99,
-      ...rest
-    } = propsWithDefaults;
+const Badge: RsRefForwardingComponent<'div', BadgeProps> = React.forwardRef<
+  HTMLDivElement,
+  BadgeProps
+>((props: BadgeProps, ref) => {
+  const { propsWithDefaults } = useCustom('Badge', props);
+  const {
+    as: Component = 'div',
+    content,
+    color,
+    className,
+    classPrefix = 'badge',
+    children,
+    compact,
+    maxCount = 99,
+    offset,
+    outline = true,
+    placement = 'topEnd',
+    shape,
+    style,
+    invisible,
+    ...rest
+  } = propsWithDefaults;
 
-    const { withClassPrefix, prefix, merge } = useClassNames(classPrefix);
-    const dot = contentText === undefined || contentText === null;
-    const classes = merge(
-      className,
-      withClassPrefix(color, {
-        independent: !children,
-        wrapper: children,
-        dot
-      })
-    );
+  const { withClassPrefix, prefix, merge } = useClassNames(classPrefix);
+  const text = typeof content === 'number' && content > maxCount ? `${maxCount}+` : content;
 
-    if (contentText === false) {
-      return React.cloneElement(children as React.ReactElement, { ref });
-    }
+  const classes = merge(
+    className,
+    withClassPrefix(isPresetColor(color) && color, shape, {
+      compact,
+      outline,
+      hidden: invisible,
+      wrapper: children,
+      independent: !children,
+      [kebabCase(placement)]: children
+    })
+  );
 
-    const content =
-      typeof contentText === 'number' && contentText > maxCount ? `${maxCount}+` : contentText;
-    if (!children) {
-      return (
-        <Component {...rest} ref={ref} className={classes}>
-          {content}
-        </Component>
-      );
-    }
+  const styles = {
+    ...style,
+
+    // Custom offset value
+    ...(offset && {
+      '--rs-badge-offset-x': getCssValue(offset[0]),
+      '--rs-badge-offset-y': getCssValue(offset[1])
+    })
+  };
+
+  // Custom color
+  if (color && !isPresetColor(color)) {
+    styles['--rs-badge-bg'] = color;
+  }
+
+  if (!children) {
     return (
-      <Component {...rest} ref={ref} className={classes}>
-        {children}
-        <div className={prefix('content')}>{content}</div>
+      <Component ref={ref} className={classes} style={styles} {...rest}>
+        {text}
       </Component>
     );
   }
-);
+  return (
+    <Component ref={ref} className={classes} style={styles} {...rest}>
+      {children}
+      <div className={prefix('content')}>{text}</div>
+    </Component>
+  );
+});
 
 Badge.displayName = 'Badge';
 

--- a/src/Badge/styles/index.less
+++ b/src/Badge/styles/index.less
@@ -5,40 +5,99 @@
 }
 
 .rs-badge {
-  display: inline-block;
+  --rs-badge-offset-x: 5%;
+  --rs-badge-offset-y: 5%;
+  --rs-badge-translate: 40%;
+
+  &-circle {
+    --rs-badge-translate: 30%;
+  }
+
+  display: inline-flex;
 
   &-independent,
   &-content {
+    opacity: 1;
+    display: flex;
+    align-items: center;
     background-color: var(--rs-badge-bg);
     color: var(--rs-badge-text);
-    border-radius: 8px;
+    border-radius: 999px;
     font-size: 12px;
     line-height: 16px;
     padding: 0 5px;
+    transition: opacity 0.3s ease-in-out;
   }
 
-  &-independent&-dot,
-  &-wrapper &-content:empty {
+  &-hidden &-content,
+  &-hidden&-independent {
+    opacity: 0;
+  }
+
+  &-compact &-content,
+  &-compact&-independent {
+    padding: 0;
+  }
+
+  &:empty,
+  &-content:empty {
     width: @badge-dot-size;
     height: @badge-dot-size;
-    border-radius: (@badge-dot-size / 2);
+    border-radius: 50%;
     padding: 0;
   }
 
   &-wrapper &-content {
     position: absolute;
-    top: 0;
-    right: 0;
-    transform: translate(50%, -50%);
+
     z-index: @zindex-badge-content;
+  }
+
+  &-outline &-content {
+    box-sizing: content-box;
+    border: 2px solid var(--rs-badge-border);
+  }
+
+  &-top {
+    &-start .rs-badge-content {
+      transform: translate(
+        calc(0px - var(--rs-badge-translate)),
+        calc(0px - var(--rs-badge-translate))
+      );
+      top: var(--rs-badge-offset-y);
+      left: var(--rs-badge-offset-x);
+    }
+
+    &-end .rs-badge-content {
+      transform: translate(var(--rs-badge-translate), calc(0px - var(--rs-badge-translate)));
+      top: var(--rs-badge-offset-y);
+      right: var(--rs-badge-offset-x);
+    }
+  }
+
+  &-bottom {
+    &-start .rs-badge-content {
+      transform: translate(calc(0px - var(--rs-badge-translate)), var(--rs-badge-translate));
+      bottom: var(--rs-badge-offset-y);
+      left: var(--rs-badge-offset-x);
+    }
+
+    &-end .rs-badge-content {
+      transform: translate(var(--rs-badge-translate), var(--rs-badge-translate));
+      bottom: var(--rs-badge-offset-y);
+      right: var(--rs-badge-offset-x);
+    }
   }
 }
 
 each(@spectrum, .(@color) {
   .rs-badge-@{color} {
+
+    --rs-badge-bg: var(~'--rs-@{color}-500');
+
     &.rs-badge-independent,
     .rs-badge-content {
-      background-color: var(~'--rs-@{color}-500');
+      background-color: var(--rs-badge-bg);
     }
   }
 });

--- a/src/Badge/test/BadgeSpec.tsx
+++ b/src/Badge/test/BadgeSpec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { testStandardProps } from '@test/utils';
+import kebabCase from 'lodash/kebabCase';
 import Badge from '../Badge';
+import { testStandardProps } from '@test/utils';
 import { render, screen } from '@testing-library/react';
 
 describe('Badge', () => {
@@ -13,11 +14,6 @@ describe('Badge', () => {
     expect(container.firstChild).to.have.class('rs-badge-independent');
   });
 
-  it('Should render dot', () => {
-    const { container } = render(<Badge />);
-    expect(container.firstChild).to.have.class('rs-badge-dot');
-  });
-
   it('Should render content', () => {
     const content = 'NEW+';
     render(<Badge content={content} />);
@@ -26,16 +22,16 @@ describe('Badge', () => {
   });
 
   it('Should be invisible', () => {
-    const { container } = render(
-      <Badge content={false}>
-        <button data-testid="button">test</button>
-      </Badge>
-    );
-
-    expect(container.firstChild).to.equal(screen.getByTestId('button'));
+    const { container } = render(<Badge invisible />);
+    expect(container.firstChild).to.have.class('rs-badge-hidden');
   });
 
-  it('MaxCount is invalid', () => {
+  it('Should be outline', () => {
+    const { container } = render(<Badge outline />);
+    expect(container.firstChild).to.have.class('rs-badge-outline');
+  });
+
+  it('Should render number content', () => {
     const content = '999';
     render(<Badge content={content} />);
 
@@ -63,5 +59,55 @@ describe('Badge', () => {
     );
 
     expect(container.firstChild).to.have.class('rs-badge-wrapper');
+  });
+
+  it('Should have a custom offset', () => {
+    const { container } = render(<Badge offset={[10, 10]} />);
+
+    expect(container.firstChild).to.have.style('--rs-badge-offset-x', '10px');
+    expect(container.firstChild).to.have.style('--rs-badge-offset-y', '10px');
+  });
+
+  it('Should have a custom color', () => {
+    const color = '#ff0000';
+    const { container } = render(<Badge color={color} />);
+
+    expect(container.firstChild).to.have.style('--rs-badge-bg', color);
+  });
+
+  it('Should render specified shape', () => {
+    const { container, rerender } = render(
+      <Badge shape="circle">
+        <button>Test</button>
+      </Badge>
+    );
+
+    expect(container.firstChild).to.have.class('rs-badge-circle');
+
+    rerender(
+      <Badge shape="rectangle">
+        <button>Test</button>
+      </Badge>
+    );
+
+    expect(container.firstChild).to.have.class('rs-badge-rectangle');
+  });
+
+  it('Should render compact', () => {
+    const { container } = render(<Badge compact />);
+    expect(container.firstChild).to.have.class('rs-badge-compact');
+  });
+
+  it('Should render placement', () => {
+    const placements: any = ['topStart', 'topEnd', 'bottomStart', 'bottomEnd'];
+
+    placements.forEach(placement => {
+      const { container } = render(
+        <Badge placement={placement}>
+          <button>Test</button>
+        </Badge>
+      );
+      expect(container.firstChild).to.have.class(`rs-badge-${kebabCase(placement)}`);
+    });
   });
 });

--- a/src/Badge/test/BadgeStylesSpec.tsx
+++ b/src/Badge/test/BadgeStylesSpec.tsx
@@ -1,67 +1,49 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import Badge from '../index';
-import { getStyle, itChrome, toRGB } from '@test/utils';
+import { render } from '@testing-library/react';
+import { getStyle, toRGB } from '@test/utils';
 
 import '../styles/index.less';
 
 describe('Badge styles', () => {
-  it('Independent should render correct style ', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    render(<Badge ref={instanceRef} />);
-    const dom = instanceRef.current as HTMLDivElement;
-    assert.equal(getStyle(dom, 'width'), '8px');
-    assert.equal(getStyle(dom, 'width'), getStyle(dom, 'height'));
+  it('Should render independent badge with fixed height and width', () => {
+    const { container } = render(<Badge />);
+
+    expect(container.firstChild).to.have.style('width', '10px');
+    expect(container.firstChild).to.have.style('height', '10px');
   });
 
-  // @description Can't get border-radius value in other browser except chrome
-  itChrome('Independent should render correct border-radius ', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    render(<Badge ref={instanceRef} />);
-    const dom = instanceRef.current as HTMLDivElement;
-    assert.equal(getStyle(dom, 'borderRadius'), '4px');
+  it('Should render independent badge with border-radius', () => {
+    const { container } = render(<Badge />);
+    expect(container.firstChild).to.have.style('border-radius', '50%');
   });
 
   it('Should render correct color', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    render(<Badge ref={instanceRef} />);
-    const dom = instanceRef.current as HTMLDivElement;
-    assert.equal(getStyle(dom, 'color'), toRGB('#fff'));
+    const { container } = render(<Badge />);
+
+    expect(container.firstChild).to.have.style('color', toRGB('#fff'));
   });
 
   it('Should render correct background color', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
     const background = '#4caf50';
-    render(<Badge ref={instanceRef} style={{ background }} />);
-    const dom = instanceRef.current as HTMLDivElement;
-    assert.equal(getStyle(dom, 'backgroundColor'), toRGB(background));
+    const { container } = render(<Badge style={{ background }} />);
+
+    expect(container.firstChild).to.have.style('background-color', toRGB(background));
   });
 
-  it('Color Badge content should render the correct color', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    render(
-      <Badge color="cyan" ref={instanceRef}>
-        Red
-      </Badge>
-    );
-    const content = (instanceRef.current as HTMLDivElement).querySelector(
-      '.rs-badge-content'
-    ) as HTMLElement;
-    assert.equal(
-      getStyle(content, 'backgroundColor'),
-      toRGB('#00bcd4'),
-      'Color badge background-color'
-    );
+  it('Should render correct color when color is preset', () => {
+    const { container } = render(<Badge color="cyan">Red</Badge>);
+
+    expect(
+      getStyle(container.querySelector('.rs-badge-content') as HTMLElement, 'backgroundColor')
+    ).to.equal(toRGB('#00bcd4'));
   });
 
   it('Color Badge independent should render the correct color', () => {
-    const instanceRef = React.createRef<HTMLDivElement>();
-    render(<Badge color="cyan" ref={instanceRef} />);
-    const dom = instanceRef.current as HTMLDivElement;
-    assert.equal(
-      getStyle(dom, 'backgroundColor'),
-      toRGB('#00bcd4'),
-      'Color badge background-color'
+    const { container } = render(<Badge color="cyan" />);
+
+    expect(getStyle(container.firstChild as HTMLElement, 'backgroundColor')).to.equal(
+      toRGB('#00bcd4')
     );
   });
 });

--- a/src/Drawer/Drawer.tsx
+++ b/src/Drawer/Drawer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Slide from '../Animation/Slide';
 import Modal, { ModalProps } from '../Modal';
-import { TypeAttributes } from '@/internals/types';
+import { PlacementCardinal } from '@/internals/types';
 import { useClassNames } from '@/internals/hooks';
 import { deprecateComponent } from '@/internals/utils';
 import { useCustom } from '../CustomProvider';
@@ -12,7 +12,7 @@ import DrawerFooter from './DrawerFooter';
 import DrawerTitle from './DrawerTitle';
 export interface DrawerProps extends Omit<ModalProps, 'overflow'> {
   /** The placement of Drawer */
-  placement?: TypeAttributes.Placement4;
+  placement?: PlacementCardinal;
 
   /** Custom close button */
   closeButton?: React.ReactNode | boolean;

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -4,7 +4,7 @@ import pick from 'lodash/pick';
 import DropdownMenu from './DropdownMenu';
 import { useClassNames } from '@/internals/hooks';
 import { mergeRefs, placementPolyfill, warnOnce } from '@/internals/utils';
-import { TypeAttributes, WithAsProps, RsRefForwardingComponent } from '@/internals/types';
+import { PlacementCorners, WithAsProps, RsRefForwardingComponent } from '@/internals/types';
 import { IconProps } from '@rsuite/icons/Icon';
 import { initialState, reducer } from './DropdownState';
 import { useCustom } from '../CustomProvider';
@@ -35,7 +35,7 @@ export interface DropdownProps<T = any>
   trigger?: DropdownTrigger | DropdownTrigger[];
 
   /** The placement of Menu */
-  placement?: TypeAttributes.Placement8;
+  placement?: PlacementCorners;
 
   /** Whether or not component is disabled */
   disabled?: boolean;

--- a/src/Dropdown/DropdownToggle.tsx
+++ b/src/Dropdown/DropdownToggle.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import Button from '../Button';
 import { useClassNames, useToggleCaret } from '@/internals/hooks';
 import { IconProps } from '@rsuite/icons/Icon';
-import { WithAsProps, RsRefForwardingComponent, TypeAttributes } from '@/internals/types';
+import { WithAsProps, RsRefForwardingComponent, PlacementCorners } from '@/internals/types';
 
 export interface DropdownToggleProps extends WithAsProps {
   icon?: React.ReactElement<IconProps>;
   noCaret?: boolean;
   renderToggle?: (props: WithAsProps, ref: React.Ref<any>) => any;
-  placement?: TypeAttributes.Placement8;
+  placement?: PlacementCorners;
 }
 
 const DropdownToggle: RsRefForwardingComponent<typeof Button, DropdownToggleProps> =

--- a/src/FormControl/FormControl.tsx
+++ b/src/FormControl/FormControl.tsx
@@ -7,7 +7,12 @@ import useRegisterModel from './hooks/useRegisterModel';
 import useField from './hooks/useField';
 import Toggle from '../Toggle';
 import { useClassNames } from '@/internals/hooks';
-import { TypeAttributes, FormControlBaseProps, WithAsProps } from '@/internals/types';
+import {
+  TypeAttributes,
+  PlacementCorners,
+  FormControlBaseProps,
+  WithAsProps
+} from '@/internals/types';
 import { useFormGroup } from '../FormGroup';
 import { useWillUnmount, useEventCallback } from '@/internals/hooks';
 import { useCustom } from '../CustomProvider';
@@ -49,7 +54,7 @@ export interface FormControlProps<P = any, ValueType = any>
   errorMessage?: React.ReactNode;
 
   /** The placement of error messages */
-  errorPlacement?: TypeAttributes.Placement8;
+  errorPlacement?: PlacementCorners;
 
   /** Make the control readonly */
   readOnly?: boolean;

--- a/src/FormErrorMessage/FormErrorMessage.tsx
+++ b/src/FormErrorMessage/FormErrorMessage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import kebabCase from 'lodash/kebabCase';
 import { useClassNames } from '@/internals/hooks';
 import { placementPolyfill } from '@/internals/utils';
-import { TypeAttributes, WithAsProps, RsRefForwardingComponent } from '@/internals/types';
+import { PlacementCorners, WithAsProps, RsRefForwardingComponent } from '@/internals/types';
 import { useCustom } from '../CustomProvider';
 
 export interface FormErrorMessageProps extends WithAsProps {
@@ -10,7 +10,7 @@ export interface FormErrorMessageProps extends WithAsProps {
   show?: boolean;
 
   /** The placement of error messages */
-  placement?: TypeAttributes.Placement8;
+  placement?: PlacementCorners;
 }
 
 /**

--- a/src/Nav/NavDropdown.tsx
+++ b/src/Nav/NavDropdown.tsx
@@ -3,7 +3,7 @@ import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 import { useClassNames } from '@/internals/hooks';
 import { mergeRefs, placementPolyfill } from '@/internals/utils';
-import { TypeAttributes, WithAsProps, RsRefForwardingComponent } from '@/internals/types';
+import { PlacementCorners, WithAsProps, RsRefForwardingComponent } from '@/internals/types';
 import { initialState, reducer } from '../Dropdown/DropdownState';
 import Menu, { MenuButtonTrigger } from '@/internals/Menu/Menu';
 import kebabCase from 'lodash/kebabCase';
@@ -28,7 +28,7 @@ export interface NavDropdownProps<T = any>
   trigger?: NavDropdownTrigger | readonly NavDropdownTrigger[];
 
   /** The placement of Menu */
-  placement?: TypeAttributes.Placement8;
+  placement?: PlacementCorners;
 
   /** Whether or not component is disabled */
   disabled?: boolean;

--- a/src/Nav/NavDropdownToggle.tsx
+++ b/src/Nav/NavDropdownToggle.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import ArrowDownLineIcon from '@rsuite/icons/ArrowDownLine';
 import Button from '../Button';
 import { useClassNames } from '@/internals/hooks';
-import { WithAsProps, RsRefForwardingComponent, TypeAttributes } from '@/internals/types';
+import { WithAsProps, RsRefForwardingComponent, PlacementCorners } from '@/internals/types';
 import NavItem, { NavItemProps } from './NavItem';
 
 export interface NavDropdownToggleProps extends WithAsProps {
   icon?: NavItemProps['icon'];
   noCaret?: boolean;
   renderToggle?: (props: WithAsProps, ref: React.Ref<any>) => any;
-  placement?: TypeAttributes.Placement8;
+  placement?: PlacementCorners;
 }
 
 /**

--- a/src/Navbar/NavbarDropdown.tsx
+++ b/src/Navbar/NavbarDropdown.tsx
@@ -3,7 +3,7 @@ import castArray from 'lodash/castArray';
 import omit from 'lodash/omit';
 import { useClassNames } from '@/internals/hooks';
 import { mergeRefs, placementPolyfill } from '@/internals/utils';
-import { TypeAttributes, WithAsProps, RsRefForwardingComponent } from '@/internals/types';
+import { PlacementCorners, WithAsProps, RsRefForwardingComponent } from '@/internals/types';
 import { IconProps } from '@rsuite/icons/Icon';
 import kebabCase from 'lodash/kebabCase';
 import { NavbarContext } from '.';
@@ -27,7 +27,7 @@ export interface NavbarDropdownProps<T = any>
   trigger?: NavbarDropdownTrigger | readonly NavbarDropdownTrigger[];
 
   /** The placement of Menu */
-  placement?: TypeAttributes.Placement8;
+  placement?: PlacementCorners;
 
   /** Whether or not component is disabled */
   disabled?: boolean;

--- a/src/Navbar/NavbarDropdownToggle.tsx
+++ b/src/Navbar/NavbarDropdownToggle.tsx
@@ -3,12 +3,12 @@ import ArrowDownLineIcon from '@rsuite/icons/ArrowDownLine';
 import NavbarItem from './NavbarItem';
 import Button from '../Button';
 import { useClassNames } from '@/internals/hooks';
-import { WithAsProps, RsRefForwardingComponent, TypeAttributes } from '@/internals/types';
+import { WithAsProps, RsRefForwardingComponent, PlacementCorners } from '@/internals/types';
 
 export interface NavbarDropdownToggleProps extends WithAsProps {
   noCaret?: boolean;
   renderToggle?: (props: WithAsProps, ref: React.Ref<any>) => any;
-  placement?: TypeAttributes.Placement8;
+  placement?: PlacementCorners;
 }
 
 /**

--- a/src/Sidenav/ExpandedSidenavDropdown.tsx
+++ b/src/Sidenav/ExpandedSidenavDropdown.tsx
@@ -4,7 +4,7 @@ import omit from 'lodash/omit';
 import { useClassNames, useInternalId } from '@/internals/hooks';
 import { placementPolyfill, mergeRefs } from '@/internals/utils';
 import { SidenavContext } from './Sidenav';
-import { TypeAttributes, WithAsProps, RsRefForwardingComponent } from '@/internals/types';
+import { PlacementCorners, WithAsProps, RsRefForwardingComponent } from '@/internals/types';
 import { IconProps } from '@rsuite/icons/Icon';
 import SidenavDropdownCollapse from './SidenavDropdownCollapse';
 import Disclosure from '@/internals/Disclosure/Disclosure';
@@ -22,7 +22,7 @@ export interface SidenavDropdownProps<T = any>
   icon?: React.ReactElement<IconProps>;
 
   /** The placement of Menu */
-  placement?: TypeAttributes.Placement8;
+  placement?: PlacementCorners;
 
   /** Whether or not component is disabled */
   disabled?: boolean;

--- a/src/Sidenav/SidenavDropdown.tsx
+++ b/src/Sidenav/SidenavDropdown.tsx
@@ -4,7 +4,7 @@ import pick from 'lodash/pick';
 import { useClassNames } from '@/internals/hooks';
 import { mergeRefs, placementPolyfill } from '@/internals/utils';
 import { SidenavContext } from './Sidenav';
-import { TypeAttributes, WithAsProps, RsRefForwardingComponent } from '@/internals/types';
+import { PlacementCorners, WithAsProps, RsRefForwardingComponent } from '@/internals/types';
 import { IconProps } from '@rsuite/icons/Icon';
 import Menu, { MenuButtonTrigger } from '@/internals/Menu/Menu';
 import MenuItem from '@/internals/Menu/MenuItem';
@@ -31,7 +31,7 @@ export interface NavDropdownProps<T = any>
   trigger?: SidenavDropdownTrigger | readonly SidenavDropdownTrigger[];
 
   /** The placement of Menu */
-  placement?: TypeAttributes.Placement8;
+  placement?: PlacementCorners;
 
   /** Whether or not component is disabled */
   disabled?: boolean;

--- a/src/Sidenav/SidenavDropdownToggle.tsx
+++ b/src/Sidenav/SidenavDropdownToggle.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import ArrowDownLineIcon from '@rsuite/icons/ArrowDownLine';
 import Button from '../Button';
 import { useClassNames } from '@/internals/hooks';
-import { WithAsProps, RsRefForwardingComponent, TypeAttributes } from '@/internals/types';
+import { WithAsProps, RsRefForwardingComponent, PlacementCorners } from '@/internals/types';
 import SidenavItem from './SidenavItem';
 
 export interface SidenavDropdownToggleProps extends WithAsProps {
   noCaret?: boolean;
   renderToggle?: (props: WithAsProps, ref: React.Ref<any>) => any;
-  placement?: TypeAttributes.Placement8;
+  placement?: PlacementCorners;
 }
 
 /**

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { useClassNames } from '@/internals/hooks';
 import { useCustom } from '../CustomProvider';
-import type { TypeAttributes, WithAsProps, RsRefForwardingComponent } from '@/internals/types';
+import type { Placement, WithAsProps, RsRefForwardingComponent } from '@/internals/types';
 
 export interface TooltipProps extends WithAsProps {
   /** Dispaly placement */
-  placement?: TypeAttributes.Placement;
+  placement?: Placement;
 
   /** Whether visible */
   visible?: boolean;

--- a/src/internals/Overlay/Overlay.tsx
+++ b/src/internals/Overlay/Overlay.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useCallback, useContext } from 'react';
 import classNames from 'classnames';
 import Position, { PositionChildProps, PositionProps } from './Position';
 import { useRootClose } from '../hooks';
-import { TypeAttributes, AnimationEventProps, CursorPosition } from '@/internals/types';
+import { Placement, AnimationEventProps, CursorPosition } from '@/internals/types';
 import { mergeRefs } from '@/internals/utils';
 import Fade from '../../Animation/Fade';
 import OverlayContext from './OverlayContext';
@@ -18,7 +18,7 @@ export interface OverlayProps extends AnimationEventProps {
   childrenProps?: React.HTMLAttributes<HTMLElement>;
   className?: string;
   containerPadding?: number;
-  placement?: TypeAttributes.Placement;
+  placement?: Placement;
   preventOverflow?: boolean;
   open?: boolean;
   rootClose?: boolean;

--- a/src/internals/Overlay/OverlayTrigger.tsx
+++ b/src/internals/Overlay/OverlayTrigger.tsx
@@ -22,7 +22,7 @@ import type {
   AnimationEventProps,
   CursorPosition,
   StandardProps,
-  TypeAttributes
+  Placement
 } from '@/internals/types';
 import type { PositionChildProps, PositionInstance } from './Position';
 
@@ -44,7 +44,7 @@ export interface OverlayTriggerProps extends Omit<StandardProps, 'children'>, An
   trigger?: OverlayTriggerType | OverlayTriggerType[];
 
   /** Display placement */
-  placement?: TypeAttributes.Placement;
+  placement?: Placement;
 
   /** Delay time */
   delay?: number;

--- a/src/internals/Overlay/Position.tsx
+++ b/src/internals/Overlay/Position.tsx
@@ -17,7 +17,7 @@ import { ResizeObserver } from '@juggle/resize-observer';
 import isElement from '../../DOMHelper/isElement';
 import positionUtils, { PositionType } from './positionUtils';
 import { getDOMNode } from '../utils';
-import { CursorPosition, TypeAttributes } from '@/internals/types';
+import { CursorPosition, Placement } from '@/internals/types';
 import { useUpdateEffect } from '../hooks';
 
 export interface PositionChildProps {
@@ -33,7 +33,7 @@ export interface PositionProps {
   className?: string;
   container?: HTMLElement | (() => HTMLElement | null) | null;
   containerPadding?: number;
-  placement?: TypeAttributes.Placement;
+  placement?: Placement;
   preventOverflow?: boolean;
   triggerTarget?: React.RefObject<any>;
   followCursor?: boolean;

--- a/src/internals/Overlay/positionUtils.ts
+++ b/src/internals/Overlay/positionUtils.ts
@@ -8,7 +8,7 @@ import scrollLeft from 'dom-lib/scrollLeft';
 import getPosition from 'dom-lib/getPosition';
 import getStyle from 'dom-lib/getStyle';
 import nodeName from 'dom-lib/nodeName';
-import { CursorPosition, TypeAttributes } from '@/internals/types';
+import { CursorPosition, Placement } from '@/internals/types';
 
 type Offset = {
   top: number;
@@ -26,7 +26,7 @@ export interface PositionType {
 }
 
 export interface UtilProps {
-  placement: TypeAttributes.Placement;
+  placement: Placement;
   preventOverflow: boolean;
   padding: number;
 }

--- a/src/internals/Picker/PickerToggle.tsx
+++ b/src/internals/Picker/PickerToggle.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useMemo } from 'react';
 import ToggleButton, { ToggleButtonProps } from './ToggleButton';
 import { useClassNames, useEventCallback, useToggleCaret } from '../hooks';
 import { mergeRefs } from '@/internals/utils';
-import { RsRefForwardingComponent, TypeAttributes, DataItemValue } from '@/internals/types';
+import { RsRefForwardingComponent, Placement, DataItemValue } from '@/internals/types';
 import Plaintext from '../Plaintext';
 import { IconProps } from '@rsuite/icons/Icon';
 import Stack from '../../Stack';
@@ -25,7 +25,7 @@ export interface PickerToggleProps<T = DataItemValue> extends ToggleButtonProps 
    */
   caretAs?: React.ElementType;
   disabled?: boolean;
-  placement?: TypeAttributes.Placement;
+  placement?: Placement;
   readOnly?: boolean;
   plaintext?: boolean;
   tabIndex?: number;

--- a/src/internals/Picker/PickerToggleTrigger.tsx
+++ b/src/internals/Picker/PickerToggleTrigger.tsx
@@ -9,7 +9,7 @@ import { PositionChildProps } from '@/internals/Overlay/Position';
 import { useUniqueId } from '@/internals/hooks';
 import { placementPolyfill } from '@/internals/utils';
 import { useCustom } from '../../CustomProvider';
-import type { TypeAttributes, AnimationEventProps } from '@/internals/types';
+import type { Placement, AnimationEventProps } from '@/internals/types';
 
 export type { OverlayTriggerHandle, PositionChildProps };
 
@@ -24,7 +24,7 @@ export interface PickerToggleTriggerProps
    */
   popupType?: 'listbox' | 'tree' | 'grid' | 'dialog' | 'menu';
   multiple?: boolean;
-  placement?: TypeAttributes.Placement;
+  placement?: Placement;
   pickerProps: any;
   open?: boolean;
   trigger?: OverlayTriggerType | OverlayTriggerType[];

--- a/src/internals/Picker/hooks/usePickerClassName.ts
+++ b/src/internals/Picker/hooks/usePickerClassName.ts
@@ -1,14 +1,14 @@
 import kebabCase from 'lodash/kebabCase';
 import omit from 'lodash/omit';
 import { useClassNames } from '@/internals/hooks';
-import { TypeAttributes } from '@/internals/types';
+import { Placement } from '@/internals/types';
 import { placementPolyfill } from '@/internals/utils';
 
 export interface PickerClassNameProps {
   name?: string;
   classPrefix: string;
   className?: string;
-  placement?: TypeAttributes.Placement;
+  placement?: Placement;
   appearance?: 'default' | 'subtle';
   cleanable?: boolean;
   block?: boolean;

--- a/src/internals/Picker/test/PickerToggleSpec.tsx
+++ b/src/internals/Picker/test/PickerToggleSpec.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 import Toggle from '../PickerToggle';
 import CustomProvider from '../../../CustomProvider';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { testStandardProps } from '@test/utils';
-import { TypeAttributes } from '../../types';
 
 describe('<PickerToggle>', () => {
   testStandardProps(<Toggle />);
@@ -132,7 +131,7 @@ describe('<PickerToggle>', () => {
   });
 
   describe('Placement', () => {
-    const placements: TypeAttributes.Placement[] = [
+    const placements: any = [
       'top',
       'bottom',
       'right',

--- a/src/internals/hooks/useToggleCaret.tsx
+++ b/src/internals/hooks/useToggleCaret.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from 'react';
+import { PlacementCorners, Placement } from '@/internals/types';
+import { useCustom } from '../../CustomProvider';
 import ArrowUpLineIcon from '@rsuite/icons/ArrowUpLine';
 import ArrowDownLineIcon from '@rsuite/icons/ArrowDownLine';
 import ArrowLeftLineIcon from '@rsuite/icons/ArrowLeftLine';
 import ArrowRightLineIcon from '@rsuite/icons/ArrowRightLine';
-import { TypeAttributes } from '@/internals/types';
-import { useCustom } from '../../CustomProvider';
 
-export function useToggleCaret(placement: TypeAttributes.Placement8 | TypeAttributes.Placement) {
+export function useToggleCaret(placement: PlacementCorners | Placement) {
   const { rtl } = useCustom();
   return useMemo(() => {
     switch (true) {

--- a/src/internals/types/colours.ts
+++ b/src/internals/types/colours.ts
@@ -1,0 +1,19 @@
+export enum Colours {
+  Red = 'red',
+  Orange = 'orange',
+  Yellow = 'yellow',
+  Green = 'green',
+  Cyan = 'cyan',
+  Blue = 'blue',
+  Violet = 'violet'
+}
+
+export type Color = `${Colours}`;
+
+export const isPresetColor = (color?: Color | string) => {
+  if (!color) {
+    return false;
+  }
+
+  return Object.values(Colours).includes(color as Colours);
+};

--- a/src/internals/types/index.ts
+++ b/src/internals/types/index.ts
@@ -7,6 +7,11 @@ import {
   FocusEventHandler
 } from 'react';
 import { ReplaceProps } from './utils';
+import { Placement } from './placement';
+import { Colours } from './colours';
+
+export * from './placement';
+export * from './colours';
 
 export interface StandardProps {
   /** The prefix of the component CSS class */
@@ -111,7 +116,7 @@ export interface PickerBaseProps<L = any> extends WithAsProps, AnimationEventPro
   placeholder?: ReactNode;
 
   /** The placement of picker */
-  placement?: TypeAttributes.Placement;
+  placement?: Placement;
 
   /** Prevent floating element overflow */
   preventOverflow?: boolean;
@@ -245,28 +250,8 @@ export interface FormControlPickerProps<T = any, L = any, D = Record<string, any
 export declare namespace TypeAttributes {
   type Size = 'lg' | 'md' | 'sm' | 'xs';
   type Status = 'success' | 'warning' | 'error' | 'info';
-  type Color = 'red' | 'orange' | 'yellow' | 'green' | 'cyan' | 'blue' | 'violet';
+  type Color = `${Colours}`;
   type Appearance = 'default' | 'primary' | 'link' | 'subtle' | 'ghost';
-  type Placement4 = 'top' | 'bottom' | 'right' | 'left';
-  type Placement8 =
-    | 'bottomStart'
-    | 'bottomEnd'
-    | 'topStart'
-    | 'topEnd'
-    | 'leftStart'
-    | 'rightStart'
-    | 'leftEnd'
-    | 'rightEnd';
-  type PlacementAuto =
-    | 'auto'
-    | 'autoVertical'
-    | 'autoVerticalStart'
-    | 'autoVerticalEnd'
-    | 'autoHorizontal'
-    | 'autoHorizontalStart'
-    | 'autoHorizontalEnd';
-
-  type Placement = Placement4 | Placement8 | PlacementAuto;
   type CheckTrigger = 'change' | 'blur' | 'none' | null;
   type DisplayState = 'show' | 'hide' | 'hiding';
 }

--- a/src/internals/types/placement.ts
+++ b/src/internals/types/placement.ts
@@ -1,0 +1,18 @@
+export type PlacementCardinal = 'top' | 'bottom' | 'right' | 'left';
+export type PlacementCornersPolyfill = 'leftStart' | 'rightStart' | 'leftEnd' | 'rightEnd';
+export type PlacementCorners =
+  | 'topStart'
+  | 'topEnd'
+  | 'bottomStart'
+  | 'bottomEnd'
+  | PlacementCornersPolyfill;
+export type PlacementAuto =
+  | 'auto'
+  | 'autoVertical'
+  | 'autoVerticalStart'
+  | 'autoVerticalEnd'
+  | 'autoHorizontal'
+  | 'autoHorizontalStart'
+  | 'autoHorizontalEnd';
+
+export type Placement = PlacementCardinal | PlacementCorners | PlacementAuto;

--- a/src/styles/color-modes/dark.less
+++ b/src/styles/color-modes/dark.less
@@ -326,6 +326,7 @@
   // Badge
   --rs-badge-bg: var(--rs-color-red);
   --rs-badge-text: var(--rs-gray-0);
+  --rs-badge-border: var(--rs-gray-900);
 
   // Close Button
   --rs-close-button-hover-color: var(--rs-color-red);

--- a/src/styles/color-modes/high-contrast.less
+++ b/src/styles/color-modes/high-contrast.less
@@ -334,6 +334,7 @@
   // Badge
   --rs-badge-bg: var(--rs-red-500);
   --rs-badge-text: var(--rs-gray-0);
+  --rs-badge-border: var(--rs-gray-900);
 
   // Close Button
   --rs-close-button-hover-color: var(--rs-color-red);

--- a/src/styles/color-modes/light.less
+++ b/src/styles/color-modes/light.less
@@ -349,6 +349,7 @@
   // Badge
   --rs-badge-bg: var(--rs-color-red);
   --rs-badge-text: var(--rs-gray-0);
+  --rs-badge-border: var(--rs-gray-0);
 
   // Close Button
   --rs-close-button-hover-color: var(--rs-color-red);

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -238,7 +238,7 @@
 
 // Badge
 
-@badge-dot-size:        8px;
+@badge-dot-size:        10px;
 
 // Avatar
 @avatar-size-xxl:         120px;


### PR DESCRIPTION
https://rsuite-nextjs-git-feat-badge-new-design-rsuite.vercel.app/components/badge/

This pull request includes significant updates to the Badge component and its related documentation. The changes enhance the Badge component's functionality, add new properties, and improve the documentation to reflect these updates.

Enhancements to the Badge component:

* [`src/Badge/Badge.tsx`](diffhunk://#diff-6c71229a85da7e9dd8ba4c89707d315d1157e04b477afa2a2de14210d0246606R2-R136): Added new properties such as `outline`, `placement`, `compact`, `shape`, `offset`, and `invisible` to the Badge component. Updated the component to handle these new properties and improve customization options.

Documentation updates:

* [`docs/pages/components/badge/en-US/index.md`](diffhunk://#diff-2c2f67448b97b33c236ed43ef4e6146e7829502d992114ed2a26341ee7c9894aR19-R43): Updated the Badge documentation to include new sections for `Placement`, `Shapes`, `Offset`, and `Colors`. Modified the description and properties table to reflect the new properties of the Badge component. [[1]](diffhunk://#diff-2c2f67448b97b33c236ed43ef4e6146e7829502d992114ed2a26341ee7c9894aR19-R43) [[2]](diffhunk://#diff-2c2f67448b97b33c236ed43ef4e6146e7829502d992114ed2a26341ee7c9894aL38-R68)
* [`docs/pages/components/badge/zh-CN/index.md`](diffhunk://#diff-884082f20f019111d6cd0699951eb6dca80d8dbe6b532043b25613cf9f579b00L15-R43): Similar updates as the English documentation, including new sections and updated properties table to reflect the new features of the Badge component. [[1]](diffhunk://#diff-884082f20f019111d6cd0699951eb6dca80d8dbe6b532043b25613cf9f579b00L15-R43) [[2]](diffhunk://#diff-884082f20f019111d6cd0699951eb6dca80d8dbe6b532043b25613cf9f579b00L38-R68)

Code examples:

* Added new code examples to demonstrate the usage of the new properties in the Badge component:
  * `docs/pages/components/badge/fragments/placement.md`
  * `docs/pages/components/badge/fragments/shape.md`
  * `docs/pages/components/badge/fragments/offset.md`
  * `docs/pages/components/badge/fragments/invisible.md`

### ⚠️ Breaking Changes

- Use `invisible` instead `content === false` to hide the badge.