### PR TITLE
test(Badge): add style test cases for positioning and independent display

### DIFF
--- a/docs/pages/_common/types/placement-corners.md
+++ b/docs/pages/_common/types/placement-corners.md
@@ -1,5 +1,5 @@
 ### `ts:PlacementCorners`
 
 ```ts
-type PlacementCorners =  'topStart' | 'topEnd' | 'bottomStart' | 'bottomEnd' |
+type PlacementCorners = 'topStart' | 'topEnd' | 'bottomStart' | 'bottomEnd';
 ```

--- a/src/Badge/styles/index.less
+++ b/src/Badge/styles/index.less
@@ -18,7 +18,7 @@
   &-independent,
   &-content {
     opacity: 1;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     background-color: var(--rs-badge-bg);
     color: var(--rs-badge-text);

--- a/src/Badge/test/BadgeStylesSpec.tsx
+++ b/src/Badge/test/BadgeStylesSpec.tsx
@@ -46,4 +46,27 @@ describe('Badge styles', () => {
       toRGB('#00bcd4')
     );
   });
+
+  it('Should render badge with correct CSS variables', () => {
+    const { container } = render(<Badge />);
+    const badgeElement = container.querySelector('.rs-badge') as HTMLElement;
+
+    expect(getStyle(badgeElement, '--rs-badge-offset-x')).to.equal('5%');
+    expect(getStyle(badgeElement, '--rs-badge-offset-y')).to.equal('5%');
+    expect(getStyle(badgeElement, '--rs-badge-translate')).to.equal('40%');
+  });
+
+  it('Should render circle badge with correct translate variable', () => {
+    const { container } = render(<Badge className="rs-badge-circle" />);
+    const badgeElement = container.querySelector('.rs-badge-circle') as HTMLElement;
+
+    expect(getStyle(badgeElement, '--rs-badge-translate')).to.equal('30%');
+  });
+
+  it('Should render independent badge with inline-flex display', () => {
+    const { container } = render(<Badge />);
+    const badgeElement = container.firstChild as HTMLElement;
+
+    expect(badgeElement).to.have.style('display', 'inline-flex');
+  });
 });


### PR DESCRIPTION
This pull request includes updates to the `Badge` component's styles and tests to ensure proper rendering and CSS variable usage. The most important changes include modifying the display property in the styles and adding new test cases to verify the correct CSS variables and display properties.

### Badge component style updates:

* [`src/Badge/styles/index.less`](diffhunk://#diff-9001c4db5dfddb8eb65766038835a1af9044d33cf7d686c49dc650f310eab6cdL21-R21): Changed the display property from `flex` to `inline-flex` for better alignment and rendering of badge content.

### Badge component test updates:

* [`src/Badge/test/BadgeStylesSpec.tsx`](diffhunk://#diff-5a38bbad8c3479f6ec2d2d165912c2f5ff5420571708ba98a39001494e2ca46fR49-R71): Added new test cases to verify the correct CSS variables (`--rs-badge-offset-x`, `--rs-badge-offset-y`, `--rs-badge-translate`) and to ensure the badge renders with `inline-flex` display.