### PR TITLE
refactor(divider): rename labelPosition to labelPlacement for consistency

### DIFF
--- a/docs/pages/components/divider/en-US/index.md
+++ b/docs/pages/components/divider/en-US/index.md
@@ -43,7 +43,7 @@ Divider are used to group content horizontally or vertically.
 | classPrefix   | string `('divider')`                             | The prefix of the component CSS class             |
 | color         | Color \| CSSProperties['color']                  | The color of the divider                          |
 | label         | ReactNode                                        | The content of the label                          |
-| labelPosition | 'left' \| 'right' \| 'center'                    | The position of the label                         |
+| labelPlacement | 'start' \| 'center' \| 'end'                    | The placement of the label                        |
 | size          | 'xs' \| 'sm' \| 'md' \| 'lg' \| number \| string | The size of the divider                           |
 | spacing       | 'xs' \| 'sm' \| 'md' \| 'lg' \| number \| string | The spacing between the divider and its content   |
 | vertical      | boolean                                          | Vertical dividing line. Cannot be used with label |

--- a/docs/pages/components/divider/fragments/with-label.md
+++ b/docs/pages/components/divider/fragments/with-label.md
@@ -5,9 +5,9 @@ import { Divider, Placeholder, Button } from 'rsuite';
 
 const App = () => (
   <>
-    <Divider spacing="md" label="Label (left)" labelPosition="left" />
-    <Divider spacing="md" label="Label (center)" labelPosition="center" />
-    <Divider spacing="md" label="Label (right)" labelPosition="right" />
+    <Divider spacing="md" label="Label (start)" labelPlacement="start" />
+    <Divider spacing="md" label="Label (center)" labelPlacement="center" />
+    <Divider spacing="md" label="Label (end)" labelPlacement="end" />
     <Divider spacing="md" label={<Button>Button</Button>} />
   </>
 );

--- a/docs/pages/components/divider/zh-CN/index.md
+++ b/docs/pages/components/divider/zh-CN/index.md
@@ -43,7 +43,7 @@
 | classPrefix   | string `('divider')`                             | 组件 CSS 类的前缀                |
 | color         | Color \| CSSProperties['color']                  | 分割线的颜色                     |
 | label         | ReactNode                                        | 标签内容                         |
-| labelPosition | 'left' \| 'right' \| 'center'                    | 标签位置                         |
+| labelPlacement | 'start' \| 'center' \| 'end'                    | 标签位置                         |
 | size          | 'xs' \| 'sm' \| 'md' \| 'lg' \| number \| string | 分割线的尺寸                     |
 | spacing       | 'xs' \| 'sm' \| 'md' \| 'lg' \| number \| string | 分割线与内容之间的间距           |
 | vertical      | boolean                                          | 垂直分割线（不能与标签同时使用） |

--- a/docs/pages/components/rate/fragments/advanced-rating.md
+++ b/docs/pages/components/rate/fragments/advanced-rating.md
@@ -42,7 +42,7 @@ const App = () => {
           ))}
         </VStack>
       </HStack>
-      <Divider label="Rate this product" labelPosition="left" />
+      <Divider label="Rate this product" labelPlacement="start" />
       <Rate defaultValue={0} color="yellow" />
     </VStack>
   );

--- a/docs/pages/components/rate/fragments/character.md
+++ b/docs/pages/components/rate/fragments/character.md
@@ -8,7 +8,7 @@ const App = () => {
   const [value, setValue] = React.useState(2.5);
   return (
     <VStack spacing={10}>
-      <Divider label="Svg icon" labelPosition="left" />
+      <Divider label="Svg icon" labelPlacement="start" />
       <Rate allowHalf value={value} character={<FaHeart />} color="red" onChange={setValue} />
       <Rate
         allowHalf
@@ -22,7 +22,7 @@ const App = () => {
           return <FaRegStar />;
         }}
       />
-      <Divider label="Emoji" labelPosition="left" />
+      <Divider label="Emoji" labelPlacement="start" />
       <Rate allowHalf value={value} character="❤️" onChange={setValue} />
       <Rate allowHalf value={value} character="👍" onChange={setValue} />
       <Rate allowHalf value={value} character="⭐️" onChange={setValue} />

--- a/docs/pages/components/rate/fragments/color.md
+++ b/docs/pages/components/rate/fragments/color.md
@@ -5,7 +5,7 @@ import { Rate, VStack, Divider } from 'rsuite';
 
 const App = () => (
   <VStack spacing={20}>
-    <Divider label="Preset colors" labelPosition="left" />
+    <Divider label="Preset colors" labelPlacement="start" />
     <VStack>
       <Rate defaultValue={5} color="red" />
       <Rate defaultValue={4} color="orange" />
@@ -16,7 +16,7 @@ const App = () => (
       <Rate defaultValue={5} color="violet" />
     </VStack>
 
-    <Divider label="Custom colors" labelPosition="left" />
+    <Divider label="Custom colors" labelPlacement="start" />
 
     <VStack>
       <Rate defaultValue={3} color="#FF0000" />

--- a/docs/pages/components/rate/fragments/custom-character.md
+++ b/docs/pages/components/rate/fragments/custom-character.md
@@ -28,7 +28,7 @@ const App = () => (
       <Rate defaultValue={5} renderCharacter={renderCharacter} />
     </VStack>
 
-    <Divider label="Max 10" labelPosition="left" />
+    <Divider label="Max 10" labelPlacement="start" />
     <Rate max={10} defaultValue={2} />
   </VStack>
 );

--- a/docs/pages/components/rate/fragments/size.md
+++ b/docs/pages/components/rate/fragments/size.md
@@ -5,7 +5,7 @@ import { Rate, VStack, Divider } from 'rsuite';
 
 const App = () => (
   <VStack spacing={20}>
-    <Divider label="Preset sizes" labelPosition="left" />
+    <Divider label="Preset sizes" labelPlacement="start" />
     <VStack>
       <Rate defaultValue={3} size="xs" />
       <Rate defaultValue={3} size="sm" />
@@ -13,7 +13,7 @@ const App = () => (
       <Rate defaultValue={3} size="lg" />
       <Rate defaultValue={3} size="xl" />
     </VStack>
-    <Divider label="Custom size" labelPosition="left" />
+    <Divider label="Custom size" labelPlacement="start" />
     <VStack>
       <Rate defaultValue={3} size={12} />
       <Rate defaultValue={3} size="2rem" />

--- a/src/Divider/Divider.tsx
+++ b/src/Divider/Divider.tsx
@@ -18,9 +18,9 @@ export interface DividerProps extends BoxProps {
   label?: React.ReactNode;
 
   /**
-   * The position of the label.
+   * The placement of the label.
    */
-  labelPosition?: 'left' | 'right' | 'center';
+  labelPlacement?: 'start' | 'center' | 'end';
 
   /**
    * Vertical dividing line. Cannot be used with label.
@@ -57,7 +57,7 @@ const Divider = forwardRef<'div', DividerProps>((props: DividerProps, ref) => {
     children,
     color,
     label = children,
-    labelPosition,
+    labelPlacement,
     vertical,
     spacing,
     style,
@@ -82,7 +82,7 @@ const Divider = forwardRef<'div', DividerProps>((props: DividerProps, ref) => {
       data-appearance={appearance}
       data-orientation={vertical ? 'vertical' : 'horizontal'}
       data-with-label={label ? 'true' : undefined}
-      data-position={labelPosition}
+      data-placement={labelPlacement}
       {...rest}
     >
       {label}

--- a/src/Divider/styles/index.less
+++ b/src/Divider/styles/index.less
@@ -75,11 +75,11 @@
     }
   }
 
-  &:where([data-position='left']):before {
+  &:where([data-placement='start']):before {
     display: none;
   }
 
-  &:where([data-position='right']):after {
+  &:where([data-placement='end']):after {
     display: none;
   }
 }

--- a/src/Divider/test/DividerSpec.tsx
+++ b/src/Divider/test/DividerSpec.tsx
@@ -49,15 +49,15 @@ describe('Divider', () => {
       expect(screen.getByRole('button')).to.exist;
     });
 
-    it('Should render with different label positions', () => {
-      const { rerender } = render(<Divider label="Left" labelPosition="left" />);
-      expect(screen.getByRole('separator')).to.have.attribute('data-position', 'left');
+    it('Should render with different label placements', () => {
+      const { rerender } = render(<Divider label="Start" labelPlacement="start" />);
+      expect(screen.getByRole('separator')).to.have.attribute('data-placement', 'start');
 
-      rerender(<Divider label="Right" labelPosition="right" />);
-      expect(screen.getByRole('separator')).to.have.attribute('data-position', 'right');
+      rerender(<Divider label="End" labelPlacement="end" />);
+      expect(screen.getByRole('separator')).to.have.attribute('data-placement', 'end');
 
       rerender(<Divider label="Center" />);
-      expect(screen.getByRole('separator')).to.not.have.attribute('data-position');
+      expect(screen.getByRole('separator')).to.not.have.attribute('data-placement');
     });
   });
 });


### PR DESCRIPTION
This pull request updates the `Divider` component to use the term "labelPlacement" instead of "labelPosition" across various files and documentation. The changes ensure consistency and clarity in the API.

