### PR TITLE
docs(PasswordInput): fix incorrect order of examples

### DIFF
--- a/docs/pages/components/password-input/en-US/index.md
+++ b/docs/pages/components/password-input/en-US/index.md
@@ -29,11 +29,11 @@ A password input component.
 You can use `startIcon` and `endIcon` to set the start and end icons, respectively.
 When using `endIcon`, the password visibility toggle icon will be overridden.
 
+<!--{include:`icons.md`}-->
+
 ### Password strength meter
 
 <!--{include:`password-strength-meter.md`}-->
-
-<!--{include:`icons.md`}-->
 
 ## Props
 

--- a/docs/pages/components/password-input/zh-CN/index.md
+++ b/docs/pages/components/password-input/zh-CN/index.md
@@ -29,11 +29,11 @@
 可以通过 `startIcon` 和 `endIcon` 分别设置前置图标和后置图标。
 当使用 `endIcon` 时，密码输入框的可见性切换图标将被覆盖。
 
+<!--{include:`icons.md`}-->
+
 ### 密码强度
 
 <!--{include:`password-strength-meter.md`}-->
-
-<!--{include:`icons.md`}-->
 
 ## Props
 


### PR DESCRIPTION
This pull request reorganizes the documentation for the password input component by moving the `icons.md` include to a more logical position in both the English and Chinese documentation files.
