### PR TITLE
fix(Tree): improve duplicate value detection in Tree data structure 

### DIFF
--- a/src/Tree/test/useFlattenTreeSpec.ts
+++ b/src/Tree/test/useFlattenTreeSpec.ts
@@ -1,0 +1,152 @@
+import sinon from 'sinon';
+import useFlattenTree from '../hooks/useFlattenTree';
+import { renderHook } from '@testing-library/react';
+import { formatNodeRefKey } from '../utils';
+import type { TreeNode } from '@/internals/Tree/types';
+
+describe('useFlattenTree', () => {
+  const defaultOptions = {
+    value: 'value',
+    labelKey: 'label',
+    valueKey: 'value',
+    childrenKey: 'children'
+  };
+
+  describe('Error handling', () => {
+    let consoleErrorStub;
+
+    beforeEach(() => {
+      consoleErrorStub = sinon.stub(console, 'error').callsFake(() => {
+        // do nothing
+      });
+    });
+
+    afterEach(() => {
+      consoleErrorStub.restore();
+    });
+
+    it('Should detect duplicate values', () => {
+      const duplicateData: TreeNode[] = [
+        {
+          label: 'node 1',
+          value: '1'
+        },
+        {
+          label: 'node 2',
+          value: '2',
+          children: [
+            {
+              label: 'node 3',
+              value: '1'
+            }
+          ]
+        }
+      ];
+
+      renderHook(() => useFlattenTree(duplicateData, defaultOptions));
+
+      expect(consoleErrorStub).to.have.been.calledWith(
+        "[rsuite] The value '1' is duplicated. Each node in the tree data must have a unique value."
+      );
+    });
+  });
+
+  describe('Basic functionality', () => {
+    it('Should handle empty data', () => {
+      const { result } = renderHook(() => useFlattenTree([], defaultOptions));
+      expect(Object.keys(result.current)).to.have.length(0);
+    });
+
+    it('Should flatten single level tree', () => {
+      const data = [
+        { label: 'Node 1', value: '1' },
+        { label: 'Node 2', value: '2' }
+      ];
+
+      const { result } = renderHook(() => useFlattenTree(data, defaultOptions));
+
+      const node1Key = formatNodeRefKey('1');
+      const node2Key = formatNodeRefKey('2');
+
+      expect(result.current[node1Key][defaultOptions.labelKey]).to.equal('Node 1');
+      expect(result.current[node2Key][defaultOptions.labelKey]).to.equal('Node 2');
+    });
+
+    it('Should flatten nested tree', () => {
+      const data = [
+        {
+          label: 'Node 1',
+          value: '1',
+          children: [
+            { label: 'Node 1.1', value: '1-1' },
+            { label: 'Node 1.2', value: '1-2' }
+          ]
+        }
+      ];
+
+      const { result } = renderHook(() => useFlattenTree(data, defaultOptions));
+
+      const node11Key = formatNodeRefKey('1-1');
+      const node12Key = formatNodeRefKey('1-2');
+
+      expect(result.current[node11Key]?.parent?.[defaultOptions.valueKey]).to.equal('1');
+      expect(result.current[node12Key]?.layer).to.equal(2);
+    });
+  });
+
+  describe('Custom keys', () => {
+    it('Should work with custom keys', () => {
+      const data = [
+        {
+          title: 'Node 1',
+          id: '1',
+          items: [{ title: 'Node 1.1', id: '1-1' }]
+        }
+      ];
+
+      const { result } = renderHook(() =>
+        useFlattenTree(data, {
+          value: '1',
+          labelKey: 'title',
+          valueKey: 'id',
+          childrenKey: 'items'
+        })
+      );
+
+      const node1Key = formatNodeRefKey('1');
+      const node11Key = formatNodeRefKey('1-1');
+
+      expect(result.current[node1Key].title).to.equal('Node 1');
+      expect(result.current[node11Key].title).to.equal('Node 1.1');
+    });
+  });
+
+  describe('Callback functionality', () => {
+    it('Should call callback when nodes change', () => {
+      const callback = sinon.spy();
+      const data = [{ label: 'Node 1', value: '1' }];
+
+      renderHook(() => useFlattenTree(data, { ...defaultOptions, callback }));
+
+      expect(callback).to.have.been.calledOnce;
+      expect(callback.firstCall.args[0]).to.have.property(formatNodeRefKey('1'));
+    });
+  });
+
+  describe('Update handling', () => {
+    it('Should update when data changes', () => {
+      const initialData = [{ label: 'Node 1', value: '1' }];
+
+      const { result, rerender } = renderHook(({ data }) => useFlattenTree(data, defaultOptions), {
+        initialProps: { data: initialData }
+      });
+
+      expect(Object.keys(result.current)).to.have.length(1);
+
+      const newData = [...initialData, { label: 'Node 2', value: '2' }];
+      rerender({ data: newData });
+
+      expect(Object.keys(result.current)).to.have.length(2);
+    });
+  });
+});


### PR DESCRIPTION
This pull request includes updates to the `useFlattenTree` hook to add duplicate value checking and corresponding tests to ensure the functionality works correctly. The changes focus on improving error handling and enhancing the robustness of the tree flattening logic.

Enhancements to `useFlattenTree` hook:

* [`src/Tree/hooks/useFlattenTree.ts`](diffhunk://#diff-3b484d2f78e934fd3597bc4e21eea71151a23aa9a39b4f7d4bc3ff10139734e6R70): Added a `seenValues` set to track and detect duplicate values in the tree data. If a duplicate value is found, an error message is logged. [[1]](diffhunk://#diff-3b484d2f78e934fd3597bc4e21eea71151a23aa9a39b4f7d4bc3ff10139734e6R70) [[2]](diffhunk://#diff-3b484d2f78e934fd3597bc4e21eea71151a23aa9a39b4f7d4bc3ff10139734e6L103-R112)
* [`src/Tree/hooks/useFlattenTree.ts`](diffhunk://#diff-3b484d2f78e934fd3597bc4e21eea71151a23aa9a39b4f7d4bc3ff10139734e6R140): Cleared the `seenValues` set when the tree data changes to avoid false positives.

Testing:

* [`src/Tree/test/useFlattenTreeSpec.ts`](diffhunk://#diff-99050762b42bbe8bfe1153410f87709003bde5586ebd7bc202108230b9709070R1-R152): Added tests to verify that the `useFlattenTree` hook correctly identifies and logs duplicate values, handles empty data, flattens single-level and nested trees, works with custom keys, calls callbacks when nodes change, and updates when data changes.