### PR TITLE
refactor(Calendar/GridCell): replace js Date with temporal-like PlainDate

### DIFF
--- a/src/Calendar/Grid/GridCell.tsx
+++ b/src/Calendar/Grid/GridCell.tsx
@@ -1,21 +1,22 @@
 import React from 'react';
 import partial from 'lodash/partial';
 import { forwardRef } from '@/internals/utils';
-import { isSameDay, getDate } from '@/internals/utils/date';
+import type { PlainDate } from '@/internals/utils/date';
+import { isSameDay } from '@/internals/utils/date/plainDate';
 import { useStyles, useCustom } from '@/internals/hooks';
 import { WithAsProps } from '@/internals/types';
 import { useCalendar } from '../hooks';
 import { getAriaLabel } from '../utils';
 
 export interface GridCellProps extends WithAsProps {
-  date: Date;
+  date: PlainDate;
   disabled?: boolean;
   selected?: boolean;
   unSameMonth?: boolean;
   rangeStart?: boolean;
   rangeEnd?: boolean;
   inRange?: boolean;
-  onSelect?: (date: Date, disabled: boolean | void, event: React.MouseEvent) => void;
+  onSelect?: (date: PlainDate, disabled: boolean | void, event: React.MouseEvent) => void;
 }
 
 const GridCell = forwardRef<'div', GridCellProps>((props: GridCellProps, ref) => {
@@ -32,6 +33,7 @@ const GridCell = forwardRef<'div', GridCellProps>((props: GridCellProps, ref) =>
     inRange,
     ...rest
   } = props;
+  const jsDate = new Date(date.year, date.month - 1, date.day);
 
   const {
     onMouseMove,
@@ -45,9 +47,8 @@ const GridCell = forwardRef<'div', GridCellProps>((props: GridCellProps, ref) =>
   const { formattedDayPattern, today } = getLocale('Calendar', overrideLocale);
 
   const formatStr = formattedDayPattern;
-  const ariaLabel = getAriaLabel(date, formatStr, formatDate);
-  const todayDate = new Date();
-  const isToday = isSameDay(date, todayDate);
+  const ariaLabel = getAriaLabel(jsDate, formatStr, formatDate);
+  const isToday = isSameDay(date, new Date());
 
   const classes = merge(
     prefix('cell', {
@@ -59,7 +60,7 @@ const GridCell = forwardRef<'div', GridCellProps>((props: GridCellProps, ref) =>
       'cell-in-range': !unSameMonth && inRange,
       'cell-disabled': disabled
     }),
-    cellClassName?.(date)
+    cellClassName?.(jsDate)
   );
 
   return (
@@ -72,17 +73,17 @@ const GridCell = forwardRef<'div', GridCellProps>((props: GridCellProps, ref) =>
       tabIndex={selected ? 0 : -1}
       title={isToday ? `${ariaLabel} (${today})` : ariaLabel}
       className={classes}
-      onMouseEnter={!disabled && onMouseMove ? onMouseMove.bind(null, date) : undefined}
+      onMouseEnter={!disabled && onMouseMove ? onMouseMove.bind(null, jsDate) : undefined}
       onClick={onSelect ? partial(onSelect, date, disabled) : undefined}
       {...rest}
     >
       <div className={prefix('cell-content')}>
         {renderCellOnPicker ? (
-          renderCellOnPicker(date)
+          renderCellOnPicker(jsDate)
         ) : (
-          <span className={prefix('cell-day')}>{getDate(date)}</span>
+          <span className={prefix('cell-day')}>{date.day}</span>
         )}
-        {renderCell?.(date)}
+        {renderCell?.(jsDate)}
       </div>
     </Component>
   );

--- a/src/Calendar/Grid/GridRow.tsx
+++ b/src/Calendar/Grid/GridRow.tsx
@@ -1,7 +1,14 @@
 import React, { useCallback } from 'react';
 import GridCell from './GridCell';
 import { forwardRef } from '@/internals/utils';
-import { isSameDay, addDays, isBefore, isAfter, format } from '@/internals/utils/date';
+import {
+  isSameDay,
+  addDays,
+  isBefore,
+  isAfter,
+  format,
+  type PlainDate
+} from '@/internals/utils/date';
 import { DATERANGE_DISABLED_TARGET } from '@/internals/constants';
 import { useStyles } from '@/internals/hooks';
 import { useCalendar } from '../hooks';
@@ -40,11 +47,11 @@ const GridRow = forwardRef<'div', GridRowProps>((props: GridRowProps, ref) => {
   const { prefix, merge } = useStyles(classPrefix);
 
   const handleSelect = useCallback(
-    (date: Date, disabled: boolean | void, event: React.MouseEvent) => {
+    (date: PlainDate, disabled: boolean | void, event: React.MouseEvent) => {
       if (disabled) {
         return;
       }
-      onSelect?.(date, event);
+      onSelect?.(new Date(date.year, date.month - 1, date.day), event);
     },
     [onSelect]
   );
@@ -90,10 +97,16 @@ const GridRow = forwardRef<'div', GridRowProps>((props: GridRowProps, ref) => {
         }
       }
 
+      const thisDatePlain = {
+        year: thisDate.getFullYear(),
+        month: thisDate.getMonth() + 1,
+        day: thisDate.getDate()
+      };
+
       days.push(
         <GridCell
           key={format(thisDate, 'yyyy-MM-dd')}
-          date={thisDate}
+          date={thisDatePlain}
           disabled={disabled}
           selected={isSelected}
           onSelect={handleSelect}

--- a/src/Calendar/test/CalendarGridCell.spec.tsx
+++ b/src/Calendar/test/CalendarGridCell.spec.tsx
@@ -6,46 +6,51 @@ import { CalendarProvider } from '../CalendarProvider';
 import { testStandardProps } from '@test/cases';
 
 describe('Calendar-GirdHeaderRow', () => {
-  testStandardProps(<GirdCell date={new Date()} />);
+  testStandardProps(<GirdCell date={{ year: 2025, month: 7, day: 26 }} />);
 
   it('Should render a div with "rs-calendar-table-cell" class', () => {
-    render(<GirdCell date={new Date()} />);
+    render(<GirdCell date={{ year: 2025, month: 7, day: 26 }} />);
 
     expect(screen.getByRole('gridcell')).to.have.class('rs-calendar-table-cell');
   });
 
   it('Should be disabled', () => {
-    render(<GirdCell date={new Date()} disabled />);
+    render(<GirdCell date={{ year: 2025, month: 7, day: 26 }} disabled />);
     expect(screen.getByRole('gridcell')).to.have.class('rs-calendar-table-cell-disabled');
   });
 
   it('Should be selected', () => {
-    render(<GirdCell date={new Date()} selected />);
+    render(<GirdCell date={{ year: 2025, month: 7, day: 26 }} selected />);
     expect(screen.getByRole('gridcell')).to.have.class('rs-calendar-table-cell-selected');
   });
 
   it('Should be selected start', () => {
-    render(<GirdCell date={new Date()} rangeStart />);
+    render(<GirdCell date={{ year: 2025, month: 7, day: 26 }} rangeStart />);
     expect(screen.getByRole('gridcell')).to.have.class('rs-calendar-table-cell-selected-start');
   });
 
   it('Should be selected end', () => {
-    render(<GirdCell date={new Date()} rangeEnd />);
+    render(<GirdCell date={{ year: 2025, month: 7, day: 26 }} rangeEnd />);
     expect(screen.getByRole('gridcell')).to.have.class('rs-calendar-table-cell-selected-end');
   });
 
   it('Should be in range', () => {
-    render(<GirdCell date={new Date()} inRange />);
+    render(<GirdCell date={{ year: 2025, month: 7, day: 26 }} inRange />);
     expect(screen.getByRole('gridcell')).to.have.class('rs-calendar-table-cell-in-range');
   });
 
   it('Should be unSameMonth', () => {
-    render(<GirdCell date={new Date()} unSameMonth />);
+    render(<GirdCell date={{ year: 2025, month: 7, day: 26 }} unSameMonth />);
     expect(screen.getByRole('gridcell')).to.have.class('rs-calendar-table-cell-un-same-month');
   });
 
   it('Should be today', () => {
-    render(<GirdCell date={new Date()} />);
+    const today = new Date();
+    render(
+      <GirdCell
+        date={{ year: today.getFullYear(), month: today.getMonth() + 1, day: today.getDate() }}
+      />
+    );
     expect(screen.getByRole('gridcell')).to.have.class('rs-calendar-table-cell-is-today');
   });
 
@@ -61,7 +66,7 @@ describe('Calendar-GirdHeaderRow', () => {
           weekStart: 0
         }}
       >
-        <GirdCell date={new Date()} />
+        <GirdCell date={{ year: 2025, month: 7, day: 26 }} />
       </CalendarProvider>
     );
     fireEvent.mouseEnter(screen.getByRole('gridcell'));
@@ -70,7 +75,7 @@ describe('Calendar-GirdHeaderRow', () => {
 
   it('Should call `onSelect` callback', () => {
     const onSelect = vi.fn();
-    render(<GirdCell date={new Date()} onSelect={onSelect} />);
+    render(<GirdCell date={{ year: 2025, month: 7, day: 26 }} onSelect={onSelect} />);
     fireEvent.click(screen.getByRole('gridcell'));
 
     expect(onSelect).toHaveBeenCalledTimes(1);
@@ -78,26 +83,26 @@ describe('Calendar-GirdHeaderRow', () => {
 
   describe('Accessibility', () => {
     it('Should have a aria-label', () => {
-      render(<GirdCell date={new Date(2022, 10, 2)} />);
+      render(<GirdCell date={{ year: 2022, month: 11, day: 2 }} />);
       expect(screen.getByRole('gridcell')).to.have.attr('aria-label', '02 Nov 2022');
     });
 
     it('Should have a aria-selected', () => {
-      render(<GirdCell date={new Date(2022, 10, 2)} selected />);
+      render(<GirdCell date={{ year: 2022, month: 11, day: 2 }} selected />);
       expect(screen.getByRole('gridcell')).to.have.attr('aria-selected', 'true');
     });
 
     it('Should have a aria-disabled', () => {
-      render(<GirdCell date={new Date(2022, 10, 2)} disabled />);
+      render(<GirdCell date={{ year: 2022, month: 11, day: 2 }} disabled />);
       expect(screen.getByRole('gridcell')).to.have.attr('aria-disabled', 'true');
     });
 
     it('Should have a tabIndex attribute', () => {
-      const { rerender } = render(<GirdCell date={new Date()} />);
+      const { rerender } = render(<GirdCell date={{ year: 2025, month: 7, day: 26 }} />);
 
       expect(screen.getByRole('gridcell')).to.have.attribute('tabindex', '-1');
 
-      rerender(<GirdCell selected date={new Date()} />);
+      rerender(<GirdCell selected date={{ year: 2025, month: 7, day: 26 }} />);
 
       expect(screen.getByRole('gridcell')).to.have.attribute('tabindex', '0');
     });

--- a/src/internals/utils/date/index.ts
+++ b/src/internals/utils/date/index.ts
@@ -58,5 +58,5 @@ export { extractTimeFormat } from './extractTimeFormat';
 export * from './formatCheck';
 
 // Export types
-export type { TimeProp, CalendarOnlyPropsType } from './types';
+export type { TimeProp, CalendarOnlyPropsType, PlainDate } from './types';
 export { calendarOnlyProps } from './types';

--- a/src/internals/utils/date/plainDate.ts
+++ b/src/internals/utils/date/plainDate.ts
@@ -1,0 +1,23 @@
+import type { PlainDate } from './types';
+
+function toPlainDate(date: Date): PlainDate {
+  return {
+    year: date.getFullYear(),
+    month: date.getMonth() + 1,
+    day: date.getDate()
+  };
+}
+
+function comparePlainDates(date1: PlainDate, date2: PlainDate): -1 | 0 | 1 {
+  if (date1.year < date2.year) return -1;
+  if (date1.year > date2.year) return 1;
+  if (date1.month < date2.month) return -1;
+  if (date1.month > date2.month) return 1;
+  if (date1.day < date2.day) return -1;
+  if (date1.day > date2.day) return 1;
+  return 0;
+}
+
+export function isSameDay(date: PlainDate, jsDate: Date): boolean {
+  return comparePlainDates(date, toPlainDate(jsDate)) === 0;
+}

--- a/src/internals/utils/date/types.ts
+++ b/src/internals/utils/date/types.ts
@@ -82,3 +82,15 @@ export interface FormatDateOptions {
    */
   useAdditionalDayOfYearTokens?: boolean;
 }
+
+/**
+ * Represents a date on the calendar.
+ *
+ * Resembles Temporal.PlainDate
+ * @see https://tc39.es/proposal-temporal/docs/plaindate.html
+ */
+export type PlainDate = {
+  readonly year: number;
+  readonly month: number;
+  readonly day: number;
+};


### PR DESCRIPTION
## Summary

Refactor GridCell component to accept a Temporal-like PlainDate object instead of a JavaScript Date, in respect of RFC #4347. 

## Changes

* In GridCell.tsx, replace Date with PlainDate for `date` and `onSelect` props.
* In GridRow.tsx, convert the Date to PlainDate before passing to GridCell. Also convert the PlainDate received from `onSelect` prop to Date before propagating.