### PR TITLE
fix(pickers): improve pickers `renderValue` property type definition

### DIFF
--- a/src/Cascader/test/Cascader.test.tsx
+++ b/src/Cascader/test/Cascader.test.tsx
@@ -32,3 +32,20 @@ const stringValuedData = [{ label: 'One', value: 'One' }];
 const ref = React.useRef<PickerHandle>(null);
 <Cascader data={[]} ref={ref} />;
 ref.current?.open?.();
+const pickerRef = React.createRef<PickerHandle>();
+
+<Cascader ref={pickerRef} data={[]} />;
+
+interface Item<T> {
+  label?: React.ReactNode;
+  value?: T;
+}
+
+// Check renderValue
+<Cascader
+  data={[]}
+  renderValue={(value: string, selectedPaths: Item<string>[]) => {
+    console.log(value, selectedPaths);
+    return selectedPaths.map(item => item.label).join(' / ');
+  }}
+/>;

--- a/src/CheckPicker/CheckPicker.tsx
+++ b/src/CheckPicker/CheckPicker.tsx
@@ -36,18 +36,25 @@ import {
 } from '@/internals/Picker';
 import type { PickerLocale } from '../locales';
 import type { ItemDataType, FormControlPickerProps } from '@/internals/types';
-import type { MultipleSelectProps } from '../SelectPicker';
+import type { SelectProps } from '../SelectPicker';
 
 export type ValueType = (number | string)[];
 export interface CheckPickerProps<T = any>
   extends FormControlPickerProps<T[], PickerLocale, ItemDataType<T>>,
-    MultipleSelectProps<T>,
+    Omit<SelectProps<T>, 'renderValue'>,
     Pick<PickerToggleProps, 'label' | 'caretAs' | 'loading'> {
   /** Top the selected option in the options */
   sticky?: boolean;
 
   /** A picker that can be counted */
   countable?: boolean;
+
+  /** Custom render selected items */
+  renderValue?: (
+    value: T[],
+    item: ItemDataType<T>[],
+    selectedElement: React.ReactNode
+  ) => React.ReactNode;
 }
 
 const emptyArray = [];
@@ -210,13 +217,18 @@ const CheckPicker = forwardRef<'div', CheckPickerProps>(
     });
 
     const handleSelect = useEventCallback(
-      (nextItemValue: any, item: ItemDataType, event: React.SyntheticEvent) => {
+      (nextItemValue: any, item: ItemDataType<T>, event: React.SyntheticEvent) => {
         onSelect?.(nextItemValue, item, event);
       }
     );
 
     const handleItemSelect = useEventCallback(
-      (nextItemValue: any, item: ItemDataType, event: React.SyntheticEvent, checked: boolean) => {
+      (
+        nextItemValue: any,
+        item: ItemDataType<T>,
+        event: React.SyntheticEvent,
+        checked: boolean
+      ) => {
         const nextValue = clone(value);
 
         if (checked) {

--- a/src/CheckPicker/test/CheckPicker.test.tsx
+++ b/src/CheckPicker/test/CheckPicker.test.tsx
@@ -41,3 +41,16 @@ const stringValuedData = [{ label: 'One', value: 'One' }];
 const ref = React.useRef<PickerHandle>(null);
 <CheckPicker data={[]} ref={ref} />;
 ref.current?.open?.();
+
+interface Item<T> {
+  label?: React.ReactNode;
+  value?: T;
+}
+// Check renderValue
+<CheckPicker
+  data={[]}
+  renderValue={(value: string[], items: Item<string>[]) => {
+    console.log(value, items);
+    return value.map(v => items.find(item => item.value === v)?.label).join(', ');
+  }}
+/>;

--- a/src/InputPicker/InputPicker.tsx
+++ b/src/InputPicker/InputPicker.tsx
@@ -51,7 +51,7 @@ import type { SelectProps } from '../SelectPicker';
 export type ValueType = any;
 export interface InputPickerProps<V = ValueType>
   extends FormControlPickerProps<V, InputPickerLocale, InputItemDataType>,
-    SelectProps<V>,
+    Omit<SelectProps<V>, 'renderValue'>,
     Pick<PickerToggleProps, 'caretAs' | 'loading'> {
   tabIndex?: number;
 
@@ -82,6 +82,12 @@ export interface InputPickerProps<V = ValueType>
     searchKeyword: string,
     filteredData: InputItemDataType<V>[]
   ) => boolean;
+
+  renderValue?: (
+    value: V,
+    item: ItemDataType<V>,
+    selectedElement: React.ReactNode
+  ) => React.ReactNode;
 }
 
 /**

--- a/src/InputPicker/test/InputPicker.test.tsx
+++ b/src/InputPicker/test/InputPicker.test.tsx
@@ -8,3 +8,16 @@ import type { PickerHandle } from '@/internals/Picker';
 const ref = React.useRef<PickerHandle>(null);
 <InputPicker data={[]} ref={ref} />;
 ref.current?.open?.();
+interface Item<T> {
+  label?: React.ReactNode;
+  value?: T;
+}
+
+// Check renderValue
+<InputPicker
+  data={[]}
+  renderValue={(value: string, item: Item<string>) => {
+    console.log(value, item);
+    return item.label;
+  }}
+/>;

--- a/src/MultiCascader/MultiCascader.tsx
+++ b/src/MultiCascader/MultiCascader.tsx
@@ -30,10 +30,10 @@ import type { FormControlPickerProps, ItemDataType, DataItemValue } from '@/inte
 import type { PickerLocale } from '../locales';
 import type { MultiCascadeTreeProps } from '../MultiCascadeTree';
 
-export interface MultiCascaderProps<T extends DataItemValue = any>
+export interface MultiCascaderProps<T = any>
   extends FormControlPickerProps<T[], PickerLocale, ItemDataType<T>, T>,
     MultiCascadeTreeProps<T, T[], PickerLocale>,
-    Pick<PickerToggleProps, 'loading'> {
+    Pick<PickerToggleProps, 'label' | 'caretAs' | 'loading'> {
   /**
    * A picker that can be counted
    */
@@ -119,7 +119,7 @@ const emptyArray = [];
  * The `MultiCascader` component is used to select multiple values from cascading options.
  * @see https://rsuitejs.com/components/multi-cascader/
  */
-const MultiCascader = forwardRef<'div', MultiCascaderProps<DataItemValue>>(
+const MultiCascader = forwardRef<'div', MultiCascaderProps>(
   <T extends DataItemValue>(props: MultiCascaderProps<T>, ref) => {
     const { propsWithDefaults, rtl } = useCustom('MultiCascader', props);
     const {

--- a/src/MultiCascader/test/MultiCascader.test.tsx
+++ b/src/MultiCascader/test/MultiCascader.test.tsx
@@ -6,3 +6,17 @@ import type { PickerHandle } from '@/internals/Picker';
 const ref = React.useRef<PickerHandle>(null);
 <MultiCascader data={[]} ref={ref} />;
 ref.current?.open?.();
+
+interface Item<T> {
+  label?: React.ReactNode;
+  value?: T;
+}
+
+// Check renderValue
+<MultiCascader
+  data={[]}
+  renderValue={(value: string[], selectedPaths: Item<string>[]) => {
+    console.log(value, selectedPaths);
+    return selectedPaths.map(item => item.label).join(' / ');
+  }}
+/>;

--- a/src/SelectPicker/SelectPicker.tsx
+++ b/src/SelectPicker/SelectPicker.tsx
@@ -66,12 +66,12 @@ export interface SelectProps<T> {
   /** Custom render selected items */
   renderValue?: (
     value: T,
-    item: ItemDataType | ItemDataType[],
+    item: ItemDataType<T>,
     selectedElement: React.ReactNode
   ) => React.ReactNode;
 
   /** Called when the option is selected */
-  onSelect?: (value: any, item: ItemDataType, event: React.SyntheticEvent) => void;
+  onSelect?: (value: any, item: ItemDataType<T>, event: React.SyntheticEvent) => void;
 
   /** Called after clicking the group title */
   onGroupTitleClick?: (event: React.SyntheticEvent) => void;
@@ -81,15 +81,6 @@ export interface SelectProps<T> {
 
   /** Called when clean */
   onClean?: (event: React.SyntheticEvent) => void;
-}
-
-export interface MultipleSelectProps<T> extends Omit<SelectProps<T>, 'renderValue'> {
-  /** Custom render selected items */
-  renderValue?: (
-    value: T[],
-    item: ItemDataType<T>[],
-    selectedElement: React.ReactNode
-  ) => React.ReactNode;
 }
 
 export interface SelectPickerProps<T = any>
@@ -207,7 +198,7 @@ const SelectPicker = forwardRef<'div', SelectPickerProps>(
     });
 
     const handleSelect = useEventCallback(
-      (value: any, item: ItemDataType, event: React.SyntheticEvent) => {
+      (value: any, item: ItemDataType<T>, event: React.SyntheticEvent) => {
         onSelect?.(value, item, event);
         target.current?.focus();
       }
@@ -296,7 +287,7 @@ const SelectPicker = forwardRef<'div', SelectPickerProps>(
     }
 
     if (!isNil(value) && isFunction(renderValue)) {
-      selectedElement = renderValue(value, activeItem as ItemDataType, selectedElement);
+      selectedElement = renderValue(value, activeItem as ItemDataType<T>, selectedElement);
       // If renderValue returns null or undefined, hasValue is false.
       if (isNil(selectedElement)) {
         hasValue = false;

--- a/src/SelectPicker/index.tsx
+++ b/src/SelectPicker/index.tsx
@@ -1,7 +1,7 @@
 import SelectPicker from './SelectPicker';
 
 // export types
-export type { SelectProps, MultipleSelectProps, SelectPickerProps } from './SelectPicker';
+export type { SelectProps, SelectPickerProps } from './SelectPicker';
 
 // export components
 export { SelectPicker };

--- a/src/SelectPicker/test/SelectPicker.test.tsx
+++ b/src/SelectPicker/test/SelectPicker.test.tsx
@@ -62,3 +62,16 @@ type SortDirection = 'asc' | 'desc';
 const ref = React.useRef<PickerHandle>(null);
 <SelectPicker data={[]} ref={ref} />;
 ref.current?.open?.();
+interface Item<T> {
+  label?: React.ReactNode;
+  value?: T;
+}
+
+// Check renderValue
+<SelectPicker
+  data={[]}
+  renderValue={(value: string, item: Item<string>) => {
+    console.log(value, item);
+    return item.label;
+  }}
+/>;

--- a/src/TagPicker/TagPicker.tsx
+++ b/src/TagPicker/TagPicker.tsx
@@ -3,14 +3,24 @@ import InputPicker, { InputPickerProps } from '../InputPicker/InputPicker';
 import { TagProvider, TagOnlyProps } from '../InputPicker/InputPickerContext';
 import { useCustom } from '../CustomProvider';
 import { forwardRef } from '@/internals/utils';
+import type { ItemDataType } from '@/internals/types';
 import type { CheckboxProps } from '../Checkbox';
 
-export interface TagPickerProps extends InputPickerProps, Partial<TagOnlyProps> {
+export interface TagPickerProps<V = any>
+  extends Omit<InputPickerProps<V>, 'renderValue'>,
+    Partial<TagOnlyProps> {
   /**
    * Custom render checkbox on menu item
    * @version 5.47.0
    **/
   renderMenuItemCheckbox?: (checkboxProps: CheckboxProps) => React.ReactNode;
+
+  /** Custom render selected items */
+  renderValue?: (
+    values: V[],
+    items: ItemDataType<V>[],
+    selectedElement: React.ReactNode
+  ) => React.ReactNode;
 }
 
 /**
@@ -25,6 +35,7 @@ const TagPicker = forwardRef<'div', TagPickerProps>((props, ref) => {
     trigger = 'Enter',
     onTagRemove,
     renderMenuItemCheckbox,
+    renderValue,
     ...rest
   } = propsWithDefaults;
 
@@ -41,7 +52,11 @@ const TagPicker = forwardRef<'div', TagPickerProps>((props, ref) => {
 
   return (
     <TagProvider value={contextValue}>
-      <InputPicker {...rest} ref={ref} />
+      <InputPicker
+        renderValue={renderValue as InputPickerProps['renderValue']}
+        {...rest}
+        ref={ref}
+      />
     </TagProvider>
   );
 });

--- a/src/TagPicker/test/TagPicker.test.tsx
+++ b/src/TagPicker/test/TagPicker.test.tsx
@@ -6,3 +6,16 @@ import type { PickerHandle } from '@/internals/Picker';
 const ref = React.useRef<PickerHandle>(null);
 <TagPicker data={[]} ref={ref} />;
 ref.current?.open?.();
+
+interface Item<T> {
+  label?: React.ReactNode;
+  value?: T;
+}
+
+<TagPicker
+  data={[]}
+  renderValue={(value: string[], items: Item<string>[]) => {
+    console.log(value, items);
+    return value.map(v => items.find(item => item.value === v)?.label).join(', ');
+  }}
+/>;


### PR DESCRIPTION
This pull request introduces several changes across multiple files to enhance the functionality of various picker components by adding support for custom rendering of selected items. The changes include the addition of `renderValue` properties, type adjustments, and test updates.

### Enhancements to Picker Components:

* [`src/CheckPicker/CheckPicker.tsx`](diffhunk://#diff-24415b62298f3c3b22e4dd6a7c6043b14459e23907b0086a567f4088fea97900L39-R57): Added `renderValue` property to `CheckPickerProps` for custom rendering of selected items. Adjusted types and updated the `handleSelect` and `handleItemSelect` methods to use generic `ItemDataType<T>`. [[1]](diffhunk://#diff-24415b62298f3c3b22e4dd6a7c6043b14459e23907b0086a567f4088fea97900L39-R57) [[2]](diffhunk://#diff-24415b62298f3c3b22e4dd6a7c6043b14459e23907b0086a567f4088fea97900L213-R231)
* [`src/InputPicker/InputPicker.tsx`](diffhunk://#diff-6378f82215e0509b44a3a4503c4177c9d87924bea9174d9f343c4cc3b228a498L54-R54): Modified `InputPickerProps` to include a `renderValue` property for custom rendering. [[1]](diffhunk://#diff-6378f82215e0509b44a3a4503c4177c9d87924bea9174d9f343c4cc3b228a498L54-R54) [[2]](diffhunk://#diff-6378f82215e0509b44a3a4503c4177c9d87924bea9174d9f343c4cc3b228a498R85-R90)
* [`src/MultiCascader/MultiCascader.tsx`](diffhunk://#diff-c1d8638909b4e501d226bc3e43d5bdf1d3cbcf512a554c4c4a87d649696fe2a9L33-R36): Added `label` and `caretAs` to `MultiCascaderProps` and included a `renderValue` property. [[1]](diffhunk://#diff-c1d8638909b4e501d226bc3e43d5bdf1d3cbcf512a554c4c4a87d649696fe2a9L33-R36) [[2]](diffhunk://#diff-c1d8638909b4e501d226bc3e43d5bdf1d3cbcf512a554c4c4a87d649696fe2a9L122-R122)
* [`src/SelectPicker/SelectPicker.tsx`](diffhunk://#diff-f1cb520bfd8ecc500dc2dcfa27bb1570365044a8729a63a5bef01351d42cffa0L69-R74): Updated `SelectProps` to use generic `ItemDataType<T>` and removed `MultipleSelectProps`. Adjusted `renderValue` and `handleSelect` methods accordingly. [[1]](diffhunk://#diff-f1cb520bfd8ecc500dc2dcfa27bb1570365044a8729a63a5bef01351d42cffa0L69-R74) [[2]](diffhunk://#diff-f1cb520bfd8ecc500dc2dcfa27bb1570365044a8729a63a5bef01351d42cffa0L86-L94) [[3]](diffhunk://#diff-f1cb520bfd8ecc500dc2dcfa27bb1570365044a8729a63a5bef01351d42cffa0L210-R201) [[4]](diffhunk://#diff-f1cb520bfd8ecc500dc2dcfa27bb1570365044a8729a63a5bef01351d42cffa0L299-R290)
* [`src/TagPicker/TagPicker.tsx`](diffhunk://#diff-ecc26ecb45ea9be10453000745a9fcbc25bcfdd76a99ed75b28013fc67c2e713R6-R23): Included `renderValue` property in `TagPickerProps` for custom rendering and passed it to `InputPicker`. [[1]](diffhunk://#diff-ecc26ecb45ea9be10453000745a9fcbc25bcfdd76a99ed75b28013fc67c2e713R6-R23) [[2]](diffhunk://#diff-ecc26ecb45ea9be10453000745a9fcbc25bcfdd76a99ed75b28013fc67c2e713R38) [[3]](diffhunk://#diff-ecc26ecb45ea9be10453000745a9fcbc25bcfdd76a99ed75b28013fc67c2e713L44-R59)

### Test Updates:

* [`src/Cascader/test/Cascader.test.tsx`](diffhunk://#diff-6c8cded6626b7d65190086b167ba01e4f09a0c77d43306822f3d2981a8048087R35-R51): Added tests for `renderValue` property.
* [`src/CheckPicker/test/CheckPicker.test.tsx`](diffhunk://#diff-7bf8a65f358d486ee72fe232bf84a94b94a5713b0ab0dafdbe211890cde1ef4dR44-R56): Added tests for `renderValue` property.
* [`src/InputPicker/test/InputPicker.test.tsx`](diffhunk://#diff-587dc3bcaf720f902de003e7a9480d65ec87b1cf11b572d88739ae265127f6f0R11-R23): Added tests for `renderValue` property.
* [`src/MultiCascader/test/MultiCascader.test.tsx`](diffhunk://#diff-d4e7fc3a4e828747c36d25decec6a45a84464254c20d5083b54b19b272cadf2eR9-R22): Added tests for `renderValue` property.
* [`src/SelectPicker/test/SelectPicker.test.tsx`](diffhunk://#diff-f9e7c4333470955ece5cb4bcffe2d94baca3b7063e36c5f1c2db7a940ca4bad9R65-R77): Added tests for `renderValue` property.
* [`src/TagPicker/test/TagPicker.test.tsx`](diffhunk://#diff-615ff19828355ddc873316bde970ab44aa9a41dd5f897a3037868f035da65bd6R9-R21): Added tests for `renderValue` property.

### Other Adjustments:

* [`src/SelectPicker/index.tsx`](diffhunk://#diff-1e5b2e6552efceeb6048a2991973fa09a80c22531fc9b8f579f94dddfec8e355L4-R4): Removed export of `MultipleSelectProps`.