### PR TITLE
Navbar.Brand scaling fix

### DIFF
--- a/src/Navbar/styles/index.less
+++ b/src/Navbar/styles/index.less
@@ -23,7 +23,8 @@
 .rs-navbar-brand {
   &:extend(.rs-navbar-header); // TODO deprecate .rs-navbar-header
 
-  padding: 18px 20px;
+  //padding: 18px 20px;
+   padding: @navbar-item-padding-y @navbar-item-padding-x; //fixed values ​​instead of using variables @navbar-item-padding-y @navbar-item-padding-x prevents these variables from working as expected
 }
 
 // Common


### PR DESCRIPTION
Fixed values ​​instead of using variables @navbar-item-padding-y @navbar-item-padding-x prevents these variables from working as expected. When decreasing the value of the @navbar-item-padding-y @navbar-item-padding-x variables, the fixed padding values ​​for Navbar.Brand do not allow the height of the entire Navbar to be reduced.
