### PR TITLE
fix(CloseButton): standardize close button styles

### DIFF
--- a/docs/pages/components/modal/index.tsx
+++ b/docs/pages/components/modal/index.tsx
@@ -18,6 +18,7 @@ import {
   Input,
   SelectPicker,
   HStack,
+  Textarea,
   Text
 } from 'rsuite';
 const inDocsComponents = {
@@ -41,6 +42,7 @@ export default function Page() {
         Input,
         HStack,
         Text,
+        Textarea,
         SelectPicker,
         RemindFillIcon,
         PasswordInput,

--- a/src/Modal/ModalHeader.tsx
+++ b/src/Modal/ModalHeader.tsx
@@ -31,13 +31,13 @@ const ModalHeader = forwardRef<'div', ModalHeaderProps>((props, ref) => {
   const classes = merge(className, withPrefix());
 
   const context = useContext(ModalContext);
-  const { isDrawer, onModalClose } = context || {};
+  const { onModalClose } = context || {};
 
   return (
     <Box as={as} {...rest} ref={ref} className={classes}>
       {closeButton && (
         <CloseButton
-          as={isDrawer ? IconButton : 'button'}
+          as={IconButton}
           className={prefix('close')}
           onClick={createChainedFunction(onClose, onModalClose)}
         />

--- a/src/internals/CloseButton/styles/index.less
+++ b/src/internals/CloseButton/styles/index.less
@@ -12,14 +12,4 @@
   .rs-icon {
     vertical-align: bottom;
   }
-
-  &:hover,
-  &:focus {
-    color: var(--rs-close-button-hover-color);
-
-    svg path {
-      stroke: var(--rs-close-button-hover-color);
-      stroke-width: 1;
-    }
-  }
 }

--- a/src/internals/Picker/styles/index.less
+++ b/src/internals/Picker/styles/index.less
@@ -353,12 +353,13 @@
 
   // Picker clear button
   .rs-picker-clean {
-    .combobox-indicator-icon();
-
-    background: inherit;
     color: var(--rs-text-secondary);
     transition: 0.2s color linear;
     cursor: pointer;
+
+    &:hover {
+      color: var(--rs-text-primary);
+    }
 
     &.rs-btn-close {
       padding: 0;

--- a/src/styles/color-modes/dark.less
+++ b/src/styles/color-modes/dark.less
@@ -336,9 +336,6 @@
   --rs-badge-text: var(--rs-gray-0);
   --rs-badge-border: var(--rs-gray-900);
 
-  // Close Button
-  --rs-close-button-hover-color: var(--rs-color-red);
-
   // Tag
   --rs-tag-bg: var(--rs-gray-600);
 

--- a/src/styles/color-modes/high-contrast.less
+++ b/src/styles/color-modes/high-contrast.less
@@ -342,9 +342,6 @@
   --rs-badge-text: var(--rs-gray-0);
   --rs-badge-border: var(--rs-gray-900);
 
-  // Close Button
-  --rs-close-button-hover-color: var(--rs-color-red);
-
   // Tag
   --rs-tag-bg: var(--rs-gray-600);
 

--- a/src/styles/color-modes/light.less
+++ b/src/styles/color-modes/light.less
@@ -351,9 +351,6 @@
   --rs-badge-text: var(--rs-gray-0);
   --rs-badge-border: var(--rs-gray-0);
 
-  // Close Button
-  --rs-close-button-hover-color: var(--rs-color-red);
-
   // Tag
   --rs-tag-bg: var(--rs-gray-50);
 


### PR DESCRIPTION
This pull request refactors the `CloseButton` component and its associated styles to simplify its implementation and improve maintainability. The changes include removing unnecessary conditional logic, cleaning up unused styles, and adjusting hover behavior for consistency.

### Component Refactor:

* Removed the `isDrawer` conditional logic in `ModalHeader` and updated the `CloseButton` to always use `IconButton` for consistency. (`src/Modal/ModalHeader.tsx`)

### Style Cleanup:

* Removed hover and focus styles for the `CloseButton` in `src/internals/CloseButton/styles/index.less`, as they are no longer needed.
* Deleted the `--rs-close-button-hover-color` variable from all color mode files (`dark.less`, `high-contrast.less`, `light.less`) since it is no longer used. [[1]](diffhunk://#diff-e4cdb20a74189b40fc05ef2ec0b326250b36f250955317dbec957ec8f47bc985L339-L341) [[2]](diffhunk://#diff-b02c23d24bb953d896497641d3eb85fb3935ba120d8fdfc81b6f7af252bab5eaL345-L347) [[3]](diffhunk://#diff-245225f85e06599d23e03e076ffac01108f62402c85f11ebc465af3ef04e5739L354-L356)

### Behavior Adjustment:

* Updated the hover behavior for the picker clear button (`.rs-picker-clean`) to use a primary text color on hover for better user feedback. (`src/internals/Picker/styles/index.less`)