### PR TITLE
fix: prevent duplicate className in DatePicker and DateRangePicker components

### DIFF
--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -644,6 +644,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
     const hasValue = isValid(value);
     const [classes, usedClassNamePropKeys] = usePickerClassName({
       ...props,
+      className,
       classPrefix,
       name: 'date',
       appearance,
@@ -689,7 +690,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
         speaker={renderCalendarOverlay}
       >
         <Component
-          className={merge(className, classes, { [prefix('error')]: invalidValue })}
+          className={merge(classes, { [prefix('error')]: invalidValue })}
           style={style}
           ref={root}
         >

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -1020,6 +1020,7 @@ const DateRangePicker: DateRangePickerComponent = React.forwardRef(
     const [classes, usedClassNamePropKeys] = usePickerClassName({
       ...props,
       classPrefix,
+      className,
       name: 'daterange',
       appearance,
       hasValue,
@@ -1095,7 +1096,7 @@ const DateRangePicker: DateRangePickerComponent = React.forwardRef(
       >
         <Component
           ref={root}
-          className={merge(className, classes, { [prefix('error')]: invalidValue })}
+          className={merge(classes, { [prefix('error')]: invalidValue })}
           style={style}
         >
           {plaintext ? (

--- a/test/utils/testStandardProps.ts
+++ b/test/utils/testStandardProps.ts
@@ -24,7 +24,13 @@ export function testClassNameProp(
       renderOptions
     );
 
-    expect(getRootElement(view)).to.have.class(customClassName);
+    const rootElement = getRootElement(view);
+
+    expect(rootElement).to.have.class(customClassName);
+    expect(rootElement.className.split(customClassName).length).to.equal(
+      2,
+      `className "${customClassName}" should not appear multiple times`
+    );
   });
 }
 


### PR DESCRIPTION
This pull request includes several changes to improve the handling of `className` properties in the `DatePicker` and `DateRangePicker` components, as well as enhancing the test coverage for class name properties.

fix: https://github.com/rsuite/rsuite/issues/4131
