### PR TITLE
docs(Rate): fix display error in Props documentation table

### DIFF
--- a/docs/pages/components/rate/zh-CN/index.md
+++ b/docs/pages/components/rate/zh-CN/index.md
@@ -61,12 +61,12 @@ WAI tutorial: https://www.w3.org/WAI/tutorials/forms/custom-controls/#a-star-rat
 ## Props
 
 | 属性名称        | 类型 `(默认值)`                                   | 描述                             |
-| --------------- | ------------------------------------------------- | -------------------------------- | --- |
+| --------------- | ------------------------------------------------- | -------------------------------- |
 | allowHalf       | boolean                                           | 是否支持半选                     |
 | character       | ReactNode                                         | 自定义字符                       |
 | cleanable       | boolean`(true)`                                   | 是否支持清除                     |
 | defaultValue    | number`(0)`                                       | 默认值（非受控）                 |
-| disabled        | boolean                                           | 是否禁用，为 true 时无法进行交互 |     |
+| disabled        | boolean                                           | 是否禁用，为 true 时无法进行交互 |
 | max             | number`(5)`                                       | 最大分数                         |
 | renderCharacter | (value: number,index: number) => ReactNode        | 自定义渲染 character 函数        |
 | readOnly        | boolean                                           | 是否只读，为 true 时无法进行交互 |


### PR DESCRIPTION
https://rsuitejs.com/zh/components/rate/

![image](https://github.com/user-attachments/assets/829d0432-db76-4807-9c87-1961f4634194)
