### PR TITLE
fix(form): support deeply nested object validation

### DIFF
--- a/src/FormControl/test/utilsSpec.ts
+++ b/src/FormControl/test/utilsSpec.ts
@@ -1,0 +1,42 @@
+import { nameToPath } from '../utils';
+
+describe('FormControl - utils', () => {
+  describe('nameToPath', () => {
+    it('Should return original name when no dots or brackets', () => {
+      expect(nameToPath('name')).to.equal('name');
+      expect(nameToPath('address')).to.equal('address');
+    });
+
+    it('Should convert dot notation to object path', () => {
+      expect(nameToPath('user.name')).to.equal('user.object.name');
+      expect(nameToPath('address.city.code')).to.equal('address.object.city.object.code');
+    });
+
+    it('Should convert array notation to array path', () => {
+      expect(nameToPath('items[0]')).to.equal('items.array[0]');
+      expect(nameToPath('data[1]')).to.equal('data.array[1]');
+    });
+
+    it('Should convert mixed dot and array notation to mixed path', () => {
+      expect(nameToPath('items[0].name')).to.equal('items.array[0].object.name');
+      expect(nameToPath('users[1].address.city')).to.equal(
+        'users.array[1].object.address.object.city'
+      );
+      expect(nameToPath('data.items[0].value')).to.equal('data.object.items.array[0].object.value');
+    });
+
+    it('Should handle multiple array indexes', () => {
+      expect(nameToPath('matrix[0][1]')).to.equal('matrix.array[0].array[1]');
+      expect(nameToPath('data[0][1].value')).to.equal('data.array[0].array[1].object.value');
+    });
+
+    it('Should handle complex nested paths', () => {
+      expect(nameToPath('users[0].addresses[1].city.code')).to.equal(
+        'users.array[0].object.addresses.array[1].object.city.object.code'
+      );
+      expect(nameToPath('data.items[0].subitems[1].name')).to.equal(
+        'data.object.items.array[0].object.subitems.array[1].object.name'
+      );
+    });
+  });
+});

--- a/src/FormControl/utils.ts
+++ b/src/FormControl/utils.ts
@@ -1,3 +1,10 @@
+/**
+ * Converts a field name to a path that can be used in a nested object.
+ * @example
+ * nameToPath('a.b.c') // 'a.object.b.object.c'
+ * @param name the field name to convert
+ * @returns the converted path
+ */
 export function nameToPath(name: string) {
-  return name.includes('.') ? name.replace('.', '.object.') : name;
+  return name.includes('.') ? name.replaceAll('.', '.object.') : name;
 }

--- a/src/FormControl/utils.ts
+++ b/src/FormControl/utils.ts
@@ -2,9 +2,48 @@
  * Converts a field name to a path that can be used in a nested object.
  * @example
  * nameToPath('a.b.c') // 'a.object.b.object.c'
+ * nameToPath('items[0].name') // 'items.array[0].object.name'
  * @param name the field name to convert
  * @returns the converted path
  */
 export function nameToPath(name: string) {
-  return name.includes('.') ? name.replaceAll('.', '.object.') : name;
+  if (!name.includes('.') && !name.includes('[')) {
+    return name;
+  }
+
+  // Split the path by dots and array accessors
+  const parts = name.split(/\.|\[|\]\.?/).filter(Boolean);
+  const result: string[] = [];
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    const isLast = i === parts.length - 1;
+
+    if (part.match(/^\d+$/)) {
+      // If it's a number (array index), add array accessor
+      result.push(`array[${part}]`);
+      // If there's a next part and it's not an array index, add .object
+      if (!isLast && !parts[i + 1].match(/^\d+$/)) {
+        result.push('object');
+      }
+    } else {
+      // For regular property names
+      if (!isLast) {
+        // Not the last part, add .object unless next part is array index
+        const nextPart = parts[i + 1];
+        if (nextPart && nextPart.match(/^\d+$/)) {
+          // Next part is array index
+          result.push(part);
+        } else {
+          // Next part is object property
+          result.push(`${part}.object`);
+        }
+      } else {
+        // Last part, just add the name
+        result.push(part);
+      }
+    }
+  }
+
+  return result.join('.');
 }


### PR DESCRIPTION
fix: https://github.com/rsuite/rsuite/issues/4120
- Fixed nameToPath function to handle multiple nested levels
- Added test cases for deeply nested object validation

fix: https://github.com/rsuite/rsuite/issues/4123

- Fixed nameToPath function to correctly handle array paths
- Added unit tests for nameToPath function
- Added test case for deeply nested array validation