### PR TITLE
fix(InputPicker): do not trigger clean when clicking delete with search keyword

### DIFF
--- a/src/InputPicker/InputPicker.tsx
+++ b/src/InputPicker/InputPicker.tsx
@@ -417,9 +417,16 @@ const InputPicker: PickerComponent<InputPickerProps> = React.forwardRef(
     });
 
     const handleClean = useEventCallback((event: React.SyntheticEvent) => {
-      if (disabled || searchKeyword !== '') {
+      if (disabled) {
         return;
       }
+
+      // When there is a value in the search box and the user presses the delete key on the keyboard,
+      // do not trigger clearing
+      if (inputRef.current === event.target && searchKeyword !== '') {
+        return;
+      }
+
       setValue(null);
       setFocusItemValue(null);
       resetSearch();

--- a/src/InputPicker/test/InputPickerSpec.tsx
+++ b/src/InputPicker/test/InputPickerSpec.tsx
@@ -335,6 +335,42 @@ describe('InputPicker', () => {
     expect(list[0]).to.text('Louisa');
   });
 
+  describe('handleClean', () => {
+    it('Should not render clean button when disabled', () => {
+      render(<InputPicker data={data} value="Eugenia" disabled />);
+
+      const cleanButton = screen.queryByLabelText('Clear');
+
+      expect(cleanButton).to.not.exist;
+    });
+
+    it('Should not trigger clean when clicking delete with search keyword', () => {
+      const onChange = sinon.spy();
+      render(<InputPicker data={data} value="Eugenia" onChange={onChange} />);
+
+      // Find the input and type a search keyword
+      const input = screen.getByTestId('picker-toggle-input');
+      fireEvent.change(input, { target: { value: 'search' } });
+
+      // Simulate pressing the delete key on the input
+      fireEvent.keyDown(input, { key: 'Delete' });
+      fireEvent.keyDown(input, { key: 'Backspace' });
+
+      expect(onChange).to.not.have.been.called;
+    });
+
+    it('Should trigger clean when clicking clean button normally', () => {
+      const onChange = sinon.spy();
+      render(<InputPicker data={data} value="Eugenia" onChange={onChange} />);
+
+      // Find and click the clean button
+      const cleanButton = screen.getByLabelText('Clear');
+      fireEvent.click(cleanButton);
+
+      expect(onChange).to.have.been.calledWith(null);
+    });
+  });
+
   it('Should call renderValue', () => {
     const { container, rerender } = render(
       <InputPicker data={[]} value="Test" renderValue={() => '1'} />

--- a/src/InputPicker/test/InputPickerSpec.tsx
+++ b/src/InputPicker/test/InputPickerSpec.tsx
@@ -328,6 +328,15 @@ describe('InputPicker', () => {
       expect(cleanButton).to.not.exist;
     });
 
+    it('Should not call `onClean` callback when disabled', () => {
+      const onClean = sinon.spy();
+      render(<InputPicker defaultOpen data={data} value="Eugenia" disabled onClean={onClean} />);
+
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Backspace' });
+
+      expect(onClean).to.not.have.been.called;
+    });
+
     it('Should call `onClean` callback', () => {
       const onClean = sinon.spy();
       render(<InputPicker data={data} defaultValue={'Eugenia'} onClean={onClean} />);

--- a/src/InputPicker/test/InputPickerSpec.tsx
+++ b/src/InputPicker/test/InputPickerSpec.tsx
@@ -234,22 +234,6 @@ describe('InputPicker', () => {
     expect(onChange).to.have.been.calledWith('Eugenia');
   });
 
-  it('Should call `onClean` callback', () => {
-    const onClean = sinon.spy();
-    render(<InputPicker data={data} defaultValue={'Eugenia'} onClean={onClean} />);
-    fireEvent.click(screen.getByRole('button', { name: /clear/i }));
-
-    expect(onClean).to.calledOnce;
-  });
-
-  it('Should call `onClean` callback by keyDown', () => {
-    const onClean = sinon.spy();
-    render(<InputPicker data={data} defaultOpen defaultValue={'Eugenia'} onClean={onClean} />);
-    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Backspace' });
-
-    expect(onClean).to.calledOnce;
-  });
-
   it('Should call `onSelect` with correct args by key=Enter ', () => {
     const onSelect = sinon.spy();
     render(<InputPicker defaultOpen data={data} onSelect={onSelect} defaultValue={'Kariane'} />);
@@ -344,19 +328,47 @@ describe('InputPicker', () => {
       expect(cleanButton).to.not.exist;
     });
 
+    it('Should call `onClean` callback', () => {
+      const onClean = sinon.spy();
+      render(<InputPicker data={data} defaultValue={'Eugenia'} onClean={onClean} />);
+      fireEvent.click(screen.getByRole('button', { name: /clear/i }));
+
+      expect(onClean).to.calledOnce;
+    });
+
+    it('Should call `onClean` callback by keyDown', () => {
+      const onClean = sinon.spy();
+      render(<InputPicker data={data} defaultOpen defaultValue={'Eugenia'} onClean={onClean} />);
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Backspace' });
+
+      expect(onClean).to.have.been.calledOnce;
+    });
+
     it('Should not trigger clean when clicking delete with search keyword', () => {
       const onChange = sinon.spy();
-      render(<InputPicker data={data} value="Eugenia" onChange={onChange} />);
+      const onSearch = sinon.spy();
+      const onClean = sinon.spy();
+      render(
+        <InputPicker
+          data={data}
+          defaultOpen
+          defaultValue="Eugenia"
+          onChange={onChange}
+          onSearch={onSearch}
+          onClean={onClean}
+        />
+      );
 
-      // Find the input and type a search keyword
-      const input = screen.getByTestId('picker-toggle-input');
-      fireEvent.change(input, { target: { value: 'search' } });
+      const input = screen.getByRole('textbox');
 
-      // Simulate pressing the delete key on the input
-      fireEvent.keyDown(input, { key: 'Delete' });
+      fireEvent.change(input, { target: { value: 'a' } });
+
+      expect(onSearch).to.have.been.calledWith('a');
+
       fireEvent.keyDown(input, { key: 'Backspace' });
 
       expect(onChange).to.not.have.been.called;
+      expect(onClean).to.not.have.been.called;
     });
 
     it('Should trigger clean when clicking clean button normally', () => {


### PR DESCRIPTION
This pull request includes changes to the `InputPicker` component and its corresponding tests to improve the handling of the clean button functionality. The most important changes include updating the `handleClean` function to prevent unintended clearing when the delete key is pressed with a search keyword and adding new tests to ensure the correct behavior of the clean button.

Improvements to the `InputPicker` component:

* [`src/InputPicker/InputPicker.tsx`](diffhunk://#diff-6378f82215e0509b44a3a4503c4177c9d87924bea9174d9f343c4cc3b228a498L420-R429): Modified the `handleClean` function to prevent clearing the input value when the delete key is pressed while there is a search keyword.

Enhancements to the test coverage:

* [`src/InputPicker/test/InputPickerSpec.tsx`](diffhunk://#diff-c684f73d2914f4e557ba020d6f1802beccbcde6a494d1a576e8a9049c60a2dc7R338-R373): Added new test cases to verify that the clean button does not render when disabled, does not trigger clean when the delete key is pressed with a search keyword, and triggers clean when the clean button is clicked normally.