### PR TITLE
fix(DateInput): ignore function keys (F1–F12) to prevent NaN input

### DIFF
--- a/src/DateInput/DateInput.tsx
+++ b/src/DateInput/DateInput.tsx
@@ -133,6 +133,11 @@ const DateInput = React.forwardRef((props: DateInputProps, ref) => {
     (event: React.KeyboardEvent<HTMLInputElement>) => {
       const input = event.target as HTMLInputElement;
       const key = event.key;
+      const isFunctionKey = key.startsWith('F') && !isNaN(Number(key.slice(1)));
+
+      if (isFunctionKey) {
+        return;
+      }
 
       const pattern = selectedState.selectedPattern;
       if (!pattern) {

--- a/src/DateInput/test/DateInputSpec.tsx
+++ b/src/DateInput/test/DateInputSpec.tsx
@@ -9,6 +9,7 @@ import DateInput from '../DateInput';
 import CustomProvider from '../../CustomProvider';
 import zhCN from '../../locales/zh_CN';
 import { keyPressTests } from './testUtils';
+import { TestKeyPressProps } from './types/TestKeyPressProps';
 
 const { testKeyPress, testKeyPressAsync, testContinuousKeyPress } = keyPressTests(DateInput);
 
@@ -176,6 +177,21 @@ describe('DateInput', () => {
   });
 
   describe('DateInput - KeyPress', () => {
+    const functionKeys = [
+      'F1',
+      'F2',
+      'F3',
+      'F4',
+      'F5',
+      'F6',
+      'F7',
+      'F8',
+      'F9',
+      'F10',
+      'F11',
+      'F12'
+    ];
+
     it('Should increase year when pressing ArrowUp ', () => {
       testKeyPress({
         key: '{arrowup}',
@@ -304,6 +320,20 @@ describe('DateInput', () => {
         expectedValue: '2023-10-dd'
       });
     });
+
+    functionKeys
+      .flatMap<TestKeyPressProps>(fnKey => [
+        {
+          key: fnKey,
+          defaultValue: new Date(2023, 9, 1),
+          expectedValue: '2023-10-01'
+        }
+      ])
+      .forEach(({ key, defaultValue, expectedValue }) => {
+        it(`Should not modify the input when function key (${key}) is pressed`, () => {
+          testKeyPress({ key, defaultValue, expectedValue });
+        });
+      });
 
     it('Should support the hour format', () => {
       testContinuousKeyPress({

--- a/src/DateRangeInput/test/DateRangeInputSpec.tsx
+++ b/src/DateRangeInput/test/DateRangeInputSpec.tsx
@@ -335,7 +335,7 @@ describe('DateRangeInput', () => {
         }
       ])
       .forEach(({ key, defaultValue, expectedValue }) => {
-        it.only(`Should not modify the input when function key (${key}) is pressed`, () => {
+        it(`Should not modify the input when function key (${key}) is pressed`, () => {
           testKeyPress({ key, defaultValue, expectedValue });
         });
       });


### PR DESCRIPTION
Related to #4263 

When pressing function keys (F1–F12) inside the DateInput, it was causing NaN to appear.
A check was added to detect and ignore function keys to avoid unintended input.