### PR TITLE
fix(overview): add optional chaining to prevent potential runtime errors in includes function

### DIFF
--- a/docs/pages/components/overview/index.tsx
+++ b/docs/pages/components/overview/index.tsx
@@ -9,7 +9,7 @@ import { ButtonGroup, HStack, IconButton, Input, InputGroup, Text } from 'rsuite
 import { FaSortAlphaUp, FaList } from 'react-icons/fa';
 
 function includes(str: string, keyword: string) {
-  return str.toLowerCase().includes(keyword.toLowerCase());
+  return str?.toLowerCase().includes(keyword?.toLowerCase());
 }
 
 const filterComponents = (item: MenuItem, search: string) => {


### PR DESCRIPTION
This pull request introduces a small but important change to improve the robustness of the `includes` function in `docs/pages/components/overview/index.tsx`. The change adds optional chaining to handle potential `null` or `undefined` values for both `str` and `keyword`.