### PR TITLE
fix(Slider): fix issue where arrow in Tooltip is not displayed

### DIFF
--- a/docs/pages/components/slider/en-US/index.md
+++ b/docs/pages/components/slider/en-US/index.md
@@ -45,9 +45,13 @@ Limit starting value to be no greater than 25 and ending value to be no smaller 
 
 <!--{include:`custom.md`}-->
 
-### Size
+### Custom width
 
 <!--{include:`size.md`}-->
+
+### Keep tooltip open
+
+<!--{include:`keep-tooltip-open.md`}-->
 
 ## Accessibility
 
@@ -98,6 +102,7 @@ WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#slider
 | handleClassName   | string                          | A css class to apply to the Handle node                          |
 | handleStyle       | CSSProperties                   | A css style to apply to the Handle node                          |
 | handleTitle       | ReactNode                       | Customizing what is displayed inside a handle                    |
+| keepTooltipOpen   | boolean`(false)`                | Whether `Tooltip` will always be visible even without hover      |
 | max               | number`(100)`                   | Maximum sliding range                                            |
 | min               | number`(0)`                     | Minimum value of sliding range                                   |
 | onChange          | (value: number) => void         | Callback function that changes data                              |
@@ -107,7 +112,6 @@ WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#slider
 | renderTooltip     | (value: number ) => ReactNode   | Customize the content of the rendered Tooltip                    |
 | step              | number`(1)`                     | Slide the value of one step                                      |
 | tooltip           | boolean`(true)`                 | Whether to show `Tooltip` when sliding                           |
-| keepTooltipOpen   | boolean`(false)`                | Whether `Tooltip` will always be visible   even without hover    |
 | value             | number                          | The current value (controlled)                                   |
 | vertical          | boolean                         | Vertical Slide                                                   |
 
@@ -124,6 +128,7 @@ WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#slider
 | handleClassName   | string                                                 | A css class to apply to the Handle node                                                                              |
 | handleStyle       | CSSProperties                                          | A css style to apply to the Handle node                                                                              |
 | handleTitle       | ReactNode                                              | Customizing what is displayed inside a handle                                                                        |
+| keepTooltipOpen   | boolean`(false)`                                       | Whether `Tooltip` will always be visible even without hover                                                          |
 | max               | number`(100)`                                          | Maximum sliding range                                                                                                |
 | min               | number`(0)`                                            | Minimum value of sliding range                                                                                       |
 | onChange          | (value: [number,number]) => void                       | Callback function that changes data                                                                                  |
@@ -133,6 +138,5 @@ WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#slider
 | renderTooltip     | (value: number ) => ReactNode                          | Customize the content of the rendered Tooltip                                                                        |
 | step              | number`(1)`                                            | Slide the value of one step                                                                                          |
 | tooltip           | boolean`(true)`                                        | Whether to show `Tooltip` when sliding                                                                               |
-| keepTooltipOpen   | boolean`(false)`                                        | Whether `Tooltip` will always be visible   even without hover                                                       |
 | value             | [number,number]                                        | The current value (controlled)                                                                                       |
 | vertical          | boolean                                                | Vertical Slide                                                                                                       |

--- a/docs/pages/components/slider/fragments/keep-tooltip-open.md
+++ b/docs/pages/components/slider/fragments/keep-tooltip-open.md
@@ -1,0 +1,17 @@
+<!--start-code-->
+
+```js
+import { Slider, RangeSlider } from 'rsuite';
+
+const App = () => (
+  <>
+    <Slider progress defaultValue={50} keepTooltipOpen />
+    <hr />
+    <RangeSlider progress defaultValue={[20, 70]} keepTooltipOpen />
+  </>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/slider/zh-CN/index.md
+++ b/docs/pages/components/slider/zh-CN/index.md
@@ -45,9 +45,13 @@
 
 <!--{include:`custom.md`}-->
 
-### 自定义大小
+### 自定义长度
 
 <!--{include:`size.md`}-->
+
+### 保持工具提示打开
+
+<!--{include:`keep-open.md`}-->
 
 ### 无障碍设计
 
@@ -96,6 +100,7 @@ WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#slider
 | handleClassName   | string                          | 应用于手柄 DOM 节点的 css class               |
 | handleStyle       | CSSProperties                   | 附加手柄样式                                  |
 | handleTitle       | ReactNode                       | 自定义手柄内显示内容                          |
+| keepTooltipOpen   | boolean`(false)`                | `Tooltip` 始终保持可见                        |
 | max               | number`(100)`                   | 滑动范围的最大值                              |
 | min               | number`(0)`                     | 滑动范围的最小值                              |
 | onChange          | (value: number, event) => void  | 数据发生改变的回调函数                        |
@@ -121,6 +126,7 @@ WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#slider
 | handleClassName   | string                                                 | 应用于手柄 DOM 节点的 css class                                            |
 | handleStyle       | CSSProperties                                          | 附加手柄样式                                                               |
 | handleTitle       | ReactNode                                              | 自定义手柄内显示内容                                                       |
+| keepTooltipOpen   | boolean`(false)`                                       | `Tooltip` 始终保持可见                                                     |
 | max               | number`(100)`                                          | 滑动范围的最大值                                                           |
 | min               | number`(0)`                                            | 滑动范围的最小值                                                           |
 | onChange          | (value: [number,number], event) => void                | 数据发生改变的回调函数                                                     |

--- a/docs/pages/components/slider/zh-CN/index.md
+++ b/docs/pages/components/slider/zh-CN/index.md
@@ -51,8 +51,7 @@
 
 ### 保持工具提示打开
 
-<!--{include:`keep-open.md`}-->
-
+<!--{include:`keep-tooltip-open.md`}-->
 ### 无障碍设计
 
 WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#slider

--- a/src/Slider/Handle.tsx
+++ b/src/Slider/Handle.tsx
@@ -85,7 +85,8 @@ const Handle = forwardRef<'div', HandleProps>((props, ref) => {
         <Tooltip
           aria-hidden="true"
           ref={tooltipRef}
-          className={merge(prefix('tooltip'), 'placement-top')}
+          className={prefix('tooltip')}
+          data-placement="top"
         >
           {renderTooltip ? renderTooltip(value) : value}
         </Tooltip>

--- a/src/Slider/styles/index.less
+++ b/src/Slider/styles/index.less
@@ -9,12 +9,6 @@
 
   .rs-tooltip {
     display: none;
-
-    &.rs-tooltip-placement-top .rs-tooltip::after {
-      margin: auto;
-      inset-inline-start: 0;
-      inset-inline-end: 0;
-    }
   }
 
   &-disabled {
@@ -68,7 +62,9 @@
     margin-inline-start: -(@slider-handle-diameter / 2);
     cursor: pointer;
     /* stylelint-disable */ //Formatted by prettier
-    transition: box-shadow @slider-handle-transition, background-color @slider-handle-transition,
+    transition:
+      box-shadow @slider-handle-transition,
+      background-color @slider-handle-transition,
       transform @slider-handle-transition;
     /* stylelint-enable */
   }


### PR DESCRIPTION
This pull request includes several changes to the slider component documentation and codebase, focusing on adding a new feature to keep the tooltip open and simplifying the tooltip placement styling.

### Documentation Updates:
* Added a new section for "Keep tooltip open" in both English and Chinese documentation files (`docs/pages/components/slider/en-US/index.md`, `docs/pages/components/slider/zh-CN/index.md`). [[1]](diffhunk://#diff-b3359ec012454c753f8eaede4385a6134bb7ae80edcaf6c8c2b166f8b00ac47bL48-R55) [[2]](diffhunk://#diff-956b780a6537411eebbd61366524971225fd37bee038bfb58cffbf8ed3a585b0L48-R55)
* Included the `keepTooltipOpen` property in the slider component's property tables in both English and Chinese documentation files (`docs/pages/components/slider/en-US/index.md`, `docs/pages/components/slider/zh-CN/index.md`). [[1]](diffhunk://#diff-b3359ec012454c753f8eaede4385a6134bb7ae80edcaf6c8c2b166f8b00ac47bR105) [[2]](diffhunk://#diff-b3359ec012454c753f8eaede4385a6134bb7ae80edcaf6c8c2b166f8b00ac47bL110) [[3]](diffhunk://#diff-b3359ec012454c753f8eaede4385a6134bb7ae80edcaf6c8c2b166f8b00ac47bR131) [[4]](diffhunk://#diff-b3359ec012454c753f8eaede4385a6134bb7ae80edcaf6c8c2b166f8b00ac47bL136) [[5]](diffhunk://#diff-956b780a6537411eebbd61366524971225fd37bee038bfb58cffbf8ed3a585b0R103) [[6]](diffhunk://#diff-956b780a6537411eebbd61366524971225fd37bee038bfb58cffbf8ed3a585b0R129)
* Added a code example for using the `keepTooltipOpen` property in a new fragment file (`docs/pages/components/slider/fragments/keep-tooltip-open.md`).

### Codebase Simplification:
* Simplified tooltip placement styling by removing unnecessary classes and properties in `src/Slider/styles/index.less`. [[1]](diffhunk://#diff-dff837e8e36e4369221127c56949372a14740273d48b27f75f652132d6ebc610L12-L17) [[2]](diffhunk://#diff-dff837e8e36e4369221127c56949372a14740273d48b27f75f652132d6ebc610L71-R67)
* Modified the `Handle` component to use `data-placement="top"` instead of a class for tooltip placement in `src/Slider/Handle.tsx`.