### PR TITLE
fix: correct locale code for Spanish (Spain)

### DIFF
--- a/src/locales/es_ES.ts
+++ b/src/locales/es_ES.ts
@@ -40,7 +40,7 @@ const CreatableComboBox = {
 };
 
 export default {
-  code: 'es-AR',
+  code: 'es-ES',
   common: {
     loading: 'Cargando...',
     emptyMessage: 'Sin datos',


### PR DESCRIPTION
The locale code in `src/locales/es_ES.ts` was incorrectly set to `es-AR` (Spanish - Argentina). This commit corrects the locale code to `es-ES` (Spanish - Spain).