### PR TITLE
docs(thumbnails): add component thumbnails for all components

### DIFF
--- a/docs/components/overview/CategorizedList.tsx
+++ b/docs/components/overview/CategorizedList.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import Link from '@/components/Link';
-import { SupportVersion } from './SupportVersion';
-import { Heading, HStack, VStack, Tag } from 'rsuite';
-
-const Item = ({ name, isComponent }: { name: string; isComponent?: boolean }) => (
-  <li>
-    <span className="rs-co-name">{isComponent ? `<${name}>` : name}</span>
-  </li>
-);
+import { Heading, HStack, VStack, Tag, Text } from 'rsuite';
+import { ComponentThumbnail } from './ComponentThumbnail';
 
 interface CategorizedListProps {
   components: any[];
@@ -33,37 +27,37 @@ export const CategorizedList = React.forwardRef(function CategorizedList(
               <HStack wrap spacing={10} align="flex-start">
                 {item.children?.map(item => {
                   return (
-                    <VStack key={item.id} className="rs-co-box" justify="space-between">
-                      <div>
-                        <Link href={`/components/${item.id}`} className="rs-co-header">
-                          {item.name}
-                          {language === 'zh' ? (
-                            <span>
-                              <br /> {item.title ? `(${item.title})` : null}
-                            </span>
-                          ) : null}
-                        </Link>
-                        <ul className="rs-co-content">
-                          {item.components
-                            ? item.components.map(name => (
-                                <Item name={name} key={name} isComponent />
-                              ))
-                            : null}
+                    <Link key={item.id} href={`/components/${item.id}`} className="rs-co-box-link">
+                      <div className="rs-co-box">
+                        <div className="rs-co-thumbnail">
+                          <ComponentThumbnail componentId={item.id} />
+                        </div>
+                        <div className="rs-co-content">
+                          <Text className="rs-co-header">
+                            {item.name}
+                            {language === 'zh' ? (
+                              <span className="rs-co-subtitle">
+                                {item.title ? item.title : null}
+                              </span>
+                            ) : null}
+                          </Text>
 
-                          {item.apis
-                            ? item.apis.map(name => <Item name={name} key={name} />)
-                            : null}
-                        </ul>
+                          <div className="rs-co-description">
+                            {item.components && item.components.length > 0 && (
+                              <Tag size="sm">{item.components.length} components</Tag>
+                            )}
+                            {item.apis && item.apis.length > 0 && (
+                              <Tag size="sm">{item.apis.length} APIs</Tag>
+                            )}
+                            {item.tag && (
+                              <Tag size="sm" color="orange">
+                                {item.tag}
+                              </Tag>
+                            )}
+                          </div>
+                        </div>
                       </div>
-                      <div>
-                        {item.tag && (
-                          <Tag size="sm" color="orange">
-                            {item.tag}
-                          </Tag>
-                        )}
-                        {item.minVersion && <SupportVersion minVersion={item.minVersion} />}
-                      </div>
-                    </VStack>
+                    </Link>
                   );
                 })}
               </HStack>

--- a/docs/components/overview/ComponentThumbnail.tsx
+++ b/docs/components/overview/ComponentThumbnail.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import * as thumbnails from '../thumbnails';
+
+interface ComponentThumbnailProps {
+  componentId: string;
+}
+
+/**
+ * Generate SVG thumbnails for different component types
+ */
+export const ComponentThumbnail: React.FC<ComponentThumbnailProps> = ({ componentId }) => {
+  // Return the appropriate SVG thumbnail based on component ID
+  const svgContent = getSvgForComponent(componentId);
+
+  return <div className="component-thumbnail">{svgContent}</div>;
+};
+
+/**
+ * Get the corresponding SVG thumbnail based on component ID
+ */
+const getSvgForComponent = (componentId: string): React.ReactNode => {
+  // Component ID to SVG thumbnail mapping
+  const thumbnailMap: Record<string, React.ReactNode> = {
+    // Layout components
+    box: <thumbnails.Box />,
+    center: <thumbnails.Center />,
+    divider: <thumbnails.Divider />,
+    frame: <thumbnails.Frame />,
+    grid: <thumbnails.Grid />,
+    stack: <thumbnails.Stack />,
+
+    // Button components
+    button: <thumbnails.Button />,
+    'icon-button': <thumbnails.IconButton />,
+    'button-group': <thumbnails.ButtonGroup />,
+
+    // Form components
+    form: <thumbnails.Form />,
+    'form-validation': <thumbnails.FormValidation />,
+    'form-formik': <thumbnails.FormValidation />,
+    'form-react-hook-form': <thumbnails.FormValidation />,
+    schema: <thumbnails.Schema />,
+    checkbox: <thumbnails.Checkbox />,
+    radio: <thumbnails.Radio />,
+    input: <thumbnails.Input />,
+    'input-number': <thumbnails.InputNumber />,
+    toggle: <thumbnails.Toggle />,
+
+    // Data Entry components
+    'auto-complete': <thumbnails.AutoComplete />,
+    slider: <thumbnails.Slider />,
+    'multi-slider': <thumbnails.Slider />,
+    'range-slider': <thumbnails.Slider />,
+    'inline-edit': <thumbnails.InlineEdit />,
+    'radio-tile': <thumbnails.RadioTile />,
+    rate: <thumbnails.Rate />,
+    'tag-input': <thumbnails.TagInput />,
+    uploader: <thumbnails.Uploader />,
+    'cascade-tree': <thumbnails.CascadeTree />,
+    tree: <thumbnails.Tree />,
+    'check-tree': <thumbnails.CheckTree />,
+    'multi-cascade-tree': <thumbnails.MultiCascadeTree />,
+
+    // Data Pickers components
+    cascader: <thumbnails.Cascader />,
+    'multi-cascader': <thumbnails.MultiCascader />,
+    'check-picker': <thumbnails.CheckPicker />,
+    'check-tree-picker': <thumbnails.CheckTreePicker />,
+    'input-picker': <thumbnails.InputPicker />,
+    'select-picker': <thumbnails.SelectPicker />,
+    'tag-picker': <thumbnails.TagPicker />,
+    'tree-picker': <thumbnails.TreePicker />,
+
+    // Date and Time components
+    calendar: <thumbnails.Calendar />,
+    'date-input': <thumbnails.DateInput />,
+    'date-picker': <thumbnails.DatePicker />,
+    'date-range-input': <thumbnails.DateRangeInput />,
+    'date-range-picker': <thumbnails.DateRangePicker />,
+    'time-picker': <thumbnails.TimePicker />,
+    'time-range-picker': <thumbnails.TimeRangePicker />,
+
+    // Data Grid components
+    table: <thumbnails.BasicTable />,
+    'table-virtualized': <thumbnails.VirtualTable />,
+    'table-tree': <thumbnails.TreeTable />,
+    'table-affix': <thumbnails.StickyTable />,
+    'table-editable': <thumbnails.EditableTable />,
+    'table-filterable': <thumbnails.FilterableTable />,
+
+    // Data Display components
+    carousel: <thumbnails.Carousel />,
+    list: <thumbnails.List />,
+    timeline: <thumbnails.Timeline />,
+    panel: <thumbnails.Panel />,
+    card: <thumbnails.Card />,
+    stat: <thumbnails.Stat />,
+    tag: <thumbnails.Tag />,
+
+    // Disclosure components
+    accordion: <thumbnails.DisclosureAccordion />,
+    tabs: <thumbnails.Tabs />,
+    'visually-hidden': <thumbnails.VisuallyHidden />,
+
+    // Misc components
+    animation: <thumbnails.Animation />,
+    'custom-provider': <thumbnails.CustomProvider />,
+    'dom-helper': <thumbnails.DOMHelper />,
+    'use-media-query': <thumbnails.Hooks />,
+    'use-breakpoint-value': <thumbnails.Hooks />,
+
+    // Status components
+    badge: <thumbnails.Badge />,
+    loader: <thumbnails.Loader />,
+    message: <thumbnails.Message />,
+    notification: <thumbnails.Notification />,
+    progress: <thumbnails.Progress />,
+    placeholder: <thumbnails.Placeholder />,
+    toaster: <thumbnails.Toaster />,
+
+    // Typography components
+    heading: <thumbnails.Heading />,
+    highlight: <thumbnails.Highlight />,
+    kbd: <thumbnails.Kbd />,
+    text: <thumbnails.Text />,
+
+    // Overlay components
+    drawer: <thumbnails.Drawer />,
+    modal: <thumbnails.Modal />,
+    popover: <thumbnails.Popover />,
+    tooltip: <thumbnails.Tooltip />,
+    whisper: <thumbnails.Whisper />,
+    'modal-integrations': <thumbnails.ModalIntegrations />,
+
+    // Navigation components
+    affix: <thumbnails.Affix />,
+    breadcrumb: <thumbnails.Breadcrumb />,
+    dropdown: <thumbnails.Dropdown />,
+    link: <thumbnails.Link />,
+    menu: <thumbnails.Menu />,
+    nav: <thumbnails.Nav />,
+    navbar: <thumbnails.Navbar />,
+    sidenav: <thumbnails.Sidenav />,
+    steps: <thumbnails.Steps />,
+    pagination: <thumbnails.Pagination />,
+
+    // Media and Icons components
+    avatar: <thumbnails.Avatar />,
+    icon: <thumbnails.Icon />,
+    image: <thumbnails.Image />,
+
+    // Default icon used when no matching thumbnail is found
+    default: <thumbnails.Default />
+  };
+
+  // Return the corresponding SVG thumbnail, or the default thumbnail if not found
+  return thumbnailMap[componentId] || <thumbnails.Default />;
+};

--- a/docs/components/thumbnails/buttons.tsx
+++ b/docs/components/thumbnails/buttons.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+
+/**
+ * Button 组件缩略图
+ */
+export const Button: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="10"
+      y="30"
+      width="60"
+      height="20"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <text
+      x="40"
+      y="45"
+      fontSize="12"
+      textAnchor="middle"
+      fill="var(--rs-primary-700)"
+      fontWeight="bold"
+    >
+      Button
+    </text>
+  </svg>
+);
+
+/**
+ * IconButton 组件缩略图
+ */
+export const IconButton: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="25"
+      y="25"
+      width="30"
+      height="30"
+      rx="15"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <path
+      d="M40 32V48M32 40H48"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * ButtonGroup 组件缩略图
+ */
+export const ButtonGroup: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Left button */}
+    <rect x="20" y="30" width="13.33" height="20" rx="4" fill="var(--rs-thumbnail-bg-secondary)" />
+
+    {/* Middle button - Active */}
+    <rect
+      x="33.33"
+      y="30"
+      width="13.34"
+      height="20"
+      rx="0"
+      fill="var(--rs-thumbnail-color-primary)"
+    />
+
+    {/* Right button */}
+    <rect
+      x="46.67"
+      y="30"
+      width="13.33"
+      height="20"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+    />
+
+    {/* Divider lines */}
+    <line
+      x1="33.33"
+      y1="30"
+      x2="33.33"
+      y2="50"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <line
+      x1="46.67"
+      y1="30"
+      x2="46.67"
+      y2="50"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+
+    {/* Simple ButtonGroup */}
+    <rect
+      x="20"
+      y="30"
+      width="40"
+      height="20"
+      rx="4"
+      fill="none"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+  </svg>
+);

--- a/docs/components/thumbnails/dataDisplay.tsx
+++ b/docs/components/thumbnails/dataDisplay.tsx
@@ -1,0 +1,403 @@
+import React from 'react';
+
+/**
+ * Accordion component thumbnail
+ */
+export const Accordion: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="15"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M55 22.5L50 17.5L45 22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <rect
+      x="15"
+      y="32.5"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M45 40L50 45L55 40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <rect
+      x="15"
+      y="50"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M45 57.5L50 62.5L55 57.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+/**
+ * Carousel component thumbnail
+ */
+export const Carousel: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="10"
+      y="20"
+      width="60"
+      height="40"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <rect
+      x="20"
+      y="30"
+      width="40"
+      height="20"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <circle cx="35" cy="55" r="2" fill="var(--rs-primary-300)" />
+    <circle cx="40" cy="55" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="45" cy="55" r="2" fill="var(--rs-primary-300)" />
+    <path
+      d="M15 40L5 40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M65 40L75 40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * List component thumbnail
+ */
+export const List: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="15"
+      y1="30"
+      x2="65"
+      y2="30"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <line
+      x1="15"
+      y1="45"
+      x2="65"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <line
+      x1="15"
+      y1="60"
+      x2="65"
+      y2="60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <circle cx="25" cy="22.5" r="3" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="35"
+      y1="22.5"
+      x2="55"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <circle cx="25" cy="37.5" r="3" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="35"
+      y1="37.5"
+      x2="55"
+      y2="37.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <circle cx="25" cy="52.5" r="3" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="35"
+      y1="52.5"
+      x2="55"
+      y2="52.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
+/**
+ * Timeline component thumbnail
+ */
+export const Timeline: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <line x1="30" y1="15" x2="30" y2="65" stroke="var(--rs-primary-300)" strokeWidth="2" />
+    <circle cx="30" cy="20" r="5" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="35"
+      y1="20"
+      x2="60"
+      y2="20"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <circle cx="30" cy="40" r="5" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="35"
+      y1="40"
+      x2="55"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <circle cx="30" cy="60" r="5" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="35"
+      y1="60"
+      x2="50"
+      y2="60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
+/**
+ * Panel component thumbnail
+ */
+export const Panel: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="15"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="25"
+      y1="22.5"
+      x2="55"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line x1="25" y1="40" x2="55" y2="40" stroke="var(--rs-primary-300)" strokeWidth="1.5" />
+    <line x1="25" y1="50" x2="45" y2="50" stroke="var(--rs-primary-300)" strokeWidth="1.5" />
+  </svg>
+);
+
+/**
+ * Card component thumbnail
+ */
+export const Card: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Simple card without header/footer */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Card content */}
+    <line
+      x1="25"
+      y1="25"
+      x2="55"
+      y2="25"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line x1="25" y1="35" x2="45" y2="35" stroke="var(--rs-primary-300)" strokeWidth="1.5" />
+
+    {/* Card image/content area */}
+    <rect
+      x="25"
+      y="42"
+      width="30"
+      height="15"
+      rx="2"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+  </svg>
+);
+
+/**
+ * Stat component thumbnail
+ */
+export const Stat: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Stat card container */}
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="40"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Title */}
+    <line
+      x1="20"
+      y1="30"
+      x2="40"
+      y2="30"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Main statistic area - represented by a bold line */}
+    <line
+      x1="20"
+      y1="42"
+      x2="35"
+      y2="42"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="3"
+      strokeLinecap="round"
+    />
+
+    {/* Secondary info */}
+    <line
+      x1="40"
+      y1="42"
+      x2="55"
+      y2="42"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Divider */}
+    <line
+      x1="20"
+      y1="50"
+      x2="55"
+      y2="50"
+      stroke="var(--rs-thumbnail-bg-secondary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+
+    {/* Bottom content */}
+    <line
+      x1="20"
+      y1="55"
+      x2="50"
+      y2="55"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Tag component thumbnail
+ */
+export const Tag: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="20"
+      y="30"
+      width="40"
+      height="20"
+      rx="10"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="30"
+      y1="40"
+      x2="45"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <circle
+      cx="55"
+      cy="40"
+      r="3"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M53 38L57 42M57 38L53 42"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+  </svg>
+);

--- a/docs/components/thumbnails/dataEntry.tsx
+++ b/docs/components/thumbnails/dataEntry.tsx
@@ -1,0 +1,1021 @@
+import React from 'react';
+
+/**
+ * Checkbox component thumbnail
+ */
+export const Checkbox: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="25"
+      y="25"
+      width="30"
+      height="30"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <path
+      d="M32 40L38 46L50 34"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+/**
+ * Radio component thumbnail
+ */
+export const Radio: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <circle
+      cx="40"
+      cy="40"
+      r="15"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <circle cx="40" cy="40" r="6" fill="var(--rs-thumbnail-color-primary)" />
+  </svg>
+);
+
+/**
+ * Input component thumbnail
+ */
+export const Input: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="20"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <line
+      x1="20"
+      y1="40"
+      x2="30"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+  </svg>
+);
+
+/**
+ * InputNumber component thumbnail
+ */
+export const InputNumber: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="20"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <text x="25" y="44" fill="var(--rs-thumbnail-color-primary)" fontSize="14" fontWeight="bold">
+      123
+    </text>
+
+    {/* Up/Down arrows */}
+    <rect
+      x="55"
+      y="30"
+      width="10"
+      height="20"
+      rx="2"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <path
+      d="M58 35L60 33L62 35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M58 45L60 47L62 45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="55"
+      y1="40"
+      x2="65"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+  </svg>
+);
+
+/**
+ * Toggle component thumbnail
+ */
+export const Toggle: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="20"
+      y="30"
+      width="40"
+      height="20"
+      rx="10"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <circle
+      cx="50"
+      cy="40"
+      r="8"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="white"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
+/**
+ * AutoComplete component thumbnail
+ */
+export const AutoComplete: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <rect
+      x="15"
+      y="35"
+      width="50"
+      height="25"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="20"
+      y1="45"
+      x2="40"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="20"
+      y1="55"
+      x2="35"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
+/**
+ * Slider component thumbnail
+ */
+export const Slider: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <line
+      x1="15"
+      y1="40"
+      x2="65"
+      y2="40"
+      stroke="var(--rs-primary-200)"
+      strokeWidth="4"
+      strokeLinecap="round"
+    />
+    <line
+      x1="15"
+      y1="40"
+      x2="35"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="4"
+      strokeLinecap="round"
+    />
+    <circle
+      cx="35"
+      cy="40"
+      r="8"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+  </svg>
+);
+
+/**
+ * InlineEdit component thumbnail
+ */
+export const InlineEdit: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="20"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="20"
+      y1="40"
+      x2="40"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M50 35L55 35L55 40L60 40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M50 45L55 45L55 40L60 40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+/**
+ * Rate component thumbnail
+ */
+export const Rate: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M20 40L23 46L30 47L25 52L26 59L20 56L14 59L15 52L10 47L17 46L20 40Z"
+      fill="var(--rs-yellow-500)"
+      stroke="var(--rs-yellow-700)"
+      strokeWidth="1"
+    />
+    <path
+      d="M40 40L43 46L50 47L45 52L46 59L40 56L34 59L35 52L30 47L37 46L40 40Z"
+      fill="var(--rs-yellow-500)"
+      stroke="var(--rs-yellow-700)"
+      strokeWidth="1"
+    />
+    <path
+      d="M60 40L63 46L70 47L65 52L66 59L60 56L54 59L55 52L50 47L57 46L60 40Z"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+  </svg>
+);
+
+/**
+ * TagInput component thumbnail
+ */
+export const TagInput: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="20"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="20"
+      y="35"
+      width="15"
+      height="10"
+      rx="5"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <rect
+      x="40"
+      y="35"
+      width="15"
+      height="10"
+      rx="5"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <path
+      d="M30 40L25 40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <path
+      d="M50 40L45 40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Uploader component thumbnail
+ */
+export const Uploader: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeDasharray="4 2"
+    />
+    <path
+      d="M40 25L40 45M30 35L40 25L50 35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M25 55L55 55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * RadioTile component thumbnail
+ */
+export const RadioTile: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="25"
+      width="20"
+      height="30"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="45"
+      y="25"
+      width="20"
+      height="30"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <circle cx="20" cy="30" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="50" cy="30" r="2" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1" />
+    <line
+      x1="20"
+      y1="40"
+      x2="30"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="20"
+      y1="45"
+      x2="25"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="50"
+      y1="40"
+      x2="60"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="50"
+      y1="45"
+      x2="55"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * CascadeTree component thumbnail
+ */
+export const CascadeTree: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Single panel with divider */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Vertical divider line */}
+    <line
+      x1="40"
+      y1="15"
+      x2="40"
+      y2="65"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+
+    {/* First level items (left side) */}
+    <line
+      x1="20"
+      y1="25"
+      x2="35"
+      y2="25"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <rect
+      x="20"
+      y="32"
+      width="15"
+      height="8"
+      rx="2"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="1"
+    />
+    <line
+      x1="20"
+      y1="45"
+      x2="35"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="20"
+      y1="55"
+      x2="30"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Second level items (right side) */}
+    <line
+      x1="45"
+      y1="25"
+      x2="60"
+      y2="25"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <rect
+      x="45"
+      y="32"
+      width="15"
+      height="8"
+      rx="2"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="1"
+    />
+    <line
+      x1="45"
+      y1="45"
+      x2="60"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="45"
+      y1="55"
+      x2="55"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Tree component thumbnail
+ */
+export const Tree: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Tree container */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Root node */}
+    <circle cx="22.5" cy="24.5" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="30"
+      y1="24.5"
+      x2="45"
+      y2="24.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* First child level */}
+    <circle cx="27.5" cy="34.5" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="35"
+      y1="34.5"
+      x2="50"
+      y2="34.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Second child */}
+    <circle cx="27.5" cy="44.5" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="35"
+      y1="44.5"
+      x2="50"
+      y2="44.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Grandchild */}
+    <circle cx="32.5" cy="54.5" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="40"
+      y1="54.5"
+      x2="55"
+      y2="54.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Connection lines */}
+    <line
+      x1="22.5"
+      y1="27"
+      x2="22.5"
+      y2="54.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="22.5"
+      y1="34.5"
+      x2="25.5"
+      y2="34.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="22.5"
+      y1="44.5"
+      x2="25.5"
+      y2="44.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="27.5"
+      y1="47"
+      x2="27.5"
+      y2="54.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="27.5"
+      y1="54.5"
+      x2="30.5"
+      y2="54.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+  </svg>
+);
+
+/**
+ * CheckTree component thumbnail
+ */
+export const CheckTree: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Tree container */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Root node with checkbox */}
+    <rect
+      x="20"
+      y="22"
+      width="5"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="30"
+      y1="24.5"
+      x2="45"
+      y2="24.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* First child level with checkboxes */}
+    <rect
+      x="25"
+      y="32"
+      width="5"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="35"
+      y1="34.5"
+      x2="50"
+      y2="34.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Second child with unchecked box */}
+    <rect
+      x="25"
+      y="42"
+      width="5"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="35"
+      y1="44.5"
+      x2="50"
+      y2="44.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Grandchild with unchecked box */}
+    <rect
+      x="30"
+      y="52"
+      width="5"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="40"
+      y1="54.5"
+      x2="55"
+      y2="54.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Connection lines */}
+    <line
+      x1="22.5"
+      y1="27"
+      x2="22.5"
+      y2="54.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="22.5"
+      y1="34.5"
+      x2="25"
+      y2="34.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="22.5"
+      y1="44.5"
+      x2="25"
+      y2="44.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="27.5"
+      y1="47"
+      x2="27.5"
+      y2="54.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="27.5"
+      y1="54.5"
+      x2="30"
+      y2="54.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+  </svg>
+);
+
+/**
+ * MultiCascadeTree component thumbnail
+ */
+export const MultiCascadeTree: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Single panel with divider */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Vertical divider line */}
+    <line
+      x1="40"
+      y1="15"
+      x2="40"
+      y2="65"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+
+    {/* First level items with checkboxes (left side) */}
+    <rect
+      x="20"
+      y="22"
+      width="5"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="28"
+      y1="24.5"
+      x2="35"
+      y2="24.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    <rect
+      x="20"
+      y="32"
+      width="5"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <path
+      d="M21 34L22 35L24 33"
+      stroke="white"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="28"
+      y1="34.5"
+      x2="35"
+      y2="34.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    <rect
+      x="20"
+      y="42"
+      width="5"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="28"
+      y1="44.5"
+      x2="35"
+      y2="44.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    <rect
+      x="20"
+      y="52"
+      width="5"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="28"
+      y1="54.5"
+      x2="35"
+      y2="54.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Second level items with checkboxes (right side) */}
+    <rect
+      x="45"
+      y="22"
+      width="5"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="53"
+      y1="24.5"
+      x2="60"
+      y2="24.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    <rect
+      x="45"
+      y="32"
+      width="5"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <path
+      d="M46 34L47 35L49 33"
+      stroke="white"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="53"
+      y1="34.5"
+      x2="60"
+      y2="34.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    <rect
+      x="45"
+      y="42"
+      width="5"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="53"
+      y1="44.5"
+      x2="60"
+      y2="44.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    <rect
+      x="45"
+      y="52"
+      width="5"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="53"
+      y1="54.5"
+      x2="60"
+      y2="54.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);

--- a/docs/components/thumbnails/dataGrid.tsx
+++ b/docs/components/thumbnails/dataGrid.tsx
@@ -1,0 +1,813 @@
+import React from 'react';
+
+/**
+ * Basic Table component thumbnail
+ */
+export const BasicTable: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="40"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="10"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="15"
+      y1="30"
+      x2="65"
+      y2="30"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="15"
+      y1="40"
+      x2="65"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="15"
+      y1="50"
+      x2="65"
+      y2="50"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="32"
+      y1="20"
+      x2="32"
+      y2="60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="49"
+      y1="20"
+      x2="49"
+      y2="60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
+/**
+ * Virtual Table component thumbnail
+ */
+export const VirtualTable: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="40"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="10"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="15"
+      y1="30"
+      x2="65"
+      y2="30"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="15"
+      y1="36"
+      x2="65"
+      y2="36"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <line
+      x1="15"
+      y1="42"
+      x2="65"
+      y2="42"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <line
+      x1="15"
+      y1="48"
+      x2="65"
+      y2="48"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <line
+      x1="15"
+      y1="54"
+      x2="65"
+      y2="54"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <line
+      x1="32"
+      y1="20"
+      x2="32"
+      y2="60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="49"
+      y1="20"
+      x2="49"
+      y2="60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect x="62" y="35" width="3" height="10" rx="1.5" fill="var(--rs-thumbnail-color-primary)" />
+    <rect
+      x="62"
+      y="35"
+      width="3"
+      height="10"
+      rx="1.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+  </svg>
+);
+
+/**
+ * Tree Table component thumbnail
+ */
+export const TreeTable: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Table container */}
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="40"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Table header */}
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="10"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Horizontal lines */}
+    <line
+      x1="15"
+      y1="30"
+      x2="65"
+      y2="30"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="15"
+      y1="40"
+      x2="65"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <line
+      x1="15"
+      y1="50"
+      x2="65"
+      y2="50"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+
+    {/* Vertical lines */}
+    <line
+      x1="32"
+      y1="20"
+      x2="32"
+      y2="60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="49"
+      y1="20"
+      x2="49"
+      y2="60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Tree structure - First level */}
+    <circle
+      cx="20"
+      cy="35"
+      r="1.5"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+    <path
+      d="M22 35H26"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <rect
+      x="26"
+      y="33"
+      width="3"
+      height="3"
+      rx="0.5"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+
+    {/* Tree structure - Second level (expanded) */}
+    <path
+      d="M20 35V45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeDasharray="1 1"
+    />
+    <circle
+      cx="20"
+      cy="45"
+      r="1.5"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+    <path
+      d="M22 45H26"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <rect
+      x="26"
+      y="43"
+      width="3"
+      height="3"
+      rx="0.5"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+
+    {/* Tree structure - Third level */}
+    <path
+      d="M20 45V55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeDasharray="1 1"
+    />
+    <circle
+      cx="20"
+      cy="55"
+      r="1.5"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+    <path
+      d="M22 55H26"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <rect
+      x="26"
+      y="53"
+      width="3"
+      height="3"
+      rx="0.5"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+
+    {/* Data in other columns */}
+    <line
+      x1="36"
+      y1="35"
+      x2="45"
+      y2="35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="53"
+      y1="35"
+      x2="60"
+      y2="35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    <line
+      x1="36"
+      y1="45"
+      x2="45"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="53"
+      y1="45"
+      x2="60"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    <line
+      x1="36"
+      y1="55"
+      x2="45"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="53"
+      y1="55"
+      x2="60"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Sticky Table component thumbnail
+ */
+export const StickyTable: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="40"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="10"
+      rx="4"
+      fill="var(--rs-primary-700)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="15"
+      y="30"
+      width="17"
+      height="30"
+      rx="0"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="15"
+      y1="30"
+      x2="65"
+      y2="30"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="15"
+      y1="40"
+      x2="65"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="15"
+      y1="50"
+      x2="65"
+      y2="50"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="32"
+      y1="20"
+      x2="32"
+      y2="60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="49"
+      y1="20"
+      x2="49"
+      y2="60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M15 15L15 20M65 15L65 20"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeDasharray="1 1"
+    />
+    <path
+      d="M10 20L15 20M70 20L65 20"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeDasharray="1 1"
+    />
+  </svg>
+);
+
+/**
+ * Editable Table component thumbnail
+ */
+export const EditableTable: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="40"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="10"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="15"
+      y1="30"
+      x2="65"
+      y2="30"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="15"
+      y1="40"
+      x2="65"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="15"
+      y1="50"
+      x2="65"
+      y2="50"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="32"
+      y1="20"
+      x2="32"
+      y2="60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="49"
+      y1="20"
+      x2="49"
+      y2="60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="32"
+      y="40"
+      width="17"
+      height="10"
+      rx="2"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M36 45L40 45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M42 45L44 45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Filterable Table component thumbnail
+ */
+export const FilterableTable: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Table container */}
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="40"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Table header */}
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="10"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Horizontal lines */}
+    <line
+      x1="15"
+      y1="30"
+      x2="65"
+      y2="30"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="15"
+      y1="40"
+      x2="65"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <line
+      x1="15"
+      y1="50"
+      x2="65"
+      y2="50"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+
+    {/* Vertical lines */}
+    <line
+      x1="32"
+      y1="20"
+      x2="32"
+      y2="60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="49"
+      y1="20"
+      x2="49"
+      y2="60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Filter icons in header */}
+    {/* First column filter */}
+    <rect
+      x="22"
+      y="23"
+      width="6"
+      height="4"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+    />
+    <path
+      d="M24 23L26 26L28 23"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+
+    {/* Second column filter */}
+    <rect
+      x="39"
+      y="23"
+      width="6"
+      height="4"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+    />
+    <path
+      d="M41 23L43 26L45 23"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+
+    {/* Third column filter */}
+    <rect
+      x="56"
+      y="23"
+      width="6"
+      height="4"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+    />
+    <path
+      d="M58 23L60 26L62 23"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+
+    {/* Filter dropdown for first column (shown open) */}
+    <rect
+      x="18"
+      y="30"
+      width="12"
+      height="8"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      filter="url(#shadow)"
+    />
+    <line
+      x1="20"
+      y1="33"
+      x2="28"
+      y2="33"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+    />
+    <line
+      x1="20"
+      y1="35"
+      x2="28"
+      y2="35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+    />
+    <circle cx="21" cy="33" r="0.75" fill="var(--rs-thumbnail-color-primary)" />
+
+    {/* Table data */}
+    <line
+      x1="20"
+      y1="45"
+      x2="28"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <line
+      x1="37"
+      y1="45"
+      x2="45"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <line
+      x1="54"
+      y1="45"
+      x2="62"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+
+    <line
+      x1="20"
+      y1="55"
+      x2="28"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <line
+      x1="37"
+      y1="55"
+      x2="45"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <line
+      x1="54"
+      y1="55"
+      x2="62"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+
+    {/* Shadow filter for dropdown */}
+    <defs>
+      <filter
+        id="shadow"
+        x="17"
+        y="29"
+        width="14"
+        height="10"
+        filterUnits="userSpaceOnUse"
+        colorInterpolationFilters="sRGB"
+      >
+        <feFlood floodOpacity="0" result="BackgroundImageFix" />
+        <feColorMatrix
+          in="SourceAlpha"
+          type="matrix"
+          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+        />
+        <feOffset dy="1" />
+        <feGaussianBlur stdDeviation="0.5" />
+        <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0" />
+        <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow" />
+        <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape" />
+      </filter>
+    </defs>
+  </svg>
+);

--- a/docs/components/thumbnails/dataPickers.tsx
+++ b/docs/components/thumbnails/dataPickers.tsx
@@ -1,0 +1,1053 @@
+import React from 'react';
+
+/**
+ * CheckPicker component thumbnail
+ */
+export const CheckPicker: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Toggle button */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M55 22.5L53 19.5L57 19.5"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="20"
+      y1="22.5"
+      x2="45"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Dropdown menu */}
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="40"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Menu items with checkboxes */}
+    <rect
+      x="20"
+      y="37"
+      width="5"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <path
+      d="M21 39L22 40L24 38"
+      stroke="white"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="30"
+      y1="39.5"
+      x2="55"
+      y2="39.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    <rect
+      x="20"
+      y="47"
+      width="5"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <path
+      d="M21 49L22 50L24 48"
+      stroke="white"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="30"
+      y1="49.5"
+      x2="50"
+      y2="49.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    <rect
+      x="20"
+      y="57"
+      width="5"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="30"
+      y1="59.5"
+      x2="45"
+      y2="59.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * CheckTreePicker component thumbnail
+ */
+export const CheckTreePicker: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Toggle button */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M55 22.5L53 19.5L57 19.5"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="20"
+      y1="22.5"
+      x2="45"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* CheckTree dropdown */}
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="40"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Root node with checkbox */}
+    <rect
+      x="20"
+      y="35"
+      width="5"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <path
+      d="M21 37L22 38L24 36"
+      stroke="white"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="30"
+      y1="37.5"
+      x2="45"
+      y2="37.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* First child level with checkbox */}
+    <rect
+      x="25"
+      y="45"
+      width="5"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <path
+      d="M26 47L27 48L29 46"
+      stroke="white"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="35"
+      y1="47.5"
+      x2="50"
+      y2="47.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Second child with unchecked box */}
+    <rect
+      x="25"
+      y="55"
+      width="5"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="35"
+      y1="57.5"
+      x2="50"
+      y2="57.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Grandchild with unchecked box */}
+    <rect
+      x="30"
+      y="65"
+      width="5"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="40"
+      y1="67.5"
+      x2="55"
+      y2="67.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Connection lines */}
+    <line
+      x1="22.5"
+      y1="40"
+      x2="22.5"
+      y2="67.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="22.5"
+      y1="47.5"
+      x2="25"
+      y2="47.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="22.5"
+      y1="57.5"
+      x2="25"
+      y2="57.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="27.5"
+      y1="60"
+      x2="27.5"
+      y2="67.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="27.5"
+      y1="67.5"
+      x2="30"
+      y2="67.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+  </svg>
+);
+
+/**
+ * InputPicker component thumbnail
+ */
+export const InputPicker: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Toggle button */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M55 22.5L53 19.5L57 19.5"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="20"
+      y1="22.5"
+      x2="35"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Dropdown menu */}
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="40"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Menu items */}
+    <rect
+      x="20"
+      y="37"
+      width="40"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+
+    <rect
+      x="20"
+      y="47"
+      width="35"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+
+    <rect
+      x="20"
+      y="57"
+      width="30"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+  </svg>
+);
+
+/**
+ * SelectPicker component thumbnail
+ */
+export const SelectPicker: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Toggle button */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M55 22.5L53 19.5L57 19.5"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="20"
+      y1="22.5"
+      x2="40"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Dropdown menu */}
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="40"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Menu items - highlighted item */}
+    <rect
+      x="20"
+      y="37"
+      width="40"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="25"
+      y1="39.5"
+      x2="55"
+      y2="39.5"
+      stroke="white"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Regular items */}
+    <line
+      x1="20"
+      y1="47.5"
+      x2="50"
+      y2="47.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="20"
+      y1="57.5"
+      x2="45"
+      y2="57.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * TagPicker component thumbnail
+ */
+export const TagPicker: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Toggle button */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M55 22.5L53 19.5L57 19.5"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <rect
+      x="20"
+      y="20"
+      width="15"
+      height="5"
+      rx="2.5"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+
+    {/* Dropdown menu */}
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="40"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Menu items */}
+    <rect
+      x="20"
+      y="37"
+      width="40"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+
+    <rect
+      x="20"
+      y="47"
+      width="35"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+
+    <rect
+      x="20"
+      y="57"
+      width="30"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+  </svg>
+);
+
+/**
+ * TreePicker component thumbnail
+ */
+export const TreePicker: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Toggle button */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M55 22.5L53 19.5L57 19.5"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="20"
+      y1="22.5"
+      x2="40"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Tree dropdown */}
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="40"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Root node */}
+    <circle cx="22.5" cy="37.5" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="30"
+      y1="37.5"
+      x2="45"
+      y2="37.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* First child level */}
+    <circle cx="27.5" cy="47.5" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="35"
+      y1="47.5"
+      x2="50"
+      y2="47.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Second child */}
+    <circle cx="27.5" cy="57.5" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="35"
+      y1="57.5"
+      x2="50"
+      y2="57.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Grandchild */}
+    <circle cx="32.5" cy="67.5" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="40"
+      y1="67.5"
+      x2="55"
+      y2="67.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Connection lines */}
+    <line
+      x1="22.5"
+      y1="40"
+      x2="22.5"
+      y2="67.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="22.5"
+      y1="47.5"
+      x2="25.5"
+      y2="47.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="22.5"
+      y1="57.5"
+      x2="25.5"
+      y2="57.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="27.5"
+      y1="60"
+      x2="27.5"
+      y2="67.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="27.5"
+      y1="67.5"
+      x2="30.5"
+      y2="67.5"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+  </svg>
+);
+
+/**
+ * MultiCascader component thumbnail
+ */
+export const MultiCascader: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Toggle button */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M55 22.5L53 19.5L57 19.5"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="20"
+      y1="22.5"
+      x2="45"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Dropdown menu - single container */}
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="40"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Vertical divider line */}
+    <line
+      x1="40"
+      y1="30"
+      x2="40"
+      y2="70"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+
+    {/* Left side items with checkboxes */}
+    <rect
+      x="20"
+      y="37"
+      width="5"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <path
+      d="M21 39L22 40L24 38"
+      stroke="white"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="30"
+      y1="39.5"
+      x2="35"
+      y2="39.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    <rect
+      x="20"
+      y="47"
+      width="5"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="30"
+      y1="49.5"
+      x2="35"
+      y2="49.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    <rect
+      x="20"
+      y="57"
+      width="5"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <path
+      d="M21 59L22 60L24 58"
+      stroke="white"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="30"
+      y1="59.5"
+      x2="35"
+      y2="59.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Right side items with checkboxes (second level) */}
+    <rect
+      x="45"
+      y="37"
+      width="5"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <path
+      d="M46 39L47 40L49 38"
+      stroke="white"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="55"
+      y1="39.5"
+      x2="60"
+      y2="39.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    <rect
+      x="45"
+      y="47"
+      width="5"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <path
+      d="M46 49L47 50L49 48"
+      stroke="white"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="55"
+      y1="49.5"
+      x2="60"
+      y2="49.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    <rect
+      x="45"
+      y="57"
+      width="5"
+      height="5"
+      rx="1"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="55"
+      y1="59.5"
+      x2="60"
+      y2="59.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Cascader component thumbnail
+ */
+export const Cascader: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Toggle button */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M55 22.5L53 19.5L57 19.5"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="20"
+      y1="22.5"
+      x2="45"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Dropdown menu - single container */}
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="40"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Vertical divider line */}
+    <line
+      x1="40"
+      y1="30"
+      x2="40"
+      y2="70"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+
+    {/* Left side items */}
+    <line
+      x1="20"
+      y1="40"
+      x2="35"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <rect
+      x="20"
+      y="45"
+      width="15"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="20"
+      y1="55"
+      x2="30"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="20"
+      y1="65"
+      x2="25"
+      y2="65"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Right side items (second level) */}
+    <line
+      x1="45"
+      y1="40"
+      x2="60"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="45"
+      y1="50"
+      x2="55"
+      y2="50"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <rect
+      x="45"
+      y="55"
+      width="15"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <line
+      x1="45"
+      y1="65"
+      x2="50"
+      y2="65"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);

--- a/docs/components/thumbnails/dateTime.tsx
+++ b/docs/components/thumbnails/dateTime.tsx
@@ -1,0 +1,1659 @@
+import React from 'react';
+
+/**
+ * Calendar component thumbnail
+ */
+export const Calendar: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="10"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="25"
+      y1="35"
+      x2="25"
+      y2="35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="35"
+      y1="35"
+      x2="35"
+      y2="35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="45"
+      y1="35"
+      x2="45"
+      y2="35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="55"
+      y1="35"
+      x2="55"
+      y2="35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="25"
+      y1="45"
+      x2="25"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="35"
+      y1="45"
+      x2="35"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <circle cx="45" cy="45" r="3" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="55"
+      y1="45"
+      x2="55"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="25"
+      y1="55"
+      x2="25"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="35"
+      y1="55"
+      x2="35"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="45"
+      y1="55"
+      x2="45"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * DateInput component thumbnail
+ */
+export const DateInput: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Input container */}
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="20"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Date format: --/--/---- using lines */}
+    {/* First -- */}
+    <line
+      x1="22"
+      y1="40"
+      x2="25"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="27"
+      y1="40"
+      x2="30"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* First / */}
+    <path
+      d="M32 38L34 42"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+
+    {/* Second -- */}
+    <line
+      x1="36"
+      y1="40"
+      x2="39"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="41"
+      y1="40"
+      x2="44"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Second / */}
+    <path
+      d="M46 38L48 42"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+
+    {/* Year ---- */}
+    <line
+      x1="50"
+      y1="40"
+      x2="53"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Calendar icon - centered vertically */}
+    <rect
+      x="55"
+      y="37.5"
+      width="5"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+    />
+    <line
+      x1="56"
+      y1="35.5"
+      x2="56"
+      y2="39.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+    />
+    <line
+      x1="59"
+      y1="35.5"
+      x2="59"
+      y2="39.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+    />
+    <line
+      x1="55"
+      y1="40.5"
+      x2="60"
+      y2="40.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * DatePicker component thumbnail
+ */
+export const DatePicker: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Toggle button part (similar to DateInput) */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Date format: --/--/---- using lines */}
+    <line
+      x1="22"
+      y1="22.5"
+      x2="25"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="27"
+      y1="22.5"
+      x2="30"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* First / */}
+    <path
+      d="M32 20.5L34 24.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+
+    {/* Second -- */}
+    <line
+      x1="36"
+      y1="22.5"
+      x2="39"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="41"
+      y1="22.5"
+      x2="44"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Calendar icon */}
+    <rect
+      x="55"
+      y="20"
+      width="5"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+    />
+    <line
+      x1="56"
+      y1="18"
+      x2="56"
+      y2="22"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+    />
+    <line
+      x1="59"
+      y1="18"
+      x2="59"
+      y2="22"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+    />
+    <line
+      x1="55"
+      y1="23"
+      x2="60"
+      y2="23"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+    />
+
+    {/* Calendar panel part (similar to Calendar) */}
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="35"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="8"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Calendar days */}
+    <line
+      x1="22"
+      y1="45"
+      x2="22"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="30"
+      y1="45"
+      x2="30"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="38"
+      y1="45"
+      x2="38"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="46"
+      y1="45"
+      x2="46"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="54"
+      y1="45"
+      x2="54"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+
+    <line
+      x1="22"
+      y1="52"
+      x2="22"
+      y2="52"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="30"
+      y1="52"
+      x2="30"
+      y2="52"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <circle cx="38" cy="52" r="3" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="46"
+      y1="52"
+      x2="46"
+      y2="52"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="54"
+      y1="52"
+      x2="54"
+      y2="52"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+
+    <line
+      x1="22"
+      y1="59"
+      x2="22"
+      y2="59"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="30"
+      y1="59"
+      x2="30"
+      y2="59"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="38"
+      y1="59"
+      x2="38"
+      y2="59"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="46"
+      y1="59"
+      x2="46"
+      y2="59"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * DateRangeInput component thumbnail
+ */
+export const DateRangeInput: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="20"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M20 40H25"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M28 40H30"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M33 40H35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M40 40H40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M45 40H50"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M53 40H55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M58 40H60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="40"
+      y1="35"
+      x2="40"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+  </svg>
+);
+
+/**
+ * DateTimeRangePicker component thumbnail
+ */
+export const DateTimeRangePicker: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M55 27.5L50 32.5L45 27.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M25 27.5H40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <rect
+      x="15"
+      y="35"
+      width="50"
+      height="30"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="17"
+      y="37"
+      width="23"
+      height="26"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <rect
+      x="40"
+      y="37"
+      width="23"
+      height="26"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <rect
+      x="17"
+      y="37"
+      width="23"
+      height="6"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <rect
+      x="40"
+      y="37"
+      width="23"
+      height="6"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <line
+      x1="20"
+      y1="47"
+      x2="20"
+      y2="47"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="25"
+      y1="47"
+      x2="25"
+      y2="47"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="30"
+      y1="47"
+      x2="30"
+      y2="47"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="35"
+      y1="47"
+      x2="35"
+      y2="47"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="20"
+      y1="52"
+      x2="20"
+      y2="52"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="25"
+      y1="52"
+      x2="25"
+      y2="52"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <circle cx="30" cy="52" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="35"
+      y1="52"
+      x2="35"
+      y2="52"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="20"
+      y1="57"
+      x2="20"
+      y2="57"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="25"
+      y1="57"
+      x2="25"
+      y2="57"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="30"
+      y1="57"
+      x2="30"
+      y2="57"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="35"
+      y1="57"
+      x2="35"
+      y2="57"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="43"
+      y1="47"
+      x2="43"
+      y2="47"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="48"
+      y1="47"
+      x2="48"
+      y2="47"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="53"
+      y1="47"
+      x2="53"
+      y2="47"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="58"
+      y1="47"
+      x2="58"
+      y2="47"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="43"
+      y1="52"
+      x2="43"
+      y2="52"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="48"
+      y1="52"
+      x2="48"
+      y2="52"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="53"
+      y1="52"
+      x2="53"
+      y2="52"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <circle cx="58" cy="52" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="43"
+      y1="57"
+      x2="43"
+      y2="57"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="48"
+      y1="57"
+      x2="48"
+      y2="57"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="53"
+      y1="57"
+      x2="53"
+      y2="57"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="58"
+      y1="57"
+      x2="58"
+      y2="57"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * TimeRangePicker component thumbnail
+ */
+export const TimeRangePicker: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Toggle button part */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Time format: --:-- to --:-- */}
+    <line
+      x1="20"
+      y1="22.5"
+      x2="23"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="25"
+      y1="22.5"
+      x2="28"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* First colon : */}
+    <circle cx="30" cy="20.5" r="1" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="30" cy="24.5" r="1" fill="var(--rs-thumbnail-color-primary)" />
+
+    {/* First time minutes */}
+    <line
+      x1="32"
+      y1="22.5"
+      x2="35"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* To symbol */}
+    <line
+      x1="37"
+      y1="22.5"
+      x2="39"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Second time hours */}
+    <line
+      x1="41"
+      y1="22.5"
+      x2="44"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Second colon : */}
+    <circle cx="46" cy="20.5" r="1" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="46" cy="24.5" r="1" fill="var(--rs-thumbnail-color-primary)" />
+
+    {/* Second time minutes */}
+    <line
+      x1="48"
+      y1="22.5"
+      x2="51"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Clock icon */}
+    <circle
+      cx="58"
+      cy="22.5"
+      r="3"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+    />
+    <line
+      x1="58"
+      y1="22.5"
+      x2="60"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+    />
+    <line
+      x1="58"
+      y1="22.5"
+      x2="58"
+      y2="20.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+    />
+
+    {/* Time panel */}
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="35"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Vertical divider line */}
+    <line
+      x1="40"
+      y1="30"
+      x2="40"
+      y2="65"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+
+    {/* Left side - start time */}
+    {/* Hours column */}
+    <rect
+      x="18"
+      y="35"
+      width="8"
+      height="25"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+    />
+    <line
+      x1="20"
+      y1="40"
+      x2="24"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <rect
+      x="20"
+      y="45"
+      width="4"
+      height="4"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <text x="22" y="48" fontSize="4" textAnchor="middle" fill="transparent" fontWeight="bold">
+      9
+    </text>
+    <line
+      x1="20"
+      y1="55"
+      x2="24"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+
+    {/* Minutes column */}
+    <rect
+      x="28"
+      y="35"
+      width="8"
+      height="25"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+    />
+    <line
+      x1="30"
+      y1="40"
+      x2="34"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <rect
+      x="30"
+      y="45"
+      width="4"
+      height="4"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <text x="32" y="48" fontSize="4" textAnchor="middle" fill="transparent" fontWeight="bold">
+      00
+    </text>
+    <line
+      x1="30"
+      y1="55"
+      x2="34"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+
+    {/* Right side - end time */}
+    {/* Hours column */}
+    <rect
+      x="44"
+      y="35"
+      width="8"
+      height="25"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+    />
+    <line
+      x1="46"
+      y1="40"
+      x2="50"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <rect
+      x="46"
+      y="45"
+      width="4"
+      height="4"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <text x="48" y="48" fontSize="4" textAnchor="middle" fill="transparent" fontWeight="bold">
+      5
+    </text>
+    <line
+      x1="46"
+      y1="55"
+      x2="50"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+
+    {/* Minutes column */}
+    <rect
+      x="54"
+      y="35"
+      width="8"
+      height="25"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+    />
+    <line
+      x1="56"
+      y1="40"
+      x2="60"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <rect
+      x="56"
+      y="45"
+      width="4"
+      height="4"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <text x="58" y="48" fontSize="4" textAnchor="middle" fill="transparent" fontWeight="bold">
+      30
+    </text>
+    <line
+      x1="56"
+      y1="55"
+      x2="60"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * DateRangePicker component thumbnail
+ */
+export const DateRangePicker: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Toggle button part */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Date format: --/--/---- to --/--/---- */}
+    <line
+      x1="20"
+      y1="22.5"
+      x2="23"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M25 20.5L27 24.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <line
+      x1="29"
+      y1="22.5"
+      x2="32"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* To symbol */}
+    <line
+      x1="35"
+      y1="22.5"
+      x2="37"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Second date */}
+    <line
+      x1="40"
+      y1="22.5"
+      x2="43"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M45 20.5L47 24.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <line
+      x1="49"
+      y1="22.5"
+      x2="52"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Calendar icon */}
+    <rect
+      x="55"
+      y="20"
+      width="5"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+    />
+    <line
+      x1="56"
+      y1="18"
+      x2="56"
+      y2="22"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+    />
+    <line
+      x1="59"
+      y1="18"
+      x2="59"
+      y2="22"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+    />
+    <line
+      x1="55"
+      y1="23"
+      x2="60"
+      y2="23"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+    />
+
+    {/* Calendar panel part - single container with divider */}
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="35"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="8"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Vertical divider line */}
+    <line
+      x1="40"
+      y1="30"
+      x2="40"
+      y2="65"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+
+    {/* Left calendar - start date */}
+    <line
+      x1="22"
+      y1="45"
+      x2="22"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="30"
+      y1="45"
+      x2="30"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <circle cx="22" cy="52" r="3" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="30"
+      y1="52"
+      x2="30"
+      y2="52"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="22"
+      y1="59"
+      x2="22"
+      y2="59"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="30"
+      y1="59"
+      x2="30"
+      y2="59"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+
+    {/* Right calendar - end date */}
+    <line
+      x1="48"
+      y1="45"
+      x2="48"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="56"
+      y1="45"
+      x2="56"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="48"
+      y1="52"
+      x2="48"
+      y2="52"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="56"
+      y1="52"
+      x2="56"
+      y2="52"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <circle cx="56" cy="59" r="3" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="48"
+      y1="59"
+      x2="48"
+      y2="59"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+
+    {/* Date range highlight */}
+    <rect
+      x="25"
+      y="52"
+      width="30"
+      height="6"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+      strokeDasharray="1 1"
+    />
+  </svg>
+);
+
+/**
+ * TimePicker component thumbnail
+ */
+export const TimePicker: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Toggle button part */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Time format: --:-- */}
+    <line
+      x1="25"
+      y1="22.5"
+      x2="28"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="30"
+      y1="22.5"
+      x2="33"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Colon : */}
+    <circle cx="35" cy="20.5" r="1" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="35" cy="24.5" r="1" fill="var(--rs-thumbnail-color-primary)" />
+
+    {/* Minutes */}
+    <line
+      x1="37"
+      y1="22.5"
+      x2="40"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="42"
+      y1="22.5"
+      x2="45"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Clock icon */}
+    <circle
+      cx="55"
+      cy="22.5"
+      r="3"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+    />
+    <line
+      x1="55"
+      y1="22.5"
+      x2="57"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+    />
+    <line
+      x1="55"
+      y1="22.5"
+      x2="55"
+      y2="20.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+      strokeLinecap="round"
+    />
+
+    {/* Time panel */}
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="35"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Time columns */}
+    <rect
+      x="20"
+      y="35"
+      width="10"
+      height="25"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+    />
+    <rect
+      x="35"
+      y="35"
+      width="10"
+      height="25"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+    />
+    <rect
+      x="50"
+      y="35"
+      width="10"
+      height="25"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.75"
+    />
+
+    {/* Hours column */}
+    <line
+      x1="22"
+      y1="40"
+      x2="28"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <rect
+      x="22"
+      y="45"
+      width="6"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <text x="25" y="49" fontSize="5" textAnchor="middle" fill="transparent" fontWeight="bold">
+      12
+    </text>
+    <line
+      x1="22"
+      y1="55"
+      x2="28"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+
+    {/* Minutes column */}
+    <line
+      x1="37"
+      y1="40"
+      x2="43"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <rect
+      x="37"
+      y="45"
+      width="6"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <text x="40" y="49" fontSize="5" textAnchor="middle" fill="transparent" fontWeight="bold">
+      30
+    </text>
+    <line
+      x1="37"
+      y1="55"
+      x2="43"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+
+    {/* AM/PM column */}
+    <line
+      x1="52"
+      y1="40"
+      x2="58"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+    <rect
+      x="52"
+      y="45"
+      width="6"
+      height="5"
+      rx="1"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="0.5"
+    />
+    <text x="55" y="49" fontSize="5" textAnchor="middle" fill="transparent" fontWeight="bold">
+      PM
+    </text>
+    <line
+      x1="52"
+      y1="55"
+      x2="58"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+    />
+  </svg>
+);

--- a/docs/components/thumbnails/default.tsx
+++ b/docs/components/thumbnails/default.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+/**
+ * 默认缩略图组件，当没有找到对应组件的缩略图时使用
+ */
+export const Default: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <path
+      d="M30 40H50M40 30V50"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);

--- a/docs/components/thumbnails/disclosure.tsx
+++ b/docs/components/thumbnails/disclosure.tsx
@@ -1,0 +1,240 @@
+import React from 'react';
+
+/**
+ * Accordion component thumbnail
+ * Note: This is a duplicate of the one in dataDisplay.tsx,
+ * but included here for organizational purposes
+ */
+export const DisclosureAccordion: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* First panel - expanded */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="15"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="25"
+      y1="22.5"
+      x2="40"
+      y2="22.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Indicator for expanded panel */}
+    <circle
+      cx="53"
+      cy="22.5"
+      r="3"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+
+    {/* Second panel - collapsed */}
+    <rect
+      x="15"
+      y="32.5"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="25"
+      y1="40"
+      x2="40"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Indicator for collapsed panel */}
+    <circle
+      cx="53"
+      cy="40"
+      r="3"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+
+    {/* Third panel - collapsed */}
+    <rect
+      x="15"
+      y="50"
+      width="50"
+      height="15"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="25"
+      y1="57.5"
+      x2="40"
+      y2="57.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Indicator for collapsed panel */}
+    <circle
+      cx="53"
+      cy="57.5"
+      r="3"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+  </svg>
+);
+
+/**
+ * Tabs component thumbnail
+ */
+export const Tabs: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="25"
+      width="50"
+      height="40"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="15"
+      y="15"
+      width="15"
+      height="10"
+      rx="4 4 0 0"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="30"
+      y="15"
+      width="15"
+      height="10"
+      rx="4 4 0 0"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="45"
+      y="15"
+      width="15"
+      height="10"
+      rx="4 4 0 0"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="22.5"
+      y1="20"
+      x2="22.5"
+      y2="20"
+      stroke="white"
+      strokeWidth="3"
+      strokeLinecap="round"
+    />
+    <line
+      x1="37.5"
+      y1="20"
+      x2="37.5"
+      y2="20"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="3"
+      strokeLinecap="round"
+    />
+    <line
+      x1="52.5"
+      y1="20"
+      x2="52.5"
+      y2="20"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="3"
+      strokeLinecap="round"
+    />
+    <line
+      x1="25"
+      y1="40"
+      x2="55"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="25"
+      y1="50"
+      x2="45"
+      y2="50"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * VisuallyHidden component thumbnail
+ */
+export const VisuallyHidden: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="20"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeDasharray="3 2"
+    />
+    <circle
+      cx="40"
+      cy="40"
+      r="10"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeDasharray="3 2"
+    />
+    <path
+      d="M30 40L50 40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeDasharray="3 2"
+    />
+    <path
+      d="M40 30L40 50"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeDasharray="3 2"
+    />
+    <path d="M30 30L50 50" stroke="var(--rs-primary-700)" strokeWidth="1.5" strokeLinecap="round" />
+    <path d="M50 30L30 50" stroke="var(--rs-primary-700)" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);

--- a/docs/components/thumbnails/form.tsx
+++ b/docs/components/thumbnails/form.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+
+/**
+ * Form component thumbnail
+ */
+export const Form: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <rect
+      x="20"
+      y="20"
+      width="40"
+      height="10"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="20"
+      y="35"
+      width="40"
+      height="10"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="20"
+      y="50"
+      width="15"
+      height="10"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
+/**
+ * FormValidation component thumbnail
+ */
+export const FormValidation: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="20"
+      y="20"
+      width="40"
+      height="10"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-red-500)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="20"
+      y="35"
+      width="40"
+      height="10"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="20"
+      y="50"
+      width="15"
+      height="10"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line x1="20" y1="33" x2="35" y2="33" stroke="var(--rs-red-500)" strokeWidth="1.5" />
+  </svg>
+);
+
+/**
+ * Schema component thumbnail
+ */
+export const Schema: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="20"
+      y="20"
+      width="40"
+      height="10"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <rect
+      x="20"
+      y="35"
+      width="40"
+      height="10"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <rect
+      x="20"
+      y="50"
+      width="40"
+      height="10"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <path
+      d="M25 25L30 25L35 25"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M25 40L30 40L35 40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M25 55L30 55L35 55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M45 25L50 25L55 25"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M45 40L50 40L55 40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M45 55L50 55L55 55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);

--- a/docs/components/thumbnails/index.ts
+++ b/docs/components/thumbnails/index.ts
@@ -1,0 +1,17 @@
+// Export all thumbnail components
+export * from './layout';
+export * from './buttons';
+export * from './status';
+export * from './typography';
+export * from './form';
+export * from './dataEntry';
+export * from './dataDisplay';
+export * from './overlays';
+export * from './navigation';
+export * from './media';
+export * from './dataPickers';
+export * from './dateTime';
+export * from './dataGrid';
+export * from './disclosure';
+export * from './misc';
+export * from './default';

--- a/docs/components/thumbnails/layout.tsx
+++ b/docs/components/thumbnails/layout.tsx
@@ -1,0 +1,287 @@
+import React from 'react';
+
+/**
+ * Box 组件缩略图
+ */
+export const Box: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <rect
+      x="25"
+      y="25"
+      width="30"
+      height="30"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
+/**
+ * Center 组件缩略图
+ */
+export const Center: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="10"
+      y="10"
+      width="60"
+      height="60"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeDasharray="4 2"
+    />
+    <rect
+      x="25"
+      y="25"
+      width="30"
+      height="30"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="40"
+      y1="10"
+      x2="40"
+      y2="25"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="40"
+      y1="55"
+      x2="40"
+      y2="70"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="10"
+      y1="40"
+      x2="25"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="55"
+      y1="40"
+      x2="70"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+  </svg>
+);
+
+/**
+ * Divider 组件缩略图
+ */
+export const Divider: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="10"
+      rx="2"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="15"
+      y1="40"
+      x2="65"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <rect
+      x="15"
+      y="50"
+      width="50"
+      height="10"
+      rx="2"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+  </svg>
+);
+
+/**
+ * Frame 组件缩略图
+ */
+export const Frame: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="10"
+      y="10"
+      width="60"
+      height="60"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <rect
+      x="10"
+      y="10"
+      width="60"
+      height="12"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="10"
+      y="58"
+      width="60"
+      height="12"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="10"
+      y="22"
+      width="15"
+      height="36"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
+/**
+ * Grid 组件缩略图
+ */
+export const Grid: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="10"
+      y="10"
+      width="60"
+      height="60"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeDasharray="4 2"
+    />
+    <rect
+      x="15"
+      y="15"
+      width="25"
+      height="25"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="45"
+      y="15"
+      width="20"
+      height="25"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="15"
+      y="45"
+      width="15"
+      height="20"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="35"
+      y="45"
+      width="30"
+      height="20"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
+/**
+ * Stack 组件缩略图
+ */
+export const Stack: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="10"
+      y="10"
+      width="60"
+      height="60"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeDasharray="4 2"
+    />
+    <rect
+      x="20"
+      y="15"
+      width="40"
+      height="15"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="20"
+      y="35"
+      width="40"
+      height="10"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="20"
+      y="50"
+      width="40"
+      height="15"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+  </svg>
+);

--- a/docs/components/thumbnails/media.tsx
+++ b/docs/components/thumbnails/media.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+
+/**
+ * Avatar component thumbnail
+ */
+export const Avatar: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <circle
+      cx="40"
+      cy="40"
+      r="20"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <circle cx="40" cy="35" r="7" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M25 55C30 45 50 45 55 55" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+  </svg>
+);
+
+/**
+ * Icon component thumbnail
+ */
+export const Icon: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="20"
+      height="20"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M20 25H30M25 20V30"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+
+    <rect
+      x="45"
+      y="15"
+      width="20"
+      height="20"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <circle cx="55" cy="25" r="5" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+
+    <rect
+      x="15"
+      y="45"
+      width="20"
+      height="20"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M20 55L30 55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+
+    <rect
+      x="45"
+      y="45"
+      width="20"
+      height="20"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M50 50L60 60M60 50L50 60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Image component thumbnail
+ */
+export const Image: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="20"
+      width="50"
+      height="40"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <circle cx="30" cy="35" r="5" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M15 50L30 40L40 50L65 35" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M40 50L50 45L65 55" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+  </svg>
+);

--- a/docs/components/thumbnails/misc.tsx
+++ b/docs/components/thumbnails/misc.tsx
@@ -1,0 +1,256 @@
+import React from 'react';
+
+/**
+ * Animation component thumbnail
+ */
+export const Animation: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="25"
+      width="20"
+      height="30"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="45"
+      y="25"
+      width="20"
+      height="30"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      opacity="0.7"
+    />
+    <path
+      d="M35 40H45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeDasharray="2 1"
+    />
+    <path
+      d="M38 35L42 40L38 45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M15 60C15 60 20 55 25 60C30 65 35 60 35 60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M45 60C45 60 50 55 55 60C60 65 65 60 65 60"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * CustomProvider component thumbnail
+ */
+export const CustomProvider: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="10"
+      y="20"
+      width="60"
+      height="40"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="15"
+      y="25"
+      width="50"
+      height="10"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <rect
+      x="15"
+      y="40"
+      width="20"
+      height="15"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <rect
+      x="40"
+      y="40"
+      width="25"
+      height="15"
+      rx="2"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <path
+      d="M25 30L30 30"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M35 30L40 30"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M45 30L55 30"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M25 47.5L25 47.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="3"
+      strokeLinecap="round"
+    />
+    <path
+      d="M52.5 47.5L52.5 47.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="3"
+      strokeLinecap="round"
+    />
+    <path
+      d="M40 15L40 10"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M40 70L40 65"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M75 40L70 40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M10 40L5 40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * DOMHelper component thumbnail
+ */
+export const DOMHelper: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M25 25L35 35L25 45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M55 25L45 35L55 45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M35 55L45 25"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Hooks component thumbnail for useMediaQuery and useBreakpointValue
+ */
+export const Hooks: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M25 30C25 25.5817 28.5817 22 33 22C37.4183 22 41 25.5817 41 30V50C41 54.4183 44.5817 58 49 58C53.4183 58 57 54.4183 57 50"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <rect
+      x="15"
+      y="30"
+      width="20"
+      height="20"
+      rx="2"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="45"
+      y="30"
+      width="20"
+      height="20"
+      rx="2"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M25 40L35 40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M45 40L55 40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M25 35L30 40L25 45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M55 35L50 40L55 45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);

--- a/docs/components/thumbnails/navigation.tsx
+++ b/docs/components/thumbnails/navigation.tsx
@@ -1,0 +1,643 @@
+import React from 'react';
+
+/**
+ * Affix component thumbnail
+ */
+export const Affix: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="10"
+      y="10"
+      width="60"
+      height="60"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeDasharray="4 2"
+    />
+    <rect
+      x="20"
+      y="20"
+      width="40"
+      height="15"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="10"
+      y1="20"
+      x2="15"
+      y2="20"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="10"
+      y1="35"
+      x2="15"
+      y2="35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="65"
+      y1="20"
+      x2="70"
+      y2="20"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="65"
+      y1="35"
+      x2="70"
+      y2="35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <path
+      d="M25 27.5L35 27.5M45 27.5L55 27.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Breadcrumb component thumbnail
+ */
+export const Breadcrumb: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* First item */}
+    <rect
+      x="5"
+      y="25"
+      width="18"
+      height="25"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* First separator */}
+    <text x="28" y="42" fontSize="16" textAnchor="middle" fill="var(--rs-gray-500)">
+      ›
+    </text>
+
+    {/* Second item */}
+    <rect
+      x="32"
+      y="25"
+      width="18"
+      height="25"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Second separator */}
+    <text x="55" y="42" fontSize="16" textAnchor="middle" fill="var(--rs-gray-500)">
+      ›
+    </text>
+
+    {/* Third item */}
+    <rect
+      x="59"
+      y="25"
+      width="18"
+      height="25"
+      rx="4"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
+/**
+ * Dropdown component thumbnail
+ */
+export const Dropdown: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Dropdown button */}
+    <rect
+      x="20"
+      y="15"
+      width="40"
+      height="15"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Dropdown arrow */}
+    <path
+      d="M52 22.5L50 19.5L54 19.5"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+
+    {/* Dropdown menu */}
+    <rect
+      x="20"
+      y="30"
+      width="40"
+      height="35"
+      rx="4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Menu items */}
+    <rect x="22" y="32" width="36" height="8" rx="2" fill="var(--rs-thumbnail-bg)" />
+    <line
+      x1="25"
+      y1="36"
+      x2="55"
+      y2="36"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    <line
+      x1="25"
+      y1="45"
+      x2="55"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="25"
+      y1="54"
+      x2="45"
+      y2="54"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Link component thumbnail
+ */
+export const Link: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Link text */}
+    <text
+      x="40"
+      y="40"
+      fontSize="12"
+      textAnchor="middle"
+      fill="var(--rs-thumbnail-color-primary)"
+      textDecoration="underline"
+    >
+      Visit Page
+    </text>
+
+    {/* Underline */}
+    <line
+      x1="20"
+      y1="42"
+      x2="60"
+      y2="42"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+  </svg>
+);
+
+/**
+ * Menu component thumbnail
+ */
+export const Menu: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="10"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="20"
+      y1="35"
+      x2="60"
+      y2="35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="20"
+      y1="45"
+      x2="60"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="20"
+      y1="55"
+      x2="60"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <rect x="20" y="25" width="10" height="5" rx="1" fill="var(--rs-thumbnail-color-primary)" />
+  </svg>
+);
+
+/**
+ * Nav component thumbnail
+ */
+export const Nav: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="10"
+      y="20"
+      width="60"
+      height="10"
+      rx="2"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect x="15" y="20" width="15" height="10" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect
+      x="35"
+      y="20"
+      width="15"
+      height="10"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <rect
+      x="55"
+      y="20"
+      width="10"
+      height="10"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <rect
+      x="10"
+      y="35"
+      width="60"
+      height="25"
+      rx="2"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="20"
+      y1="45"
+      x2="60"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="20"
+      y1="55"
+      x2="50"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeLinecap="round"
+      strokeDasharray="2 1"
+    />
+  </svg>
+);
+
+/**
+ * Navbar component thumbnail
+ */
+export const Navbar: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="10"
+      y="15"
+      width="60"
+      height="15"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect x="15" y="17.5" width="15" height="10" rx="1" fill="var(--rs-thumbnail-color-primary)" />
+    <rect
+      x="35"
+      y="17.5"
+      width="10"
+      height="10"
+      rx="1"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <rect
+      x="50"
+      y="17.5"
+      width="10"
+      height="10"
+      rx="1"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <rect
+      x="10"
+      y="35"
+      width="60"
+      height="30"
+      rx="2"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeDasharray="2 1"
+    />
+  </svg>
+);
+
+/**
+ * Sidenav component thumbnail
+ */
+export const Sidenav: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="10"
+      y="10"
+      width="60"
+      height="60"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="10"
+      y="10"
+      width="20"
+      height="60"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect x="10" y="10" width="20" height="10" rx="4" fill="var(--rs-thumbnail-color-primary)" />
+    <line
+      x1="15"
+      y1="30"
+      x2="25"
+      y2="30"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="15"
+      y1="40"
+      x2="25"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="15"
+      y1="50"
+      x2="25"
+      y2="50"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="40"
+      y1="25"
+      x2="60"
+      y2="25"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="40"
+      y1="35"
+      x2="55"
+      y2="35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="40"
+      y1="45"
+      x2="50"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Steps component thumbnail
+ */
+export const Steps: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <circle
+      cx="20"
+      cy="40"
+      r="10"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="1.5"
+    />
+    <text x="20" y="44" fontSize="12" textAnchor="middle" fill="transparent" fontWeight="bold">
+      1
+    </text>
+    <line
+      x1="30"
+      y1="40"
+      x2="40"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <circle
+      cx="50"
+      cy="40"
+      r="10"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <text
+      x="50"
+      y="44"
+      fontSize="12"
+      textAnchor="middle"
+      fill="var(--rs-thumbnail-color-primary)"
+      fontWeight="bold"
+    >
+      2
+    </text>
+    <line
+      x1="60"
+      y1="40"
+      x2="70"
+      y2="40"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="2"
+      strokeDasharray="2 1"
+    />
+  </svg>
+);
+
+/**
+ * Pagination component thumbnail
+ */
+export const Pagination: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Left arrow button */}
+    <rect
+      x="10"
+      y="30"
+      width="10"
+      height="20"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <polyline
+      points="16,35 12,40 16,45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      fill="none"
+    />
+
+    {/* Page buttons */}
+    <rect
+      x="25"
+      y="30"
+      width="10"
+      height="20"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <text
+      x="30"
+      y="44"
+      fontSize="12"
+      textAnchor="middle"
+      fill="var(--rs-thumbnail-color-primary)"
+      fontWeight="bold"
+    >
+      1
+    </text>
+
+    <rect
+      x="40"
+      y="30"
+      width="10"
+      height="20"
+      rx="2"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-primary-700)"
+      strokeWidth="1.5"
+    />
+    <text x="45" y="44" fontSize="12" textAnchor="middle" fill="transparent" fontWeight="bold">
+      2
+    </text>
+
+    <rect
+      x="55"
+      y="30"
+      width="10"
+      height="20"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <text
+      x="60"
+      y="44"
+      fontSize="12"
+      textAnchor="middle"
+      fill="var(--rs-thumbnail-color-primary)"
+      fontWeight="bold"
+    >
+      3
+    </text>
+
+    {/* Right arrow button */}
+    <rect
+      x="70"
+      y="30"
+      width="10"
+      height="20"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <polyline
+      points="74,35 78,40 74,45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      fill="none"
+    />
+  </svg>
+);

--- a/docs/components/thumbnails/overlays.tsx
+++ b/docs/components/thumbnails/overlays.tsx
@@ -1,0 +1,421 @@
+import React from 'react';
+
+/**
+ * Drawer component thumbnail
+ */
+export const Drawer: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Background */}
+    <rect
+      x="10"
+      y="10"
+      width="60"
+      height="60"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Drawer panel - left side */}
+    <rect
+      x="10"
+      y="10"
+      width="30"
+      height="60"
+      rx="4 0 0 4"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Drawer header */}
+    <rect
+      x="10"
+      y="10"
+      width="30"
+      height="10"
+      rx="4 0 0 0"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="15"
+      y1="15"
+      x2="25"
+      y2="15"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Drawer content */}
+    <line
+      x1="15"
+      y1="30"
+      x2="35"
+      y2="30"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="15"
+      y1="40"
+      x2="35"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="15"
+      y1="50"
+      x2="30"
+      y2="50"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Main content area indicators */}
+    <line
+      x1="50"
+      y1="25"
+      x2="60"
+      y2="25"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="45"
+      y1="35"
+      x2="65"
+      y2="35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="50"
+      y1="45"
+      x2="60"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="45"
+      y1="55"
+      x2="55"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Modal component thumbnail
+ */
+export const Modal: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Background overlay */}
+    <rect x="5" y="5" width="70" height="70" rx="4" fill="var(--rs-gray-300)" fillOpacity="0.5" />
+
+    {/* Modal dialog */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="8"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Modal header */}
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="10"
+      rx="8 8 0 0"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="20"
+      y1="20"
+      x2="40"
+      y2="20"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Close button */}
+    <circle
+      cx="55"
+      cy="20"
+      r="2.5"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M53.5 18.5L56.5 21.5M56.5 18.5L53.5 21.5"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Modal body */}
+    <line
+      x1="25"
+      y1="35"
+      x2="55"
+      y2="35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="25"
+      y1="45"
+      x2="45"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Modal footer */}
+    <rect
+      x="15"
+      y="55"
+      width="50"
+      height="10"
+      rx="0 0 8 8"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="45"
+      y="58"
+      width="15"
+      height="4"
+      rx="2"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="0.5"
+    />
+  </svg>
+);
+
+/**
+ * Popover component thumbnail
+ */
+export const Popover: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Popover content */}
+    <rect
+      x="10"
+      y="15"
+      width="60"
+      height="35"
+      rx="8"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+
+    {/* Content lines */}
+    <line
+      x1="20"
+      y1="30"
+      x2="60"
+      y2="30"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="20"
+      y1="40"
+      x2="50"
+      y2="40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Arrow - pointing down */}
+    <polygon
+      points="40,55 35,50 45,50"
+      fill="transparent"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
+/**
+ * Tooltip component thumbnail
+ */
+export const Tooltip: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* Tooltip */}
+    <rect
+      x="10"
+      y="20"
+      width="60"
+      height="25"
+      rx="4"
+      fill="var(--rs-gray-800)"
+      stroke="var(--rs-gray-900)"
+      strokeWidth="1.5"
+    />
+
+    {/* Tooltip text */}
+    <circle cx="25" cy="32.5" r="2.5" fill="transparent" />
+    <line
+      x1="30"
+      y1="32.5"
+      x2="55"
+      y2="32.5"
+      stroke="white"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Arrow - pointing down */}
+    <polygon
+      points="40,50 35,45 45,45"
+      fill="var(--rs-gray-800)"
+      stroke="var(--rs-gray-900)"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
+/**
+ * Whisper component thumbnail
+ */
+export const Whisper: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="25"
+      y="25"
+      width="30"
+      height="15"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="15"
+      y="45"
+      width="50"
+      height="20"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeDasharray="2 1"
+    />
+    <path
+      d="M40 45L35 40L45 40L40 45Z"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeDasharray="2 1"
+    />
+    <line
+      x1="25"
+      y1="55"
+      x2="55"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeDasharray="2 1"
+    />
+  </svg>
+);
+
+/**
+ * ModalIntegrations component thumbnail
+ */
+export const ModalIntegrations: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="10"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="20"
+      y="30"
+      width="20"
+      height="15"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <rect
+      x="45"
+      y="30"
+      width="15"
+      height="15"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <rect
+      x="20"
+      y="50"
+      width="15"
+      height="10"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+    <rect
+      x="40"
+      y="50"
+      width="20"
+      height="10"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+    />
+  </svg>
+);

--- a/docs/components/thumbnails/status.tsx
+++ b/docs/components/thumbnails/status.tsx
@@ -1,0 +1,250 @@
+import React from 'react';
+
+/**
+ * Badge 组件缩略图
+ */
+export const Badge: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="20"
+      y="25"
+      width="30"
+      height="30"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <circle cx="46" cy="25" r="10" fill="var(--rs-red-500)" stroke="white" strokeWidth="2" />
+    <text x="46" y="29" fontSize="10" textAnchor="middle" fill="transparent" fontWeight="bold">
+      5
+    </text>
+  </svg>
+);
+
+/**
+ * Loader 组件缩略图
+ */
+export const Loader: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="40" cy="40" r="20" stroke="var(--rs-primary-200)" strokeWidth="4" />
+    <path
+      d="M40 20C51.0457 20 60 28.9543 60 40"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="4"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Message 组件缩略图
+ */
+export const Message: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="10"
+      y="25"
+      width="60"
+      height="30"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <circle
+      cx="25"
+      cy="40"
+      r="8"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="40"
+      y1="35"
+      x2="60"
+      y2="35"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="40"
+      y1="45"
+      x2="55"
+      y2="45"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Notification 组件缩略图
+ */
+export const Notification: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <rect
+      x="20"
+      y="20"
+      width="40"
+      height="10"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <line
+      x1="20"
+      y1="40"
+      x2="60"
+      y2="40"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="20"
+      y1="50"
+      x2="50"
+      y2="50"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Progress 组件缩略图
+ */
+export const Progress: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="35"
+      width="50"
+      height="10"
+      rx="5"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect x="15" y="35" width="30" height="10" rx="5" fill="var(--rs-thumbnail-color-primary)" />
+  </svg>
+);
+
+/**
+ * Placeholder 组件缩略图
+ */
+export const Placeholder: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="50"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeDasharray="4 2"
+    />
+    <rect
+      x="20"
+      y="20"
+      width="40"
+      height="10"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <rect
+      x="20"
+      y="35"
+      width="40"
+      height="5"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <rect
+      x="20"
+      y="45"
+      width="30"
+      height="5"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+    <rect
+      x="20"
+      y="55"
+      width="20"
+      height="5"
+      rx="2"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1"
+      strokeDasharray="2 1"
+    />
+  </svg>
+);
+
+/**
+ * Toaster 组件缩略图
+ */
+export const Toaster: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="15"
+      y="15"
+      width="50"
+      height="20"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+    />
+    <rect
+      x="25"
+      y="35"
+      width="30"
+      height="15"
+      rx="4"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeDasharray="2 1"
+    />
+    <rect
+      x="35"
+      y="50"
+      width="10"
+      height="15"
+      rx="2"
+      fill="var(--rs-thumbnail-bg)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeDasharray="2 1"
+    />
+  </svg>
+);

--- a/docs/components/thumbnails/styles.less
+++ b/docs/components/thumbnails/styles.less
@@ -1,0 +1,11 @@
+:root {
+  --rs-thumbnail-color-primary: var(--rs-primary-500);
+  --rs-thumbnail-bg: var(--rs-primary-50);
+  --rs-thumbnail-bg-secondary: var(--rs-primary-100);
+}
+
+.rs-theme-high-contrast, .rs-theme-dark {
+  --rs-thumbnail-color-primary: var(--rs-primary-800);
+  --rs-thumbnail-bg: transparent;
+  --rs-thumbnail-bg-secondary: transparent;
+}

--- a/docs/components/thumbnails/typography.tsx
+++ b/docs/components/thumbnails/typography.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+
+/**
+ * Heading 组件缩略图
+ */
+export const Heading: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <text x="20" y="30" fontSize="16" fill="var(--rs-primary-700)" fontWeight="bold">
+      H1
+    </text>
+    <text x="20" y="45" fontSize="14" fill="var(--rs-primary-700)" fontWeight="bold">
+      H2
+    </text>
+    <text x="20" y="58" fontSize="12" fill="var(--rs-primary-700)" fontWeight="bold">
+      H3
+    </text>
+    <line
+      x1="40"
+      y1="30"
+      x2="60"
+      y2="30"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="3"
+      strokeLinecap="round"
+    />
+    <line
+      x1="40"
+      y1="45"
+      x2="55"
+      y2="45"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="40"
+      y1="58"
+      x2="50"
+      y2="58"
+      stroke="var(--rs-primary-300)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+/**
+ * Highlight 组件缩略图
+ */
+export const Highlight: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="20"
+      y="30"
+      width="40"
+      height="20"
+      rx="2"
+      fill="var(--rs-yellow-100)"
+      stroke="var(--rs-yellow-500)"
+      strokeWidth="1.5"
+    />
+    <text
+      x="40"
+      y="45"
+      fontSize="12"
+      textAnchor="middle"
+      fill="var(--rs-yellow-700)"
+      fontWeight="bold"
+    >
+      Text
+    </text>
+  </svg>
+);
+
+/**
+ * Kbd 组件缩略图
+ */
+export const Kbd: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* First key with padding */}
+    <rect
+      x="15"
+      y="25"
+      width="22"
+      height="22"
+      rx="4"
+      fill="var(--rs-gray-100)"
+      stroke="var(--rs-gray-500)"
+      strokeWidth="1.5"
+    />
+    <text
+      x="26"
+      y="39"
+      fontSize="12"
+      textAnchor="middle"
+      fill="var(--rs-gray-700)"
+      fontWeight="bold"
+    >
+      A
+    </text>
+
+    {/* Second key with padding */}
+    <rect
+      x="45"
+      y="25"
+      width="22"
+      height="22"
+      rx="4"
+      fill="var(--rs-gray-100)"
+      stroke="var(--rs-gray-500)"
+      strokeWidth="1.5"
+    />
+    <text
+      x="56"
+      y="39"
+      fontSize="10"
+      textAnchor="middle"
+      fill="var(--rs-gray-700)"
+      fontWeight="bold"
+    >
+      Ctrl
+    </text>
+  </svg>
+);
+
+/**
+ * Text 组件缩略图
+ */
+export const Text: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <line
+      x1="20"
+      y1="25"
+      x2="60"
+      y2="25"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <line
+      x1="20"
+      y1="35"
+      x2="55"
+      y2="35"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="20"
+      y1="45"
+      x2="50"
+      y2="45"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <line
+      x1="20"
+      y1="55"
+      x2="40"
+      y2="55"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);

--- a/docs/less/index.less
+++ b/docs/less/index.less
@@ -19,6 +19,7 @@
 @import '../components/ColorPicker/styles.less';
 @import '../components/Simulation/styles.less';
 @import '../components/CodeView/styles.less';
+@import '../components/thumbnails/styles.less';
 
 /** Pages **/
 @import './pages.less';

--- a/docs/pages/components/frame/examples/center.tsx
+++ b/docs/pages/components/frame/examples/center.tsx
@@ -52,16 +52,15 @@ const App = () => {
         </Navbar>
       </Header>
       <Content p={20}>
-        {/** @ts-ignore */}
         <Stack align="center" justify="center" h="100%">
           <Panel header="Sign in" bordered w={360}>
             <Form fluid>
               <Form.Group>
-                <Form.ControlLabel>Email address</Form.ControlLabel>
+                <Form.Label>Email address</Form.Label>
                 <Form.Control name="email" autoFocus={false} />
               </Form.Group>
               <Form.Group>
-                <Form.ControlLabel>Password</Form.ControlLabel>
+                <Form.Label>Password</Form.Label>
                 <Form.Control name="password" autoComplete="off" accepter={Password} />
               </Form.Group>
 

--- a/docs/pages/components/frame/examples/horizontal.tsx
+++ b/docs/pages/components/frame/examples/horizontal.tsx
@@ -37,8 +37,7 @@ const NavHeader = ({ expanded }) => {
 
   return (
     <>
-      {/* @ts-ignore */}
-      <VStack p="10px 10px 0 10px" spacing={12}>
+      <VStack spacing={12}>
         <HStack>
           <SiProtondb size={32} /> Brand
         </HStack>
@@ -61,9 +60,7 @@ const App = () => {
 
   return (
     <Container>
-      {/* @ts-ignore */}
       <Sidebar h="100vh" width={isExpanded ? 260 : 56} collapsible>
-        {/* @ts-ignore */}
         <Sidenav expanded={isExpanded} defaultOpenKeys={['3', '4']} h="100%">
           <Sidenav.Header>
             <NavHeader expanded={isExpanded} />
@@ -104,7 +101,6 @@ const App = () => {
       </Sidebar>
       <Container>
         <Header>
-          {/* @ts-ignore */}
           <HStack spacing={16} align="center" p="1rem">
             <Breadcrumb>
               <Breadcrumb.Item>Home</Breadcrumb.Item>
@@ -113,7 +109,6 @@ const App = () => {
             </Breadcrumb>
           </HStack>
         </Header>
-        {/* @ts-ignore */}
         <Content px="1rem">
           <Placeholder.Paragraph rows={10} />
         </Content>

--- a/docs/pages/components/overview/styles.less
+++ b/docs/pages/components/overview/styles.less
@@ -6,42 +6,94 @@
   }
 
   .rs-co-group {
-    margin-top: 20px;
+    margin-top: 30px;
   }
   .rs-co-title {
-    display: block !important;
+
     clear: both;
-    border: none !important;
-    margin: 10px 0 !important;
     width: 100%;
+    font-size: 20px;
+    color: var(--rs-text-heading);
+    position: relative;
+  }
+
+  .rs-co-box-link {
+    text-decoration: none;
+    display: block;
   }
 
   .rs-co-box {
-    background: var(--rs-placeholder);
-    padding: 10px;
-    width: 150px;
-    border-radius: 6px;
+    background: var(--rs-bg-card);
+    padding: 0;
+    width: 200px;
+    border-radius: 8px;
     color: var(--rs-text-secondary);
-    aspect-ratio: 1 / 1;
+    height: auto;
+    transition: all 0.2s ease;
+    border: 1px solid var(--rs-border-secondary);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 
-    code {
-      padding: 0;
-    }
     &:hover {
-      color: var(--rs-text-primary);
+      transform: translateY(-2px);
+      box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
+      border-color: var(--rs-primary-300);
     }
   }
 
   .rs-co-header {
-    margin: 4px 0;
+    margin: 0 0 4px 0;
     display: block;
+    font-weight: 600;
+    font-size: 18px;
+    color: var(--rs-text-primary);
+    line-height: 1.4;
+  }
+
+  .rs-co-subtitle {
+    display: block;
+    font-size: 14px;
+    font-weight: normal;
+    color: var(--rs-text-secondary);
+    margin-top: 2px;
+  }
+
+  .rs-co-description {
+    margin-top: 12px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .rs-co-thumbnail {
+    width: 100%;
+    height: 140px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(45deg, var(--rs-primary-50), var(--rs-bg-card));
+    border-bottom: 1px solid var(--rs-border-secondary);
+
+    svg {
+      width: 80px;
+      height: 80px;
+    }
+
+    .rs-theme-dark &, .rs-theme-high-contrast & {
+      background: linear-gradient(45deg, rgba(var(--rs-primary-500), 0.15), var(--rs-bg-card));
+    }
   }
 
   .rs-co-content {
-    .rs-co-name {
-      font-size: 12px;
-      color: var(text);
-    }
+    padding: 16px;
+  }
+
+
+
+  .rs-stack {
+    gap: 24px;
   }
 
   .sorted-list {


### PR DESCRIPTION
This pull request introduces a significant update to the component overview section by adding thumbnail images for various components and reorganizing the `CategorizedList` to include these thumbnails. The changes span multiple files and focus on enhancing the visual representation and organization of component data.

https://rsuite-nextjs-git-docs-add-component-thumbnails-rsuite.vercel.app/components/overview/