### PR TITLE
fix(Dropdown): prevent focus moving to first item when focusing on disabled item

### DIFF
--- a/docs/pages/components/dropdown/fragments/disabled.md
+++ b/docs/pages/components/dropdown/fragments/disabled.md
@@ -12,9 +12,9 @@ const App = () => (
     </Dropdown>
 
     <Dropdown title="Disabled Menu Item">
-      <Dropdown.Item disabled>Disabled Item 1</Dropdown.Item>
+      <Dropdown.Item>Item 1</Dropdown.Item>
       <Dropdown.Item>Item 2</Dropdown.Item>
-      <Dropdown.Item>Item 3</Dropdown.Item>
+      <Dropdown.Item disabled>Item 3 - Disabled</Dropdown.Item>
     </Dropdown>
   </ButtonToolbar>
 );

--- a/src/Dropdown/styles/index.less
+++ b/src/Dropdown/styles/index.less
@@ -173,7 +173,6 @@
   &-disabled {
     color: var(--rs-text-disabled);
     cursor: @cursor-disabled;
-    pointer-events: none;
 
     .rs-text {
       color: var(--rs-text-disabled);

--- a/src/Dropdown/test/DropdownMenuSpec.tsx
+++ b/src/Dropdown/test/DropdownMenuSpec.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 import DropdownMenu from '../DropdownMenu';
 import DropdownItem from '../DropdownItem';
 import Dropdown from '../Dropdown';
-import userEvent from '@testing-library/user-event';
+import Popover from '../../Popover';
+import Whisper from '../../Whisper';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { testStandardProps } from '@test/utils';
 
 describe('<Dropdown.Menu>', () => {
@@ -284,5 +286,34 @@ describe('<Dropdown.Menu>', () => {
     expect(screen.getByTestId('menu'))
       .to.have.class('custom')
       .and.to.have.class('rs-dropdown-menu');
+  });
+
+  // fix: https://github.com/rsuite/rsuite/issues/4133
+  it('Should not move visual focus to first item when focus on a disabled item', () => {
+    const renderSpeaker = ({ left, top, className }: any, ref: React.Ref<HTMLDivElement>) => {
+      return (
+        <Popover ref={ref} className={className} style={{ left, top }} full>
+          <Dropdown.Menu>
+            <Dropdown.Item eventKey={1}>Item 1</Dropdown.Item>
+            <Dropdown.Item eventKey={2} disabled>
+              Item 2
+            </Dropdown.Item>
+          </Dropdown.Menu>
+        </Popover>
+      );
+    };
+
+    render(
+      <Whisper trigger="click" speaker={renderSpeaker}>
+        <button>Click</button>
+      </Whisper>
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.focus(screen.getByRole('menuitem', { name: 'Item 2' }));
+
+    expect(screen.getByRole('menuitem', { name: 'Item 1' })).to.not.have.class(
+      'rs-dropdown-item-focus'
+    );
   });
 });

--- a/src/internals/Menu/Menubar.tsx
+++ b/src/internals/Menu/Menubar.tsx
@@ -38,7 +38,10 @@ export default function Menubar({ vertical = false, children, onActivateItem }: 
         // Skip if focus is moving to a focusable element within this menu
         !(event.target !== event.currentTarget && isFocusableElement(event.target))
       ) {
-        if (activeItemIndex === null) {
+        const disabled = event.target.getAttribute('aria-disabled');
+
+        // Skip if the item is disabled
+        if (activeItemIndex === null && disabled !== 'true') {
           dispatch({ type: MenuActionTypes.MoveFocus, to: MoveFocusTo.First });
         }
       }


### PR DESCRIPTION
fix: https://github.com/rsuite/rsuite/issues/4133

- Added test case for disabled item focus behavior
- Updated disabled item styles
- Modified Menubar focus handling for disabled items
- Updated dropdown documentation examples

