### PR TITLE
fix(InlineEdit): reset input value to original on cancel instead of preserving edited value

### DIFF
--- a/src/InlineEdit/test/InlineEditSpec.tsx
+++ b/src/InlineEdit/test/InlineEditSpec.tsx
@@ -145,6 +145,31 @@ describe('InlineEdit', () => {
     expect(onEdit).to.not.have.been.called;
   });
 
+  it('Should call onFocus and set editing state when not editing', () => {
+    const onFocus = sinon.spy();
+
+    render(<InlineEdit onFocus={onFocus} defaultValue="test value" />);
+
+    const element = screen.getByText('test value');
+    fireEvent.focus(element);
+
+    expect(onFocus).to.have.been.calledOnce;
+    expect(screen.getByRole('textbox')).to.exist;
+  });
+
+  it('Should not call onFocus again if already editing', () => {
+    const onFocus = sinon.spy();
+
+    render(<InlineEdit onFocus={onFocus} defaultValue="test value" />);
+
+    const element = screen.getByText('test value');
+    fireEvent.focus(element);
+    // By the second focus call, isEditing is already set.
+    fireEvent.focus(element);
+
+    expect(onFocus).to.have.been.calledOnce;
+  });
+
   it('Should have a custom size', () => {
     const { container } = render(<InlineEdit size="lg" defaultValue="input something" />);
 

--- a/src/InlineEdit/useEditState.ts
+++ b/src/InlineEdit/useEditState.ts
@@ -44,7 +44,7 @@ const useEditState = (props: EditStateProps) => {
   });
 
   const handleFocus = useEventCallback((event?: React.FocusEvent) => {
-    if (disabled) return;
+    if (disabled || isEditing) return;
     onFocus?.(event);
     setIsEditing(true);
     setResetValue(value);


### PR DESCRIPTION
This PR fixes an issue in the InlineEdit component where the current input value was incorrectly preserved after triggering the onCancel callback.

Previously, when onCancel was called, the value that had been modified in the input field was stored and reused, instead of reverting to the original unedited value.

The component now correctly resets the input to its initial value when canceling an edit.

Related issue: #4274 

https://github.com/user-attachments/assets/303abcea-0db7-4b97-acf3-ae70ebae4072

