### PR TITLE
fix(toaster): fix issue where delayed closing affects state

### DIFF
--- a/src/toaster/ToastContainer.tsx
+++ b/src/toaster/ToastContainer.tsx
@@ -120,7 +120,7 @@ const useMessages = () => {
     // Remove all invisible messages after 400ms.
     // The delay removal here is to preserve the animation.
     setTimeout(() => {
-      setMessages([]);
+      setMessages(prevMessages => []);
     }, 400);
   }, [messages]);
 
@@ -138,7 +138,7 @@ const useMessages = () => {
 
       // Remove invisible messages after 400ms.
       setTimeout(() => {
-        setMessages(messages.filter(msg => msg.visible));
+        setMessages(prevMessages => prevMessages.filter(msg => msg.visible));
       }, 400);
     },
     [messages, getKey]

--- a/src/toaster/ToastContainer.tsx
+++ b/src/toaster/ToastContainer.tsx
@@ -120,7 +120,7 @@ const useMessages = () => {
     // Remove all invisible messages after 400ms.
     // The delay removal here is to preserve the animation.
     setTimeout(() => {
-      setMessages(prevMessages => []);
+      setMessages(() => []);
     }, 400);
   }, [messages]);
 


### PR DESCRIPTION
This pull request updates the `useMessages` function in `src/toaster/ToastContainer.tsx` to ensure state updates are based on the previous state, improving reliability when handling asynchronous updates.

State management improvements:

* Updated the `setMessages` call to use a functional state update in the `setTimeout` for clearing all messages. This ensures the state update is based on the most recent state.
* Updated the `setMessages` call to use a functional state update when filtering visible messages. This prevents potential issues caused by stale state references.