### PR TITLE
fix(message): update spacing to use css variables

### DIFF
--- a/src/Message/styles/index.less
+++ b/src/Message/styles/index.less
@@ -13,10 +13,11 @@
   --rs-message-line-height: var(--rs-text-line-height-sm);
   --rs-message-border-radius: var(--rs-radius-md);
   --rs-message-icon-size: var(--rs-font-size-md);
-  --rs-message-padding: 1.25rem;
+  --rs-message-padding: calc(var(--rs-spacing) * 4);
   --rs-message-header-color: var(--rs-text-heading);
   --rs-message-body-color: var(--rs-text-primary);
   --rs-message-icon-color: var(--rs-text-secondary);
+  --rs-message-spacing: calc(var(--rs-spacing) * 2);
 
   border-radius: var(--rs-message-border-radius);
   font-size: var(--rs-message-font-size);
@@ -50,6 +51,7 @@
     padding: var(--rs-message-padding);
     display: flex;
     align-items: baseline;
+    gap: var(--rs-message-spacing);
   }
 
   // Message with a title
@@ -84,7 +86,7 @@
       flex-direction: column;
       align-items: center;
       text-align: center;
-      gap: 20px;
+      gap: calc(var(--rs-spacing) * 4);
     }
 
     .rs-message-icon {
@@ -108,7 +110,6 @@
   &-icon {
     align-self: center;
     font-size: 0; // remove whitespace before svg
-    margin-inline-end: 10px;
 
     // Icon
     .rs-icon {


### PR DESCRIPTION
This pull request updates the `src/Message/styles/index.less` file to improve the flexibility and maintainability of spacing and padding by using CSS variables consistently. It replaces hardcoded values with calculations based on the `--rs-spacing` variable and introduces a new `--rs-message-spacing` variable for managing gaps between elements.

### Spacing and padding improvements:

* Updated `--rs-message-padding` to use a calculation based on `--rs-spacing` for consistency and easier scalability.
* Introduced a new `--rs-message-spacing` variable to standardize gaps between elements and applied it to the `gap` property for message containers. [[1]](diffhunk://#diff-df24926ca5248a419c0138994fe566accd26195dece1055a9dc4b7f721c141c3L16-R20) [[2]](diffhunk://#diff-df24926ca5248a419c0138994fe566accd26195dece1055a9dc4b7f721c141c3R54)

### Removal of hardcoded values:

* Replaced the hardcoded `gap` value of `20px` with a calculation using `--rs-spacing` for column-aligned messages.
* Removed the hardcoded `margin-inline-end` value of `10px` for message icons to simplify the styles.