### PR TITLE
docs: add guidance for usage issues with `useToaster`

### DIFF
--- a/docs/pages/components/toaster/en-US/index.md
+++ b/docs/pages/components/toaster/en-US/index.md
@@ -45,6 +45,21 @@ return () => {
 };
 ```
 
+The toaster instance created by `useToaster` needs to be used within a specified container. Therefore, we need to provide a `CustomProvider` component to wrap the application outside the App component. Here's an example:
+
+```tsx
+import { createRoot } from 'react-dom/client';
+import { CustomProvider } from 'rsuite';
+
+const root = createRoot(document.getElementById('root')!);
+
+root.render(
+  <CustomProvider>
+    <App />
+  </CustomProvider>
+);
+```
+
 #### toaster.push
 
 Push a message and return a unique toastId.

--- a/docs/pages/components/toaster/zh-CN/index.md
+++ b/docs/pages/components/toaster/zh-CN/index.md
@@ -33,7 +33,7 @@ Toaster 用于在应用程序中显示简短的、临时的通知，用于表示
 ```ts
 import { useToaster } from 'rsuite';
 
-return () => {
+function App() {
   const toaster = useToaster();
 
   const handleClick = () => {
@@ -42,7 +42,22 @@ return () => {
   };
 
   return <Button onClick={handleClick}>Push</Button>;
-};
+}
+```
+
+通过 `useToaster` 创建的 toaster 实例需要在指定的容器中使用。因此，我们需要在 App 组件外部提供一个 `CustomProvider` 组件来包裹应用。示例如下：
+
+```tsx
+import { createRoot } from 'react-dom/client';
+import { CustomProvider } from 'rsuite';
+
+const root = createRoot(document.getElementById('root')!);
+
+root.render(
+  <CustomProvider>
+    <App />
+  </CustomProvider>
+);
 ```
 
 #### toaster.push


### PR DESCRIPTION
This pull request includes updates to the documentation for the `Toaster` component in both English and Chinese. The changes provide additional guidance on how to use the `useToaster` hook within a specified container using a `CustomProvider` component.