### PR TITLE
docs: disable auto-focus and autocomplete on email input

### DIFF
--- a/docs/pages/components/frame/examples/center.tsx
+++ b/docs/pages/components/frame/examples/center.tsx
@@ -57,7 +57,7 @@ const App = () => {
             <Form fluid>
               <Form.Group>
                 <Form.Label>Email address</Form.Label>
-                <Form.Control name="email" autoFocus={false} />
+                <Form.Control name="email" autoFocus={false} autoComplete="off" />
               </Form.Group>
               <Form.Group>
                 <Form.Label>Password</Form.Label>


### PR DESCRIPTION
This pull request introduces a small improvement to the `Form.Control` component in the `docs/pages/components/frame/examples/center.tsx` file. The change disables autocomplete for the email input field.

* [`docs/pages/components/frame/examples/center.tsx`](diffhunk://#diff-137329b02f06c3c4c9fd3cd9473f00097564c1a77e608707b8c444cb8eb48c4cL60-R60): Added the `autoComplete="off"` attribute to the email input field to prevent browsers from autofilling the field.