### PR TITLE
refactor(styles): replace physical CSS properties with logical properties for RTL support

### DIFF
--- a/docs/components/CodeView/styles.less
+++ b/docs/components/CodeView/styles.less
@@ -1,2 +1,0 @@
-.copy-code-button {
-}

--- a/docs/components/Frame.tsx
+++ b/docs/components/Frame.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import SideNavbar from './SideNavbar';
 import TopLevelNav from './TopLevelNav';
-import { useApp } from './AppContext';
 
 export interface FrameProps {
   submenu?: boolean;
@@ -20,13 +19,9 @@ export default function Frame(props: FrameProps) {
     setSubmenu(typeof open === 'undefined' ? !submenu : open);
   }
 
-  const {
-    theme: [, direction]
-  } = useApp();
-
   const contextStyle = {
-    [`margin${direction === 'rtl' ? 'Right' : 'Left'}`]: submenu ? 324 : 80
-  };
+    ['--page-context-margin-inline-start']: submenu ? '324px' : '80px'
+  } as React.CSSProperties;
 
   return (
     <div className={submenu ? '' : 'submenu-close'}>

--- a/docs/components/PageToolbar/styles.less
+++ b/docs/components/PageToolbar/styles.less
@@ -39,6 +39,9 @@
       align-items: center;
       gap: 10px;
     }
+    .rs-radio{
+      margin-inline: calc(var(--rs-spacing) * 2);
+    }
   }
 }
 

--- a/docs/less/code-view.less
+++ b/docs/less/code-view.less
@@ -1,6 +1,9 @@
-@import '~react-code-view/styles/react-code-view.css';
+@import '~codemirror/lib/codemirror.css';
+@import '~codemirror/theme/base16-light.css';
+@import '~codemirror/theme/base16-dark.css';
 
 .rcv-highlight {
+  direction: ltr /*rtl:ignore*/;
   position: relative;
   background-color: @doc-highlight-bg;
   padding: 10px;
@@ -18,6 +21,11 @@
   .rs-theme-dark &,
   .rs-theme-high-contrast & {
     background-color: @doc-highlight-bg;
+  }
+
+  .copy-code-button {
+    right: 8px /*rtl:ignore*/;
+    top: 8px;
   }
 }
 
@@ -61,13 +69,18 @@ a code {
   transition: 0.3s linear border-color;
   margin: 18px 0;
   padding: 0;
+  border-width: 1px;
+  border-style: solid;
   border-color: @code-view-wrapper-border-color;
   background-color: @code-view-wrapper-bg;
   border-radius: 6px;
 
   .CodeMirror {
+    direction: ltr /*rtl:ignore*/;
+    padding: 10px;
     margin: 0;
     background-color: @doc-highlight-bg;
+    height: auto !important;
   }
   .CodeMirror-gutters {
     background-color: @doc-highlight-bg;
@@ -78,6 +91,9 @@ a code {
   }
 
   .rcv-toolbar {
+    right: 0;
+    bottom: 0;
+    text-align: right;
     padding: 8px;
     border-color: @code-view-wrapper-border-color;
 
@@ -97,6 +113,13 @@ a code {
 
   .rcv-render {
     padding: 18px;
+    position: relative;
+
+    .notification-container {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+    }
   }
 
   .rs-theme-dark &,
@@ -109,28 +132,32 @@ a code {
   }
 }
 
-.rcv-render .notification-container {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-}
-
 .rcv-editor {
+  direction: ltr /*rtl:ignore*/;
   border-radius: 0 0 6px 6px;
+  height: auto;
+  overflow: hidden;
+  position: relative;
+
+  &-loader {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background: #ffffff;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .copy-code-button {
+    right: 8px /*rtl:ignore*/;
+    top: 8px;
+    z-index: 1;
+  }
 }
 
 .copy-code-button {
   position: absolute;
   color: #858b94;
-}
-
-.rcv-editor .copy-code-button {
-  right: 8px;
-  top: 8px;
-  z-index: 1;
-}
-
-.rcv-highlight .copy-code-button {
-  right: 8px;
-  top: 8px;
 }

--- a/docs/less/index.less
+++ b/docs/less/index.less
@@ -39,6 +39,7 @@
 :root {
   --font-family-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono',
     monospace;
+  --page-context-margin-inline-start: 324px;
 }
 
 body {
@@ -66,7 +67,7 @@ body {
     }
 
     @media (min-width: @media-xs) {
-      margin-left: 324px;
+      margin-inline-start: var(--page-context-margin-inline-start);
     }
   }
 }

--- a/docs/pages/components/animation/fragments/collapse.md
+++ b/docs/pages/components/animation/fragments/collapse.md
@@ -43,14 +43,14 @@ const App = () => {
 
       <HStack spacing={16} alignItems="flex-start">
         <VStack style={{ minWidth: 240 }}>
-          <Text>Vertical Collapse:</Text>
+          <Text>Vertical Collapse</Text>
           <Animation.Collapse in={show}>
             {(props, ref) => <AnimatedPanel {...props} ref={ref} />}
           </Animation.Collapse>
         </VStack>
 
         <VStack style={{ minWidth: 240 }}>
-          <Text>Horizontal Collapse:</Text>
+          <Text>Horizontal Collapse</Text>
           <Animation.Collapse in={show} dimension="width">
             {(props, ref) => <AnimatedPanel {...props} ref={ref} />}
           </Animation.Collapse>

--- a/docs/pages/components/check-tree-picker/fragments/cascade.md
+++ b/docs/pages/components/check-tree-picker/fragments/cascade.md
@@ -16,13 +16,14 @@ const App = () => {
   const [cascade, setCascade] = React.useState(false);
   return (
     <div>
-      Cascade:{' '}
       <Toggle
         checked={cascade}
         onChange={checked => {
           setCascade(checked);
         }}
-      />
+      >
+        Cascade
+      </Toggle>
       <hr />
       <CheckTreePicker
         defaultExpandAll

--- a/docs/pages/components/check-tree/fragments/cascade.md
+++ b/docs/pages/components/check-tree/fragments/cascade.md
@@ -16,13 +16,14 @@ const App = () => {
   const [cascade, setCascade] = React.useState(false);
   return (
     <div>
-      Cascade:{' '}
       <Toggle
         checked={cascade}
         onChange={checked => {
           setCascade(checked);
         }}
-      />
+      >
+        Cascade
+      </Toggle>
       <hr />
       <CheckTree defaultExpandAll cascade={cascade} defaultValue={[2, 38]} data={data} />
     </div>

--- a/src/AutoComplete/AutoComplete.tsx
+++ b/src/AutoComplete/AutoComplete.tsx
@@ -229,9 +229,7 @@ const AutoComplete = forwardRef<'div', AutoCompleteProps>((props: AutoCompletePr
   const [htmlInputProps, restProps] = partitionHTMLProps(omit(rest, pickTriggerPropKeys));
 
   const renderPopup = (positionProps: PositionChildProps, speakerRef) => {
-    const { left, top, className } = positionProps;
-    const styles = { left, top };
-
+    const { className } = positionProps;
     const menu = (
       <Listbox
         classPrefix="auto-complete-menu"
@@ -249,7 +247,6 @@ const AutoComplete = forwardRef<'div', AutoCompleteProps>((props: AutoCompletePr
     return (
       <PickerPopup
         ref={mergeRefs(overlay, speakerRef)}
-        style={styles}
         className={className}
         onKeyDown={handleKeyDownEvent}
         target={trigger}

--- a/src/Avatar/styles/index.less
+++ b/src/Avatar/styles/index.less
@@ -59,18 +59,6 @@
     width: var(--rs-avatar-size);
     height: var(--rs-avatar-size);
     line-height: var(--rs-avatar-size);
-
-    &::before {
-      content: attr(alt);
-      position: absolute;
-      width: 100%;
-      height: inherit;
-      top: 0;
-      left: 0;
-      background: var(--rs-avatar-bg);
-      text-align: center;
-      padding: 0 2px;
-    }
   }
 
   &-icon {

--- a/src/Button/styles/index.less
+++ b/src/Button/styles/index.less
@@ -83,12 +83,12 @@
 
 .rs-btn-start-icon {
   line-height: 0; // Eliminate whitespace
-  margin-right: @btn-icon-gap;
+  margin-inline-end: @btn-icon-gap;
 }
 
 .rs-btn-end-icon {
   line-height: 0; // Eliminate whitespace
-  margin-left: @btn-icon-gap;
+  margin-inline-start: @btn-icon-gap;
 }
 
 // Appearance variants
@@ -297,9 +297,9 @@ each(@spectrum, .(@color) {
       height: @btn-loading-spin-default-diameter;
       margin: auto;
       top: 0;
-      right: 0;
       bottom: 0;
-      left: 0;
+      inset-inline-end: 0;
+      inset-inline-start: 0;
       border-radius: var(--rs-radius-full);
       z-index: 1;
 

--- a/src/ButtonGroup/styles/index.less
+++ b/src/ButtonGroup/styles/index.less
@@ -24,7 +24,7 @@
 // Horizontal Button remove border radius
 .rs-btn-group:not(.rs-btn-group-vertical) {
   > .rs-btn {
-    float: left;
+    float: inline-start;
 
     &:not(:last-child) {
       .border-right-radius(0);
@@ -37,7 +37,7 @@
 
   // collapse border
   > .rs-btn-ghost + .rs-btn-ghost {
-    margin-left: -1px;
+    margin-inline-start: -1px;
   }
 
   &.rs-btn-group-divided > .rs-btn {

--- a/src/Calendar/styles/index.less
+++ b/src/Calendar/styles/index.less
@@ -39,7 +39,7 @@
   }
 
   &-panel &-header &-btn-today {
-    float: right;
+    float: inline-end;
   }
 
   &-panel &-header-forward,
@@ -59,13 +59,13 @@
   }
 
   &-panel&-month-view &-header-month-toolbar {
-    padding-left: 0;
-    padding-right: 0;
+    padding-inline-start: 0;
+    padding-inline-end: 0;
   }
 
   &-panel &-month-view {
-    padding-left: 0;
-    padding-right: 0;
+    padding-inline-start: 0;
+    padding-inline-end: 0;
   }
 
   &-panel &-table-header-row &-table-header-cell-content {
@@ -79,8 +79,8 @@
     height: @calendar-panel-today-active-side-length;
     background-color: var(--rs-calendar-today-bg);
     border-radius: var(--rs-radius-full);
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
   }
 
   &-panel &-table-cell-is-today &-table-cell-content {
@@ -99,8 +99,8 @@
   }
 
   &-panel &-month-dropdown {
-    margin-left: 10px;
-    margin-right: 10px;
+    margin-inline-start: 10px;
+    margin-inline-end: 10px;
     border-radius: var(--rs-radius-md);
     width: ~'calc(100% - 20px)';
   }
@@ -144,8 +144,8 @@
   &-btn-close {
     position: absolute;
     bottom: 0;
-    left: 0;
-    right: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
     height: 14px;
     padding: 0;
     border: 0;
@@ -177,8 +177,8 @@
 // Show month dropdown
 .rs-calendar-month-view {
   .rs-calendar-header-month-toolbar {
-    padding-left: 24px;
-    padding-right: 24px;
+    padding-inline-start: 24px;
+    padding-inline-end: 24px;
   }
 
   .rs-calendar-header-backward,
@@ -252,8 +252,8 @@
 
 .rs-calendar-header {
   width: @calendar-header-width;
-  padding-left: @calendar-picker-padding;
-  padding-right: @calendar-picker-padding;
+  padding-inline-start: @calendar-picker-padding;
+  padding-inline-end: @calendar-picker-padding;
   .clearfix();
 
   // Month toolbar && Time toolbar
@@ -263,11 +263,11 @@
   }
 
   &-month-toolbar {
-    float: left;
+    float: inline-start;
   }
 
   &-time-toolbar {
-    float: right;
+    float: inline-end;
   }
 
   &-title {
@@ -277,7 +277,7 @@
   &-meridiem {
     // Designer think it's nice!
     font-size: var(--rs-font-size-xs);
-    margin-left: 4px;
+    margin-inline-start: 4px;
   }
 
   &-error {
@@ -285,7 +285,6 @@
   }
 
   &-btn-disabled {
-
     &,
     &:hover,
     &:hover:focus {
@@ -302,8 +301,8 @@
   // Only Has month
   &-has-month:not(&-has-time) {
     margin: 0 auto;
-    padding-left: @calendar-picker-padding;
-    padding-right: @calendar-picker-padding;
+    padding-inline-start: @calendar-picker-padding;
+    padding-inline-end: @calendar-picker-padding;
   }
 
   &-has-month:not(&-has-time) &-month-toolbar {
@@ -314,11 +313,11 @@
   }
 
   &-has-month:not(&-has-time) &-backward {
-    float: left;
+    float: inline-start;
   }
 
   &-has-month:not(&-has-time) &-forward {
-    float: right;
+    float: inline-end;
   }
 
   // Only Has time
@@ -341,7 +340,6 @@
 /* rtl:begin:ignore */
 /* stylelint-disable-next-line */
 [dir='rtl'] .rs-calendar-header {
-
   &-backward,
   &-forward {
     .rs-icon {
@@ -392,7 +390,6 @@
 
   &-un-same-month &-content,
   &-disabled &-content {
-
     &,
     &:hover {
       color: var(--rs-text-disabled);
@@ -400,7 +397,6 @@
   }
 
   &-disabled &-content {
-
     &,
     &:hover {
       background: none;
@@ -488,8 +484,8 @@
 
   &-row {
     position: relative;
-    padding-left: @calendar-picker-padding + 38px; // 30px for the year label + 8px gap
-    padding-right: @calendar-picker-padding;
+    padding-inline-start: @calendar-picker-padding + 38px; // 30px for the year label + 8px gap
+    padding-inline-end: @calendar-picker-padding;
     padding-top: 5px;
     padding-bottom: 5px;
 
@@ -501,7 +497,7 @@
   &-year {
     position: absolute;
     top: ~'calc(50% - 0.5em)';
-    left: @calendar-picker-padding;
+    inset-inline-start: @calendar-picker-padding;
 
     &-active {
       color: var(--rs-text-active);
@@ -545,8 +541,8 @@
   display: none;
   position: absolute;
   top: @calendar-dropdown-top;
-  padding-left: @calendar-picker-padding;
-  padding-right: @calendar-picker-padding;
+  padding-inline-start: @calendar-picker-padding;
+  padding-inline-end: @calendar-picker-padding;
   width: 100%;
   background-color: var(--rs-bg-overlay);
   color: var(--rs-text-primary);
@@ -576,14 +572,14 @@
       height: calc(100% - 30px);
     }
 
-    >ul,
-    >ul>li {
+    > ul,
+    > ul > li {
       list-style: none;
       margin: 0;
       padding: 0;
     }
 
-    >ul {
+    > ul {
       height: 230px;
       overflow-y: auto;
       scroll-behavior: smooth;
@@ -635,20 +631,20 @@
           .listbox-option-active();
         }
       });
-  }
+    }
 
-  &&-disabled {
-    color: var(--rs-text-disabled);
-    background: none;
-    cursor: not-allowed;
-    text-decoration: line-through;
-  }
+    &&-disabled {
+      color: var(--rs-text-disabled);
+      background: none;
+      cursor: not-allowed;
+      text-decoration: line-through;
+    }
 
-  &-active&-disabled& {
-    opacity: 0.3;
-    cursor: not-allowed;
+    &-active&-disabled& {
+      opacity: 0.3;
+      cursor: not-allowed;
+    }
   }
-}
 }
 
 .rs-calendar-only-time {

--- a/src/Calendar/test/CalendarStyleSpec.tsx
+++ b/src/Calendar/test/CalendarStyleSpec.tsx
@@ -15,7 +15,7 @@ describe('Calendar styles', () => {
       .getByTestId('calendar')
       ?.querySelector('.rs-calendar-header-month-toolbar');
 
-    expect(toolbar).to.have.style('float', 'left');
+    expect(toolbar).to.have.style('float', 'inline-start');
     expect(toolbar).to.have.style('display', 'block');
     expect(toolbar).to.have.style('text-align', 'center');
   });

--- a/src/Carousel/styles/index.less
+++ b/src/Carousel/styles/index.less
@@ -18,14 +18,14 @@
 
   &-slider {
     position: relative;
-    left: 0;
+    inset-inline-start:  0;
     height: 100%;
     transition: transform @carousel-animation-duration ease;
     will-change: transform;
 
     &-item {
       background-color: var(--rs-carousel-bg);
-      float: left;
+      float: inline-start;
       height: 100%;
       width: 100%;
     }
@@ -33,7 +33,7 @@
 
   &-slider-after {
     position: absolute;
-    left: 0;
+    inset-inline-start:  0;
     height: 100%;
     width: 100%;
     background-color: var(--rs-carousel-bg);
@@ -87,9 +87,9 @@
       content: '';
       position: absolute;
       top: -1 * @carousel-handler-sense-width;
-      right: -1 * @carousel-handler-sense-width;
       bottom: -1 * @carousel-handler-sense-width;
-      left: -1 * @carousel-handler-sense-width;
+      inset-inline-end: -1 * @carousel-handler-sense-width;
+      inset-inline-start:  -1 * @carousel-handler-sense-width;
     }
 
     &:hover {
@@ -132,7 +132,7 @@
 
   &-placement-top &-toolbar,
   &-placement-bottom &-toolbar {
-    left: 0;
+    inset-inline-start:  0;
     width: 100%;
 
     > ul {
@@ -163,11 +163,11 @@
   }
 
   &-placement-left &-toolbar {
-    left: @carousel-toolbar-wrapper-margin;
+    inset-inline-start:  @carousel-toolbar-wrapper-margin;
   }
 
   &-placement-right &-toolbar {
-    right: @carousel-toolbar-wrapper-margin;
+    inset-inline-end: @carousel-toolbar-wrapper-margin;
   }
 
   @keyframes moveLeftHalf {

--- a/src/CascadeTree/styles/index.less
+++ b/src/CascadeTree/styles/index.less
@@ -52,7 +52,7 @@
 
   // Has children
   &s-has-children & {
-    padding-right: @dropdown-toggle-padding-right;
+    padding-inline-end: @dropdown-toggle-padding-right;
   }
 
   &:hover,

--- a/src/Cascader/Cascader.tsx
+++ b/src/Cascader/Cascader.tsx
@@ -401,8 +401,8 @@ const Cascader = forwardRef<'div', CascaderProps>(
     };
 
     const renderTreeView = (positionProps?: PositionChildProps, speakerRef?) => {
-      const { left, top, className } = positionProps || {};
-      const styles = { ...DEPRECATED_menuStyle, ...popupStyle, left, top };
+      const { className } = positionProps || {};
+      const styles = { ...DEPRECATED_menuStyle, ...popupStyle };
       const classes = merge(
         className,
         DEPRECATED_menuClassName,

--- a/src/CheckPicker/CheckPicker.tsx
+++ b/src/CheckPicker/CheckPicker.tsx
@@ -289,9 +289,8 @@ const CheckPicker = forwardRef<'div', CheckPickerProps>(
     }
 
     const renderPopup = (positionProps: PositionChildProps, speakerRef) => {
-      const { left, top, className } = positionProps;
+      const { className } = positionProps;
       const classes = merge(className, menuClassName, prefix('check-menu'));
-      const styles = { ...menuStyle, left, top };
       let items = filteredData;
       let filteredStickyItems: ItemDataType[] = [];
 
@@ -342,7 +341,7 @@ const CheckPicker = forwardRef<'div', CheckPickerProps>(
           ref={mergeRefs(overlay, speakerRef)}
           autoWidth={menuAutoWidth}
           className={classes}
-          style={styles}
+          style={menuStyle}
           onKeyDown={onPickerKeyDown}
           target={trigger}
         >

--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -257,14 +257,14 @@ const CheckTreePicker = forwardRef<'div', CheckTreePickerProps>((props, ref) => 
   );
 
   const renderTreeView = (positionProps: PositionChildProps, speakerRef) => {
-    const { left, top, className } = positionProps;
+    const { className } = positionProps;
     const classes = classNames(
       className,
       popupClassName,
       DEPRECATED_menuClassName,
       prefix('check-tree-menu')
     );
-    const mergedMenuStyle = { ...popupStyle, ...DEPRECATED_menuStyle, left, top };
+    const mergedMenuStyle = { ...popupStyle, ...DEPRECATED_menuStyle };
 
     return (
       <PickerPopup

--- a/src/Col/styles/index.less
+++ b/src/Col/styles/index.less
@@ -4,11 +4,11 @@
 //
 // Common styles for small and large grid columns
 .rs-col {
-  float: left;
+  float: inline-start;
   position: relative;
   // Prevent columns from collapsing when empty
   min-height: 1px;
   // Inner gutter via padding
-  padding-left: ceil((@grid-gutter-width / 2));
-  padding-right: floor((@grid-gutter-width / 2));
+  padding-inline-start: ceil((@grid-gutter-width / 2));
+  padding-inline-end: floor((@grid-gutter-width / 2));
 }

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -568,9 +568,8 @@ const DatePicker = forwardRef<'div', DatePickerProps>((props: DatePickerProps, r
   const { sideRanges, bottomRanges } = splitRanges(ranges);
 
   const renderCalendarOverlay = (positionProps: PositionChildProps, speakerRef) => {
-    const { left, top, className } = positionProps;
+    const { className } = positionProps;
     const classes = merge(menuClassName, className, prefix('popup-date'));
-    const styles = { ...menuStyle, left, top };
 
     return (
       <PickerPopup
@@ -579,7 +578,7 @@ const DatePicker = forwardRef<'div', DatePickerProps>((props: DatePickerProps, r
         tabIndex={-1}
         className={classes}
         ref={mergeRefs(overlay, speakerRef)}
-        style={styles}
+        style={menuStyle}
         target={trigger}
         onKeyDown={handlePickerPopupKeyDown}
       >

--- a/src/DatePicker/styles/index.less
+++ b/src/DatePicker/styles/index.less
@@ -43,7 +43,7 @@
   }
 
   > .rs-input-group.rs-input-group-inside .rs-input {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
 }
 
@@ -90,8 +90,8 @@
       min-width: @calendar-width;
 
       & .rs-calendar-body {
-        padding-left: @calendar-padding-x-condensed;
-        padding-right: @calendar-padding-x-condensed;
+        padding-inline-start: @calendar-padding-x-condensed;
+        padding-inline-end: @calendar-padding-x-condensed;
       }
     }
 
@@ -100,8 +100,8 @@
     }
 
     &-body {
-      padding-left: @calendar-padding-x;
-      padding-right: @calendar-padding-x;
+      padding-inline-start: @calendar-padding-x;
+      padding-inline-end: @calendar-padding-x;
     }
 
     &-table {
@@ -142,8 +142,8 @@
     }
 
     .rs-calendar-table-cell-content {
-      padding-left: 0;
-      padding-right: 0;
+      padding-inline-start: 0;
+      padding-inline-end: 0;
       display: inline-block;
     }
 

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -864,7 +864,7 @@ const DateRangePicker = forwardRef<'div', DateRangePickerProps, typeof StaticMet
       : undefined;
 
     const renderCalendarOverlay = (positionProps: PositionChildProps, speakerRef) => {
-      const { left, top, className } = positionProps;
+      const { className } = positionProps;
       const classes = merge(className, menuClassName, prefix('popup-daterange'));
       const panelClasses = prefix('daterange-panel', {
         'daterange-panel-show-one-calendar': showOneCalendar,
@@ -878,7 +878,6 @@ const DateRangePicker = forwardRef<'div', DateRangePickerProps, typeof StaticMet
       const panelStyles: React.CSSProperties = {
         minWidth: showOneCalendar || onlyShowTime ? 'auto' : 528
       };
-      const styles = { ...menuStyle, left, top };
 
       const calendarProps = {
         locale,
@@ -934,7 +933,7 @@ const DateRangePicker = forwardRef<'div', DateRangePickerProps, typeof StaticMet
           className={classes}
           ref={mergeRefs(overlay, speakerRef)}
           target={trigger}
-          style={styles}
+          style={menuStyle}
         >
           <div className={panelClasses} style={panelStyles}>
             <Stack alignItems="flex-start">

--- a/src/DateRangePicker/styles/index.less
+++ b/src/DateRangePicker/styles/index.less
@@ -24,7 +24,7 @@
   }
 
   > .rs-input-group.rs-input-group-inside .rs-input {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
 }
 
@@ -106,14 +106,14 @@
       width: 50%;
       bottom: -1px;
       border-bottom: 2px solid #3498ff;
-      left: 0;
+      inset-inline-start:  0;
       transition: left 0.3s;
     }
   }
 
   &.rs-picker-tab-active-end {
     &::after {
-      left: 50%;
+      inset-inline-start:  50%;
     }
   }
 }

--- a/src/Drawer/styles/index.less
+++ b/src/Drawer/styles/index.less
@@ -70,11 +70,11 @@
 
   // Drawer directions
   &-right {
-    right: 0;
+    inset-inline-end: 0;
   }
 
   &-left {
-    left: 0;
+    inset-inline-start: 0;
   }
 
   &-top {
@@ -90,7 +90,7 @@
   position: fixed;
   z-index: @zindex-drawer;
   top: 0;
-  left: 0;
+  inset-inline-start: 0;
   width: 100%;
   height: 100%;
 
@@ -122,9 +122,9 @@
 .rs-drawer-backdrop {
   position: fixed;
   top: 0;
-  right: 0;
   bottom: 0;
-  left: 0;
+  inset-inline-end: 0;
+  inset-inline-start: 0;
   z-index: @zindex-drawer-background;
   background-color: var(--rs-bg-backdrop);
 
@@ -151,7 +151,7 @@
 
   .rs-drawer-header-close {
     position: absolute;
-    left: 15px;
+    inset-inline-start: 15px;
     top: 23px;
   }
 }
@@ -174,26 +174,26 @@
   .clearfix(); // clear it in case folks use .pull-* classes on buttons
 
   flex-shrink: 0;
-  text-align: right; // right align buttons
+  text-align: end; // right align buttons
   border-top: none;
-  margin-left: auto;
+  margin-inline-start: auto;
 
   .rs-drawer-title ~ & {
-    margin-left: 10px;
+    margin-inline-start: 10px;
   }
 
   // Properly space out buttons
   .rs-btn + .rs-btn {
-    margin-left: 10px;
+    margin-inline-start: 10px;
     margin-bottom: 0; // account for input[type="submit"] which gets the bottom margin like all other inputs
   }
   // but override that for button groups
   .rs-btn-group .rs-btn + .rs-btn {
-    margin-left: -1px;
+    margin-inline-start: -1px;
   }
   // and override it for block buttons as well
   .rs-btn-block + .rs-btn-block {
-    margin-left: 0;
+    margin-inline-start: 0;
   }
 }
 
@@ -210,7 +210,7 @@
 
   &-close {
     position: absolute;
-    left: 15px;
+    inset-inline-start: 15px;
     top: 25px;
 
     .rs-drawer-header ~ .rs-drawer-body & {
@@ -233,21 +233,21 @@
 .rs-drawer-footer {
   .clearfix(); // clear it in case folks use .pull-* classes on buttons
 
-  text-align: right; // right align buttons
+  text-align: end; // right align buttons
   border-top: none;
   margin: 0 @drawer-content-spacing @drawer-content-spacing;
 
   // Properly space out buttons
   .rs-btn + .rs-btn {
-    margin-left: 10px;
+    margin-inline-start: 10px;
     margin-bottom: 0; // account for input[type="submit"] which gets the bottom margin like all other inputs
   }
   // but override that for button groups
   .rs-btn-group .rs-btn + .rs-btn {
-    margin-left: -1px;
+    margin-inline-start: -1px;
   }
   // and override it for block buttons as well
   .rs-btn-block + .rs-btn-block {
-    margin-left: 0;
+    margin-inline-start: 0;
   }
 }

--- a/src/Dropdown/styles/index.less
+++ b/src/Dropdown/styles/index.less
@@ -73,7 +73,7 @@
   }
 
   &.rs-dropdown-toggle-no-caret {
-    padding-right: @padding-x;
+    padding-inline-end: @padding-x;
   }
 }
 
@@ -82,7 +82,7 @@
   margin: 0; // override default ul
   list-style: none;
   font-size: var(--rs-font-size-sm);
-  text-align: left; // Ensures proper alignment if parent has it changed (e.g., modal footer)
+  text-align: start; // Ensures proper alignment if parent has it changed (e.g., modal footer)
   background-color: var(--rs-bg-overlay);
   border-radius: var(--rs-radius-md);
   padding: @dropdown-menu-padding-y 0;
@@ -96,7 +96,7 @@
     position: absolute;
     // dropdown-menu zindex value is greater than dropdown-toggle
     z-index: @zindex-dropdown + 1;
-    float: left;
+    float: inline-start;
     box-shadow: var(--rs-dropdown-shadow);
     outline: none;
 
@@ -219,21 +219,21 @@
 
     .rs-dropdown-item-toggle {
       padding: @dropdown-item-padding-y @dropdown-item-padding-x;
-      padding-right: @dropdown-item-padding-x+ @dropdown-item-submenu-icon-angle-spacing+
+      padding-inline-end: @dropdown-item-padding-x+ @dropdown-item-submenu-icon-angle-spacing+
         @dropdown-item-submenu-icon-angle-width;
     }
 
     .rs-dropdown-menu-toggle-icon {
-      right: @dropdown-caret-icon-padding-horizontal;
+      inset-inline-end: @dropdown-caret-icon-padding-horizontal;
     }
   }
 
   .rs-dropdown-menu {
-    left: 100%;
+    inset-inline-start: 100%;
 
     &[data-direction='start'] {
-      left: unset;
-      right: 100%;
+      inset-inline-start: unset;
+      inset-inline-end: 100%;
     }
   }
 
@@ -274,14 +274,14 @@
   &.rs-dropdown-placement-left-start,
   &.rs-dropdown-placement-left-end {
     > .rs-dropdown-menu {
-      right: 100%;
+      inset-inline-end: 100%;
     }
   }
 
   &.rs-dropdown-placement-right-start,
   &.rs-dropdown-placement-right-end {
     > .rs-dropdown-menu {
-      left: 100%;
+      inset-inline-start: 100%;
     }
   }
 
@@ -295,14 +295,14 @@
   &.rs-dropdown-placement-top-start,
   &.rs-dropdown-placement-bottom-start {
     > .rs-dropdown-menu {
-      left: 0;
+      inset-inline-start: 0;
     }
   }
 
   &.rs-dropdown-placement-top-end,
   &.rs-dropdown-placement-bottom-end {
     > .rs-dropdown-menu {
-      right: 0;
+      inset-inline-end: 0;
     }
   }
 

--- a/src/FormControl/styles/index.less
+++ b/src/FormControl/styles/index.less
@@ -54,7 +54,7 @@
 
 .rs-form-horizontal .rs-form-group {
   .rs-form-control-wrapper {
-    float: left;
+    float: inline-start;
   }
 
   .rs-form-control-wrapper + .rs-form-help-text {
@@ -70,7 +70,7 @@
 
   // Form control wrapper behind Screen only dom no need margin left.
   .rs-sr-only + .rs-form-control-wrapper {
-    margin-left: 0;
+    margin-inline-start: 0;
   }
 }
 

--- a/src/FormErrorMessage/styles/index.less
+++ b/src/FormErrorMessage/styles/index.less
@@ -97,32 +97,32 @@
 
   &-placement-bottom-start,
   &-placement-top-start {
-    left: 0;
+    inset-inline-start: 0;
 
     .rs-form-error-message {
-      left: 0;
+      inset-inline-start: 0;
     }
 
     .rs-form-error-message-arrow {
       &::before,
       &::after {
-        left: @form-error-message-triangle-gap;
+        inset-inline-start: @form-error-message-triangle-gap;
       }
     }
   }
 
   &-placement-bottom-end,
   &-placement-top-end {
-    right: 0;
+    inset-inline-end: 0;
 
     .rs-form-error-message {
-      right: 0;
+      inset-inline-end: 0;
     }
 
     .rs-form-error-message-arrow {
       &::before,
       &::after {
-        right: @form-error-message-triangle-gap;
+        inset-inline-end: @form-error-message-triangle-gap;
       }
     }
   }
@@ -135,10 +135,10 @@
 .rs-form-error-message {
   &-placement-left-start,
   &-placement-left-end {
-    left: 0;
+    inset-inline-start: 0;
 
     .rs-form-error-message {
-      right: 0;
+      inset-inline-end: 0;
 
       &-show {
         animation-name: errorMessageSlideRightIn;
@@ -151,11 +151,11 @@
         border-width: @form-error-message-triangle-width 0 @form-error-message-triangle-width
           @form-error-message-triangle-width;
         border-left-color: var(--rs-form-errormessage-border);
-        right: -1 * @form-error-message-triangle-width;
+        inset-inline-end: -1 * @form-error-message-triangle-width;
       }
 
       &::after {
-        right: -1 * (@form-error-message-triangle-width - 1);
+        inset-inline-end: -1 * (@form-error-message-triangle-width - 1);
         border-left-color: var(--rs-form-errormessage-bg);
       }
     }
@@ -163,10 +163,10 @@
 
   &-placement-right-start,
   &-placement-right-end {
-    right: 0;
+    inset-inline-end: 0;
 
     .rs-form-error-message {
-      left: 0;
+      inset-inline-start: 0;
 
       &-show {
         animation-name: errorMessageSlideLeftIn;
@@ -179,11 +179,11 @@
         border-width: @form-error-message-triangle-width @form-error-message-triangle-width
           @form-error-message-triangle-width 0;
         border-right-color: var(--rs-form-errormessage-border);
-        left: -1 * @form-error-message-triangle-width;
+        inset-inline-start: -1 * @form-error-message-triangle-width;
       }
 
       &::after {
-        left: -1 * (@form-error-message-triangle-width - 1);
+        inset-inline-start: -1 * (@form-error-message-triangle-width - 1);
         border-right-color: var(--rs-form-errormessage-bg);
       }
     }

--- a/src/FormGroup/styles/index.less
+++ b/src/FormGroup/styles/index.less
@@ -44,7 +44,7 @@
       display: inline-block;
       font-size: var(--rs-font-size-sm);
       width: var(--rs-form-control-label-width);
-      text-align: right;
+      text-align: end;
     }
 
     .rs-btn-toolbar {

--- a/src/FormGroup/test/FormGroupStylesSpec.tsx
+++ b/src/FormGroup/test/FormGroupStylesSpec.tsx
@@ -16,6 +16,6 @@ describe('FormGroup styles', () => {
       </Form>
     );
 
-    expect(screen.getByTestId('form-control-wrapper')).to.have.style('float', 'left');
+    expect(screen.getByTestId('form-control-wrapper')).to.have.style('float', 'inline-start');
   });
 });

--- a/src/Grid/styles/grid-framework.less
+++ b/src/Grid/styles/grid-framework.less
@@ -5,21 +5,21 @@
       width: percentage((@value / 24));
     }
     .rs-col-@{size}-pull-@{value} {
-      right: percentage((@value / 24));
+      inset-inline-end: percentage((@value / 24));
     }
     .rs-col-@{size}-push-@{value} {
-      left: percentage((@value / 24));
+      inset-inline-start: percentage((@value / 24));
     }
 
     .rs-col-@{size}-offset-@{value} {
-      margin-left: percentage((@value / 24));
+      margin-inline-start: percentage((@value / 24));
     }
   });
   .rs-col-@{size}-pull-0 {
-    right: auto;
+    inset-inline-end: auto;
   }
   .rs-col-@{size}-push-0 {
-    left: auto;
+    inset-inline-start: auto;
   }
 }
 

--- a/src/Grid/styles/mixin.less
+++ b/src/Grid/styles/mixin.less
@@ -4,16 +4,16 @@
 
 // Centered container element
 .container-fixed(@gutter: @grid-gutter-width) {
-  margin-right: auto;
-  margin-left: auto;
-  padding-left: floor((@gutter / 2));
-  padding-right: ceil((@gutter / 2));
+  margin-inline-end: auto;
+  margin-inline-start: auto;
+  padding-inline-start: floor((@gutter / 2));
+  padding-inline-end: ceil((@gutter / 2));
   .clearfix();
 }
 
 // Creates a wrapper for a series of columns
 .make-row(@gutter: @grid-gutter-width) {
-  margin-left: ceil((@gutter / -2));
-  margin-right: floor((@gutter / -2));
+  margin-inline-start: ceil((@gutter / -2));
+  margin-inline-end: floor((@gutter / -2));
   .clearfix();
 }

--- a/src/InputGroup/styles/index.less
+++ b/src/InputGroup/styles/index.less
@@ -159,13 +159,13 @@
     // If the input has an element on the left, remove the left padding
     .rs-input:not(:first-child),
     .rs-auto-complete:not(:first-child) .rs-input {
-      padding-left: 0;
+      padding-inline-start: 0;
     }
 
     // If the input has an element on the right, remove the right padding
     .rs-input:not(:last-child),
     .rs-auto-complete:not(:last-child) .rs-input {
-      padding-right: 0;
+      padding-inline-end: 0;
     }
   }
 }

--- a/src/InputPicker/InputPicker.tsx
+++ b/src/InputPicker/InputPicker.tsx
@@ -571,10 +571,9 @@ const InputPicker = forwardRef<'div', InputPickerProps>((props, ref) => {
   };
 
   const renderPopup = (positionProps: PositionChildProps, speakerRef) => {
-    const { left, top, className } = positionProps;
+    const { className } = positionProps;
     const menuClassPrefix = multi ? 'picker-check-menu' : 'picker-select-menu';
     const classes = merge(className, menuClassName, prefix(multi ? 'check-menu' : 'select-menu'));
-    const styles = { ...menuStyle, left, top };
 
     let items: ItemDataType[] = filterNodesOfTree(data, checkShouldDisplay);
 
@@ -629,7 +628,7 @@ const InputPicker = forwardRef<'div', InputPickerProps>((props, ref) => {
         ref={mergeRefs(overlay, speakerRef)}
         autoWidth={menuAutoWidth}
         className={classes}
-        style={styles}
+        style={menuStyle}
         target={triggerRef}
         onKeyDown={onPickerKeyDown}
       >

--- a/src/Kbd/styles/mixin.less
+++ b/src/Kbd/styles/mixin.less
@@ -9,8 +9,8 @@
   user-select: none;
   border-radius: var(--rs-radius-sm);
   line-height: 1.7em;
-  padding-left: 0.5em;
-  padding-right: 0.5em;
+  padding-inline-start: 0.5em;
+  padding-inline-end: 0.5em;
   padding-bottom: 0.05em;
   height: fit-content;
   box-sizing: border-box;

--- a/src/List/styles/index.less
+++ b/src/List/styles/index.less
@@ -34,8 +34,8 @@
   position: relative;
 
   &-bordered {
-    padding-left: 20px;
-    padding-right: 20px;
+    padding-inline-start: 20px;
+    padding-inline-end: 20px;
   }
 
   &-lg {
@@ -71,7 +71,7 @@
     width: calc(100% - 2px);
     border-radius: var(--rs-radius-md);
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     z-index: @zindex-list-helper;
     border: none;
     cursor: move;
@@ -96,7 +96,7 @@
       position: absolute;
       visibility: visible;
       top: @list-border-width;
-      left: @list-border-width;
+      inset-inline-start: @list-border-width;
       width: calc(100% - 2 * @list-border-width);
       height: calc(100% - 2 * @list-border-width);
       border: @list-border-width var(--rs-list-placeholder-border) dashed;

--- a/src/Loader/styles/index.less
+++ b/src/Loader/styles/index.less
@@ -24,7 +24,7 @@
   &-backdrop {
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     width: 100%;
     height: 100%;
     background: var(--rs-loader-backdrop);
@@ -77,9 +77,9 @@
   &-center {
     position: absolute;
     top: 0;
-    left: 0;
-    right: 0;
     bottom: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
     margin: auto;
     width: 100%;
     height: 100%;

--- a/src/Loader/styles/mixin.less
+++ b/src/Loader/styles/mixin.less
@@ -14,8 +14,8 @@
   &::after {
     content: '';
     position: absolute;
-    left: 0;
-    right: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
     display: block;
     border-radius: var(--rs-radius-full);
   }

--- a/src/Message/styles/index.less
+++ b/src/Message/styles/index.less
@@ -97,7 +97,7 @@
   &-icon {
     align-self: center;
     font-size: 0; // remove whitespace before svg
-    margin-right: 10px;
+    margin-inline-end: 10px;
 
     // Icon
     .rs-icon {
@@ -169,8 +169,8 @@
 .rs-message-full {
   position: absolute;
   top: 0;
-  left: 0;
+  inset-inline-start: 0;
   width: 100%;
-   border-radius: var(--rs-radius-none);
+  border-radius: var(--rs-radius-none);
   z-index: @zindex-message-full;
 }

--- a/src/Modal/styles/index.less
+++ b/src/Modal/styles/index.less
@@ -47,7 +47,7 @@
       position: absolute;
       height: 100%;
       width: 100%;
-       border-radius: var(--rs-radius-none);
+      border-radius: var(--rs-radius-none);
       display: flex;
       flex-direction: column;
 
@@ -84,7 +84,7 @@
   .rs-modal-header {
     .clearfix();
 
-    padding-right: @line-height-computed;
+    padding-inline-end: @line-height-computed;
 
     .rs-modal-header-close {
       position: absolute;
@@ -127,7 +127,7 @@
 .rs-modal-backdrop {
   position: fixed;
   top: 0;
-  left: 0;
+  inset-inline-start: 0;
   width: 100vw;
   height: 100vh;
   z-index: @zindex-modal - 1;
@@ -154,7 +154,7 @@
   overflow: auto;
   z-index: @zindex-modal;
   top: 0;
-  left: 0;
+  inset-inline-start: 0;
   width: 100%;
   height: 100%;
 }

--- a/src/MultiCascadeTree/styles/index.less
+++ b/src/MultiCascadeTree/styles/index.less
@@ -29,13 +29,13 @@
 
   &-column&-column-uncheckable {
     .rs-check-item .rs-checkbox-checker > label {
-      padding-left: @picker-item-content-padding-horizontal;
+      padding-inline-start: @picker-item-content-padding-horizontal;
     }
   }
 }
 .rs-cascade-tree-multi {
   .rs-cascade-search-view-row {
-    padding-left: 0;
+    padding-inline-start: 0;
     padding-top: 0;
     padding-bottom: 0;
   }

--- a/src/MultiCascader/MultiCascader.tsx
+++ b/src/MultiCascader/MultiCascader.tsx
@@ -331,8 +331,8 @@ const MultiCascader = forwardRef<'div', MultiCascaderProps>(
     };
 
     const renderTreeView = (positionProps?: PositionChildProps, speakerRef?) => {
-      const { left, top, className } = positionProps || {};
-      const styles = { ...DEPRECATED_menuStyle, ...popupStyle, left, top };
+      const { className } = positionProps || {};
+      const styles = { ...DEPRECATED_menuStyle, ...popupStyle };
 
       const classes = merge(
         className,

--- a/src/MultiCascader/styles/index.less
+++ b/src/MultiCascader/styles/index.less
@@ -4,7 +4,7 @@
 
 .rs-picker-popup-multi-cascader {
   .rs-cascade-search-view-row {
-    padding-left: 0;
+    padding-inline-start: 0;
     padding-top: 0;
     padding-bottom: 0;
   }

--- a/src/Nav/styles/index.less
+++ b/src/Nav/styles/index.less
@@ -89,13 +89,13 @@
   }
 
   &-icon {
-    margin-right: 6px;
+    margin-inline-end: 6px;
   }
 
   &-caret {
     font-size: var(--rs-nav-caret-font-size);
     vertical-align: text-bottom;
-    margin-left: 6px;
+    margin-inline-start: 6px;
   }
 }
 
@@ -135,7 +135,7 @@
 
     > .rs-dropdown-toggle {
       width: 100%;
-      text-align: left;
+      text-align: start;
       z-index: 0;
     }
   }
@@ -146,10 +146,10 @@
     position: absolute;
     top: 0;
     bottom: 0;
-    right: 0;
+    inset-inline-end: 0;
 
     .rs-nav-reversed& {
-      right: auto;
+      inset-inline-end: auto;
     }
   }
 }
@@ -280,8 +280,8 @@
     // Active item
     .rs-nav-item.rs-nav-item-active::before {
       bottom: 0;
-      left: 0;
-      right: 0;
+      inset-inline-start: 0;
+      inset-inline-end: 0;
       height: 2px;
       // Reversed
       .rs-nav-reversed& {
@@ -301,14 +301,14 @@
 
     // Active item
     .rs-nav-item.rs-nav-item-active::before {
-      right: 0;
+      inset-inline-end: 0;
       top: 0;
       bottom: 0;
       width: 2px;
       // Reversed
       .rs-nav-reversed& {
-        right: auto;
-        left: 0;
+        inset-inline-end: auto;
+        inset-inline-start: 0;
       }
     }
   }
@@ -360,6 +360,6 @@
 
   > .rs-dropdown .rs-dropdown-toggle {
     width: 100%;
-    text-align: left;
+    text-align: start;
   }
 }

--- a/src/Navbar/styles/index.less
+++ b/src/Navbar/styles/index.less
@@ -65,7 +65,7 @@
 .rs-navbar-item {
   // Reset padding
   padding: @navbar-item-padding-y @navbar-item-padding-x;
- border-radius: var(--rs-radius-md);
+  border-radius: var(--rs-radius-md);
   color: inherit;
   background-color: transparent;
   position: relative;
@@ -75,12 +75,12 @@
 
   &-icon {
     font-size: var(--rs-navbar-icon-font-size);
-    margin-right: 5px;
+    margin-inline-end: 5px;
   }
 
   &-caret {
     font-size: var(--rs-navbar-caret-font-size);
-    margin-left: 6px;
+    margin-inline-start: 6px;
   }
 }
 
@@ -128,7 +128,7 @@
     &:extend(.rs-navbar-item:focus-visible);
   }
 
-  padding-right: @navbar-item-padding-x+ @dropdown-caret-width+ @dropdown-caret-padding;
+  padding-inline-end: @navbar-item-padding-x+ @dropdown-caret-width+ @dropdown-caret-padding;
 
   .high-contrast-mode({
     border: none;
@@ -140,7 +140,7 @@
 
   .rs-dropdown-toggle-caret {
     top: @navbar-item-padding-y;
-    right: @navbar-item-padding-x;
+    inset-inline-end: @navbar-item-padding-x;
   }
 }
 

--- a/src/Pagination/styles/index.less
+++ b/src/Pagination/styles/index.less
@@ -10,7 +10,7 @@
 // --------------------------------------------------
 .rs-pagination {
   display: inline-block;
-  padding-left: 0;
+  padding-inline-start: 0;
   margin-bottom: 0;
   // Pagination Sizes
   // --------------------------------------------------
@@ -67,7 +67,7 @@
 
   margin: 0 2px;
   position: relative;
-  float: left; // Collapse white-space
+  float: inline-start; // Collapse white-space
   text-decoration: none;
   cursor: pointer;
   user-select: none;

--- a/src/Panel/styles/index.less
+++ b/src/Panel/styles/index.less
@@ -91,7 +91,7 @@
   &-title {
     margin: 0;
     flex: 1 1 0%;
-    text-align: left;
+    text-align: start;
     a {
       color: inherit;
 

--- a/src/PanelGroup/styles/index.less
+++ b/src/PanelGroup/styles/index.less
@@ -6,7 +6,7 @@
 
 .rs-panel-group {
   // The first panel and the last panel in a panel group need set border-radius.
- border-radius: var(--rs-radius-md);
+  border-radius: var(--rs-radius-md);
   overflow: hidden;
 
   &-bordered {
@@ -26,8 +26,8 @@
         position: absolute;
         top: 0;
         border-top: 1px solid var(--rs-border-primary);
-        left: 20px;
-        right: 20px;
+        inset-inline-start: 20px;
+        inset-inline-end: 20px;
       }
     }
   }

--- a/src/Placeholder/styles/index.less
+++ b/src/Placeholder/styles/index.less
@@ -44,7 +44,7 @@
           content: '';
           width: 0;
           height: 0;
-          left: 10px;
+          inset-inline-start: 10px;
           bottom: 10px;
           position: absolute;
           border-bottom: 36px solid var(--rs-placeholder-img-color);
@@ -56,7 +56,7 @@
           content: '';
           width: 0;
           height: 0;
-          left: 40px;
+          inset-inline-start: 40px;
           bottom: 10px;
           position: absolute;
           border-bottom: 22px solid var(--rs-placeholder-img-color);
@@ -68,7 +68,7 @@
       &-image &-inner {
         width: 12px;
         height: 12px;
-        right: 18px;
+        inset-inline-end: 18px;
         top: 10px;
         border-radius: var(--rs-radius-full);
         background: var(--rs-placeholder-img-color);

--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Heading from '../Heading';
-import { forwardRef } from '@/internals/utils';
+import { forwardRef, mergeStyles } from '@/internals/utils';
 import { useClassNames } from '@/internals/hooks';
 import { useCustom } from '../CustomProvider';
 import type { WithAsProps } from '@/internals/types';
@@ -41,11 +41,10 @@ const Popover = forwardRef<'div', PopoverProps>((props, ref) => {
   const { withClassPrefix, merge, prefix } = useClassNames(classPrefix);
   const classes = merge(className, withClassPrefix({ full }));
 
-  const styles = {
-    display: 'block',
-    opacity: visible ? 1 : undefined,
-    ...style
-  };
+  const styles = useMemo(
+    () => mergeStyles(style, { ['--rs-opacity']: visible ? 1 : undefined }),
+    [visible, style]
+  );
 
   return (
     <Component role="dialog" {...rest} ref={ref} className={classes} style={styles}>

--- a/src/Popover/styles/index.less
+++ b/src/Popover/styles/index.less
@@ -11,18 +11,22 @@
   --rs-popover-title-font-size: var(--rs-font-size-sm);
   --rs-popover-title-line-height: var(--rs-text-line-height-sm);
   --rs-popover-border-radius: var(--rs-radius-sm);
+  --rs-popover-position-x: var(--rs-position-x);
+  --rs-popover-position-y: var(--rs-position-y);
+  --rs-popover-opacity: var(--rs-opacity, 0);
 
   position: absolute;
-  top: 0;
-  left: 0 /* rtl:ignore */;
+  top: var(--rs-popover-position-y);
+  left: var(--rs-popover-position-x) /* rtl:ignore */;
   z-index: @zindex-popover;
-  display: none;
+  display: block;
   padding: 12px;
   font-size: var(--rs-popover-font-size);
   background-color: var(--rs-bg-overlay);
   background-clip: padding-box;
   border-radius: var(--rs-popover-border-radius);
-  opacity: 0;
+  opacity: var(--rs-popover-opacity);
+
   .drop-shadow(var(--rs-popover-shadow));
 
   &.rs-anim-fade {

--- a/src/Progress/styles/index.less
+++ b/src/Progress/styles/index.less
@@ -68,9 +68,9 @@
       opacity: 0;
       position: absolute;
       top: 0;
-      left: 0;
-      right: 0;
       bottom: 0;
+      inset-inline-start: 0;
+      inset-inline-end: 0;
       background-color: #fff;
       border-radius: var(--rs-radius-lg);
       animation: progress-active 2s cubic-bezier(0.23, 1, 0.32, 1) infinite;
@@ -148,7 +148,7 @@
 
   &&-vertical .rs-progress-info {
     flex-basis: auto;
-    padding-left: 0;
+    padding-inline-start: 0;
     width: auto;
   }
 

--- a/src/Radio/styles/index.less
+++ b/src/Radio/styles/index.less
@@ -43,7 +43,7 @@
   .rs-radio-inner::after {
     content: '';
     position: absolute;
-    left: 0;
+    inset-inline-start: 0;
     top: 0;
     display: block;
   }

--- a/src/SelectPicker/SelectPicker.tsx
+++ b/src/SelectPicker/SelectPicker.tsx
@@ -295,9 +295,8 @@ const SelectPicker = forwardRef<'div', SelectPickerProps>(
     }
 
     const renderPopup = (positionProps: PositionChildProps, speakerRef) => {
-      const { left, top, className } = positionProps;
+      const { className } = positionProps;
       const classes = merge(className, menuClassName, prefix('select-menu'));
-      const styles = { ...menuStyle, left, top };
       let items = filteredData;
 
       // Create a tree structure data when set `groupBy`
@@ -338,7 +337,7 @@ const SelectPicker = forwardRef<'div', SelectPickerProps>(
           ref={mergeRefs(overlay, speakerRef)}
           autoWidth={menuAutoWidth}
           className={classes}
-          style={styles}
+          style={menuStyle}
           onKeyDown={onPickerKeyDown}
           target={trigger}
         >

--- a/src/SelectPicker/styles/index.less
+++ b/src/SelectPicker/styles/index.less
@@ -13,7 +13,7 @@
   .picker-menu-group-closed(picker);
 
   .rs-picker-menu-group ~ [role='option'] > .rs-picker-select-menu-item {
-    padding-left: 26px;
+    padding-inline-start: 26px;
   }
 }
 
@@ -42,6 +42,6 @@
 
   .grouped &,
   .rs-picker-select-menu-group-children & {
-    padding-left: @picker-group-children-padding-left;
+    padding-inline-start: @picker-group-children-padding-left;
   }
 }

--- a/src/Sidenav/styles/index.less
+++ b/src/Sidenav/styles/index.less
@@ -78,12 +78,12 @@
       width: 100%;
       text-align: start;
       background: none;
-      padding-right: (@sidenav-padding-horizontal + @sidenav-dropdown-toggle-caret-width);
+      padding-inline-end: (@sidenav-padding-horizontal + @sidenav-dropdown-toggle-caret-width);
       position: relative;
       border-width: 0;
 
       .rs-sidenav-collapse-in & {
-        padding-left: @sidenav-level2-retract;
+        padding-inline-start: @sidenav-level2-retract;
       }
 
       &:focus {
@@ -155,7 +155,7 @@
 
     .rs-sidenav-dropdown-toggle-caret {
       font-size: var(--rs-font-size-sm);
-      margin-left: auto;
+      margin-inline-start: auto;
 
       // Make Caret AngleRight direction at down.
       &[aria-label='angle-right'] {
@@ -441,7 +441,7 @@
   // Make sure icon text-align center
   &.rs-sidenav-collapse-out {
     .rs-dropdown .rs-dropdown-menu {
-      padding-left: @sidenav-default-width - @sidenav-level2-retract;
+      padding-inline-start: @sidenav-default-width - @sidenav-level2-retract;
     }
 
     .rs-dropdown-item {

--- a/src/Sidenav/styles/mixin.less
+++ b/src/Sidenav/styles/mixin.less
@@ -13,11 +13,11 @@
 .dropdown-menu-icon-left-position(@left) {
   &.rs-dropdown-item-with-icon > .rs-dropdown-item-content {
     > .rs-dropdown-item-menu-icon {
-      left: @left;
+      inset-inline-start: @left;
     }
 
     > .rs-dropdown-menu-toggle {
-      padding-left: (@left + 20px);
+      padding-inline-start: (@left + 20px);
     }
   }
 }

--- a/src/Slider/styles/index.less
+++ b/src/Slider/styles/index.less
@@ -12,8 +12,8 @@
 
     &.rs-tooltip-placement-top .rs-tooltip::after {
       margin: auto;
-      left: 0;
-      right: 0;
+      inset-inline-start: 0;
+      inset-inline-end: 0;
     }
   }
 
@@ -65,7 +65,7 @@
     border-radius: var(--rs-radius-full);
     border: @slider-handle-border-width solid var(--rs-slider-thumb-border);
     background-color: var(--rs-slider-thumb-bg);
-    margin-left: -(@slider-handle-diameter / 2);
+    margin-inline-start: -(@slider-handle-diameter / 2);
     cursor: pointer;
     /* stylelint-disable */ //Formatted by prettier
     transition: box-shadow @slider-handle-transition, background-color @slider-handle-transition,
@@ -89,7 +89,7 @@
     top: unset;
 
     &::before {
-      left: ((@slider-handle-diameter - @slider-bar-side-length)/2);
+      inset-inline-start: ((@slider-handle-diameter - @slider-bar-side-length)/2);
       margin-top: (-@slider-handle-diameter / 2);
     }
   }
@@ -104,7 +104,7 @@
   .rs-slider-vertical & {
     top: -33px;
     // Make sure tooltip align center.
-    margin-left: 3px;
+    margin-inline-start: 3px;
   }
 }
 
@@ -112,20 +112,20 @@
 .rs-slider-mark {
   position: absolute;
   top: (@slider-bar-side-length + @slider-mark-margin-top);
-  left: -2px;
+  inset-inline-start: -2px;
   white-space: nowrap;
 
   &-content {
-    margin-left: -50%;
+    margin-inline-start: -50%;
   }
 }
 
 .rs-slider-mark-last {
-  left: auto;
-  right: -2px;
+  inset-inline-start: auto;
+  inset-inline-end: -2px;
 
   .rs-slider-mark-content {
-    margin-left: 50%;
+    margin-inline-start: 50%;
   }
 }
 
@@ -140,7 +140,7 @@
 
   > ol {
     display: flex;
-    padding-left: 0;
+    padding-inline-start: 0;
     width: 100%;
 
     > li {
@@ -158,23 +158,23 @@
         background-color: var(--rs-slider-thumb-bg);
         box-sizing: border-box;
         border: @slider-calibration-border-width solid var(--rs-slider-bar);
-        margin-left: -4px;
+        margin-inline-start: -4px;
         top: -1px;
 
         // Vertical styles
         .rs-slider-vertical & {
           top: unset;
           bottom: -4px;
-          margin-left: -1px;
+          margin-inline-start: -1px;
         }
       }
 
       &:last-child::after {
-        right: -4px;
+        inset-inline-end: -4px;
 
         // Vertical styles
         .rs-slider-vertical & {
-          left: 0;
+          inset-inline-start: 0;
           bottom: unset;
           top: -4px;
         }
@@ -233,10 +233,10 @@
   .rs-slider-mark {
     top: unset;
     bottom: -8px;
-    left: (@slider-bar-side-length + @slider-mark-margin-top);
+    inset-inline-start: (@slider-bar-side-length + @slider-mark-margin-top);
 
     &-content {
-      margin-left: auto;
+      margin-inline-start: auto;
     }
   }
 

--- a/src/Steps/styles/index.less
+++ b/src/Steps/styles/index.less
@@ -88,7 +88,7 @@
   text-align: center;
   position: absolute;
   top: 0;
-  left: 0;
+  inset-inline-start: 0;
   display: flex;
   align-items: center;
   border: 1px solid var(--rs-steps-border);
@@ -177,10 +177,10 @@
 
     // There is a 10px spacing between each item.
     &:not(:first-child) {
-      padding-left: calc(var(--rs-steps-icon-size) + var(--rs-spacing) * 5);
+      padding-inline-start: calc(var(--rs-steps-icon-size) + var(--rs-spacing) * 5);
 
       .rs-steps-item-icon-wrapper {
-        left: calc(var(--rs-spacing) * 2.5);
+        inset-inline-start: calc(var(--rs-spacing) * 2.5);
       }
     }
   }
@@ -189,7 +189,7 @@
     &::after {
       content: '';
       top: calc(var(--rs-steps-icon-size) / 2);
-      left: 100%;
+      inset-inline-start: 100%;
       width: 9999px;
       border-top-width: 1px;
       border-top-style: solid;
@@ -215,7 +215,7 @@
   .rs-steps-item-tail {
     top: var(--rs-steps-item-spacing);
     bottom: 0;
-    left: calc(var(--rs-steps-icon-size) / 2);
+    inset-inline-start: calc(var(--rs-steps-icon-size) / 2);
     border-left-width: 1px;
     border-left-style: solid;
   }

--- a/src/Table/styles/index.less
+++ b/src/Table/styles/index.less
@@ -139,7 +139,7 @@
 
       display: inline-block;
       position: relative;
-      margin-right: @loader-content-spin-spacing-horizontal;
+      margin-inline-end: @loader-content-spin-spacing-horizontal;
       // Make sure loader vertical-align center
       padding-top: 3px;
     }
@@ -192,7 +192,7 @@
     &-header {
       &-sort-wrapper {
         cursor: pointer;
-        margin-left: @table-header-sort-wrapper-margin-left;
+        margin-inline-start: @table-header-sort-wrapper-margin-left;
         display: inline-block;
       }
 
@@ -245,14 +245,14 @@
       border-style: dashed solid dashed dashed;
       border-color: transparent var(--rs-table-resize) transparent transparent;
       border-width: @table-column-resize-spanner-triangle-side-length;
-      right: 4px;
+      inset-inline-end: 4px;
     }
 
     &::after {
       border-style: dashed dashed dashed solid;
       border-color: transparent transparent transparent var(--rs-table-resize);
       border-width: @table-column-resize-spanner-triangle-side-length;
-      left: 4px;
+      inset-inline-start: 4px;
     }
   }
 
@@ -288,7 +288,7 @@
   &-mouse-area {
     display: none;
     background-color: var(--rs-table-resize);
-    left: -1px;
+    inset-inline-start: -1px;
     top: 0;
     position: absolute;
     width: 1px;
@@ -299,7 +299,7 @@
 
       background-color: var(--rs-table-resize);
       position: absolute;
-      left: (-1 * (@table-column-resize-spanner-width / 2));
+      inset-inline-start: (-1 * (@table-column-resize-spanner-width / 2));
     }
   }
 
@@ -317,8 +317,8 @@
 
   &-column-group {
     position: absolute;
-    left: 0;
-    right: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
     top: 0;
     width: 100%;
 
@@ -347,7 +347,7 @@
 // Tree Table
 
 .rs-table-cell-expand-wrapper {
-  margin-right: 10px;
+  margin-inline-end: 10px;
   display: inline-block;
   cursor: pointer;
 }
@@ -411,7 +411,7 @@
 
   &-vertical {
     top: 0;
-    right: 0;
+    inset-inline-end: 0;
     width: @table-scrollbar-width;
     // Reserve scroll bar position.
     bottom: @table-scrollbar-width;
@@ -422,7 +422,7 @@
     min-height: 20px;
     width: @table-scrollbar-handle-width;
     top: 0;
-    left: @table-scrollbar-handle-gap;
+    inset-inline-start: @table-scrollbar-handle-gap;
   }
 
   &-pressed&-vertical:hover,

--- a/src/TagPicker/styles/index.less
+++ b/src/TagPicker/styles/index.less
@@ -13,7 +13,7 @@
 
   .rs-picker-toggle {
     // Make sure align with input
-    left: 0;
+    inset-inline-start: 0;
     cursor: text;
     box-shadow: none;
     padding-block: var(--rs-tag-picker-padding-block);

--- a/src/Text/styles/index.less
+++ b/src/Text/styles/index.less
@@ -11,7 +11,7 @@
 
   blockquote& {
     font-style: italic;
-    padding-left: 1.5rem;
+    padding-inline-start: 1.5rem;
     border-left: 2px solid var(--rs-gray-200);
   }
 
@@ -25,7 +25,7 @@
 
   // Text Align: left | center | right | justify
   &-left {
-    text-align: left;
+    text-align: start;
   }
 
   &-center {
@@ -33,7 +33,7 @@
   }
 
   &-right {
-    text-align: right;
+    text-align: end;
   }
 
   &-justify {

--- a/src/Timeline/stories/styles.less
+++ b/src/Timeline/stories/styles.less
@@ -1,26 +1,26 @@
 .custom-timeline {
-  margin-left: 20px;
+  margin-inline-start: 20px;
 
   .rs-timeline-item-custom-dot {
     .rs-icon {
       position: absolute;
       background: #fff;
       top: 0;
-      left: -2px;
+      inset-inline-start: -2px;
       border: 2px solid #ddd;
       width: 40px;
       height: 40px;
       border-radius: var(--rs-radius-full);
       font-size: var(--rs-font-size-lg);
       color: #999;
-      margin-left: -13px;
+      margin-inline-start: -13px;
       justify-content: center;
       padding: 8px;
     }
   }
 
   .rs-timeline-item-content {
-    margin-left: 24px;
+    margin-inline-start: 24px;
   }
 }
 

--- a/src/Timeline/styles/index.less
+++ b/src/Timeline/styles/index.less
@@ -13,7 +13,7 @@
 
   &-item {
     position: relative;
-    text-align: left;
+    text-align: start;
   }
 
   &-item:not(:last-child) &-item-content {
@@ -78,27 +78,27 @@
   .time-line-align(left);
 
   &-align-left &-item {
-    padding-left: @time-line-item-padding-left;
+    padding-inline-start: @time-line-item-padding-left;
   }
 
   // Align right
   .time-line-align(right);
 
   &-align-right &-item-content {
-    text-align: right;
+    text-align: end;
   }
 
   // Align alternate
   &-align-alternate &-item-dot {
     @dot-offset: (@time-line-dot-side-length / 2);
 
-    left: ~'calc(50% - @{dot-offset})';
+    inset-inline-start: ~'calc(50% - @{dot-offset})';
   }
 
   &-align-alternate &-item-tail {
     @tail-offset: (@time-line-tail-width / 2);
 
-    left: ~'calc(50% - @{tail-offset})';
+    inset-inline-start: ~'calc(50% - @{tail-offset})';
   }
 
   &-align-alternate &-item-content {
@@ -106,34 +106,34 @@
   }
 
   &-align-alternate &-item:nth-child(even) &-item-content {
-    text-align: right;
+    text-align: end;
   }
 
   &-align-alternate &-item:nth-child(odd) {
-    text-align: right;
+    text-align: end;
   }
 
   &-align-alternate &-item:nth-child(odd) &-item-content {
     display: inline-block;
-    text-align: left;
+    text-align: start;
   }
 
   // With time
   &-with-time &-item {
     display: flex;
-    padding-left: 0;
+    padding-inline-start: 0;
   }
 
   &-with-time &-item-dot {
     @dot-offset: (@time-line-dot-side-length / 2);
 
-    left: ~'calc(50% - @{dot-offset})';
+    inset-inline-start: ~'calc(50% - @{dot-offset})';
   }
 
   &-with-time &-item-tail {
     @tail-offset: (@time-line-tail-width / 2);
 
-    left: ~'calc(50% - @{tail-offset})';
+    inset-inline-start: ~'calc(50% - @{tail-offset})';
   }
 
   &-with-time &-item-time,
@@ -147,28 +147,28 @@
   }
 
   &-with-time&-align-right &-item {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
 
   &-with-time&-align-left &-item-time {
-    text-align: right;
+    text-align: end;
   }
 
   &-with-time&-align-right &-item-time {
-    text-align: left;
+    text-align: start;
   }
 
   &-with-time&-align-left &-item-time,
   &-with-time&-align-right &-item-content,
   &-align-alternate &-item:nth-child(2n + 1) &-item-time,
   &-align-alternate &-item:nth-child(2n) &-item-content {
-    padding-right: @time-line-alternate-time-offset;
+    padding-inline-end: @time-line-alternate-time-offset;
   }
 
   &-with-time&-align-left &-item-content,
   &-with-time&-align-right &-item-time,
   &-align-alternate &-item:nth-child(2n + 1) &-item-content,
   &-align-alternate &-item:nth-child(2n) &-item-time {
-    padding-left: @time-line-alternate-time-offset;
+    padding-inline-start: @time-line-alternate-time-offset;
   }
 }

--- a/src/Toggle/styles/index.less
+++ b/src/Toggle/styles/index.less
@@ -32,7 +32,7 @@
   &-label {
     cursor: pointer;
     font-size: inherit;
-    margin-left: 10px;
+    margin-inline-start: 10px;
   }
 
   &-inner {
@@ -41,8 +41,8 @@
     transition: margin var(--rs-toggle-transition);
     font-size: var(--rs-toggle-inner-font-size);
     line-height: var(--rs-toggle-line-height);
-    margin-left: var(--rs-toggle-size);
-    margin-right: var(--rs-toggle-inner-margin);
+    margin-inline-start: var(--rs-toggle-size);
+    margin-inline-end: var(--rs-toggle-inner-margin);
     height: var(--rs-toggle-size);
 
     .rs-icon {
@@ -77,7 +77,7 @@
     &::after {
       width: var(--rs-toggle-handle-size);
       height: var(--rs-toggle-handle-size);
-      left: var(--rs-toggle-handle-gap);
+      inset-inline-start: var(--rs-toggle-handle-gap);
       top: var(--rs-toggle-handle-gap);
       border-radius: var(--rs-radius-full);
     }
@@ -132,17 +132,17 @@
       box-shadow: none;
 
       &::after {
-        left: 100%;
-        margin-left: var(--rs-toggle-checked-margin-left);
+        inset-inline-start: 100%;
+        margin-inline-start: var(--rs-toggle-checked-margin-left);
       }
 
       &:active::after {
-        margin-left: var(--rs-toggle-active-checked-margin-left);
+        margin-inline-start: var(--rs-toggle-active-checked-margin-left);
       }
 
       .rs-toggle-inner {
-        margin-right: var(--rs-toggle-size);
-        margin-left: var(--rs-toggle-inner-margin);
+        margin-inline-end: var(--rs-toggle-size);
+        margin-inline-start: var(--rs-toggle-inner-margin);
       }
 
       &:hover {
@@ -170,7 +170,7 @@
       width var(--rs-toggle-transition);
     width: var(--rs-toggle-handle-size);
     height: var(--rs-toggle-handle-size);
-    left: var(--rs-toggle-handle-gap);
+    inset-inline-start: var(--rs-toggle-handle-gap);
     top: var(--rs-toggle-handle-gap);
 
     .rs-loader-spin,
@@ -188,8 +188,8 @@
     }
 
     .rs-toggle-checked & {
-      left: 100%;
-      margin-left: var(--rs-toggle-checked-margin-left);
+      inset-inline-start: 100%;
+      margin-inline-start: var(--rs-toggle-checked-margin-left);
     }
 
     .rs-loader-spin {

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { forwardRef } from '@/internals/utils';
+import React, { useMemo } from 'react';
+import { forwardRef, mergeStyles } from '@/internals/utils';
 import { useClassNames } from '@/internals/hooks';
 import { useCustom } from '../CustomProvider';
 import type { Placement, WithAsProps } from '@/internals/types';
@@ -43,10 +43,11 @@ const Tooltip = forwardRef<'div', TooltipProps>((props: TooltipProps, ref) => {
       arrow
     })
   );
-  const styles = {
-    opacity: visible ? 1 : undefined,
-    ...style
-  };
+
+  const styles = useMemo(
+    () => mergeStyles(style, { ['--rs-opacity']: visible ? 1 : undefined }),
+    [visible, style]
+  );
 
   return (
     <Component role="tooltip" {...rest} ref={ref} className={classes} style={styles}>

--- a/src/Tooltip/styles/index.less
+++ b/src/Tooltip/styles/index.less
@@ -13,12 +13,17 @@
   --rs-tooltip-z-index: @zindex-tooltip;
   --rs-tooltip-max-width: @tooltip-max-width;
   --rs-tooltip-line-height: var(--rs-text-line-height-xs);
+  --rs-tooltip-position-x: var(--rs-position-x);
+  --rs-tooltip-position-y: var(--rs-position-y);
+  --rs-tooltip-opacity: var(--rs-opacity, 0);
 
   position: absolute;
+  top: var(--rs-tooltip-position-y);
+  left: var(--rs-tooltip-position-x) /* rtl:ignore */;
   z-index: var(--rs-tooltip-z-index);
   display: block;
   font-size: var(--rs-font-size-xs);
-  opacity: 0;
+  opacity: var(--rs-tooltip-opacity);
   line-height: var(--rs-tooltip-line-height);
   max-width: var(--rs-tooltip-max-width);
   padding: var(--rs-tooltip-padding-block) var(--rs-tooltip-padding-inline);

--- a/src/Tree/styles/indent-line.less
+++ b/src/Tree/styles/indent-line.less
@@ -3,6 +3,6 @@
   position: absolute;
   width: 1px;
   top: -10px;
-  left: 12px;
+  inset-inline-start: 12px;
   bottom: -4px;
 }

--- a/src/Tree/styles/index.less
+++ b/src/Tree/styles/index.less
@@ -56,12 +56,12 @@
 }
 
 .rs-tree-group {
-  padding-left: 18px;
+  padding-inline-start: 18px;
 }
 
 .rs-tree-node {
   position: relative;
-  text-align: left;
+  text-align: start;
   margin: 0 0 4px 0;
   display: flex;
   align-items: center;
@@ -92,7 +92,7 @@
       position: absolute;
       width: 0;
       height: 0;
-      left: -8px;
+      inset-inline-start: -8px;
       border-left: 6px solid var(--rs-text-link);
       border-top: 3px solid transparent;
       border-bottom: 3px solid transparent;

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -255,9 +255,9 @@ const TreePicker = forwardRef<'div', TreePickerProps>((props, ref) => {
   );
 
   const renderTreeView = (positionProps: PositionChildProps, speakerRef) => {
-    const { left, top, className } = positionProps;
+    const { className } = positionProps;
     const classes = merge(className, DEPRECATED_menuClassName, popupClassName, prefix('tree-menu'));
-    const mergedMenuStyle = { ...DEPRECATED_menuStyle, ...popupStyle, left, top };
+    const mergedMenuStyle = { ...DEPRECATED_menuStyle, ...popupStyle };
 
     return (
       <PickerPopup

--- a/src/Uploader/styles/index.less
+++ b/src/Uploader/styles/index.less
@@ -37,7 +37,7 @@
 
   &-file-item-icon-reupload {
     cursor: pointer;
-    margin-left: 10px;
+    margin-inline-start: 10px;
     color: var(--rs-text-primary);
     font-size: var(--rs-font-size-xs);
   }
@@ -71,7 +71,7 @@
       display: inline-flex;
       align-items: center;
       top: @padding-y;
-      left: @padding-x;
+      inset-inline-start: @padding-x;
       width: @line-height-computed;
       height: @line-height-computed;
       justify-content: center;
@@ -119,7 +119,7 @@
       position: absolute;
       font-size: var(--rs-font-size-sm);
       top: 12px;
-      right: @padding-x;
+      inset-inline-end: @padding-x;
       color: var(--rs-text-secondary);
       cursor: pointer;
       padding: 0;
@@ -138,7 +138,7 @@
       position: absolute;
       bottom: 0;
       width: 100%;
-      left: 0;
+      inset-inline-start: 0;
 
       &-bar {
         height: 2px;
@@ -184,7 +184,7 @@
 
   .rs-uploader-trigger,
   .rs-uploader-file-item {
-    float: left;
+    float: inline-start;
   }
 
   .rs-uploader-file-items {
@@ -199,7 +199,7 @@
     border-radius: var(--rs-radius-md);
     position: relative;
     margin-top: @uploader-picture-item-gap;
-    margin-right: @uploader-picture-item-gap;
+    margin-inline-end: @uploader-picture-item-gap;
 
     &-preview {
       position: relative;
@@ -221,7 +221,7 @@
     &-status {
       position: absolute;
       top: 0;
-      left: 0;
+      inset-inline-start: 0;
       width: @uploader-picture-side-length;
       height: @uploader-picture-side-length;
       text-align: center;
@@ -252,7 +252,7 @@
       cursor: pointer;
       position: absolute;
       top: 3px;
-      right: 3px;
+      inset-inline-end: 3px;
       width: @uploader-picture-remove-button-radius;
       height: @uploader-picture-remove-button-radius;
       line-height: @uploader-picture-remove-button-radius;
@@ -287,7 +287,7 @@
       background-color: var(--rs-uploader-overlay-bg);
       position: absolute;
       top: 0;
-      left: 0;
+      inset-inline-start: 0;
       z-index: @zindex-uploader-picture-loading-wrapper;
       text-align: center;
 
@@ -307,7 +307,7 @@
 
   // Reset margin-left.
   .rs-uploader-file-item-icon-reupload {
-    margin-left: 0;
+    margin-inline-start: 0;
     display: block;
   }
 }
@@ -316,9 +316,9 @@
   .rs-uploader-file-item {
     position: relative;
     height: @uploader-picture-text-preview-side-length;
-    padding-left: @uploader-picture-text-preview-side-length;
+    padding-inline-start: @uploader-picture-text-preview-side-length;
     margin-top: @uploader-picture-item-gap;
-    padding-right: 30px;
+    padding-inline-end: 30px;
     border: 1px solid var(--rs-border-primary);
     border-radius: var(--rs-radius-md);
     overflow: hidden;
@@ -334,7 +334,7 @@
 
     &-preview {
       position: absolute;
-      left: 0;
+      inset-inline-start: 0;
       top: 0;
       width: @uploader-picture-text-preview-side-length;
       height: @uploader-picture-text-preview-side-length;
@@ -377,7 +377,7 @@
     &-btn-remove {
       position: absolute;
       top: 0;
-      right: @padding-x;
+      inset-inline-end: @padding-x;
       color: var(--rs-text-secondary);
       cursor: pointer;
       height: @uploader-picture-text-preview-side-length;
@@ -396,8 +396,8 @@
       position: absolute;
       bottom: 0;
       width: 100%;
-      left: 0;
-      padding-left: @uploader-picture-text-preview-side-length;
+      inset-inline-start: 0;
+      padding-inline-start: @uploader-picture-text-preview-side-length;
 
       &-bar {
         height: 2px;
@@ -409,7 +409,7 @@
     &-icon-loading {
       position: absolute;
       top: 0;
-      left: 0;
+      inset-inline-start: 0;
       display: block;
       width: @uploader-picture-text-preview-side-length;
       height: @uploader-picture-text-preview-side-length;

--- a/src/internals/Overlay/Overlay.tsx
+++ b/src/internals/Overlay/Overlay.tsx
@@ -2,7 +2,12 @@ import React, { useState, useRef, useCallback, useContext } from 'react';
 import classNames from 'classnames';
 import Fade from '../../Animation/Fade';
 import OverlayContext from './OverlayContext';
-import Position, { PositionChildProps, PositionProps } from './Position';
+import Position, {
+  PositionChildProps,
+  PositionProps,
+  CSS_POSITION_X,
+  CSS_POSITION_Y
+} from './Position';
 import { useRootClose } from '../hooks';
 import { mergeRefs } from '@/internals/utils';
 import type { Placement, AnimationEventProps, ReactElement } from '@/internals/types';
@@ -108,11 +113,17 @@ const Overlay = React.forwardRef((props: OverlayProps, ref) => {
           // Position will return coordinates and className
           const { left, top, className } = childProps;
           const childElement = children as ReactElement;
+          const childStyles = {
+            [CSS_POSITION_X]: `${left}px`,
+            [CSS_POSITION_Y]: `${top}px`,
+            ...childElement.props.style
+          };
+
           return React.cloneElement(childElement, {
             ...childrenProps,
             ...childElement.props,
             className: classNames(className, childElement.props.className),
-            style: { left, top, ...childElement.props.style },
+            style: childStyles,
             ref: mergeRefs(childRef, overlayTarget)
           });
         }}

--- a/src/internals/Overlay/Position.tsx
+++ b/src/internals/Overlay/Position.tsx
@@ -21,6 +21,9 @@ import { useUpdateEffect } from '../hooks';
 import type { Placement } from '@/internals/types';
 import type { CursorPosition } from './types';
 
+export const CSS_POSITION_X = '--rs-position-x';
+export const CSS_POSITION_Y = '--rs-position-y';
+
 export interface PositionChildProps {
   className: string;
   left?: number;
@@ -119,7 +122,10 @@ const usePosition = (
         if (posi.positionClassName) {
           addClass(overlay, posi.positionClassName);
         }
-        addStyle(overlay, { left: `${posi.positionLeft}px`, top: `${posi.positionTop}px` });
+        addStyle(overlay, {
+          [CSS_POSITION_X]: `${posi.positionLeft}px`,
+          [CSS_POSITION_Y]: `${posi.positionTop}px`
+        });
       } else {
         setPosition(posi);
       }

--- a/src/internals/Overlay/test/OverlayTriggerSpec.tsx
+++ b/src/internals/Overlay/test/OverlayTriggerSpec.tsx
@@ -251,7 +251,7 @@ describe('OverlayTrigger', () => {
     });
 
     expect(count).to.equal(2);
-    expect(screen.getByRole('tooltip').style).to.have.property('left', '10px');
+    expect(screen.getByRole('tooltip')).to.have.style('--rs-position-x', '10px');
   });
 
   it('Should open the Overlay', () => {

--- a/src/internals/Picker/styles/index.less
+++ b/src/internals/Picker/styles/index.less
@@ -92,7 +92,7 @@
 
   &-label.rs-input-group-addon {
     color: var(--rs-text-primary);
-    padding-right: 4px !important;
+    padding-inline-end: 4px !important;
   }
 
   &-loader {
@@ -123,9 +123,13 @@
   --rs-picker-search-box-padding: calc(var(--rs-spacing) * 1.5) calc(var(--rs-spacing) * 3);
   --rs-picker-popup-z-index: @zindex-picker-popup;
   --rs-picker-popup-shadow: var(--rs-shadow-md);
+  --rs-picker-popup-position-x: var(--rs-position-x);
+  --rs-picker-popup-position-y: var(--rs-position-y);
 
   position: absolute;
-  text-align: left;
+  top: var(--rs-picker-popup-position-y);
+  left: var(--rs-picker-popup-position-x) /* rtl:ignore */;
+  text-align: start;
   overflow: hidden;
   transition: none;
   display: flex;
@@ -194,7 +198,7 @@
     position: absolute;
     width: 100%;
     height: 100%;
-    left: 0;
+    inset-inline-start: 0;
     top: 0;
     border: 1px solid #0000;
     padding-inline-start: 10px;
@@ -249,7 +253,7 @@
 }
 
 .rs-picker-toggle.rs-btn {
-  text-align: left;
+  text-align: start;
   display: inline-flex;
   width: 100%;
   align-items: center;
@@ -345,7 +349,7 @@
 
       .grouped &,
       .@{ckpns}-menu-group-children & {
-        padding-left: @picker-check-item-content-padding-left +
+        padding-inline-start: @picker-check-item-content-padding-left +
           @picker-children-check-item-padding-left;
       }
     }
@@ -353,7 +357,9 @@
     .rs-checkbox-control {
       .grouped &,
       .@{ckpns}-menu-group-children & {
-        left: (@picker-item-content-padding-horizontal + @picker-children-check-item-padding-left);
+        inset-inline-start: (
+          @picker-item-content-padding-horizontal + @picker-children-check-item-padding-left
+        );
       }
     }
   }

--- a/src/internals/Picker/styles/mixin.less
+++ b/src/internals/Picker/styles/mixin.less
@@ -27,7 +27,7 @@
 .picker-menu-group-title(@prefix) {
   .rs-@{prefix}-menu-group-title {
     padding: @picker-item-content-padding-vertical @picker-item-content-padding-horizontal;
-    padding-right: (@padding-x + @dropdown-caret-width + @dropdown-caret-padding);
+    padding-inline-end: (@padding-x + @dropdown-caret-width + @dropdown-caret-padding);
     position: relative;
     cursor: pointer;
     color: var(--rs-text-heading);
@@ -37,7 +37,7 @@
       margin-inline-start: 2px;
       position: absolute;
       top: @padding-y;
-      right: @padding-x;
+      inset-inline-end: @padding-x;
       color: var(--rs-text-secondary);
     }
   }

--- a/src/internals/Ripple/styles/index.less
+++ b/src/internals/Ripple/styles/index.less
@@ -22,7 +22,7 @@
     width: 100%;
     height: 100%;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     pointer-events: none;
 
     & when (@enable-ripple-effect = false) {

--- a/src/internals/utils/css.ts
+++ b/src/internals/utils/css.ts
@@ -20,15 +20,15 @@ export function getCssValue(value?: number | string | null, unit = 'px') {
   return value.toString();
 }
 
-type CSSVariables = Partial<Record<`--${string}`, string>>;
-type StyleProperties = React.CSSProperties & CSSVariables;
+type CSSVariables = Partial<Record<`--${string}`, string | number | undefined>>;
+type StyleProperties = React.CSSProperties | CSSVariables;
 
 /**
  * Merge multiple style objects, filtering out undefined values
  */
 export function mergeStyles(
-  ...styles: (React.CSSProperties | undefined | null)[]
-): StyleProperties {
+  ...styles: (StyleProperties | undefined | null)[]
+): React.CSSProperties {
   return styles.filter(Boolean).reduce<StyleProperties>((acc, style) => {
     if (!style) return acc;
     return { ...acc, ...style };

--- a/src/styles/typography.less
+++ b/src/styles/typography.less
@@ -117,7 +117,7 @@ dt {
 }
 
 dd {
-  margin-left: 0; // Undo browser default
+  margin-inline-start: 0; // Undo browser default
   margin-bottom: (@line-height-computed / 2);
 }
 

--- a/src/toaster/styles/index.less
+++ b/src/toaster/styles/index.less
@@ -38,7 +38,7 @@
   &-bottom-start,
   &-top-start {
     align-items: flex-start;
-    left: @toast-spacing;
+    inset-inline-start: @toast-spacing;
 
     .rs-toast-fade-entered {
       animation-name: notificationMoveInLeft;
@@ -48,10 +48,10 @@
   &-bottom-end,
   &-top-end {
     align-items: flex-end;
-    right: @toast-spacing;
+    inset-inline-end: @toast-spacing;
 
     .rs-toast-fade-entered {
-      margin-left: auto;
+      margin-inline-start: auto;
       animation-name: notificationMoveInRight;
     }
   }


### PR DESCRIPTION
This pull request includes several changes to improve the styling and layout of various components, as well as some minor code cleanups. The most important changes include updating CSS properties for better RTL (right-to-left) support, removing unnecessary code, and making minor adjustments to component properties.

### CSS Property Updates for RTL Support:

| Original Property       | Modified Property               |
|-------------------------|----------------------------------|
| `left`                  | `inset-inline-start`            |
| `right`                 | `inset-inline-end`              |
| `padding-left`          | `padding-inline-start`         |
| `padding-right`         | `padding-inline-end`           |
| `margin-left`           | `margin-inline-start`          |
| `margin-right`          | `margin-inline-end`            |
| `text-align: left`      | `text-align: start`            |
| `text-align: right`     | `text-align: end`              |
