### PR TITLE
feat: implement responsive shorthand CSS properties for Box component

### DIFF
--- a/docs/pages/_common/types/appearance.md
+++ b/docs/pages/_common/types/appearance.md
@@ -1,4 +1,4 @@
-### `ts:Appearance`
+##### `ts:Appearance`
 
 ```ts
 type Appearance = 'default' | 'primary' | 'link' | 'subtle' | 'ghost';

--- a/docs/pages/_common/types/breakpoints.md
+++ b/docs/pages/_common/types/breakpoints.md
@@ -1,4 +1,4 @@
-### `ts:Breakpoints`
+#### `ts:Breakpoints`
 
 ```ts
 type Breakpoints = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';

--- a/docs/pages/_common/types/color-scheme.md
+++ b/docs/pages/_common/types/color-scheme.md
@@ -1,4 +1,4 @@
-### `ts:ColorScheme`
+#### `ts:ColorScheme`
 
 ```ts
 type Color = 'red' | 'orange' | 'yellow' | 'green' | 'cyan' | 'blue' | 'violet';

--- a/docs/pages/_common/types/color.md
+++ b/docs/pages/_common/types/color.md
@@ -1,4 +1,4 @@
-### `ts:Color`
+#### `ts:Color`
 
 ```ts
 type Color = 'red' | 'orange' | 'yellow' | 'green' | 'cyan' | 'blue' | 'violet';

--- a/docs/pages/_common/types/file-type.md
+++ b/docs/pages/_common/types/file-type.md
@@ -1,4 +1,4 @@
-### `ts:FileType`
+#### `ts:FileType`
 
 ```ts
 interface FileType {

--- a/docs/pages/_common/types/item-data-type.md
+++ b/docs/pages/_common/types/item-data-type.md
@@ -1,4 +1,4 @@
-### `ts:Option`
+#### `ts:Option`
 
 ```ts
 interface Option<V> {

--- a/docs/pages/_common/types/list-props.md
+++ b/docs/pages/_common/types/list-props.md
@@ -1,4 +1,4 @@
-### `ts:ListProps`
+#### `ts:ListProps`
 
 ```ts
 interface ListProps {

--- a/docs/pages/_common/types/month-dropdown-props.md
+++ b/docs/pages/_common/types/month-dropdown-props.md
@@ -1,4 +1,4 @@
-### `ts:MonthDropdownProps`
+#### `ts:MonthDropdownProps`
 
 ```ts
 import type { FixedSizeListProps } from 'react-window';

--- a/docs/pages/_common/types/placement-all.md
+++ b/docs/pages/_common/types/placement-all.md
@@ -1,4 +1,4 @@
-### `ts:Placement`
+#### `ts:Placement`
 
 ```ts
 type Placement =

--- a/docs/pages/_common/types/placement-corners.md
+++ b/docs/pages/_common/types/placement-corners.md
@@ -1,4 +1,4 @@
-### `ts:PlacementCorners`
+#### `ts:PlacementCorners`
 
 ```ts
 type PlacementCorners = 'topStart' | 'topEnd' | 'bottomStart' | 'bottomEnd';

--- a/docs/pages/_common/types/placement-error-message.md
+++ b/docs/pages/_common/types/placement-error-message.md
@@ -1,4 +1,4 @@
-### `ts:Placement`
+#### `ts:Placement`
 
 ```ts
 /**

--- a/docs/pages/_common/types/placement-start.md
+++ b/docs/pages/_common/types/placement-start.md
@@ -1,4 +1,4 @@
-### `ts:Placement`
+#### `ts:Placement`
 
 ```ts
 type Placement = 'bottomStart' | 'topStart' | 'autoVerticalStart';

--- a/docs/pages/_common/types/placement-toaster.md
+++ b/docs/pages/_common/types/placement-toaster.md
@@ -1,4 +1,4 @@
-### `ts:Placement`
+#### `ts:Placement`
 
 ```ts
 type Placement = 'topStart' | 'topCenter' | 'topEnd' | 'bottomStart' | 'bottomCenter' | 'bottomEnd';

--- a/docs/pages/_common/types/placement.md
+++ b/docs/pages/_common/types/placement.md
@@ -1,4 +1,4 @@
-### `ts:Placement`
+#### `ts:Placement`
 
 ```ts
 type Placement =

--- a/docs/pages/_common/types/placement4.md
+++ b/docs/pages/_common/types/placement4.md
@@ -1,4 +1,4 @@
-### `ts:Placement`
+#### `ts:Placement`
 
 ```ts
 type Placement = 'top' | 'bottom' | 'right' | 'left';

--- a/docs/pages/_common/types/placement8.md
+++ b/docs/pages/_common/types/placement8.md
@@ -1,4 +1,4 @@
-### `ts:Placement`
+#### `ts:Placement`
 
 ```ts
 type Placement =

--- a/docs/pages/_common/types/range.md
+++ b/docs/pages/_common/types/range.md
@@ -1,4 +1,4 @@
-### `ts:Range`
+#### `ts:Range`
 
 ```ts
 interface Range {

--- a/docs/pages/_common/types/react-suite-components.md
+++ b/docs/pages/_common/types/react-suite-components.md
@@ -1,4 +1,4 @@
-### `ts:Components`
+#### `ts:Components`
 
 ```ts
 import type { ButtonProps } from '../Button';

--- a/docs/pages/_common/types/responsive-value.md
+++ b/docs/pages/_common/types/responsive-value.md
@@ -1,4 +1,4 @@
-### `ts:ResponsiveValue`
+#### `ts:ResponsiveValue`
 
 ```ts
 type ResponsiveValue<T> = {

--- a/docs/pages/_common/types/size.md
+++ b/docs/pages/_common/types/size.md
@@ -1,4 +1,4 @@
-### `ts:Size`
+#### `ts:Size`
 
 ```ts
 type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl';

--- a/docs/pages/_common/types/text-size.md
+++ b/docs/pages/_common/types/text-size.md
@@ -1,4 +1,4 @@
-### `ts:TextSize`
+#### `ts:TextSize`
 
 ```ts
 type TextSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl' | '6xl';

--- a/docs/pages/_common/types/tree-node.md
+++ b/docs/pages/_common/types/tree-node.md
@@ -1,4 +1,4 @@
-### `ts:TreeNode`
+#### `ts:TreeNode`
 
 ```ts
 interface TreeNode {

--- a/docs/pages/_common/types/trigger.md
+++ b/docs/pages/_common/types/trigger.md
@@ -1,4 +1,4 @@
-### `ts:Trigger`
+#### `ts:Trigger`
 
 ```ts
 type Trigger = 'click' | 'hover' | 'contextMenu' | Array<'click' | 'hover' | 'contextMenu'>;

--- a/docs/pages/components/box/en-US/index.md
+++ b/docs/pages/components/box/en-US/index.md
@@ -26,6 +26,18 @@ Box component is the base component for all components, providing shorthand for 
 
 ## Responsive
 
+Box component supports responsive values for all shorthand CSS properties. This allows you to define different styles for different breakpoints.
+
+```jsx
+<Box
+  w={{ xs: '100%', md: '80%', lg: '60%' }}
+  p={{ xs: '10px', md: '20px' }}
+  display={{ xs: 'block', md: 'flex' }}
+>
+  This box has responsive width, padding and display
+</Box>
+```
+
 <!--{include:<example-responsive>}-->
 
 ## Props
@@ -45,33 +57,38 @@ Box component is the base component for all components, providing shorthand for 
 
 ### `Style Shorthand`
 
-| Property | Type`(default)`                                            | Description                                                           |
-| -------- | ---------------------------------------------------------- | --------------------------------------------------------------------- |
-| bd       | CSSProperties['border']                                    | CSS border property for the box                                       |
-| bg       | [ColorScheme][color-scheme] \| CSSProperties['background'] | Background color of the box. Supports theme colors (e.g., 'blue.600') |
-| c        | [ColorScheme][color-scheme] \| CSSProperties['color']      | Text color of the box. Supports theme colors (e.g., 'blue.600')       |
-| h        | CSSProperties['height']                                    | Height of the box                                                     |
-| m        | CSSProperties['margin']                                    | Margin on all sides                                                   |
-| maxh     | CSSProperties['maxHeight']                                 | Maximum height of the box                                             |
-| maxw     | CSSProperties['maxWidth']                                  | Maximum width of the box                                              |
-| mb       | CSSProperties['marginBottom']                              | Margin bottom                                                         |
-| minh     | CSSProperties['minHeight']                                 | Minimum height of the box                                             |
-| minw     | CSSProperties['minWidth']                                  | Minimum width of the box                                              |
-| ml       | CSSProperties['marginLeft']                                | Margin left                                                           |
-| mr       | CSSProperties['marginRight']                               | Margin right                                                          |
-| mt       | CSSProperties['marginTop']                                 | Margin top                                                            |
-| mx       | CSSProperties['marginInline']                              | Margin on left and right sides                                        |
-| my       | CSSProperties['marginBlock']                               | Margin on top and bottom sides                                        |
-| p        | CSSProperties['padding']                                   | Padding on all sides                                                  |
-| pb       | CSSProperties['paddingBottom']                             | Padding bottom                                                        |
-| pl       | CSSProperties['paddingLeft']                               | Padding left                                                          |
-| pr       | CSSProperties['paddingRight']                              | Padding right                                                         |
-| pt       | CSSProperties['paddingTop']                                | Padding top                                                           |
-| px       | CSSProperties['paddingInline']                             | Padding on left and right sides                                       |
-| py       | CSSProperties['paddingBlock']                              | Padding on top and bottom sides                                       |
-| rounded  | [Size][size] \| CSSProperties['borderRadius']              | Border radius of the box                                              |
-| shadow   | [Size][size] \| CSSProperties['boxShadow']                 | Box shadow                                                            |
-| w        | CSSProperties['width']                                     | Width of the box                                                      |
+The Box component provides a series of shorthand properties for more concise style settings. These properties directly map to their corresponding CSS properties.
+
+- **Theme Values**: Provided theme presets, such as `bg='blue.600'`, `rounded='lg'`, etc.
+- **Responsive Values**: Provided responsive values, such as `w={{ xs: '100%', md: '80%', lg: '60%' }}`, etc.
+
+| Property | CSS Property  | Theme Values                |
+| -------- | ------------- | --------------------------- |
+| bd       | border        | -                           |
+| bg       | background    | [ColorScheme][color-scheme] |
+| c        | color         | [ColorScheme][color-scheme] |
+| h        | height        | -                           |
+| m        | margin        | -                           |
+| maxh     | maxHeight     | -                           |
+| maxw     | maxWidth      | -                           |
+| mb       | marginBottom  | -                           |
+| minh     | minHeight     | -                           |
+| minw     | minWidth      | -                           |
+| ml       | marginLeft    | -                           |
+| mr       | marginRight   | -                           |
+| mt       | marginTop     | -                           |
+| mx       | marginInline  | -                           |
+| my       | marginBlock   | -                           |
+| p        | padding       | -                           |
+| pb       | paddingBottom | -                           |
+| pl       | paddingLeft   | -                           |
+| pr       | paddingRight  | -                           |
+| pt       | paddingTop    | -                           |
+| px       | paddingInline | -                           |
+| py       | paddingBlock  | -                           |
+| rounded  | borderRadius  | [Size][size]                |
+| shadow   | boxShadow     | [Size][size]                |
+| w        | width         | -                           |
 
 <!--{include:(_common/types/breakpoints.md)}-->
 

--- a/docs/pages/components/box/examples/responsive.tsx
+++ b/docs/pages/components/box/examples/responsive.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 'use client';
 
 import React from 'react';
@@ -5,7 +6,34 @@ import { Box, Text } from 'rsuite';
 
 const App = () => {
   return (
-    <>
+    <Box p={20}>
+      <Box
+        // @ts-ignore
+        rounded={{
+          xs: 2,
+          md: 4,
+          lg: 6
+        }}
+        // @ts-ignore
+        bg={{
+          xs: 'linear-gradient(45deg, #4CAF50, #2196F3)',
+          md: '#4CAF50',
+          lg: '#2196F3'
+        }}
+        // @ts-ignore
+        w={{ xs: '100%', md: '80%', lg: '60%' }}
+        // @ts-ignore
+        p={{ xs: '10px', md: '20px' }}
+        // @ts-ignore
+        display={{ xs: 'flex', md: 'block' }}
+      >
+        <Text align="center" color="white">
+          This box has responsive width, padding and display
+        </Text>
+      </Box>
+
+      <hr />
+
       <Box bg="green.600" p={20} h={200} hideFrom="xs">
         <Text color="white">The component will be hidden at breakpoints larger than `xs`</Text>
       </Box>
@@ -13,7 +41,7 @@ const App = () => {
       <Box bg="blue.600" p={20} h={200} showFrom="xs">
         <Text color="white">The component will be visible only at the `xs` breakpoint</Text>
       </Box>
-    </>
+    </Box>
   );
 };
 

--- a/docs/pages/components/box/zh-CN/index.md
+++ b/docs/pages/components/box/zh-CN/index.md
@@ -24,6 +24,22 @@ Box 组件是所有组件的基础组件，为样式属性提供了简写方式�
 
 <!--{include:`shadow.md`}-->
 
+## 响应式
+
+Box 组件支持所有简写 CSS 属性的响应式值。这允许你为不同的断点定义不同的样式。
+
+```jsx
+<Box
+  w={{ xs: '100%', md: '80%', lg: '60%' }}
+  p={{ xs: '10px', md: '20px' }}
+  display={{ xs: 'block', md: 'flex' }}
+>
+  这个 Box 组件有响应式宽度、内边距和显示
+</Box>
+```
+
+<!--{include:<example-responsive>}-->
+
 ## Props
 
 ### `<Box>`
@@ -41,33 +57,40 @@ Box 组件是所有组件的基础组件，为样式属性提供了简写方式�
 
 ### `Style Shorthand`
 
-| 属性    | 类型                                                       | 描述                                             |
-| ------- | ---------------------------------------------------------- | ------------------------------------------------ |
-| bd      | CSSProperties['border']                                    | 盒子的 CSS 边框属性                              |
-| bg      | [ColorScheme][color-scheme] \| CSSProperties['background'] | 盒子的背景颜色。支持主题颜色（例如：'blue.600'） |
-| c       | [ColorScheme][color-scheme] \| CSSProperties['color']      | 文本颜色。支持主题颜色（例如：'blue.600'）       |
-| h       | CSSProperties['height']                                    | 盒子的高度                                       |
-| m       | CSSProperties['margin']                                    | 四周外边距                                       |
-| maxh    | CSSProperties['maxHeight']                                 | 盒子的最大高度                                   |
-| maxw    | CSSProperties['maxWidth']                                  | 盒子的最大宽度                                   |
-| mb      | CSSProperties['marginBottom']                              | 底部外边距                                       |
-| minh    | CSSProperties['minHeight']                                 | 盒子的最小高度                                   |
-| minw    | CSSProperties['minWidth']                                  | 盒子的最小宽度                                   |
-| ml      | CSSProperties['marginLeft']                                | 左侧外边距                                       |
-| mr      | CSSProperties['marginRight']                               | 右侧外边距                                       |
-| mt      | CSSProperties['marginTop']                                 | 顶部外边距                                       |
-| mx      | CSSProperties['marginInline']                              | 左右两侧外边距                                   |
-| my      | CSSProperties['marginBlock']                               | 上下两侧外边距                                   |
-| p       | CSSProperties['padding']                                   | 四周内边距                                       |
-| pb      | CSSProperties['paddingBottom']                             | 底部内边距                                       |
-| pl      | CSSProperties['paddingLeft']                               | 左侧内边距                                       |
-| pr      | CSSProperties['paddingRight']                              | 右侧内边距                                       |
-| pt      | CSSProperties['paddingTop']                                | 顶部内边距                                       |
-| px      | CSSProperties['paddingInline']                             | 左右两侧内边距                                   |
-| py      | CSSProperties['paddingBlock']                              | 上下两侧内边距                                   |
-| rounded | [Size][size] \| CSSProperties['borderRadius']              | 盒子的边框圆角                                   |
-| shadow  | [Size][size] \| CSSProperties['boxShadow']                 | 盒子阴影                                         |
-| w       | CSSProperties['width']                                     | 盒子的宽度                                       |
+Box 组件提供了一系列简写属性，可以更简洁地设置常用样式。这些属性直接映射到对应的 CSS 属性。
+
+- **主题值**：提供的主题预设值, 例如 `bg='blue.600'`, `rounded='lg'` 等。
+- **响应式值**：提供的响应式值, 例如 `w={{ xs: '100%', md: '80%', lg: '60%' }}` 等。
+
+| 属性    | CSS 属性      | 主题值                      |
+| ------- | ------------- | --------------------------- |
+| bd      | border        | -                           |
+| bg      | background    | [ColorScheme][color-scheme] |
+| c       | color         | [ColorScheme][color-scheme] |
+| h       | height        | -                           |
+| m       | margin        | -                           |
+| maxh    | maxHeight     | -                           |
+| maxw    | maxWidth      | -                           |
+| mb      | marginBottom  | -                           |
+| minh    | minHeight     | -                           |
+| minw    | minWidth      | -                           |
+| ml      | marginLeft    | -                           |
+| mr      | marginRight   | -                           |
+| mt      | marginTop     | -                           |
+| mx      | marginInline  | -                           |
+| my      | marginBlock   | -                           |
+| p       | padding       | -                           |
+| pb      | paddingBottom | -                           |
+| pl      | paddingLeft   | -                           |
+| pr      | paddingRight  | -                           |
+| pt      | paddingTop    | -                           |
+| px      | paddingInline | -                           |
+| py      | paddingBlock  | -                           |
+| rounded | borderRadius  | [Size][size]                |
+| shadow  | boxShadow     | [Size][size]                |
+| w       | width         | -                           |
+
+### 类型定义
 
 <!--{include:(_common/types/breakpoints.md)}-->
 <!--{include:(_common/types/size.md)}-->

--- a/docs/styles/_markdown.scss
+++ b/docs/styles/_markdown.scss
@@ -25,14 +25,13 @@
 
   h2 {
     font-size: 24px;
-    padding: 10px 0;
     font-weight: bold;
-    margin-top: 10px;
+    margin-top: calc(var(--rs-spacing) * 8);
   }
 
   h3 {
     font-size: 18px;
-    margin-top: 10px;
+    margin-top: calc(var(--rs-spacing) * 6);
 
     code {
       font-size: 18px !important;
@@ -41,12 +40,12 @@
 
   h4 {
     font-size: 16px;
-    margin-top: 10px;
+    margin-top: calc(var(--rs-spacing) * 4);
   }
 
   // Page heading styles
   .page-heading {
-    margin-bottom: 10px;
+    margin-bottom: calc(var(--rs-spacing) * 4);
     line-height: 1.2;
     display: flex;
     align-items: center;
@@ -80,7 +79,7 @@
   /* ===== Tables ===== */
   table {
     width: 100%;
-    margin-top: 10px;
+    margin-top: calc(var(--rs-spacing) * 4);
 
     td,
     th {

--- a/src/internals/Box/Box.tsx
+++ b/src/internals/Box/Box.tsx
@@ -3,7 +3,13 @@ import isEmpty from 'lodash/isEmpty';
 import { forwardRef } from '@/internals/utils/react/forwardRef';
 import { getBoxCSSVariables, extractBoxProps, omitBoxProps } from './utils';
 import { useStyled } from '@/internals/hooks/useStyled';
-import type { WithAsProps, Breakpoints, ColorScheme, Size } from '@/internals/types';
+import type {
+  WithAsProps,
+  Breakpoints,
+  ResponsiveValue,
+  ColorScheme,
+  Size
+} from '@/internals/types';
 
 export interface BoxProps extends WithAsProps {
   /** Breakpoint below which the component is shown with `display: block` */
@@ -13,48 +19,52 @@ export interface BoxProps extends WithAsProps {
   hideFrom?: Breakpoints;
 
   /** Display property */
-  display?: CSS['display'];
+  display?: CSS['display'] | ResponsiveValue<CSS['display']>;
 
   /** Padding */
-  p?: CSS['padding'];
-  pt?: CSS['paddingTop'];
-  pb?: CSS['paddingBottom'];
-  pl?: CSS['paddingLeft'];
-  pr?: CSS['paddingRight'];
-  px?: CSS['paddingInline'];
-  py?: CSS['paddingBlock'];
+  p?: CSS['padding'] | ResponsiveValue<CSS['padding']>;
+  pt?: CSS['paddingTop'] | ResponsiveValue<CSS['paddingTop']>;
+  pb?: CSS['paddingBottom'] | ResponsiveValue<CSS['paddingBottom']>;
+  pl?: CSS['paddingLeft'] | ResponsiveValue<CSS['paddingLeft']>;
+  pr?: CSS['paddingRight'] | ResponsiveValue<CSS['paddingRight']>;
+  px?: CSS['paddingInline'] | ResponsiveValue<CSS['paddingInline']>;
+  py?: CSS['paddingBlock'] | ResponsiveValue<CSS['paddingBlock']>;
 
   /** Margin */
-  m?: CSS['margin'];
-  mt?: CSS['marginTop'];
-  mb?: CSS['marginBottom'];
-  ml?: CSS['marginLeft'];
-  mr?: CSS['marginRight'];
-  mx?: CSS['marginInline'];
-  my?: CSS['marginBlock'];
+  m?: CSS['margin'] | ResponsiveValue<CSS['margin']>;
+  mt?: CSS['marginTop'] | ResponsiveValue<CSS['marginTop']>;
+  mb?: CSS['marginBottom'] | ResponsiveValue<CSS['marginBottom']>;
+  ml?: CSS['marginLeft'] | ResponsiveValue<CSS['marginLeft']>;
+  mr?: CSS['marginRight'] | ResponsiveValue<CSS['marginRight']>;
+  mx?: CSS['marginInline'] | ResponsiveValue<CSS['marginInline']>;
+  my?: CSS['marginBlock'] | ResponsiveValue<CSS['marginBlock']>;
 
   /** Box size */
-  w?: CSS['width'];
-  h?: CSS['height'];
-  minw?: CSS['minWidth'];
-  maxw?: CSS['maxWidth'];
-  minh?: CSS['minHeight'];
-  maxh?: CSS['maxHeight'];
+  w?: CSS['width'] | ResponsiveValue<CSS['width']>;
+  h?: CSS['height'] | ResponsiveValue<CSS['height']>;
+  minw?: CSS['minWidth'] | ResponsiveValue<CSS['minWidth']>;
+  maxw?: CSS['maxWidth'] | ResponsiveValue<CSS['maxWidth']>;
+  minh?: CSS['minHeight'] | ResponsiveValue<CSS['minHeight']>;
+  maxh?: CSS['maxHeight'] | ResponsiveValue<CSS['maxHeight']>;
 
   /** Box Color */
-  c?: ColorScheme | CSS['color'];
+  c?: ColorScheme | CSS['color'] | ResponsiveValue<ColorScheme | CSS['color']>;
 
   /** Box Border */
-  bd?: CSS['border'];
+  bd?: CSS['border'] | ResponsiveValue<CSS['border']>;
 
   /** Box Background */
-  bg?: ColorScheme | CSS['backgroundColor'];
+  bg?: ColorScheme | CSS['backgroundColor'] | ResponsiveValue<ColorScheme | CSS['backgroundColor']>;
 
   /** Box Border Radius */
-  rounded?: Size | CSS['borderRadius'] | 'full';
+  rounded?:
+    | Size
+    | CSS['borderRadius']
+    | 'full'
+    | ResponsiveValue<Size | CSS['borderRadius'] | 'full'>;
 
   /** Box Shadow */
-  shadow?: Size | CSS['boxShadow'];
+  shadow?: Size | CSS['boxShadow'] | ResponsiveValue<Size | CSS['boxShadow']>;
 }
 
 /**

--- a/src/internals/Box/test/BoxResponsive.spec.tsx
+++ b/src/internals/Box/test/BoxResponsive.spec.tsx
@@ -1,0 +1,252 @@
+import React from 'react';
+import Box from '../Box';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import StyleManager from '@/internals/utils/style-sheet/style-manager';
+
+// Mock StyleManager
+vi.mock('@/internals/utils/style-sheet/style-manager', () => ({
+  default: {
+    addRule: vi.fn(),
+    removeRule: vi.fn(),
+    styleMap: new Map(),
+    updateStyles: vi.fn()
+  }
+}));
+
+describe('Box Responsive Props', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('Should render with responsive padding', () => {
+    render(<Box p={{ xs: '5px', md: '15px', lg: '25px' }}>Content</Box>);
+
+    expect(StyleManager.addRule).toHaveBeenCalled();
+    const addRuleCalls = (StyleManager.addRule as any).mock.calls;
+
+    // Check base styles
+    const baseStyles = addRuleCalls.find(call => !call[1].includes('@media'));
+    expect(baseStyles).toBeDefined();
+
+    // Check media queries for each breakpoint
+    const xsMediaQuery = addRuleCalls.find(
+      call => call[0] === '@media (min-width: 0px)' && call[1].includes('--rs-box-p: 5px')
+    );
+    const mdMediaQuery = addRuleCalls.find(
+      call => call[0] === '@media (min-width: 768px)' && call[1].includes('--rs-box-p: 15px')
+    );
+    const lgMediaQuery = addRuleCalls.find(
+      call => call[0] === '@media (min-width: 992px)' && call[1].includes('--rs-box-p: 25px')
+    );
+
+    expect(xsMediaQuery).toBeDefined();
+    expect(mdMediaQuery).toBeDefined();
+    expect(lgMediaQuery).toBeDefined();
+  });
+
+  it('Should render with responsive width and height', () => {
+    render(
+      <Box
+        w={{ xs: '100%', sm: '80%', md: '60%', lg: '40%' }}
+        h={{ xs: '100px', md: '200px', xl: '300px' }}
+      >
+        Content
+      </Box>
+    );
+
+    expect(StyleManager.addRule).toHaveBeenCalled();
+    const addRuleCalls = (StyleManager.addRule as any).mock.calls;
+
+    // Check media queries for width
+    const xsWidthQuery = addRuleCalls.find(
+      call => call[0] === '@media (min-width: 0px)' && call[1].includes('--rs-box-w: 100%')
+    );
+    const smWidthQuery = addRuleCalls.find(
+      call => call[0] === '@media (min-width: 576px)' && call[1].includes('--rs-box-w: 80%')
+    );
+    const mdWidthQuery = addRuleCalls.find(
+      call => call[0] === '@media (min-width: 768px)' && call[1].includes('--rs-box-w: 60%')
+    );
+    const lgWidthQuery = addRuleCalls.find(
+      call => call[0] === '@media (min-width: 992px)' && call[1].includes('--rs-box-w: 40%')
+    );
+
+    expect(xsWidthQuery).toBeDefined();
+    expect(smWidthQuery).toBeDefined();
+    expect(mdWidthQuery).toBeDefined();
+    expect(lgWidthQuery).toBeDefined();
+
+    // Check media queries for height
+    const xsHeightQuery = addRuleCalls.find(
+      call => call[0] === '@media (min-width: 0px)' && call[1].includes('--rs-box-h: 100px')
+    );
+    const mdHeightQuery = addRuleCalls.find(
+      call => call[0] === '@media (min-width: 768px)' && call[1].includes('--rs-box-h: 200px')
+    );
+    const xlHeightQuery = addRuleCalls.find(
+      call => call[0] === '@media (min-width: 1200px)' && call[1].includes('--rs-box-h: 300px')
+    );
+
+    expect(xsHeightQuery).toBeDefined();
+    expect(mdHeightQuery).toBeDefined();
+    expect(xlHeightQuery).toBeDefined();
+  });
+
+  it('Should render with responsive display', () => {
+    render(<Box display={{ xs: 'block', md: 'flex', xl: 'grid' }}>Content</Box>);
+
+    expect(StyleManager.addRule).toHaveBeenCalled();
+    const addRuleCalls = (StyleManager.addRule as any).mock.calls;
+
+    // Check media queries for each breakpoint
+    const xsDisplayQuery = addRuleCalls.find(
+      call => call[0] === '@media (min-width: 0px)' && call[1].includes('--rs-box-display: block')
+    );
+    const mdDisplayQuery = addRuleCalls.find(
+      call => call[0] === '@media (min-width: 768px)' && call[1].includes('--rs-box-display: flex')
+    );
+    const xlDisplayQuery = addRuleCalls.find(
+      call => call[0] === '@media (min-width: 1200px)' && call[1].includes('--rs-box-display: grid')
+    );
+
+    expect(xsDisplayQuery).toBeDefined();
+    expect(mdDisplayQuery).toBeDefined();
+    expect(xlDisplayQuery).toBeDefined();
+  });
+
+  it('Should render with responsive colors', () => {
+    render(
+      <Box
+        c={{ xs: 'red', md: 'blue.500', xl: '#000000' }}
+        bg={{ xs: 'green.100', lg: 'blue.100' }}
+      >
+        Content
+      </Box>
+    );
+
+    expect(StyleManager.addRule).toHaveBeenCalled();
+    const addRuleCalls = (StyleManager.addRule as any).mock.calls;
+
+    // Check media queries for text color
+    const xsColorQuery = addRuleCalls.find(
+      call => call[0] === '@media (min-width: 0px)' && call[1].includes('--rs-box-c:')
+    );
+    const mdColorQuery = addRuleCalls.find(
+      call => call[0] === '@media (min-width: 768px)' && call[1].includes('--rs-box-c:')
+    );
+    const xlColorQuery = addRuleCalls.find(
+      call => call[0] === '@media (min-width: 1200px)' && call[1].includes('--rs-box-c:')
+    );
+
+    expect(xsColorQuery).toBeDefined();
+    expect(mdColorQuery).toBeDefined();
+    expect(xlColorQuery).toBeDefined();
+
+    // Check media queries for background color
+    const xsBgQuery = addRuleCalls.find(
+      call =>
+        call[0] === '@media (min-width: 0px)' &&
+        call[1].includes('--rs-box-bg: var(--rs-green-100)')
+    );
+    const lgBgQuery = addRuleCalls.find(
+      call =>
+        call[0] === '@media (min-width: 992px)' &&
+        call[1].includes('--rs-box-bg: var(--rs-blue-100)')
+    );
+
+    expect(xsBgQuery).toBeDefined();
+    expect(lgBgQuery).toBeDefined();
+  });
+
+  it('Should render with responsive rounded and shadow', () => {
+    render(
+      <Box rounded={{ xs: 'sm', md: 'lg', xl: 'full' }} shadow={{ xs: 'sm', lg: 'lg' }}>
+        Content
+      </Box>
+    );
+
+    expect(StyleManager.addRule).toHaveBeenCalled();
+    const addRuleCalls = (StyleManager.addRule as any).mock.calls;
+
+    // Check media queries for rounded
+    const xsRoundedQuery = addRuleCalls.find(
+      call =>
+        call[0] === '@media (min-width: 0px)' &&
+        call[1].includes('--rs-box-rounded: var(--rs-box-rounded-sm)')
+    );
+    const mdRoundedQuery = addRuleCalls.find(
+      call =>
+        call[0] === '@media (min-width: 768px)' &&
+        call[1].includes('--rs-box-rounded: var(--rs-box-rounded-lg)')
+    );
+    const xlRoundedQuery = addRuleCalls.find(
+      call =>
+        call[0] === '@media (min-width: 1200px)' &&
+        call[1].includes('--rs-box-rounded: var(--rs-box-rounded-full)')
+    );
+
+    expect(xsRoundedQuery).toBeDefined();
+    expect(mdRoundedQuery).toBeDefined();
+    expect(xlRoundedQuery).toBeDefined();
+
+    // Check media queries for shadow
+    const xsShadowQuery = addRuleCalls.find(
+      call =>
+        call[0] === '@media (min-width: 0px)' &&
+        call[1].includes('--rs-box-shadow: var(--rs-box-shadow-sm)')
+    );
+    const lgShadowQuery = addRuleCalls.find(
+      call =>
+        call[0] === '@media (min-width: 992px)' &&
+        call[1].includes('--rs-box-shadow: var(--rs-box-shadow-lg)')
+    );
+
+    expect(xsShadowQuery).toBeDefined();
+    expect(lgShadowQuery).toBeDefined();
+  });
+
+  it('Should render with multiple responsive props', () => {
+    render(
+      <Box
+        p={{ xs: '10px', md: '20px' }}
+        m={{ xs: '5px', lg: '15px' }}
+        w={{ xs: '100%', xl: '50%' }}
+        h={{ sm: '200px', lg: '400px' }}
+        display={{ xs: 'block', md: 'flex' }}
+        c={{ xs: 'red', lg: 'blue' }}
+        bg={{ xs: 'white', md: 'gray.100' }}
+        rounded={{ xs: 'sm', lg: 'lg' }}
+        shadow={{ xs: 'sm', xl: 'lg' }}
+      >
+        Content
+      </Box>
+    );
+
+    expect(StyleManager.addRule).toHaveBeenCalled();
+    const addRuleCalls = (StyleManager.addRule as any).mock.calls;
+
+    // Check that we have media queries for each breakpoint
+    const xsQueries = addRuleCalls.filter(call => call[0] === '@media (min-width: 0px)');
+    const smQueries = addRuleCalls.filter(call => call[0] === '@media (min-width: 576px)');
+    const mdQueries = addRuleCalls.filter(call => call[0] === '@media (min-width: 768px)');
+    const lgQueries = addRuleCalls.filter(call => call[0] === '@media (min-width: 992px)');
+    const xlQueries = addRuleCalls.filter(call => call[0] === '@media (min-width: 1200px)');
+
+    expect(xsQueries.length).toBeGreaterThan(0);
+    expect(smQueries.length).toBeGreaterThan(0);
+    expect(mdQueries.length).toBeGreaterThan(0);
+    expect(lgQueries.length).toBeGreaterThan(0);
+    expect(xlQueries.length).toBeGreaterThan(0);
+  });
+
+  it('Should clean up responsive styles when unmounted', () => {
+    const { unmount } = render(<Box p={{ xs: '10px', md: '20px' }}>Content</Box>);
+
+    unmount();
+
+    expect(StyleManager.removeRule).toHaveBeenCalled();
+    expect(StyleManager.removeRule).toHaveBeenCalledWith('@media (min-width: 0px)');
+    expect(StyleManager.removeRule).toHaveBeenCalledWith('@media (min-width: 768px)');
+  });
+});

--- a/src/internals/Box/utils.ts
+++ b/src/internals/Box/utils.ts
@@ -1,4 +1,7 @@
 import { getCssValue, getSizeStyle, getColorVar } from '@/internals/utils';
+import { BREAKPOINTS } from '@/internals/constants';
+import type { ResponsiveValue } from '@/internals/types';
+import type { Color } from '@/internals/types/colours';
 
 // Mapping for padding properties to their CSS style equivalents
 const paddingStyleMap: Record<string, string> = {
@@ -82,56 +85,234 @@ export const omitBoxProps = (props: Record<string, any>): Record<string, any> =>
 };
 
 /**
+ * Checks if a value is a responsive value object
+ * @param value - Value to check
+ * @returns True if the value is a responsive value object
+ */
+function isResponsiveValue(value: any): value is ResponsiveValue<any> {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.keys(value).some(key => BREAKPOINTS.includes(key))
+  );
+}
+
+/**
+ * Process a value that might be a responsive value
+ * @param value - Value to process
+ * @param processor - Function to process non-responsive values
+ * @returns Processed value or responsive object with processed values
+ */
+function processResponsiveValue<T, R extends string | number | undefined>(
+  value: T | ResponsiveValue<T> | undefined,
+  processor: (val: T) => R
+): R | ResponsiveValue<R> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (isResponsiveValue(value)) {
+    const result: ResponsiveValue<R> = {};
+    Object.entries(value).forEach(([breakpoint, val]) => {
+      if (val !== undefined) {
+        const processed = processor(val as T);
+        if (processed !== undefined) {
+          result[breakpoint as keyof ResponsiveValue<R>] = processed;
+        }
+      }
+    });
+    return Object.keys(result).length > 0 ? result : undefined;
+  }
+
+  return processor(value as T);
+}
+
+// Type for CSS variable values that can be string, number, or responsive values
+type CSSVarValue = string | number | undefined | ResponsiveValue<string | number>;
+
+// Silence ESLint warnings for unused parameters in forEach callbacks
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/**
  * Converts layout properties to CSS variables with abbreviated names
  * @param props Object containing layout properties
  * @returns Object with CSS variables
  */
-export const getBoxCSSVariables = (
-  props: Record<string, any>
-): Record<string, string | number | undefined> => {
-  const cssVars: Record<string, string | number | undefined> = {};
+export const getBoxCSSVariables = (props: Record<string, any>): Record<string, CSSVarValue> => {
+  const cssVars: Record<string, CSSVarValue> = {};
   const prefix = `--rs-box-`;
 
   // Process padding properties
   Object.keys(paddingStyleMap).forEach(propKey => {
     if (props[propKey] !== undefined) {
-      cssVars[`${prefix}${propKey}`] = getCssValue(props[propKey]);
+      cssVars[`${prefix}${propKey}`] = processResponsiveValue(
+        props[propKey],
+        val => getCssValue(val) as string
+      );
     }
   });
 
   // Process margin properties
   Object.keys(marginStyleMap).forEach(propKey => {
     if (props[propKey] !== undefined) {
-      cssVars[`${prefix}${propKey}`] = getCssValue(props[propKey]);
+      cssVars[`${prefix}${propKey}`] = processResponsiveValue(
+        props[propKey],
+        val => getCssValue(val) as string
+      );
     }
   });
 
   // Process size properties
   Object.keys(sizeStyleMap).forEach(propKey => {
     if (props[propKey] !== undefined) {
-      cssVars[`${prefix}${propKey}`] = getCssValue(props[propKey]);
+      cssVars[`${prefix}${propKey}`] = processResponsiveValue(
+        props[propKey],
+        val => getCssValue(val) as string
+      );
     }
   });
 
   if (props.bd !== undefined) {
-    cssVars[`${prefix}bd`] = getCssValue(props.bd);
+    cssVars[`${prefix}bd`] = processResponsiveValue(props.bd, val => getCssValue(val) as string);
   }
 
   if (props.display !== undefined) {
-    cssVars[`${prefix}display`] = props.display;
+    cssVars[`${prefix}display`] = processResponsiveValue(props.display, val => val as string);
   }
 
   if (props.c !== undefined) {
-    cssVars[`${prefix}c`] = getColorVar(props.c);
+    cssVars[`${prefix}c`] = processResponsiveValue(
+      props.c,
+      val => getColorVar(val as Color | string) as string
+    );
   }
 
   if (props.bg !== undefined) {
-    cssVars[`${prefix}bg`] = getColorVar(props.bg);
+    cssVars[`${prefix}bg`] = processResponsiveValue(
+      props.bg,
+      val => getColorVar(val as Color | string) as string
+    );
   }
 
-  return {
-    ...cssVars,
-    ...getSizeStyle(props.rounded, 'box', 'rounded'),
-    ...getSizeStyle(props.shadow, 'box', 'shadow')
-  };
+  // Handle special cases for rounded and shadow
+  if (props.rounded !== undefined) {
+    const processRounded = (val: any) => {
+      const result = getSizeStyle(val, 'box', 'rounded');
+      return result ? result : undefined;
+    };
+
+    if (isResponsiveValue(props.rounded)) {
+      // Handle responsive rounded values
+      const responsiveRounded: ResponsiveValue<Record<string, string | number | undefined>> = {};
+
+      Object.entries(props.rounded).forEach(([breakpoint, val]) => {
+        if (val !== undefined) {
+          const styleObj = processRounded(val);
+          if (styleObj) {
+            responsiveRounded[breakpoint as keyof ResponsiveValue<Record<string, string>>] =
+              styleObj;
+          }
+        }
+      });
+
+      // For each CSS variable key in the rounded styles, create a responsive value
+      const processedKeys = new Set<string>();
+
+      Object.entries(responsiveRounded).forEach(([_breakpoint, styleObj]) => {
+        if (styleObj) {
+          Object.entries(styleObj).forEach(([key, _value]) => {
+            processedKeys.add(key);
+          });
+        }
+      });
+
+      processedKeys.forEach(key => {
+        const responsiveValue: ResponsiveValue<string | number> = {};
+
+        Object.entries(responsiveRounded).forEach(([breakpoint, styleObj]) => {
+          if (styleObj && styleObj[key] !== undefined) {
+            // Ensure we're only using string values for CSS variables
+            const value = styleObj[key];
+            if (typeof value === 'string' || typeof value === 'number') {
+              responsiveValue[breakpoint as keyof ResponsiveValue<string | number>] = value;
+            }
+          }
+        });
+
+        if (Object.keys(responsiveValue).length > 0) {
+          cssVars[key] = responsiveValue;
+        }
+      });
+    } else {
+      // Handle non-responsive rounded value
+      const styleObj = processRounded(props.rounded);
+      if (styleObj) {
+        Object.entries(styleObj).forEach(([key, value]) => {
+          cssVars[key] = value;
+        });
+      }
+    }
+  }
+
+  if (props.shadow !== undefined) {
+    const processShadow = (val: any) => {
+      const result = getSizeStyle(val, 'box', 'shadow');
+      return result ? result : undefined;
+    };
+
+    if (isResponsiveValue(props.shadow)) {
+      // Handle responsive shadow values
+      const responsiveShadow: ResponsiveValue<Record<string, string | number | undefined>> = {};
+
+      Object.entries(props.shadow).forEach(([breakpoint, val]) => {
+        if (val !== undefined) {
+          const styleObj = processShadow(val);
+          if (styleObj) {
+            responsiveShadow[breakpoint as keyof ResponsiveValue<Record<string, string>>] =
+              styleObj;
+          }
+        }
+      });
+
+      // For each CSS variable key in the shadow styles, create a responsive value
+      const processedKeys = new Set<string>();
+
+      Object.entries(responsiveShadow).forEach(([_breakpoint, styleObj]) => {
+        if (styleObj) {
+          Object.entries(styleObj).forEach(([key, _value]) => {
+            processedKeys.add(key);
+          });
+        }
+      });
+
+      processedKeys.forEach(key => {
+        const responsiveValue: ResponsiveValue<string | number> = {};
+
+        Object.entries(responsiveShadow).forEach(([breakpoint, styleObj]) => {
+          if (styleObj && styleObj[key] !== undefined) {
+            // Ensure we're only using string values for CSS variables
+            const value = styleObj[key];
+            if (typeof value === 'string' || typeof value === 'number') {
+              responsiveValue[breakpoint as keyof ResponsiveValue<string | number>] = value;
+            }
+          }
+        });
+
+        if (Object.keys(responsiveValue).length > 0) {
+          cssVars[key] = responsiveValue;
+        }
+      });
+    } else {
+      // Handle non-responsive shadow value
+      const styleObj = processShadow(props.shadow);
+      if (styleObj) {
+        Object.entries(styleObj).forEach(([key, value]) => {
+          cssVars[key] = value;
+        });
+      }
+    }
+  }
+
+  return cssVars;
 };

--- a/src/internals/constants/index.ts
+++ b/src/internals/constants/index.ts
@@ -1,5 +1,5 @@
-export const SIZE = ['lg', 'md', 'sm', 'xs'];
-export const BREAKPOINTS = ['xxl', 'xl', 'lg', 'md', 'sm', 'xs'];
+export const SIZE = ['xs', 'sm', 'md', 'lg'];
+export const BREAKPOINTS = ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'];
 export const STATUS = ['success', 'warning', 'error', 'info'];
 export const COLOR = ['red', 'orange', 'yellow', 'green', 'cyan', 'blue', 'violet'];
 

--- a/src/internals/hooks/useStyled.ts
+++ b/src/internals/hooks/useStyled.ts
@@ -1,8 +1,9 @@
 import { CSSProperties, useId, useLayoutEffect, useContext } from 'react';
 import isEmpty from 'lodash/isEmpty';
-import StyleManager from '../utils/style-sheet/style-manager';
-import type { Breakpoints } from '../types';
+import { StyleManager } from '@/internals/utils/style-sheet/style-manager';
+import { BREAKPOINTS } from '@/internals/constants';
 import { CustomContext } from '@/internals/Provider/CustomContext';
+import type { Breakpoints, ResponsiveValue } from '../types';
 
 // CSS Property Map
 const propertyMap: Record<string, string> = {
@@ -52,6 +53,16 @@ const propertyMap: Record<string, string> = {
   justify: 'justify-content'
 };
 
+// Breakpoint values in pixels - matching SCSS variables
+const breakpointValues: Record<Breakpoints, number> = {
+  xs: 0, // Base mobile first
+  sm: 576, // $screen-sm
+  md: 768, // $screen-md
+  lg: 992, // $screen-lg
+  xl: 1200, // $screen-xl
+  xxl: 1400 // $screen-xxl
+};
+
 /**
  * Options for the useStyled hook
  */
@@ -59,7 +70,7 @@ interface UseStyledOptions {
   /**
    * CSS variables to apply
    */
-  cssVars?: Record<string, string | number | undefined>;
+  cssVars?: Record<string, string | number | undefined | ResponsiveValue<string | number>>;
 
   /**
    * Base class name to include
@@ -105,12 +116,27 @@ interface UseStyledResult {
 }
 
 /**
+ * Checks if a value is a responsive value object
+ * @param value - Value to check
+ * @returns True if the value is a responsive value object
+ */
+function isResponsiveValue(value: any): value is ResponsiveValue<any> {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.keys(value).some(key => BREAKPOINTS.includes(key))
+  );
+}
+
+/**
  * Custom hook for managing component styling with scoped CSS variables
  *
  * This hook handles:
  * 1. Generating a unique class name for the component
  * 2. Creating a scoped style rule to prevent CSS variable inheritance
  * 3. Managing the lifecycle of style rules
+ * 4. Handling responsive values for different breakpoints
  *
  * @param options - Styling options
  * @returns Styling properties to apply to the component
@@ -125,7 +151,7 @@ export function useStyled(options: UseStyledOptions): UseStyledResult {
 
   // Generate a unique ID for this component instance
   const uniqueId = useId().replace(/:/g, '');
-  const componentId = `${prefix}-${uniqueId}`;
+  const componentId = `rs-${prefix}-${uniqueId}`;
 
   // Only apply styling if enabled and there are CSS variables
   const shouldApplyStyles = enabled && !isEmpty(cssVars);
@@ -134,39 +160,137 @@ export function useStyled(options: UseStyledOptions): UseStyledResult {
   useLayoutEffect(() => {
     if (!shouldApplyStyles) return;
 
-    // Create CSS rules for the variables
-    let cssRules = '';
+    // Create base CSS rules for the variables
+    let baseVarRules = '';
+    let basePropRules = '';
 
-    // Add CSS variable definitions
+    // Track responsive variables to handle separately
+    const responsiveVars: Record<string, ResponsiveValue<string | number>> = {};
+
+    // Process CSS variables, separating responsive from non-responsive
     Object.entries(cssVars).forEach(([key, value]) => {
       if (value !== undefined) {
-        cssRules += `${key}: ${value}; `;
+        if (isResponsiveValue(value)) {
+          // Store responsive values for later processing
+          responsiveVars[key] = value;
+
+          // Add xs (mobile first) values to base styles if present
+          const xsValue = (value as ResponsiveValue<string | number>).xs;
+          if (xsValue !== undefined) {
+            baseVarRules += `${key}: ${xsValue}; `;
+          }
+        } else {
+          // Add non-responsive values directly
+          baseVarRules += `${key}: ${value}; `;
+        }
       }
     });
 
     // Add actual style rules based on CSS variables
-    if (!isEmpty(cssVars)) {
-      // Iterate over all CSS variables and add corresponding CSS properties
-      Object.keys(cssVars).forEach(varName => {
-        // Extract property name from variable name (remove prefix)
-        const propName = varName.startsWith(cssVarPrefix)
-          ? varName.substring(cssVarPrefix.length)
-          : varName;
+    Object.keys(cssVars).forEach(varName => {
+      // Skip responsive values that don't have xs values
+      if (
+        responsiveVars[varName] &&
+        !(responsiveVars[varName] as ResponsiveValue<string | number>).xs
+      )
+        return;
 
-        // Check if the property has a corresponding CSS property mapping
-        const cssProperty = propertyMap[propName];
-        if (cssProperty) {
-          cssRules += `${cssProperty}: var(${varName}); `;
+      // Extract property name from variable name (remove prefix)
+      const propName = varName.startsWith(cssVarPrefix)
+        ? varName.substring(cssVarPrefix.length)
+        : varName;
+
+      // Check if the property has a corresponding CSS property mapping
+      const cssProperty = propertyMap[propName];
+      if (cssProperty) {
+        basePropRules += `${cssProperty}: var(${varName}); `;
+      }
+    });
+
+    // Combine variable definitions and property assignments
+    const baseCssRules = baseVarRules + basePropRules;
+
+    // Add the base rule to the style manager
+    StyleManager.addRule(`.${componentId}`, baseCssRules, { nonce: csp?.nonce });
+
+    // Process responsive variables
+    if (!isEmpty(responsiveVars)) {
+      // Create media queries for each breakpoint
+      const breakpointVarRules: Record<Breakpoints, string> = {
+        xs: '', // xs rules will be merged into base styles
+        sm: '',
+        md: '',
+        lg: '',
+        xl: '',
+        xxl: ''
+      };
+
+      const breakpointPropRules: Record<Breakpoints, string> = {
+        xs: '',
+        sm: '',
+        md: '',
+        lg: '',
+        xl: '',
+        xxl: ''
+      };
+
+      // Group styles by breakpoint
+      Object.entries(responsiveVars).forEach(([varName, responsiveValue]) => {
+        Object.entries(responsiveValue).forEach(([breakpoint, value]) => {
+          const bp = breakpoint as Breakpoints;
+          if (value !== undefined && bp !== 'xs') {
+            // Skip xs as it's already in base styles
+            // Add the CSS variable definition for this breakpoint
+            breakpointVarRules[bp] += `${varName}: ${value}; `;
+
+            // Extract property name from variable name (remove prefix)
+            const propName = varName.startsWith(cssVarPrefix)
+              ? varName.substring(cssVarPrefix.length)
+              : varName;
+
+            // Check if the property has a corresponding CSS property mapping
+            const cssProperty = propertyMap[propName];
+            if (cssProperty) {
+              breakpointPropRules[bp] += `${cssProperty}: var(${varName}); `;
+            }
+          }
+        });
+      });
+
+      // Combine variable definitions and property assignments for each breakpoint
+      const breakpointRules: Record<Breakpoints, string> = {
+        xs: '',
+        sm: breakpointVarRules.sm + breakpointPropRules.sm,
+        md: breakpointVarRules.md + breakpointPropRules.md,
+        lg: breakpointVarRules.lg + breakpointPropRules.lg,
+        xl: breakpointVarRules.xl + breakpointPropRules.xl,
+        xxl: breakpointVarRules.xxl + breakpointPropRules.xxl
+      };
+
+      // Add media queries for each breakpoint with rules (skip xs)
+      Object.entries(breakpointRules).forEach(([breakpoint, rules]) => {
+        if (rules && breakpoint !== 'xs') {
+          const bp = breakpoint as Breakpoints;
+          const minWidth = breakpointValues[bp];
+          StyleManager.addRule(
+            `@media (min-width: ${minWidth}px)`,
+            `.${componentId} { ${rules} }`,
+            { nonce: csp?.nonce }
+          );
         }
       });
     }
 
-    // Add the rule to the style manager with CSP nonce
-    StyleManager.addRule(`.${componentId}`, cssRules, { nonce: csp?.nonce });
-
     return () => {
       // Clean up rules when component unmounts
       StyleManager.removeRule(`.${componentId}`);
+
+      // Clean up media query rules
+      Object.keys(breakpointValues).forEach(breakpoint => {
+        const bp = breakpoint as Breakpoints;
+        const minWidth = breakpointValues[bp];
+        StyleManager.removeRule(`@media (min-width: ${minWidth}px)`);
+      });
     };
   }, [componentId, cssVars, shouldApplyStyles]);
 

--- a/src/internals/utils/style-sheet/style-manager.ts
+++ b/src/internals/utils/style-sheet/style-manager.ts
@@ -7,7 +7,7 @@
  */
 
 // Global style sheet manager
-const StyleManager = {
+export const StyleManager = {
   styleElement: null as HTMLStyleElement | null,
   styleMap: new Map<string, string>(),
   nonce: undefined as string | undefined,


### PR DESCRIPTION
- Add responsive value support for all Box shorthand CSS properties
- Optimize CSS generation in useStyled hook
- Remove unnecessary media query for base mobile-first styles
- Reorder CSS variables to come before property assignments
- Add comprehensive tests in BoxResponsive.spec.tsx
- Update documentation with responsive examples