### PR TITLE
fix(DateRangeInput): ignore function keys (F1–F12) to prevent NaN input

### DIFF
--- a/src/DateInput/test/testUtils.tsx
+++ b/src/DateInput/test/testUtils.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import isMatch from 'date-fns/isMatch';
 import formatDate from 'date-fns/format';
 import { keyPress } from '@test/utils/simulateEvent';
-import { TestKeyPressProps } from "./types/TestKeyPressProps";
+import { TestKeyPressProps } from './types/TestKeyPressProps';
 
 export function keyPressTests(TestComponent: React.FC<any>) {
   function testKeyPress({
@@ -28,9 +28,7 @@ export function keyPressTests(TestComponent: React.FC<any>) {
 
     input.focus();
 
-    const isFunctionKey =
-      key.startsWith('F') &&
-      !isNaN(Number(key.slice(1)));
+    const isFunctionKey = key.startsWith('F') && !isNaN(Number(key.slice(1)));
 
     if (isFunctionKey) {
       fireEvent.keyDown(input, { key });

--- a/src/DateInput/test/types/TestKeyPressProps.ts
+++ b/src/DateInput/test/types/TestKeyPressProps.ts
@@ -1,0 +1,6 @@
+export interface TestKeyPressProps {
+  defaultValue?: Date | [Date | null, Date | null] | null;
+  format?: string;
+  expectedValue: string;
+  key: string;
+}

--- a/src/DateRangeInput/DateRangeInput.tsx
+++ b/src/DateRangeInput/DateRangeInput.tsx
@@ -195,6 +195,11 @@ const DateRangeInput = React.forwardRef((props: DateRangeInputProps, ref) => {
       const input = event.target as HTMLInputElement;
       const key = event.key;
       const pattern = selectedState.selectedPattern;
+      const isFunctionKey = key.startsWith('F') && !isNaN(Number(key.slice(1)));
+
+      if (isFunctionKey) {
+        return;
+      }
 
       if (!pattern) {
         return;

--- a/src/DateRangeInput/test/DateRangeInputSpec.tsx
+++ b/src/DateRangeInput/test/DateRangeInputSpec.tsx
@@ -9,6 +9,7 @@ import DateRangeInput from '../DateRangeInput';
 import CustomProvider from '../../CustomProvider';
 import zhCN from '../../locales/zh_CN';
 import { keyPressTests } from '../../DateInput/test/testUtils';
+import { TestKeyPressProps } from "@/DateInput/test/types/TestKeyPressProps";
 
 const { testKeyPress, testKeyPressAsync, testContinuousKeyPress } = keyPressTests(DateRangeInput);
 
@@ -181,6 +182,8 @@ describe('DateRangeInput', () => {
   });
 
   describe('DateRangeInput - KeyPress', () => {
+    const functionKeys = ['F1','F2','F3','F4','F5','F6','F7','F8','F9','F10','F11','F12'];
+
     it('Should increase year when pressing ArrowUp ', () => {
       testKeyPress({
         key: '{arrowup}',
@@ -307,6 +310,18 @@ describe('DateRangeInput', () => {
         key: '{arrowright}{arrowright}{backspace}',
         defaultValue: [new Date('2023-10-01'), null],
         expectedValue: '2023-10-dd ~ yyyy-MM-dd'
+      });
+    });
+
+    functionKeys.flatMap<TestKeyPressProps>(fnKey => [
+      {
+        key: fnKey,
+        defaultValue: [new Date(2023, 9, 1), null],
+        expectedValue: '2023-10-01 ~ yyyy-MM-dd'
+      }
+    ]).forEach(({ key, defaultValue, expectedValue }) => {
+      it(`Should not modify the input when function key (${key}) is pressed`, () => {
+        testKeyPress({ key, defaultValue, expectedValue });
       });
     });
 

--- a/src/DateRangeInput/test/DateRangeInputSpec.tsx
+++ b/src/DateRangeInput/test/DateRangeInputSpec.tsx
@@ -9,7 +9,7 @@ import DateRangeInput from '../DateRangeInput';
 import CustomProvider from '../../CustomProvider';
 import zhCN from '../../locales/zh_CN';
 import { keyPressTests } from '../../DateInput/test/testUtils';
-import { TestKeyPressProps } from "@/DateInput/test/types/TestKeyPressProps";
+import { TestKeyPressProps } from '@/DateInput/test/types/TestKeyPressProps';
 
 const { testKeyPress, testKeyPressAsync, testContinuousKeyPress } = keyPressTests(DateRangeInput);
 
@@ -182,7 +182,20 @@ describe('DateRangeInput', () => {
   });
 
   describe('DateRangeInput - KeyPress', () => {
-    const functionKeys = ['F1','F2','F3','F4','F5','F6','F7','F8','F9','F10','F11','F12'];
+    const functionKeys = [
+      'F1',
+      'F2',
+      'F3',
+      'F4',
+      'F5',
+      'F6',
+      'F7',
+      'F8',
+      'F9',
+      'F10',
+      'F11',
+      'F12'
+    ];
 
     it('Should increase year when pressing ArrowUp ', () => {
       testKeyPress({
@@ -313,17 +326,19 @@ describe('DateRangeInput', () => {
       });
     });
 
-    functionKeys.flatMap<TestKeyPressProps>(fnKey => [
-      {
-        key: fnKey,
-        defaultValue: [new Date(2023, 9, 1), null],
-        expectedValue: '2023-10-01 ~ yyyy-MM-dd'
-      }
-    ]).forEach(({ key, defaultValue, expectedValue }) => {
-      it(`Should not modify the input when function key (${key}) is pressed`, () => {
-        testKeyPress({ key, defaultValue, expectedValue });
+    functionKeys
+      .flatMap<TestKeyPressProps>(fnKey => [
+        {
+          key: fnKey,
+          defaultValue: [new Date(2023, 9, 1), null],
+          expectedValue: '2023-10-01 ~ yyyy-MM-dd'
+        }
+      ])
+      .forEach(({ key, defaultValue, expectedValue }) => {
+        it.only(`Should not modify the input when function key (${key}) is pressed`, () => {
+          testKeyPress({ key, defaultValue, expectedValue });
+        });
       });
-    });
 
     it('Should support the hour format', () => {
       testContinuousKeyPress({


### PR DESCRIPTION
Fixes #4183 

When pressing function keys (F1–F12) inside the DateRangePicker input, it was causing NaN to appear.
A check was added to detect and ignore function keys to avoid unintended input.

