### PR TITLE
docs(Stat): update ring progress documentation and related examples

### DIFF
--- a/docs/pages/components/stat/fragments/ring-progress.md
+++ b/docs/pages/components/stat/fragments/ring-progress.md
@@ -1,13 +1,13 @@
 <!--start-code-->
 
 ```js
-import { Stat, StatGroup, Progress, HStack, VStack } from 'rsuite';
+import { Stat, StatGroup, ProgressCircle, HStack, VStack } from 'rsuite';
 
 const App = () => (
   <StatGroup spacing={20} columns={3}>
     <Stat bordered>
       <HStack spacing={16}>
-        <Progress.Circle percent={50} width={50} strokeWidth={10} trailWidth={10} />
+        <ProgressCircle percent={50} w={50} strokeWidth={10} trailWidth={10} />
         <VStack>
           <Stat.Label>Processing</Stat.Label>
           <Stat.Value>1,200</Stat.Value>
@@ -17,9 +17,9 @@ const App = () => (
 
     <Stat bordered>
       <HStack spacing={16}>
-        <Progress.Circle
+        <ProgressCircle
           percent={10}
-          width={50}
+          w={50}
           strokeColor="#ffc107"
           strokeWidth={10}
           trailWidth={10}
@@ -33,9 +33,9 @@ const App = () => (
 
     <Stat bordered>
       <HStack spacing={16}>
-        <Progress.Circle
+        <ProgressCircle
           percent={45}
-          width={50}
+          w={50}
           strokeColor="#87d068"
           strokeWidth={10}
           trailWidth={10}

--- a/docs/pages/components/stat/index.tsx
+++ b/docs/pages/components/stat/index.tsx
@@ -5,6 +5,7 @@ import {
   HStack,
   VStack,
   Progress,
+  ProgressCircle,
   SelectPicker,
   useBreakpointValue
 } from 'rsuite';
@@ -27,6 +28,7 @@ export default function Page() {
         HStack,
         VStack,
         Progress,
+        ProgressCircle,
         Stat,
         StatGroup,
         SelectPicker,


### PR DESCRIPTION
This pull request updates the documentation and imports to replace `Progress.Circle` with `ProgressCircle` for better consistency and readability. The changes include modifications to the `ring-progress` documentation and the `stat` component's imports.
