### PR TITLE
build(deps): bump schema-typed from 2.4.1 to 2.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react-use-set": "^1.0.0",
         "react-window": "^1.8.8",
         "rsuite-table": "^5.19.1",
-        "schema-typed": "^2.4.1"
+        "schema-typed": "^2.4.2"
       },
       "devDependencies": {
         "@babel/cli": "^7.25.9",
@@ -20512,9 +20512,9 @@
       }
     },
     "node_modules/schema-typed": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.4.1.tgz",
-      "integrity": "sha512-0GL4a9OUhBCjE7rXnmUOscEyISW0TImzagKwbIxs4d5E2AldiqjFb+7Ah8lm9aBiHKQ/bdxTDtE/3QOUVDDmFA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/schema-typed/-/schema-typed-2.4.2.tgz",
+      "integrity": "sha512-4eYZiheiPps+I7JEKrhm/S8OIPncXqY0lKQbvI/Agn9QMJUQ3cgfFZ2spy4Ta9Qr3xLYB3/qj4wGbsNcVwEO/w==",
       "dependencies": {
         "lodash": "^4.17.21"
       }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-use-set": "^1.0.0",
     "react-window": "^1.8.8",
     "rsuite-table": "^5.19.1",
-    "schema-typed": "^2.4.1"
+    "schema-typed": "^2.4.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0",


### PR DESCRIPTION
This pull request includes a minor version update to the `schema-typed` dependency in the `package.json` file. The version has been updated from `^2.4.1` to `^2.4.2` to ensure compatibility with the latest features or fixes.