### PR TITLE
fix(form): support explicit type of array type when use rule of formControl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react-use-set": "^1.0.0",
         "react-window": "^1.8.8",
         "rsuite-table": "^5.19.1",
-        "schema-typed": "^2.3.0"
+        "schema-typed": "^2.4.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.25.9",
@@ -20512,9 +20512,9 @@
       }
     },
     "node_modules/schema-typed": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.3.0.tgz",
-      "integrity": "sha512-GwUKUxj2h2zPpighJfFOJD94/LDoaCUGQFWg1rJIa59VjME93u8txvaW28oScVvb7cboeKHh05lScTyGAtifeA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.4.1.tgz",
+      "integrity": "sha512-0GL4a9OUhBCjE7rXnmUOscEyISW0TImzagKwbIxs4d5E2AldiqjFb+7Ah8lm9aBiHKQ/bdxTDtE/3QOUVDDmFA==",
       "dependencies": {
         "lodash": "^4.17.21"
       }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-use-set": "^1.0.0",
     "react-window": "^1.8.8",
     "rsuite-table": "^5.19.1",
-    "schema-typed": "^2.3.0"
+    "schema-typed": "^2.4.1"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/src/Form/hooks/useSchemaModel.ts
+++ b/src/Form/hooks/useSchemaModel.ts
@@ -1,7 +1,8 @@
-import { SchemaModel, ObjectType } from 'schema-typed';
+import { SchemaModel } from 'schema-typed';
 import { useRef, useCallback } from 'react';
 import type { MutableRefObject } from 'react';
 import type { CheckType, Schema } from 'schema-typed';
+import { constructFlatSchema } from '../utils/constructFlatSchema';
 
 export type FieldRuleType = MutableRefObject<CheckType<unknown, any> | undefined>;
 type RealFieldRuleType = MutableRefObject<CheckType<unknown, any>>;
@@ -12,62 +13,6 @@ interface RuleInfoType {
 }
 interface RealRuleInfoType extends RuleInfoType {
   fieldRule: RealFieldRuleType;
-}
-
-/**
- * Convert a flat schema object to a nested schema object
- *
- * @example
- *
- * ```js
- * const schema = {
- *  'address.city': StringType().isRequired('City is required'),
- *  'address.street': StringType().isRequired('Street is required')
- * };
- *
- * const result = unflattenSchemaObject(schema);
- *
- * // result
- * {
- *    address: ObjectType().shape({
- *      city: StringType().isRequired('City is required'),
- *      street: StringType().isRequired('Street is required')
- *    })
- * }
- * ```
- */
-function unflattenSchemaObject(schema) {
-  const result = {};
-  const $type = Symbol('schema-type');
-
-  Object.keys(schema).forEach(key => {
-    if (key.includes('.')) {
-      const keys = key.split('.');
-      const lastKey = keys.pop() || '';
-
-      let current = result;
-      keys.forEach(subKey => {
-        current[subKey] = current[subKey] || { [$type]: 'object-type' };
-        current = current[subKey];
-      });
-
-      current[lastKey] = schema[key];
-    } else {
-      result[key] = schema[key];
-    }
-  });
-
-  function convertToShape(obj) {
-    Object.keys(obj).forEach(key => {
-      if (obj[key]?.[$type] === 'object-type') {
-        delete obj[key][$type];
-        obj[key] = ObjectType().shape(convertToShape(obj[key]));
-      }
-    });
-    return obj;
-  }
-
-  return convertToShape(result);
 }
 
 function useSchemaModel(formModel: Schema, nestedField: boolean) {
@@ -98,7 +43,7 @@ function useSchemaModel(formModel: Schema, nestedField: boolean) {
 
     return SchemaModel.combine(
       formModel,
-      SchemaModel(nestedField ? unflattenSchemaObject(subRuleObject) : subRuleObject)
+      SchemaModel(nestedField ? constructFlatSchema(subRuleObject) : subRuleObject)
     );
   }, [formModel, nestedField]);
 

--- a/src/Form/test/FormValidationSpec.tsx
+++ b/src/Form/test/FormValidationSpec.tsx
@@ -1154,6 +1154,170 @@ describe('Form Validation', () => {
       });
     });
 
+    it('Should validate explicit nested ArrayType', async () => {
+      const formRef = React.createRef<FormInstance>();
+      const onError = sinon.spy();
+      const defaultValues = {
+        name: '',
+        address: [
+          {
+            city: '',
+            postCode: ''
+          },
+          ''
+        ]
+      };
+      const model = Schema.Model({
+        name: Schema.Types.StringType().isRequired('Name is required.'),
+        address: Schema.Types.ArrayType().of(
+          Schema.Types.ObjectType().shape({
+            city: Schema.Types.StringType().isRequired('City is required.'),
+            postCode: Schema.Types.StringType().isRequired('Post Code is required.')
+          }),
+          Schema.Types.StringType().isRequired('Phone Number is required.')
+        )
+      });
+
+      render(
+        <Form formValue={defaultValues} model={model} ref={formRef} onError={onError} nestedField>
+          <FormControl name="name" />
+          <FormControl name="address[0].city" />
+          <FormControl name="address[0].postCode" />
+          <FormControl name="address[1]" />
+        </Form>
+      );
+
+      act(() => {
+        formRef.current?.check();
+      });
+
+      expect(onError).to.have.been.calledOnce;
+
+      await waitFor(() => {
+        expect(onError).to.have.been.calledWith({
+          name: 'Name is required.',
+          address: {
+            hasError: true,
+            array: [
+              {
+                hasError: true,
+                object: {
+                  city: {
+                    hasError: true,
+                    errorMessage: 'City is required.'
+                  },
+                  postCode: {
+                    hasError: true,
+                    errorMessage: 'Post Code is required.'
+                  }
+                }
+              },
+              {
+                hasError: true,
+                errorMessage: 'Phone Number is required.'
+              }
+            ]
+          }
+        });
+      });
+
+      expect(screen.getAllByRole('alert')).to.have.length(4);
+
+      screen.getAllByRole('alert').forEach((alert, index) => {
+        expect(alert).to.have.text(
+          [
+            'Name is required.',
+            'City is required.',
+            'Post Code is required.',
+            'Phone Number is required.'
+          ][index]
+        );
+      });
+    });
+
+    it('Should validate explicit nested ArrayType with FormControl set rule', async () => {
+      const formRef = React.createRef<FormInstance>();
+      const onError = sinon.spy();
+      const defaultValues = {
+        name: '',
+        address: [
+          {
+            city: '',
+            postCode: ''
+          },
+          ''
+        ]
+      };
+
+      render(
+        <Form formValue={defaultValues} ref={formRef} onError={onError} nestedField>
+          <FormControl
+            name="name"
+            rule={Schema.Types.StringType().isRequired('Name is required.')}
+          />
+          <FormControl
+            name="address[0].city"
+            rule={Schema.Types.StringType().isRequired('City is required.')}
+          />
+          <FormControl
+            name="address[0].postCode"
+            rule={Schema.Types.StringType().isRequired('Post Code is required.')}
+          />
+          <FormControl
+            name="address[1]"
+            rule={Schema.Types.StringType().isRequired('Phone Number is required.')}
+          />
+        </Form>
+      );
+
+      act(() => {
+        formRef.current?.check();
+      });
+
+      expect(onError).to.have.been.calledOnce;
+
+      await waitFor(() => {
+        expect(onError).to.have.been.calledWith({
+          name: 'Name is required.',
+          address: {
+            hasError: true,
+            array: [
+              {
+                hasError: true,
+                object: {
+                  city: {
+                    hasError: true,
+                    errorMessage: 'City is required.'
+                  },
+                  postCode: {
+                    hasError: true,
+                    errorMessage: 'Post Code is required.'
+                  }
+                }
+              },
+              {
+                hasError: true,
+                errorMessage: 'Phone Number is required.'
+              }
+            ]
+          }
+        });
+      });
+
+      expect(screen.getAllByRole('alert')).to.have.length(4);
+
+      screen.getAllByRole('alert').forEach((alert, index) => {
+        expect(alert).to.have.text(
+          [
+            'Name is required.',
+            'City is required.',
+            'Post Code is required.',
+            'Phone Number is required.'
+          ][index]
+        );
+      });
+    });
+
     it('Should validate deeply nested ArrayType when checkTrigger = blur', async () => {
       const model = Schema.Model({
         address: Schema.Types.ArrayType().of(

--- a/src/Form/test/constructFlatSchemaSpec.ts
+++ b/src/Form/test/constructFlatSchemaSpec.ts
@@ -1,0 +1,96 @@
+import { ObjectType, StringType, ArrayType, SchemaModel } from 'schema-typed';
+import { constructFlatSchema } from '../utils/constructFlatSchema';
+
+describe('constructFlatSchema', () => {
+  const valueShape = {
+    name: '',
+    address: {
+      city: '',
+      street: ''
+    },
+    items: ['', ''],
+    users: [
+      {
+        name: '',
+        address: {
+          city: ''
+        }
+      }
+    ],
+    customer: {
+      name: '',
+      address: {
+        city: '',
+        street: ''
+      },
+      items: [''],
+      users: [
+        {
+          name: '',
+          address: {
+            city: ''
+          }
+        }
+      ]
+    }
+  };
+  const type1 = StringType().isRequired();
+  const type2 = StringType().isRequiredOrEmpty();
+  const finalSchema = {
+    name: type1,
+    address: ObjectType()
+      .shape({
+        city: type1,
+        street: type1
+      })
+      .isRequired(),
+    items: ArrayType().of(type1, type2),
+    users: ArrayType().of(
+      ObjectType().shape({
+        name: type1,
+        address: ObjectType().shape({
+          city: type1
+        })
+      })
+    ),
+    customer: ObjectType().shape({
+      address: ObjectType().shape({
+        city: type1,
+        street: type1
+      }),
+      items: ArrayType().of(
+        type1,
+        ObjectType().shape({
+          city: type1,
+          street: type1
+        })
+      )
+    })
+  };
+  const flatSchema = {
+    name: type1,
+    'address.city': type1,
+    'address.street': type1,
+    'items[0]': type1,
+    'items[1]': type2,
+    'users[0].name': type1,
+    'users[0].address.city': type1,
+    'customer.address.city': type1,
+    'customer.address.street': type1,
+    'customer.items[0]': type1,
+    'customer.items[1].city': type1,
+    'customer.items[1].street': type1
+  };
+  it('should convert a flat schema object to a nested schema object', () => {
+    Object.keys(flatSchema).forEach(key => {
+      assert.deepEqual(
+        SchemaModel(constructFlatSchema(flatSchema)).checkForField(key, valueShape, {
+          nestedObject: true
+        }),
+        SchemaModel(finalSchema).checkForField(key as any, valueShape, {
+          nestedObject: true
+        })
+      );
+    });
+  });
+});

--- a/src/Form/utils/constructFlatSchema.ts
+++ b/src/Form/utils/constructFlatSchema.ts
@@ -1,0 +1,41 @@
+import { ObjectType, ArrayType } from 'schema-typed';
+
+import set from 'lodash/set';
+
+/**
+ * combine flat schema to nested schema
+ */
+export function constructFlatSchema(schema) {
+  const shape = {};
+
+  Object.keys(schema).forEach(key => {
+    set(shape, key, {
+      schema: schema[key],
+      primitiveType: true
+    });
+  });
+  function convertShapeToSchema(shape, result, internal?: boolean) {
+    Object.keys(shape).forEach(key => {
+      const currentShape = shape[key];
+      if (Array.isArray(currentShape)) {
+        result[key] = ArrayType().of(
+          ...currentShape.map(v => {
+            if (v.primitiveType) {
+              return v.schema;
+            }
+            return convertShapeToSchema(v, {}, true);
+          })
+        );
+      } else {
+        if (currentShape.primitiveType) {
+          result[key] = currentShape.schema;
+        } else {
+          result[key] = convertShapeToSchema(currentShape, {}, true);
+        }
+      }
+    });
+    return internal ? ObjectType().shape(result) : result;
+  }
+
+  return convertShapeToSchema(shape, {});
+}


### PR DESCRIPTION
Reproduction: https://codesandbox.io/p/devbox/nifty-breeze-5r2sfn?workspaceId=ws_QeEyaqyPtYWhjP5TTM8Yhh

<img width="500" alt="image" src="https://github.com/user-attachments/assets/7d18055c-1625-46a1-8624-0cbe230c416f" />


When using a nested array and passing different types of elements within array

<img width="500" alt="image" src="https://github.com/user-attachments/assets/dcaefb73-5dce-46f7-b05d-e2f29bc46bb3" />

After this change

<img width="500" alt="image" src="https://github.com/user-attachments/assets/6e3af5c0-b3ad-490b-a2c6-36ea0f349ac0" />
