### PR TITLE
refactor(IconButton): use data-shape for circle styling instead of class name

### DIFF
--- a/docs/pages/components/icon-button/en-US/index.md
+++ b/docs/pages/components/icon-button/en-US/index.md
@@ -76,9 +76,11 @@ Icon button renders an icon within in a button.
 | icon        | Element&lt;typeof Icon&gt;                           | Set the icon of button                                                 |            |
 | loading     | boolean                                              | A button can show a loading indicator                                  |            |
 | onToggle    | (active: boolean, event: MouseEvent) => void         | Callback when the button is toggled between active and inactive states | ![][6.0.0] |
-| placement   | 'left' \| 'right' `('left')`                         | The placement of icon                                                  |            |
+| placement   | 'left' \| 'right' \| 'start' \| 'end' `('start')`    | The placement of icon                                                  |            |
 | size        | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`                | A button can have different sizes                                      |            |
 | toggleable  | boolean                                              | A button can switch between active and inactive states                 | ![][6.0.0] |
+
+### Type Definitions
 
 <!--{include:(_common/types/appearance.md)}-->
 <!--{include:(_common/types/color.md)}-->

--- a/docs/pages/components/icon-button/zh-CN/index.md
+++ b/docs/pages/components/icon-button/zh-CN/index.md
@@ -76,9 +76,11 @@
 | icon        | Element&lt;typeof Icon&gt;                           | 设置图标               |            |
 | loading     | boolean                                              | 按钮可以显示加载指示器 |            |
 | onToggle    | (event: React.MouseEvent, active: boolean) => void   | 切换状态时的回调       | ![][6.0.0] |
-| placement   | 'left' \| 'right' `('left')`                         | icon 的位置            |            |
+| placement   | 'left' \| 'right' \| 'start' \| 'end' `('start')`    | icon 的位置            |            |
 | size        | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`                | 设置按钮尺寸           |            |
 | toggleable  | boolean                                              | 可切换状态             | ![][6.0.0] |
+
+### 类型定义
 
 <!--{include:(_common/types/appearance.md)}-->
 <!--{include:(_common/types/color.md)}-->

--- a/src/IconButton/IconButton.tsx
+++ b/src/IconButton/IconButton.tsx
@@ -12,7 +12,7 @@ export interface IconButtonProps extends ButtonProps {
   circle?: boolean;
 
   /** The placement of icon */
-  placement?: 'left' | 'right';
+  placement?: 'left' | 'right' | 'start' | 'end';
 }
 
 /**
@@ -22,26 +22,27 @@ export interface IconButtonProps extends ButtonProps {
 const IconButton = forwardRef<typeof Button, IconButtonProps>((props, ref) => {
   const { propsWithDefaults } = useCustom('IconButton', props);
   const {
-    icon,
-    placement = 'left',
-    children,
     circle,
-    classPrefix = 'btn-icon',
+    children,
     className,
+    classPrefix = 'btn-icon',
+    placement = 'start',
+    icon,
     ...rest
   } = propsWithDefaults;
 
   const { merge, withPrefix } = useStyles(classPrefix);
-  const classes = merge(
-    className,
-    withPrefix(`placement-${placement}`, {
-      circle,
-      'with-text': typeof children !== 'undefined'
-    })
-  );
+  const classes = merge(className, withPrefix());
 
   return (
-    <Button {...rest} ref={ref} className={classes}>
+    <Button
+      {...rest}
+      ref={ref}
+      className={classes}
+      data-shape={circle ? 'circle' : undefined}
+      data-placement={placement}
+      data-with-text={typeof children !== 'undefined' || undefined}
+    >
       {icon}
       {children}
     </Button>

--- a/src/IconButton/styles/index.scss
+++ b/src/IconButton/styles/index.scss
@@ -1,5 +1,5 @@
-@use '../../Button/styles/index' as button;
-@use '../../Button/styles/mixin' as button-mixin;
+@use '../../Button/styles/index';
+@use '../../Button/styles/mixin' as btn-mixin;
 
 //
 // IconButton
@@ -13,12 +13,12 @@
     vertical-align: bottom;
   }
 
-  &:not(.rs-btn-icon-with-text) {
+  &:not([data-with-text]) {
     width: var(--rs-btn-size);
   }
 
   // Circle Button
-  &.rs-btn-icon-circle {
+  &[data-shape='circle'] {
     border-radius: var(--rs-radius-full);
   }
 }
@@ -31,7 +31,7 @@
 }
 
 // Only support default/primary button
-.rs-btn-icon-with-text {
+.rs-btn-icon[data-with-text] {
   > .rs-icon {
     position: absolute;
     top: 0;
@@ -43,7 +43,7 @@
     padding: calc((var(--rs-btn-size) - var(--rs-btn-icon-size)) / 2);
   }
 
-  &.rs-btn-icon-placement-left {
+  &:where([data-placement='start'], [data-placement='left']) {
     padding-inline-start: calc(var(--rs-btn-padding-inline) + var(--rs-btn-size));
 
     > .rs-icon {
@@ -52,7 +52,7 @@
     }
   }
 
-  &.rs-btn-icon-placement-right {
+  &:where([data-placement='end'], [data-placement='right']) {
     padding-inline-end: calc(var(--rs-btn-padding-inline) + var(--rs-btn-size));
 
     > .rs-icon {
@@ -60,31 +60,31 @@
     }
   }
 
-  @include button-mixin.button-activated {
+  @include btn-mixin.button-activated {
     @include btn-icon-with-text(var(--rs-iconbtn-activated-addon));
   }
 
-  @include button-mixin.button-pressed {
+  @include btn-mixin.button-pressed {
     @include btn-icon-with-text(var(--rs-iconbtn-pressed-addon));
   }
 
-  @include button-mixin.button-disabled {
+  @include btn-mixin.button-disabled {
     @include btn-icon-with-text(var(--rs-iconbtn-addon));
   }
 }
 
-.rs-btn-icon-with-text.rs-btn-primary {
+.rs-btn-icon[data-with-text].rs-btn-primary {
   @include btn-icon-with-text(var(--rs-iconbtn-primary-addon));
 
-  @include button-mixin.button-activated {
+  @include btn-mixin.button-activated {
     @include btn-icon-with-text(var(--rs-iconbtn-primary-activated-addon));
   }
 
-  @include button-mixin.button-pressed {
+  @include btn-mixin.button-pressed {
     @include btn-icon-with-text(var(--rs-iconbtn-primary-pressed-addon));
   }
 
-  @include button-mixin.button-disabled {
+  @include btn-mixin.button-disabled {
     @include btn-icon-with-text(var(--rs-iconbtn-primary-addon));
   }
 }

--- a/src/IconButton/test/IconButton.spec.tsx
+++ b/src/IconButton/test/IconButton.spec.tsx
@@ -24,4 +24,51 @@ describe('IconButton', () => {
 
     expect(icon).to.exist;
   });
+
+  it('Should apply circle class when circle prop is true', () => {
+    render(<IconButton circle />);
+    expect(screen.getByRole('button')).to.have.attr('data-shape', 'circle');
+  });
+
+  it('Should not apply circle class when circle prop is false', () => {
+    render(<IconButton circle={false} />);
+    expect(screen.getByRole('button')).not.to.have.attr('data-shape', 'circle');
+  });
+
+  it('Should add circle class to className when circle prop is true', () => {
+    render(<IconButton circle />);
+    expect(screen.getByRole('button')).to.have.attr('data-shape', 'circle');
+  });
+
+  it('Should apply default placement when not specified', () => {
+    render(<IconButton />);
+    expect(screen.getByRole('button')).to.have.attr('data-placement', 'start');
+  });
+
+  it('Should apply correct placement prop', () => {
+    const placements = ['left', 'right', 'start', 'end'] as const;
+
+    render(
+      <>
+        {placements.map(placement => (
+          <IconButton key={placement} placement={placement} data-testid={`btn-${placement}`} />
+        ))}
+      </>
+    );
+
+    placements.forEach(placement => {
+      const button = screen.getByTestId(`btn-${placement}`);
+      expect(button).to.have.attr('data-placement', placement);
+    });
+  });
+
+  it('Should add data-with-text attribute when children is provided', () => {
+    render(<IconButton>Text</IconButton>);
+    expect(screen.getByRole('button')).to.have.attr('data-with-text', 'true');
+  });
+
+  it('Should not add data-with-text attribute when no children', () => {
+    render(<IconButton />);
+    expect(screen.getByRole('button')).not.to.have.attr('data-with-text');
+  });
 });


### PR DESCRIPTION
This pull request introduces enhancements and refactoring to the `IconButton` component, including updates to its API, styling, and test coverage. The most significant changes involve adding new placement options, replacing class-based styling with data attributes, and improving test coverage for the component's behavior.

### Component API Updates:
* Added new placement options (`start` and `end`) to the `placement` prop in `IconButtonProps` and set the default placement to `start`. (`src/IconButton/IconButton.tsx`, [[1]](diffhunk://#diff-d4c771526353735c71f0e18256a8228e97af18f3f47925ddbebbd856f94e8faaL15-R15) [[2]](diffhunk://#diff-d4c771526353735c71f0e18256a8228e97af18f3f47925ddbebbd856f94e8faaL25-R45)

### Styling Refactor:
* Replaced class-based selectors (e.g., `.rs-btn-icon-circle`) with attribute-based selectors (e.g., `[data-shape='circle']`) for styling. (`src/IconButton/styles/index.scss`, [[1]](diffhunk://#diff-67ab13baf3d49621e55171e8ef9c3b1f73b7aedcb1494cd76e009b10bdb0fa95L16-R21) [[2]](diffhunk://#diff-67ab13baf3d49621e55171e8ef9c3b1f73b7aedcb1494cd76e009b10bdb0fa95L34-R34)
* Updated SCSS mixin usage by renaming `button-mixin` to `btn-mixin` for consistency. (`src/IconButton/styles/index.scss`, [[1]](diffhunk://#diff-67ab13baf3d49621e55171e8ef9c3b1f73b7aedcb1494cd76e009b10bdb0fa95L1-R2) [[2]](diffhunk://#diff-67ab13baf3d49621e55171e8ef9c3b1f73b7aedcb1494cd76e009b10bdb0fa95L55-R87)

### Test Coverage Improvements:
* Added tests to verify the behavior of the `circle` prop, `placement` prop, and the presence of the `data-with-text` attribute when children are provided. (`src/IconButton/test/IconButton.spec.tsx`, [src/IconButton/test/IconButton.spec.tsxR27-R73](diffhunk://#diff-fd3daf3f372f31c99d0e041c5acd26fded171677c25aa33d480e3483852d3534R27-R73))