### PR TITLE
fix(ToastContainer): fix the server-side rendering error

### DIFF
--- a/src/toaster/ToastContainer.tsx
+++ b/src/toaster/ToastContainer.tsx
@@ -2,12 +2,16 @@ import React, { useState, useImperativeHandle, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import kebabCase from 'lodash/kebabCase';
 import Transition from '../Animation/Transition';
+import ToastContext from './ToastContext';
+import canUseDOM from 'dom-lib/canUseDOM';
 import { useClassNames } from '@/internals/hooks';
 import { guid, createChainedFunction } from '@/internals/utils';
 import { WithAsProps, RsRefForwardingComponent } from '@/internals/types';
-import ToastContext from './ToastContext';
 import { render } from './render';
-export const defaultToasterContainer = document.body;
+
+export const defaultToasterContainer = () => {
+  return canUseDOM ? document.body : null;
+};
 
 export type PlacementType =
   | 'topCenter'
@@ -74,7 +78,7 @@ interface MessageType extends PushOptions {
 }
 
 export type GetInstancePropsType = Omit<ToastContainerProps, 'container' | 'placement'> & {
-  container: HTMLElement;
+  container: HTMLElement | null;
   placement: PlacementType;
 };
 

--- a/src/toaster/render.ts
+++ b/src/toaster/render.ts
@@ -7,7 +7,7 @@ const SuperposedReactDOM = ReactDOM as any;
 
 export const toasterKeyOfContainerElement = 'toasterId';
 
-export function render(element: React.ReactElement<any>, container: HTMLElement): string {
+export function render(element: React.ReactElement<any>, container: HTMLElement | null): string {
   const mountElement = document.createElement('div');
 
   mountElement.className = 'rs-toaster-mount-element';

--- a/src/toaster/toaster.tsx
+++ b/src/toaster/toaster.tsx
@@ -60,12 +60,13 @@ function getContainer(containerId: string, placement: PlacementType) {
 const toaster: Toaster = (message: React.ReactNode) => toaster.push(message);
 
 toaster.push = (message: React.ReactNode, options: ToastContainerProps = {}) => {
-  const { placement = 'topCenter', container, ...restOptions } = options;
+  const { placement = 'topCenter', container = defaultToasterContainer, ...restOptions } = options;
 
-  const containerElement =
-    (typeof container === 'function' ? container() : container) || defaultToasterContainer;
+  const containerElement = typeof container === 'function' ? container() : container;
 
-  const containerElementId = containerElement[toasterKeyOfContainerElement];
+  const containerElementId = containerElement
+    ? containerElement[toasterKeyOfContainerElement]
+    : null;
 
   if (containerElementId) {
     const existedContainer = getContainer(containerElementId, placement);


### PR DESCRIPTION
This pull request includes several changes to improve the handling of the `container` element in the toaster component, ensuring better compatibility with server-side rendering (SSR) and null safety.

Changes to improve SSR compatibility and null safety:

* [`src/toaster/ToastContainer.tsx`](diffhunk://#diff-fe85eeb309e268bd345a9aa793dae807020d7fd1472ed1c7351ed3f9f8c12c99R5-R14): Modified the `defaultToasterContainer` to return `null` when `canUseDOM` is false, improving SSR compatibility.
* [`src/toaster/ToastContainer.tsx`](diffhunk://#diff-fe85eeb309e268bd345a9aa793dae807020d7fd1472ed1c7351ed3f9f8c12c99L77-R81): Updated the `GetInstancePropsType` interface to allow `container` to be `HTMLElement | null`, enhancing null safety.
* [`src/toaster/render.ts`](diffhunk://#diff-d81e6f3c628379faa3ac7272e5ebb89a1dc6133ee44b95b8f8733882d16548d3L10-R10): Changed the `render` function to accept `container` as `HTMLElement | null`, ensuring it handles null values gracefully.
* [`src/toaster/toaster.tsx`](diffhunk://#diff-2f7f4b3f56127733e3a9fc7642b825cce975d6720b604467b6ac674394ea8ff1L63-R69): Adjusted the `toaster.push` method to use the updated `defaultToasterContainer` and handle null `containerElement` values, improving robustness.