### PR TITLE
fix(DateRangePicker): allow ranges option value to be null

### DIFF
--- a/docs/pages/components/date-range-picker/fragments/custom-shortcut-options.md
+++ b/docs/pages/components/date-range-picker/fragments/custom-shortcut-options.md
@@ -62,6 +62,11 @@ const predefinedRanges = [
     placement: 'left'
   },
   {
+    label: 'Clear',
+    value: null,
+    placement: 'left'
+  },
+  {
     label: 'Last week',
     closeOverlay: false,
     value: value => {
@@ -127,6 +132,10 @@ const predefinedBottomRanges = [
   {
     label: 'All time',
     value: [new Date(new Date().getFullYear() - 1, 0, 1), new Date()]
+  },
+  {
+    label: 'Clear',
+    value: null
   }
 ];
 

--- a/src/DatePicker/types.ts
+++ b/src/DatePicker/types.ts
@@ -5,12 +5,12 @@ export type ToolbarValue = Date | [Date?, Date?];
 export interface RangeType<T> {
   label: ReactNode;
   closeOverlay?: boolean;
-  value: T | ((value: T) => T);
+  value: T | ((value: T) => T) | null;
   placement?: 'bottom' | 'left';
 }
 
 export interface InnerRange<T> extends Omit<RangeType<T>, 'value'> {
-  value: T;
+  value: T | null;
 }
 
 export interface DeprecatedProps {

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -851,7 +851,11 @@ const DateRangePicker: DateRangePickerComponent = React.forwardRef(
     /**
      * Check if a shortcut is disabled based on the selected date range
      */
-    const shouldDisableShortcut = (selectedDates: SelectedDatesState = []): boolean => {
+    const shouldDisableShortcut = (selectedDates: SelectedDatesState | null = []): boolean => {
+      if (selectedDates === null) {
+        return false;
+      }
+
       const [startDate, endDate] = selectedDates;
 
       // Disable if either start or end date is missing

--- a/src/DateRangePicker/test/DateRangePickerSpec.tsx
+++ b/src/DateRangePicker/test/DateRangePickerSpec.tsx
@@ -530,6 +530,28 @@ describe('DateRangePicker', () => {
     });
   });
 
+  it('Should clear the value after predefined range is clicked', () => {
+    const onChange = sinon.spy();
+
+    render(
+      <DateRangePicker
+        defaultOpen
+        defaultValue={[new Date(), new Date()]}
+        ranges={[
+          {
+            label: 'Clear it',
+            value: null
+          }
+        ]}
+        onChange={onChange}
+      />
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Clear it' }));
+
+    expect(onChange).to.been.calledWith(null);
+  });
+
   it('Should not close picker', async () => {
     const onClose = sinon.spy();
     const onChange = sinon.spy();

--- a/src/DateRangePicker/types.ts
+++ b/src/DateRangePicker/types.ts
@@ -1,16 +1,11 @@
-import React from 'react';
 import { DATERANGE_DISABLED_TARGET } from '@/internals/constants';
+import type { RangeType as DatePickerRangeType } from '../DatePicker/types';
 
-export type ValueType = [Date?, Date?];
+export type ValueType = [Date?, Date?] | null;
 
 export type DateRange = [Date, Date];
 
-export interface RangeType<T = DateRange> {
-  label: React.ReactNode;
-  value: T | ((value?: T) => T);
-  closeOverlay?: boolean;
-  placement?: 'bottom' | 'left';
-}
+export type RangeType<T = DateRange> = DatePickerRangeType<T>;
 
 export type DisabledDateFunction = (
   /**


### PR DESCRIPTION
fix: https://github.com/rsuite/rsuite/issues/4138
```tsx
<DateRangePicker
  ranges={[
    {
      label: 'Clear',
      value: null
    }
  ]}
/>
```



This pull request includes changes to enhance the handling of null values in the `DateRangePicker` component and its associated types. 


