### PR TITLE
feat(DateRangePicker): support custom render calendar cell content

### DIFF
--- a/docs/pages/components/date-range-picker/en-US/index.md
+++ b/docs/pages/components/date-range-picker/en-US/index.md
@@ -182,6 +182,7 @@ Has keyboard interaction for the DateRangeInput component by default.
 | placement            | [Placement](#code-ts-placement-code) `('bottomStart')`          | The placement of component                                                                                                        |
 | preventOverflow      | boolean                                                         | Prevent floating element overflow                                                                                                 |
 | ranges               | [Range[]](#code-ts-range-code) ([Ranges](#code-ts-ranges-code)) | Set predefined date ranges the user can select from. Default: `Today`,`Yesterday`，`Last 7 days`                                  |
+| renderCell           | (date: Date) => ReactNode                                       | Custom calendar cell rendering <br/>![][5.77.0]                                                                                   |
 | renderTitle          | (date: Date) => ReactNode                                       | Custom render for month's title                                                                                                   |
 | renderValue          | (date: [Date, Date], format: string) => string                  | Custom render value                                                                                                               |
 | shouldDisableDate    | [DisabledDateFunction](#code-ts-disabled-date-function-code)    | Disabled date                                                                                                                     |
@@ -257,3 +258,4 @@ const Ranges = [
 [5.62.0]: https://img.shields.io/badge/>=-v5.62.0-blue
 [5.69.0]: https://img.shields.io/badge/>=-v5.69.0-blue
 [5.71.0]: https://img.shields.io/badge/>=-v5.71.0-blue
+[5.77.0]: https://img.shields.io/badge/>=-v5.77.0-blue

--- a/docs/pages/components/date-range-picker/zh-CN/index.md
+++ b/docs/pages/components/date-range-picker/zh-CN/index.md
@@ -185,8 +185,9 @@ const { combine, allowedMaxDays, beforeToday } = DateRangePicker;
 | placement            | [Placement](#code-ts-placement-code) `('bottomStart')`          | 显示位置                                                                                      |
 | preventOverflow      | boolean                                                         | 防止浮动元素溢出                                                                              |
 | ranges               | [Range[]](#code-ts-range-code) ([Ranges](#code-ts-ranges-code)) | 快捷项配置，默认 `今天`,`昨天`，`最近 7 天`                                                   |
+| renderCell           | (date: Date) => ReactNode                                       | 自定义渲染日历面板上的日期单元格<br/>![][5.77.0]                                              |
 | renderTitle          | (date: Date) => ReactNode                                       | 自定义渲染日历面板上的月份标题                                                                |
-| renderValue          | (date: [Date, Date], format: string) => string                  | Custom render value                                                                           |
+| renderValue          | (date: [Date, Date], format: string) => string                  | 自定义渲染值                                                                                  |
 | shouldDisableDate    | [DisabledDateFunction](#code-ts-disabled-date-function-code)    | 禁用日期                                                                                      |
 | showHeader           | boolean `(true)`                                                | 是否在日历面板的头部显示格式化的日期范围<br/>![][5.52.0]                                      |
 | showMeridiem         | boolean                                                         | 显示 12 小时制的时间格式                                                                      |
@@ -254,3 +255,4 @@ const Ranges = [
 [5.62.0]: https://img.shields.io/badge/>=-v5.62.0-blue
 [5.69.0]: https://img.shields.io/badge/>=-v5.69.0-blue
 [5.71.0]: https://img.shields.io/badge/>=-v5.71.0-blue
+[5.77.0]: https://img.shields.io/badge/>=-v5.77.0-blue

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -252,6 +252,13 @@ export interface DateRangePickerProps
    * Custom render for calendar title
    */
   renderTitle?: (date: Date) => React.ReactNode;
+
+  /**
+   * Custom rendering calendar cell content.
+   *
+   * @version 5.77.0
+   */
+  renderCell?: (date: Date) => React.ReactNode;
 }
 
 export interface DateRangePickerComponent extends PickerComponent<DateRangePickerProps> {
@@ -345,6 +352,7 @@ const DateRangePicker: DateRangePickerComponent = React.forwardRef(
       onShortcutClick,
       renderTitle,
       renderValue,
+      renderCell,
       ...restProps
     } = propsWithDefaults;
 
@@ -922,7 +930,8 @@ const DateRangePicker: DateRangePickerComponent = React.forwardRef(
         onChangeCalendarMonth,
         onChangeCalendarTime,
         onMouseMove,
-        renderTitle
+        renderTitle,
+        renderCellOnPicker: renderCell
       };
 
       const getCalendars = () => {

--- a/src/DateRangePicker/test/DateRangePickerSpec.tsx
+++ b/src/DateRangePicker/test/DateRangePickerSpec.tsx
@@ -469,6 +469,22 @@ describe('DateRangePicker', () => {
     expect(secondTitle).to.have.text('2 - 2022');
   });
 
+  it('Should custom render cell', () => {
+    render(
+      <DateRangePicker
+        open
+        value={[new Date('2025-01-01'), new Date('2025-01-02')]}
+        renderCell={date => {
+          const day = date.getDate();
+
+          return day === 1 ? <span>1🎉</span> : day;
+        }}
+      />
+    );
+
+    expect(screen.getByRole('gridcell', { name: '01 Jan 2025' })).to.have.text('1🎉');
+  });
+
   it('Should cancel the Ok button disable when the shortcut button is clicked', () => {
     render(
       <DateRangePicker
@@ -1284,8 +1300,19 @@ describe('DateRangePicker', () => {
   });
 
   describe('Error handling', () => {
+    let consoleErrorStub;
+
+    beforeEach(() => {
+      consoleErrorStub = sinon.stub(console, 'error').callsFake(() => {
+        // do nothing
+      });
+    });
+
+    afterEach(() => {
+      consoleErrorStub.restore();
+    });
+
     it('Should render an error message when the format is deprecated', () => {
-      sinon.spy(console, 'error');
       expect(() => {
         render(<DateRangePicker format="YY" value={[new Date(), new Date()]} />);
       }).to.not.throw();
@@ -1293,11 +1320,10 @@ describe('DateRangePicker', () => {
       expect(screen.getByRole('textbox')).to.have.value(
         'Error: Invalid date format ~ Error: Invalid date format'
       );
-      expect(console.error).to.have.been.calledWith(sinon.match(/Error: Invalid date format/));
+      expect(consoleErrorStub).to.have.been.calledWith(sinon.match(/Error: Invalid date format/));
     });
 
     it('Should render an error message when the format is incorrect', () => {
-      sinon.spy(console, 'error');
       expect(() => {
         render(<DateRangePicker format="_error_" value={[new Date(), new Date()]} />);
       }).to.not.throw();
@@ -1305,7 +1331,7 @@ describe('DateRangePicker', () => {
       expect(screen.getByRole('textbox')).to.have.value(
         'Error: Invalid date format ~ Error: Invalid date format'
       );
-      expect(console.error).to.have.been.calledWith(sinon.match(/Error: Invalid date format/));
+      expect(consoleErrorStub).to.have.been.calledWith(sinon.match(/Error: Invalid date format/));
     });
   });
 


### PR DESCRIPTION
This pull request introduces several enhancements and bug fixes for the `DateRangePicker` component. The key changes include adding a new `renderCell` prop for custom calendar cell rendering, updating documentation, and improving error handling in tests.

### Enhancements to DateRangePicker component:

* [`src/DateRangePicker/DateRangePicker.tsx`](diffhunk://#diff-7f89a1ffee8cf9975c367c9826b37a1f35d7ca45e6b0b334386320badc61dc84R255-R261): Added `renderCell` prop to allow custom rendering of calendar cells. This new prop is documented as being available from version 5.77.0. [[1]](diffhunk://#diff-7f89a1ffee8cf9975c367c9826b37a1f35d7ca45e6b0b334386320badc61dc84R255-R261) [[2]](diffhunk://#diff-7f89a1ffee8cf9975c367c9826b37a1f35d7ca45e6b0b334386320badc61dc84R355) [[3]](diffhunk://#diff-7f89a1ffee8cf9975c367c9826b37a1f35d7ca45e6b0b334386320badc61dc84L925-R934)

### Documentation updates:

* [`docs/pages/components/date-range-picker/en-US/index.md`](diffhunk://#diff-27ea2ad6b1503077cbc4798100d17fa0ab7f433506dd7c74b733aa9bfd556f32R185): Added `renderCell` prop description to the English documentation.
* [`docs/pages/components/date-range-picker/zh-CN/index.md`](diffhunk://#diff-84f568ade7463449d25c701db3dc6041786df672cccd319c816d39480bec5b90R188-R190): Added `renderCell` prop description to the Chinese documentation and corrected the description of the `renderValue` prop.

### Test improvements:

* [`src/DateRangePicker/test/DateRangePickerSpec.tsx`](diffhunk://#diff-1db89ab0f1f8ac2683cb3743232e600a5b139468b94779ce3ba3202546dc7838R472-R487): Added a test case to verify the custom rendering of calendar cells using the `renderCell` prop.
* [`src/DateRangePicker/test/DateRangePickerSpec.tsx`](diffhunk://#diff-1db89ab0f1f8ac2683cb3743232e600a5b139468b94779ce3ba3202546dc7838R1303-R1334): Improved error handling in tests by stubbing `console.error` to prevent actual error messages during test execution.

### Additional changes:

* `docs/pages/components/date-range-picker/en-US/index.md` and `docs/pages/components/date-range-picker/zh-CN/index.md`: Updated the version badge to include version 5.77.0. [[1]](diffhunk://#diff-27ea2ad6b1503077cbc4798100d17fa0ab7f433506dd7c74b733aa9bfd556f32R261) [[2]](diffhunk://#diff-84f568ade7463449d25c701db3dc6041786df672cccd319c816d39480bec5b90R258)