### PR TITLE
fix(DatePicker): adjust label padding based on size

### DIFF
--- a/src/DatePicker/test/DatePickerStylesSpec.tsx
+++ b/src/DatePicker/test/DatePickerStylesSpec.tsx
@@ -22,4 +22,18 @@ describe('DatePicker styles', () => {
     render(<DatePicker open />);
     expect(screen.getByRole('dialog')).to.have.style('padding', '0px');
   });
+
+  it('Should update the label padding based on size', () => {
+    const { rerender } = render(<DatePicker label="custom-label" />);
+    expect(screen.getByText('custom-label')).to.have.style('padding', '0px 11px');
+
+    rerender(<DatePicker label="custom-label" size="lg" />);
+    expect(screen.getByText('custom-label')).to.have.style('padding', '0px 15px');
+
+    rerender(<DatePicker label="custom-label" size="sm" />);
+    expect(screen.getByText('custom-label')).to.have.style('padding', '0px 9px');
+
+    rerender(<DatePicker label="custom-label" size="xs" />);
+    expect(screen.getByText('custom-label')).to.have.style('padding', '0px 7px');
+  });
 });

--- a/src/internals/Picker/styles/index.less
+++ b/src/internals/Picker/styles/index.less
@@ -92,7 +92,9 @@
 
   &-label.rs-input-group-addon {
     color: var(--rs-text-primary);
-    padding-inline-end: 4px !important;
+    padding-inline: calc(
+      var(--rs-input-group-inside-btn-padding) * 2 - var(--rs-picker-toggle-border-width)
+    );
   }
 
   &-loader {


### PR DESCRIPTION
This pull request includes changes to the `DatePicker` component to enhance its styling and ensure consistency across different sizes. The most important changes are as follows:

### Enhancements to `DatePicker` styling:

* [`src/DatePicker/test/DatePickerStylesSpec.tsx`](diffhunk://#diff-4e0bdaac42a7fd9426cfa651c3a83cfb828c5abbbc07f0eb8eea029252ea0beeR25-R38): Added a new test to verify that the label padding updates correctly based on the size of the `DatePicker` component.

* [`src/internals/Picker/styles/index.less`](diffhunk://#diff-39e60be854f6f35595816822070452a633398f2f4e4923a5c32ace4bcd07346bL95-R97): Modified the padding style for the `DatePicker` label to use a calculated value based on existing CSS variables, ensuring consistent spacing.