### PR TITLE
fix(Uploader): refine children prop type and improve class handling

### DIFF
--- a/src/Uploader/Uploader.tsx
+++ b/src/Uploader/Uploader.tsx
@@ -50,7 +50,7 @@ export interface UploaderProps
   autoUpload?: boolean;
 
   /** Primary content */
-  children?: React.ReactNode;
+  children?: React.ReactElement;
 
   /** List of uploaded files */
   defaultFileList?: FileType[];
@@ -607,7 +607,7 @@ Uploader.propTypes = {
   action: PropTypes.string.isRequired,
   accept: PropTypes.string,
   autoUpload: PropTypes.bool,
-  children: PropTypes.node,
+  children: PropTypes.element,
   className: PropTypes.string,
   classPrefix: PropTypes.string,
   defaultFileList: PropTypes.array,

--- a/src/Uploader/test/UploaderSpec.tsx
+++ b/src/Uploader/test/UploaderSpec.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import sinon from 'sinon';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { testStandardProps } from '@test/utils';
-
 import Uploader from '../Uploader';
 import Button from '../../Button';
 import userEvent from '@testing-library/user-event';
@@ -144,5 +143,15 @@ describe('Uploader', () => {
 
     expect(screen.getByRole('button')).to.have.class('rs-btn-primary');
     expect(screen.getByRole('button')).to.have.class('rs-btn-red');
+  });
+
+  it('Should apply custom button className', () => {
+    render(
+      <Uploader action="">
+        <Button className="custom-buttom">Select files</Button>
+      </Uploader>
+    );
+
+    expect(screen.getByRole('button')).to.have.class('custom-buttom');
   });
 });


### PR DESCRIPTION
fix: https://github.com/rsuite/rsuite/issues/4174

- Change children prop type from ReactNode to ReactElement in Uploader and UploadTrigger
- Refactor event handler assignment in UploadTrigger using object spread
- Preserve custom className when cloning child element
- Add test case for custom button className