### PR TITLE
feat(InlineEdit): enhance focus handling with TAB navigation support

### DIFF
--- a/src/InlineEdit/InlineEdit.tsx
+++ b/src/InlineEdit/InlineEdit.tsx
@@ -94,7 +94,7 @@ const InlineEdit: RsRefForwardingComponent<'div', InlineEditProps> = React.forwa
   } = propsWithDefaults;
 
   const { withClassPrefix, merge, prefix } = useClassNames(classPrefix);
-  const { value, isEditing, onSave, onCancel, onChange, onKeyDown, onClick, htmlProps } =
+  const { value, isEditing, onSave, onCancel, onChange, onKeyDown, onClick, onFocus, htmlProps } =
     useEditState({ ...rest, disabled });
 
   const { target, root, onBlur } = useFocusEvent({
@@ -121,6 +121,7 @@ const InlineEdit: RsRefForwardingComponent<'div', InlineEditProps> = React.forwa
       className={merge(className, withClassPrefix(size, { disabled }))}
       onClick={onClick}
       onKeyDown={onKeyDown}
+      onFocus={onFocus}
       {...htmlProps}
     >
       {renderChildren(children, childrenProps, target)}

--- a/src/InlineEdit/useEditState.ts
+++ b/src/InlineEdit/useEditState.ts
@@ -10,6 +10,7 @@ interface EditStateProps {
   onCancel?: (event?: React.MouseEvent) => void;
   onSave?: (event?: React.MouseEvent) => void;
   onClick?: (event: React.SyntheticEvent) => void;
+  onFocus?: (event?: React.FocusEvent) => void;
 }
 
 const useEditState = (props: EditStateProps) => {
@@ -22,6 +23,7 @@ const useEditState = (props: EditStateProps) => {
     onCancel,
     onSave,
     onClick,
+    onFocus,
     ...htmlProps
   } = props;
 
@@ -37,6 +39,13 @@ const useEditState = (props: EditStateProps) => {
     }
     onClick?.(event);
     onEdit?.(event);
+    setIsEditing(true);
+    setResetValue(value);
+  });
+
+  const handleFocus = useEventCallback((event?: React.FocusEvent) => {
+    if (disabled) return;
+    onFocus?.(event);
     setIsEditing(true);
     setResetValue(value);
   });
@@ -80,6 +89,7 @@ const useEditState = (props: EditStateProps) => {
     value,
     onClick: handleClick,
     onChange: handleChange,
+    onFocus: handleFocus,
     onCancel: handleCancel,
     onSave: handleSave,
     onKeyDown: handleKeyDown,


### PR DESCRIPTION
## feat(InlineEdit): enhance focus handling with TAB navigation support

Add internal focus management to improve keyboard navigation:
- Implement onFocus event handling in useEditState hook
- Add TAB key support for moving between inputs
- Add disabled state validation in focus handling
- Export onFocus event for component usage

Focus management improvements:
- Validate disabled state before edit mode
- Support keyboard navigation with TAB
- Maintain consistent edit state behavior

## Actual behavior in original repo:

Before TAB key down:
![image](https://github.com/user-attachments/assets/2fe14aea-0e31-427b-b189-726b560fdfff)

After TAB key down:  (It isn't available to type or edit content)
![image](https://github.com/user-attachments/assets/45311586-46cd-4cba-814e-4d993b74308b)

## With my changes, new Behavior

Before TAB key down:
![image](https://github.com/user-attachments/assets/2fe14aea-0e31-427b-b189-726b560fdfff)

After TAB key down: now instantly is available to keep editing the form and keep the editing state of the last component.
![image](https://github.com/user-attachments/assets/0df04ade-a071-45ee-9f9d-58f1d127ee2f)

also, when finished the editing state of the last component, it works properly. 
use case: 
1.  Edit the first input, press enter key to save.
2. Press Tab key, and start editing the next one.

![image](https://github.com/user-attachments/assets/859efa3a-7925-4885-824c-4f6743cd5867)

Hope this can be merge. 

Greetings from #Colombia 🟨🟨🟦🟥



