### PR TITLE
fix: add separate state for calendar selected date

### DIFF
--- a/src/Calendar/CalendarContainer.tsx
+++ b/src/Calendar/CalendarContainer.tsx
@@ -42,6 +42,11 @@ export interface CalendarProps
   calendarDate: Date;
 
   /**
+   * The date that is currently clicked in the picker (before definitive selection)
+   */
+  selectedDate?: Date;
+
+  /**
    * Whether to show week numbers
    */
   showWeekNumbers?: boolean;
@@ -241,6 +246,7 @@ const CalendarContainer: RsRefForwardingComponent<'div', CalendarProps> = React.
       renderCellOnPicker,
       renderTitle,
       renderToolbar,
+      selectedDate,
       ...rest
     } = props;
 
@@ -287,6 +293,7 @@ const CalendarContainer: RsRefForwardingComponent<'div', CalendarProps> = React.
 
     const contextValue = {
       date: calendarDate,
+      selectedDate,
       dateRange,
       format,
       hoverRangeValue,

--- a/src/Calendar/CalendarProvider.ts
+++ b/src/Calendar/CalendarProvider.ts
@@ -13,6 +13,11 @@ export interface CalendarInnerContextValue {
   date?: Date;
 
   /**
+   * The current date of the calendar.
+   */
+  selectedDate?: Date;
+
+  /**
    * The date range selected in the calendar.
    */
   dateRange?: Date[];

--- a/src/Calendar/Grid/GridRow.tsx
+++ b/src/Calendar/Grid/GridRow.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { isSameDay, addDays, isBefore, isAfter, format } from '@/internals/utils/date';
+import { isSameDay, isSameMonth, addDays, isBefore, isAfter, format } from '@/internals/utils/date';
 import { DATERANGE_DISABLED_TARGET } from '@/internals/constants';
 import { useClassNames } from '@/internals/hooks';
 import { useCalendar } from '../hooks';
@@ -22,7 +22,7 @@ const GridRow: RsRefForwardingComponent<'div', GridRowProps> = React.forwardRef(
     } = props;
 
     const {
-      date: selected = new Date(),
+      selectedDate = new Date(),
       dateRange,
       hoverRangeValue,
       isoWeek,
@@ -62,7 +62,7 @@ const GridRow: RsRefForwardingComponent<'div', GridRowProps> = React.forwardRef(
         const rangeEnd = !unSameMonth && selectedEndDate && isSameDay(thisDate, selectedEndDate);
         const isSelected = isRangeSelectionMode
           ? rangeStart || rangeEnd
-          : isSameDay(thisDate, selected);
+          : isSameDay(thisDate, selectedDate) && isSameMonth(thisDate, selectedDate);
 
         // TODO-Doma Move those logic that's for DatePicker/DateRangePicker to a separate component
         //           Calendar is not supposed to be reused this way

--- a/src/Calendar/hooks/useCalendarDate.ts
+++ b/src/Calendar/hooks/useCalendarDate.ts
@@ -6,11 +6,20 @@ export const useCalendarDate = (value: Date | null | undefined, defaultDate: Dat
   const valueRef = useRef(value);
 
   const [calendarDate, setValue] = useState<Date>(value ?? defaultDate ?? startOfToday());
+  const [selectedDate, setSelected] = useState<Date>(value ?? defaultDate ?? startOfToday());
 
   const setCalendarDate = useCallback(
     (date: React.SetStateAction<Date> | undefined) => {
       if (date && date?.valueOf() !== calendarDate?.valueOf()) {
         setValue(date);
+      }
+    },
+    [calendarDate]
+  );
+  const setSelectedDate = useCallback(
+    (date: React.SetStateAction<Date> | undefined) => {
+      if (date && date?.valueOf() !== selectedDate?.valueOf()) {
+        setSelected(date);
       }
     },
     [calendarDate]
@@ -30,5 +39,5 @@ export const useCalendarDate = (value: Date | null | undefined, defaultDate: Dat
     }
   }, [value, defaultDate]);
 
-  return { calendarDate, setCalendarDate, resetCalendarDate };
+  return { calendarDate, setCalendarDate, resetCalendarDate, selectedDate, setSelectedDate };
 };

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -321,10 +321,8 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
     const formatStr = format || locale?.shortDateFormat || 'yyyy-MM-dd';
     const { merge, prefix } = useClassNames(classPrefix);
     const [value, setValue] = useControlled(valueProp, defaultValue);
-    const { calendarDate, setCalendarDate, resetCalendarDate } = useCalendarDate(
-      value,
-      calendarDefaultDate
-    );
+    const { calendarDate, setCalendarDate, resetCalendarDate, selectedDate, setSelectedDate } =
+      useCalendarDate(value, calendarDefaultDate);
 
     const { setMonthView, monthView, toggleMonthView } = useMonthView({ onToggleMonthDropdown });
     const { mode } = useDateMode(formatStr);
@@ -469,7 +467,8 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
      * The callback triggered after clicking the OK button.
      */
     const handleOK = useEventCallback((event: React.SyntheticEvent) => {
-      updateValue(event);
+      console.log('selectedDate', selectedDate);
+      updateValue(event, selectedDate);
       onOk?.(calendarDate, event);
       focusInput();
     });
@@ -510,6 +509,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
         const nextValue = copyTime({ from: calendarDate, to: date });
 
         setCalendarDate(nextValue);
+        setSelectedDate(nextValue);
         handleDateChange(nextValue);
 
         if (oneTap && updatableValue) {
@@ -615,6 +615,7 @@ const DatePicker: RsRefForwardingComponent<'div', DatePickerProps> = React.forwa
                 isoWeek={isoWeek}
                 weekStart={weekStart}
                 calendarDate={calendarDate}
+                selectedDate={selectedDate}
                 monthDropdownProps={monthDropdownProps}
                 renderCellOnPicker={renderCell}
                 onMoveForward={handleMoveForward}


### PR DESCRIPTION
This PR introduces a separate state for tracking the selected date by:

1. Adding a `selectedDate` property to the Calendar context
2. Extending the `useCalendarDate` hook to maintain separate states
3. Updating the GridRow component to properly render selected dates based on both date equality and month context