### PR TITLE
Fix font-family

### DIFF
--- a/src/styles/typography.less
+++ b/src/styles/typography.less
@@ -116,8 +116,3 @@ dd {
   margin-bottom: (@line-height-computed / 2);
 }
 
-// font-face
-@font-face {
-  font-family: Apple-System;
-  src: local(-apple-system), local(BlinkMacSystemFont), local(system-ui);
-}

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -124,7 +124,7 @@
 // Typography
 // Font, line-height, and color for body text, headings, and more.
 
-@font-family-base:      -apple-system, Arial, Helvetica, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', STXihei, sans-serif;
+@font-family-base:      -apple-system, BlinkMacSystemFont, Arial, Helvetica, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', STXihei, sans-serif;
 
 @font-size-extra-large: 18px;
 @font-size-large:       16px;

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -124,7 +124,7 @@
 // Typography
 // Font, line-height, and color for body text, headings, and more.
 
-@font-family-base:      Apple-System, Arial, Helvetica, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', STXihei, sans-serif;
+@font-family-base:      -apple-system, Arial, Helvetica, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', STXihei, sans-serif;
 
 @font-size-extra-large: 18px;
 @font-size-large:       16px;


### PR DESCRIPTION
~~It’s `-apple-system` with a beginning dash.~~

This does not work in Chrome.

```css
@font-face {
  font-family: Apple-System;
  src: local(-apple-system), local(BlinkMacSystemFont), local(system-ui);
}
```