### PR TITLE
build(deps): bump gulp-sourcemaps from 2.6.4 to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "gulp-postcss": "^10.0.0",
         "gulp-rename": "^1.2.2",
         "gulp-rtlcss": "^2.0.0",
-        "gulp-sourcemaps": "^2.6.4",
+        "gulp-sourcemaps": "^3.0.0",
         "husky": "^7.0.2",
         "inquirer": "^9.2.7",
         "karma": "^6.3.14",
@@ -2791,24 +2791,26 @@
       "dev": true
     },
     "node_modules/@gulp-sourcemaps/identity-map": {
-      "version": "1.0.2",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-2.0.1.tgz",
+      "integrity": "sha512-Tb+nSISZku+eQ4X1lAkevcQa+jknn/OVUgZ3XCxEKIsLsqYuPoJwJOPQeaOk75X3WPftb29GWY1eqE7GLsXb1Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "acorn": "^5.0.3",
-        "css": "^2.2.1",
-        "normalize-path": "^2.1.1",
+        "acorn": "^6.4.1",
+        "normalize-path": "^3.0.0",
+        "postcss": "^7.0.16",
         "source-map": "^0.6.0",
-        "through2": "^2.0.3"
+        "through2": "^3.0.1"
       },
       "engines": {
         "node": ">= 0.10"
       }
     },
     "node_modules/@gulp-sourcemaps/identity-map/node_modules/acorn": {
-      "version": "5.7.4",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2816,15 +2818,37 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/@gulp-sourcemaps/identity-map/node_modules/normalize-path": {
-      "version": "2.1.1",
+    "node_modules/@gulp-sourcemaps/identity-map/node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "dev": true
+    },
+    "node_modules/@gulp-sourcemaps/identity-map/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "remove-trailing-separator": "^1.0.1"
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/@gulp-sourcemaps/identity-map/node_modules/through2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
       }
     },
     "node_modules/@gulp-sourcemaps/map-sources": {
@@ -6482,8 +6506,9 @@
     },
     "node_modules/atob": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true,
-      "license": "(MIT OR Apache-2.0)",
       "bin": {
         "atob": "bin/atob.js"
       },
@@ -7976,14 +8001,14 @@
       }
     },
     "node_modules/css": {
-      "version": "2.2.4",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+      "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.3",
+        "inherits": "^2.0.4",
         "source-map": "^0.6.1",
-        "source-map-resolve": "^0.5.2",
-        "urix": "^0.1.0"
+        "source-map-resolve": "^0.6.0"
       }
     },
     "node_modules/css-declaration-sorter": {
@@ -8403,8 +8428,9 @@
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
@@ -11319,30 +11345,32 @@
       }
     },
     "node_modules/gulp-sourcemaps": {
-      "version": "2.6.5",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-3.0.0.tgz",
+      "integrity": "sha512-RqvUckJkuYqy4VaIH60RMal4ZtG0IbQ6PXMNkNsshEGJ9cldUPRb/YCgboYae+CLAs1HQNb4ADTKCx65HInquQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
-        "@gulp-sourcemaps/identity-map": "1.X",
-        "@gulp-sourcemaps/map-sources": "1.X",
-        "acorn": "5.X",
-        "convert-source-map": "1.X",
-        "css": "2.X",
-        "debug-fabulous": "1.X",
-        "detect-newline": "2.X",
-        "graceful-fs": "4.X",
-        "source-map": "~0.6.0",
-        "strip-bom-string": "1.X",
-        "through2": "2.X"
+        "@gulp-sourcemaps/identity-map": "^2.0.1",
+        "@gulp-sourcemaps/map-sources": "^1.0.0",
+        "acorn": "^6.4.1",
+        "convert-source-map": "^1.0.0",
+        "css": "^3.0.0",
+        "debug-fabulous": "^1.0.0",
+        "detect-newline": "^2.0.0",
+        "graceful-fs": "^4.0.0",
+        "source-map": "^0.6.0",
+        "strip-bom-string": "^1.0.0",
+        "through2": "^2.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">= 6"
       }
     },
     "node_modules/gulp-sourcemaps/node_modules/acorn": {
-      "version": "5.7.4",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -17371,11 +17399,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/resolve-url": {
-      "version": "0.2.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
       "dev": true,
@@ -18048,15 +18071,14 @@
       }
     },
     "node_modules/source-map-resolve": {
-      "version": "0.5.3",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+      "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "decode-uri-component": "^0.2.0"
       }
     },
     "node_modules/source-map-support": {
@@ -18067,11 +18089,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/source-map-url": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/sparkles": {
       "version": "2.1.0",
@@ -20008,11 +20025,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/urix": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "gulp-postcss": "^10.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-rtlcss": "^2.0.0",
-    "gulp-sourcemaps": "^2.6.4",
+    "gulp-sourcemaps": "^3.0.0",
     "husky": "^7.0.2",
     "inquirer": "^9.2.7",
     "karma": "^6.3.14",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change updates the version of `gulp-sourcemaps` from `^2.6.4` to `^3.0.0`. 

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L146-R146): Updated `gulp-sourcemaps` to version `^3.0.0` to ensure compatibility with the latest features and improvements.