### PR TITLE
feat(Rate): add custom color support

### DIFF
--- a/docs/pages/components/rate/en-US/index.md
+++ b/docs/pages/components/rate/en-US/index.md
@@ -20,7 +20,7 @@ The size of the rate component
 
 ### Color
 
-The color of the rate component
+The color of the rate component. Supports both preset theme colors and custom colors (hex, rgb, etc.).
 
 <!--{include:`color.md`}}-->
 
@@ -60,21 +60,21 @@ WAI tutorial: https://www.w3.org/WAI/tutorials/forms/custom-controls/#a-star-rat
 
 ## Props
 
-| Property        | Type `(Default)`                                  | Description                                                   |
-| --------------- | ------------------------------------------------- | ------------------------------------------------------------- |
-| allowHalf       | boolean`(false)`                                  | Whether to support half option                                |
-| character       | ReactNode                                         | custom character                                              |
-| cleanable       | boolean`(true)`                                   | Whether clear is supported                                    |
-| defaultValue    | number`(0)`                                       | The default value (uncontrolled)                              |
-| disabled        | boolean`(false)`                                  | Disabled，Cannot interact when value is true                  |
-| max             | number`(5)`                                       | Maximum score                                                 |
-| renderCharacter | (value: number) => ReactNode                      | Customize the render character function                       |
-| readOnly        | boolean                                           | Whether it is read-only, if true, no interaction is possible  |
-| size            | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')` | Set component size                                            |
-| color           | [Color](#code-ts-color-code)                      | A button can have different colors                            |
-| value           | number                                            | The current value (controlled)                                |
-| vertical        | boolean`(false)`                                  | direction when half select                                    |
-| onChange        | (value: number, event) => void                    | Callback function that changes value                          |
-| onChangeActive  | (value: number, event) => void                    | Callback function that is fired when the hover state changes. |
+| Property        | Type `(Default)`                                       | Description                                                                          |
+| --------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| allowHalf       | boolean`(false)`                                       | Whether to support half option                                                       |
+| character       | ReactNode                                              | custom character                                                                     |
+| cleanable       | boolean`(true)`                                        | Whether clear is supported                                                           |
+| defaultValue    | number`(0)`                                            | The default value (uncontrolled)                                                     |
+| disabled        | boolean`(false)`                                       | Disabled，Cannot interact when value is true                                         |
+| max             | number`(5)`                                            | Maximum score                                                                        |
+| renderCharacter | (value: number) => ReactNode                           | Customize the render character function                                              |
+| readOnly        | boolean                                                | Whether it is read-only, if true, no interaction is possible                         |
+| size            | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`                  | Set component size                                                                   |
+| color           | [Color](#code-ts-color-code) \| CSSProperties['color'] | Set component color. Supports preset theme colors and custom colors (hex, rgb, etc.) |
+| value           | number                                                 | The current value (controlled)                                                       |
+| vertical        | boolean`(false)`                                       | direction when half select                                                           |
+| onChange        | (value: number, event) => void                         | Callback function that changes value                                                 |
+| onChangeActive  | (value: number, event) => void                         | Callback function that is fired when the hover state changes.                        |
 
 <!--{include:(_common/types/color.md)}-->

--- a/docs/pages/components/rate/fragments/character.md
+++ b/docs/pages/components/rate/fragments/character.md
@@ -2,30 +2,19 @@
 
 ```js
 import { Rate, VStack } from 'rsuite';
-import HeartIcon from '@rsuite/icons/legacy/Heart';
-import BeerIcon from '@rsuite/icons/legacy/Beer';
-import FrownIcon from '@rsuite/icons/legacy/FrownO';
+import { FaHeart } from 'react-icons/fa';
 
-const App = () => (
-  <VStack>
-    <Rate defaultValue={3} character={<HeartIcon />} />
-    <Rate defaultValue={3} character={<BeerIcon />} color="yellow" />
-    <Rate defaultValue={3} character="A" />
-    <Rate
-      defaultValue={2}
-      character={({ index }) => {
-        return index + 1;
-      }}
-    />
-    <Rate
-      defaultValue={2}
-      character={<FrownIcon />}
-      renderCharacter={(value, index) => {
-        return index < value ? <HeartIcon style={{ color: 'red' }} /> : <FrownIcon />;
-      }}
-    />
-  </VStack>
-);
+const App = () => {
+  const [value, setValue] = React.useState(2.5);
+  return (
+    <VStack>
+      <Rate allowHalf value={value} character={<FaHeart />} color="red" onChange={setValue} />
+      <Rate allowHalf value={value} character="鼎" color="blue" onChange={setValue} />
+      <Rate allowHalf value={value} character="A" onChange={setValue} />
+      <Rate allowHalf value={value} character="👍" onChange={setValue} />
+    </VStack>
+  );
+};
 
 ReactDOM.render(<App />, document.getElementById('root'));
 ```

--- a/docs/pages/components/rate/fragments/character.md
+++ b/docs/pages/components/rate/fragments/character.md
@@ -1,30 +1,31 @@
 <!--start-code-->
 
 ```js
-import { Rate } from 'rsuite';
-import { Icon } from '@rsuite/icons';
+import { Rate, VStack } from 'rsuite';
 import HeartIcon from '@rsuite/icons/legacy/Heart';
+import BeerIcon from '@rsuite/icons/legacy/Beer';
+import FrownIcon from '@rsuite/icons/legacy/FrownO';
 
-const App = () => {
-  const [value, setValue] = React.useState(2.5);
-
-  return (
-    <>
-      <div>
-        <Rate allowHalf value={value} character={<HeartIcon />} color="red" onChange={setValue} />
-      </div>
-      <div>
-        <Rate allowHalf value={value} character="鼎" color="blue" onChange={setValue} />
-      </div>
-      <div>
-        <Rate allowHalf value={value} character="A" onChange={setValue} />
-      </div>
-      <div>
-        <Rate allowHalf value={value} character="👍" onChange={setValue} />
-      </div>
-    </>
-  );
-};
+const App = () => (
+  <VStack>
+    <Rate defaultValue={3} character={<HeartIcon />} />
+    <Rate defaultValue={3} character={<BeerIcon />} color="yellow" />
+    <Rate defaultValue={3} character="A" />
+    <Rate
+      defaultValue={2}
+      character={({ index }) => {
+        return index + 1;
+      }}
+    />
+    <Rate
+      defaultValue={2}
+      character={<FrownIcon />}
+      renderCharacter={(value, index) => {
+        return index < value ? <HeartIcon style={{ color: 'red' }} /> : <FrownIcon />;
+      }}
+    />
+  </VStack>
+);
 
 ReactDOM.render(<App />, document.getElementById('root'));
 ```

--- a/docs/pages/components/rate/fragments/color.md
+++ b/docs/pages/components/rate/fragments/color.md
@@ -1,32 +1,28 @@
 <!--start-code-->
 
 ```js
-import { Rate } from 'rsuite';
+import { Rate, VStack } from 'rsuite';
 
 const App = () => (
-  <>
-    <div>
+  <VStack spacing={20}>
+    {/* Preset theme colors */}
+    <VStack>
       <Rate defaultValue={5} color="red" />
-    </div>
-    <div>
       <Rate defaultValue={4} color="orange" />
-    </div>
-    <div>
       <Rate defaultValue={3} color="yellow" />
-    </div>
-    <div>
       <Rate defaultValue={2} color="green" />
-    </div>
-    <div>
       <Rate defaultValue={3} color="cyan" />
-    </div>
-    <div>
       <Rate defaultValue={4} color="blue" />
-    </div>
-    <div>
       <Rate defaultValue={5} color="violet" />
-    </div>
-  </>
+    </VStack>
+
+    {/* Custom colors */}
+    <VStack>
+      <Rate defaultValue={3} color="#FF5733" />
+      <Rate defaultValue={3} color="rgb(51, 204, 108)" />
+      <Rate defaultValue={3} color="#8A2BE2" />
+    </VStack>
+  </VStack>
 );
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/docs/pages/components/rate/fragments/color.md
+++ b/docs/pages/components/rate/fragments/color.md
@@ -16,9 +16,10 @@ const App = () => (
       <Rate defaultValue={5} color="violet" />
     </VStack>
 
-    {/* Custom colors */}
+    <p>Custom colors</p>
+
     <VStack>
-      <Rate defaultValue={3} color="#FF5733" />
+      <Rate defaultValue={3} color="#FF0000" />
       <Rate defaultValue={3} color="rgb(51, 204, 108)" />
       <Rate defaultValue={3} color="#8A2BE2" />
     </VStack>

--- a/docs/pages/components/rate/fragments/custom-character.md
+++ b/docs/pages/components/rate/fragments/custom-character.md
@@ -2,22 +2,20 @@
 
 ```js
 import { Rate } from 'rsuite';
-import FrownIcon from '@rsuite/icons/legacy/FrownO';
-import MehIcon from '@rsuite/icons/legacy/MehO';
-import SmileIcon from '@rsuite/icons/legacy/SmileO';
+import { FaFrown, FaMeh, FaSmile } from 'react-icons/fa';
 
 const renderCharacter = (value, index) => {
   // unselected character
   if (value < index + 1) {
-    return <MehIcon />;
+    return <FaMeh />;
   }
   if (value < 3) {
-    return <FrownIcon style={{ color: '#99A9BF' }} />;
+    return <FaFrown style={{ color: '#99A9BF' }} />;
   }
   if (value < 4) {
-    return <MehIcon style={{ color: '#F4CA1D' }} />;
+    return <FaMeh style={{ color: '#F4CA1D' }} />;
   }
-  return <SmileIcon style={{ color: '#ff9800' }} />;
+  return <FaSmile style={{ color: '#ff9800' }} />;
 };
 
 const App = () => (

--- a/docs/pages/components/rate/fragments/size.md
+++ b/docs/pages/components/rate/fragments/size.md
@@ -1,23 +1,15 @@
 <!--start-code-->
 
 ```js
-import { Rate } from 'rsuite';
+import { Rate, VStack } from 'rsuite';
 
 const App = () => (
-  <>
-    <div>
-      <Rate defaultValue={1} size="xs" />
-    </div>
-    <div>
-      <Rate defaultValue={2} size="sm" />
-    </div>
-    <div>
-      <Rate defaultValue={3} size="md" />
-    </div>
-    <div>
-      <Rate defaultValue={4} size="lg" />
-    </div>
-  </>
+  <VStack>
+    <Rate defaultValue={3} size="xs" />
+    <Rate defaultValue={3} size="sm" />
+    <Rate defaultValue={3} size="md" />
+    <Rate defaultValue={3} size="lg" />
+  </VStack>
 );
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/docs/pages/components/rate/fragments/vertical.md
+++ b/docs/pages/components/rate/fragments/vertical.md
@@ -2,10 +2,10 @@
 
 ```js
 import { Rate } from 'rsuite';
-import BeerIcon from '@rsuite/icons/legacy/Beer';
+import { FaBeer } from "react-icons/fa";
 
 const App = () => (
-  <Rate defaultValue={2.5} allowHalf vertical character={<BeerIcon />} color="blue" />
+  <Rate defaultValue={2.5} allowHalf vertical character={<FaBeer />} color="blue" />
 );
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/docs/pages/components/rate/index.tsx
+++ b/docs/pages/components/rate/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Badge, Button, Toggle, Rate } from 'rsuite';
+import { Badge, Button, Toggle, Rate, VStack } from 'rsuite';
 import DefaultPage from '@/components/Page';
 import ImportGuide from '@/components/ImportGuide';
 import Icon from '@rsuite/icons/Icon';
@@ -23,6 +23,7 @@ export default function Page() {
         Toggle,
         Rate,
         Icon,
+        VStack,
         HeartIcon,
         BeerIcon,
         FrownIcon,

--- a/docs/pages/components/rate/index.tsx
+++ b/docs/pages/components/rate/index.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
-import { Badge, Button, Toggle, Rate, VStack } from 'rsuite';
 import DefaultPage from '@/components/Page';
 import ImportGuide from '@/components/ImportGuide';
 import Icon from '@rsuite/icons/Icon';
-import HeartIcon from '@rsuite/icons/legacy/Heart';
-import BeerIcon from '@rsuite/icons/legacy/Beer';
-import FrownIcon from '@rsuite/icons/legacy/FrownO';
-import MehIcon from '@rsuite/icons/legacy/MehO';
-import SmileIcon from '@rsuite/icons/legacy/SmileO';
+import { Badge, Button, Toggle, Rate, VStack } from 'rsuite';
+import { FaHeart, FaBeer, FaFrown, FaMeh, FaSmile } from 'react-icons/fa';
 
 const inDocsComponents = {
   'import-guide': () => <ImportGuide components={['Rate']} />
@@ -24,11 +20,11 @@ export default function Page() {
         Rate,
         Icon,
         VStack,
-        HeartIcon,
-        BeerIcon,
-        FrownIcon,
-        MehIcon,
-        SmileIcon
+        FaHeart,
+        FaBeer,
+        FaFrown,
+        FaMeh,
+        FaSmile
       }}
     />
   );

--- a/docs/pages/components/rate/zh-CN/index.md
+++ b/docs/pages/components/rate/zh-CN/index.md
@@ -20,7 +20,7 @@
 
 ### 颜色
 
-设置组件的颜色
+设置组件的颜色。支持预设主题颜色和自定义颜色（hex、rgb 等）。
 
 <!--{include:`color.md`}}-->
 
@@ -60,21 +60,21 @@ WAI tutorial: https://www.w3.org/WAI/tutorials/forms/custom-controls/#a-star-rat
 
 ## Props
 
-| 属性名称        | 类型 `(默认值)`                                   | 描述                             |
-| --------------- | ------------------------------------------------- | -------------------------------- | --- |
-| allowHalf       | boolean                                           | 是否支持半选                     |
-| character       | ReactNode                                         | 自定义字符                       |
-| cleanable       | boolean`(true)`                                   | 是否支持清除                     |
-| defaultValue    | number`(0)`                                       | 默认值（非受控）                 |
-| disabled        | boolean                                           | 是否禁用，为 true 时无法进行交互 |     |
-| max             | number`(5)`                                       | 最大分数                         |
-| renderCharacter | (value: number,index: number) => ReactNode        | 自定义渲染 character 函数        |
-| readOnly        | boolean                                           | 是否只读，为 true 时无法进行交互 |
-| size            | 'lg' &#124; 'md' &#124; 'sm' &#124; 'xs' `('md')` | 设置组件尺寸                     |
-| color           | [Color](#code-ts-color-code)                      | 设置颜色                         |
-| value           | number                                            | 当前值（受控）                   |
-| vertical        | boolean                                           | 是否竖直方向上半选               |
-| onChange        | (value: number, event) => void                    | `value` 发生改变时的回调函数     |
-| onChangeActive  | (value: number, event) => void                    | 悬停状态更改时触发的回调函数。   |
+| 属性名称        | 类型 `(默认值)`                                        | 描述                                                      |
+| --------------- | ------------------------------------------------------ | --------------------------------------------------------- | --- |
+| allowHalf       | boolean                                                | 是否支持半选                                              |
+| character       | ReactNode                                              | 自定义字符                                                |
+| cleanable       | boolean`(true)`                                        | 是否支持清除                                              |
+| defaultValue    | number`(0)`                                            | 默认值（非受控）                                          |
+| disabled        | boolean                                                | 是否禁用，为 true 时无法进行交互                          |     |
+| max             | number`(5)`                                            | 最大分数                                                  |
+| renderCharacter | (value: number,index: number) => ReactNode             | 自定义渲染 character 函数                                 |
+| readOnly        | boolean                                                | 是否只读，为 true 时无法进行交互                          |
+| size            | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`                  | 设置组件尺寸                                              |
+| color           | [Color](#code-ts-color-code) \| CSSProperties['color'] | 设置组件颜色。支持预设主题颜色和自定义颜色（hex、rgb 等） |
+| value           | number                                                 | 当前值（受控）                                            |
+| vertical        | boolean                                                | 是否竖直方向上半选                                        |
+| onChange        | (value: number, event) => void                         | `value` 发生改变时的回调函数                              |
+| onChangeActive  | (value: number, event) => void                         | 悬停状态更改时触发的回调函数。                            |
 
 <!--{include:(_common/types/color.md)}-->

--- a/src/Badge/Badge.tsx
+++ b/src/Badge/Badge.tsx
@@ -1,9 +1,13 @@
 import React, { useMemo } from 'react';
 import kebabCase from 'lodash/kebabCase';
 import { useClassNames } from '@/internals/hooks';
-import { mergeStyles, createOffsetStyles } from '@/internals/utils';
+import {
+  mergeStyles,
+  createOffsetStyles,
+  isPresetColor,
+  createColorVariables
+} from '@/internals/utils';
 import { useCustom } from '../CustomProvider';
-import { isPresetColor, createColorVariables } from '@/internals/utils/colours';
 import { Color, WithAsProps, PlacementCorners, RsRefForwardingComponent } from '@/internals/types';
 
 export interface BadgeProps extends WithAsProps {

--- a/src/Rate/Character.tsx
+++ b/src/Rate/Character.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useRef } from 'react';
-import { isNil } from 'lodash';
+import React, { useRef } from 'react';
 import contains from 'dom-lib/contains';
-import { useClassNames } from '@/internals/hooks';
+import isNil from 'lodash/isNil';
+import { useClassNames, useEventCallback } from '@/internals/hooks';
 import { WithAsProps, RsRefForwardingComponent } from '@/internals/types';
 
 const characterStatus = {
@@ -41,19 +41,13 @@ const Character: RsRefForwardingComponent<'li', CharacterProps> = React.forwardR
     const beforeRef = useRef<HTMLDivElement>(null);
     const classes = merge(className, withClassPrefix(!isNil(status) && characterStatus[status]));
 
-    const handleMouseMove = useCallback(
-      (event: React.MouseEvent) => {
-        onMouseMove?.(getKey(beforeRef.current, event.target), event);
-      },
-      [onMouseMove]
-    );
+    const handleMouseMove = useEventCallback((event: React.MouseEvent) => {
+      onMouseMove?.(getKey(beforeRef.current, event.target), event);
+    });
 
-    const handleClick = useCallback(
-      (event: React.MouseEvent) => {
-        onClick?.(getKey(beforeRef.current, event.target), event);
-      },
-      [onClick]
-    );
+    const handleClick = useEventCallback((event: React.MouseEvent) => {
+      onClick?.(getKey(beforeRef.current, event.target), event);
+    });
 
     return (
       <Component

--- a/src/Rate/styles/index.less
+++ b/src/Rate/styles/index.less
@@ -122,7 +122,10 @@
   // Color variants
   each(@spectrum, .(@color) {
     &-@{color} {
-      color: var(~'--rs-@{color}-500');
+
+      --rs-rate-symbol-checked: var(~'--rs-@{color}-500');
+
+      color: var(--rs-rate-symbol-checked);
     }
   });
 }

--- a/src/Rate/styles/index.less
+++ b/src/Rate/styles/index.less
@@ -71,7 +71,8 @@
       bottom: 3px;
     }
 
-    .rs-icon {
+    .rs-icon,
+    svg {
       position: absolute;
       height: 1em;
       width: 1em;

--- a/src/Rate/test/RateSpec.tsx
+++ b/src/Rate/test/RateSpec.tsx
@@ -180,6 +180,49 @@ describe('Rate', () => {
     );
   });
 
+  describe('Custom colors', () => {
+    it('Should render with preset color', () => {
+      render(<Rate defaultValue={3} color="red" />);
+      expect(screen.getByRole('radiogroup')).to.have.class('rs-rate-red');
+    });
+
+    it('Should render with custom hex color', () => {
+      const { container } = render(<Rate defaultValue={3} color="#FF5733" />);
+      const rateElement = container.querySelector('.rs-rate');
+      const style = getComputedStyle(rateElement as HTMLElement);
+      expect(style.getPropertyValue('--rs-rate-symbol-checked').toLowerCase()).to.equal('#ff5733');
+    });
+
+    it('Should render with custom rgb color', () => {
+      const { container } = render(<Rate defaultValue={3} color="rgb(255, 87, 51)" />);
+      const rateElement = container.querySelector('.rs-rate');
+      const style = getComputedStyle(rateElement as HTMLElement);
+      expect(style.getPropertyValue('--rs-rate-symbol-checked')).to.equal('rgb(255, 87, 51)');
+    });
+
+    it('Should update color when prop changes', () => {
+      const { container, rerender } = render(<Rate defaultValue={3} color="#FF5733" />);
+      const rateElement = container.querySelector('.rs-rate');
+      const style = getComputedStyle(rateElement as HTMLElement);
+      expect(style.getPropertyValue('--rs-rate-symbol-checked').toLowerCase()).to.equal('#ff5733');
+
+      rerender(<Rate defaultValue={3} color="#33FF57" />);
+      expect(style.getPropertyValue('--rs-rate-symbol-checked').toLowerCase()).to.equal('#33ff57');
+    });
+
+    it('Should render correctly when switching between preset and custom colors', () => {
+      const { container, rerender } = render(<Rate defaultValue={3} color="red" />);
+      let rateElement = screen.getByRole('radiogroup');
+      expect(rateElement).to.have.class('rs-rate-red');
+
+      rerender(<Rate defaultValue={3} color="#FF5733" />);
+      rateElement = container.querySelector('.rs-rate') as HTMLElement;
+      const style = getComputedStyle(rateElement);
+      expect(style.getPropertyValue('--rs-rate-symbol-checked').toLowerCase()).to.equal('#ff5733');
+      expect(rateElement).to.not.have.class('rs-rate-red');
+    });
+  });
+
   describe('Plain text', () => {
     it('Should render current value and max value', () => {
       render(

--- a/src/internals/utils/colours.ts
+++ b/src/internals/utils/colours.ts
@@ -67,7 +67,9 @@ export const createColorVariables = (
   textFieldName?: string
 ): React.CSSProperties | undefined => {
   if (color && !isPresetColor(color)) {
-    const bgColor = expandHexColor(color.toString());
+    const colorStr = color.toString();
+    // Only convert to hex if it's a hex color
+    const bgColor = colorStr.startsWith('#') ? expandHexColor(colorStr) : colorStr;
     const styles: React.CSSProperties = {
       [bgFieldName]: bgColor
     };


### PR DESCRIPTION
- Add support for custom colors (hex and rgb) in Rate component
- Update color handling in colours.ts to preserve RGB format
- Add unit tests for custom colors
- Update documentation with custom color examples and descriptions