### PR TITLE
feat(Stat/StatTrend): add 'equal' trend indicator

### DIFF
--- a/docs/pages/components/stat/en-US/index.md
+++ b/docs/pages/components/stat/en-US/index.md
@@ -86,12 +86,12 @@ Used to display statistical data with a title and its corresponding value, empha
 
 ### `<Stat.Trend>`
 
-| Property    | Type `(Default)`        | Description                           |
-| ----------- | ----------------------- | ------------------------------------- |
-| as          | elementType `('span')`  | HTML tag of the component             |
-| children    | ReactNode               | The children of the component         |
-| classPrefix | string `('stat-trend')` | The prefix of the component CSS class |
-| indicator   | 'up' \| 'down'          | The trend indicator of the component  |
+| Property    | Type `(Default)`          | Description                           |
+| ----------- | ------------------------- | ------------------------------------- |
+| as          | elementType `('span')`    | HTML tag of the component             |
+| children    | ReactNode                 | The children of the component         |
+| classPrefix | string `('stat-trend')`   | The prefix of the component CSS class |
+| indicator   | 'up' \| 'down' \| 'equal' | The trend indicator of the component  |
 
 ### `<Stat.HelpText>`
 

--- a/docs/pages/components/stat/fragments/trend.md
+++ b/docs/pages/components/stat/fragments/trend.md
@@ -22,6 +22,14 @@ const App = () => (
     </Stat>
 
     <Stat>
+      <Stat.Label>Staff</Stat.Label>
+      <HStack spacing={10}>
+        <Stat.Value>110</Stat.Value>
+        <Stat.Trend indicator="equal">0%</Stat.Trend>
+      </HStack>
+    </Stat>
+
+    <Stat>
       <Stat.Label>Cost</Stat.Label>
       <HStack spacing={10}>
         <Stat.Value>2,800</Stat.Value>

--- a/docs/pages/components/stat/zh-CN/index.md
+++ b/docs/pages/components/stat/zh-CN/index.md
@@ -84,12 +84,12 @@
 
 ### `<Stat.Trend>`
 
-| 属性        | 类型 `(默认值)`         | 描述                |
-| ----------- | ----------------------- | ------------------- |
-| as          | elementType `('span')`  | 组件的 HTML 标签    |
-| children    | ReactNode               | 组件的子元素        |
-| classPrefix | string `('stat-trend')` | 组件 CSS 类名的前缀 |
-| indicator   | 'up' \| 'down'          | 组件的趋势指示器    |
+| 属性        | 类型 `(默认值)`           | 描述                |
+| ----------- | ------------------------- | ------------------- |
+| as          | elementType `('span')`    | 组件的 HTML 标签    |
+| children    | ReactNode                 | 组件的子元素        |
+| classPrefix | string `('stat-trend')`   | 组件 CSS 类名的前缀 |
+| indicator   | 'up' \| 'down' \| 'equal' | 组件的趋势指示器    |
 
 ### `<Stat.HelpText>`
 

--- a/src/Stat/StatTrend.tsx
+++ b/src/Stat/StatTrend.tsx
@@ -33,8 +33,17 @@ const ArrowDown = (props: React.SVGProps<SVGSVGElement>) => {
   );
 };
 
+const ArrowEqual = (props: React.SVGProps<SVGSVGElement>) => {
+  return (
+    <svg {...svgProps} {...props}>
+      <path d="M7 9l10 0"></path>
+      <path d="M7 15l10 0"></path>
+    </svg>
+  );
+};
+
 interface StatTrendProps extends WithAsProps {
-  indicator?: 'up' | 'down';
+  indicator?: 'up' | 'down' | 'equal';
   appearance?: 'default' | 'subtle';
 }
 
@@ -52,7 +61,8 @@ const StatTrend: RsRefForwardingComponent<'dd', StatTrendProps> = React.forwardR
 
     const { merge, prefix, withClassPrefix } = useClassNames(classPrefix);
     const classes = merge(className, withClassPrefix(appearance, indicator));
-    const IndicatorIcon = indicator === 'up' ? ArrowUp : ArrowDown;
+    const IndicatorIcon =
+      indicator === 'up' ? ArrowUp : indicator === 'down' ? ArrowDown : ArrowEqual;
 
     return (
       <Component ref={ref} className={classes} {...rest}>
@@ -65,7 +75,7 @@ const StatTrend: RsRefForwardingComponent<'dd', StatTrendProps> = React.forwardR
 
 StatTrend.displayName = 'StatTrend';
 StatTrend.propTypes = {
-  indicator: oneOf(['up', 'down']),
+  indicator: oneOf(['up', 'down', 'equal']),
   appearance: oneOf(['default', 'subtle'])
 };
 

--- a/src/Stat/styles/index.less
+++ b/src/Stat/styles/index.less
@@ -75,6 +75,10 @@
       color: var(--rs-red-900);
     }
 
+    &-equal {
+      color: var(--rs-primary-900);
+    }
+
     &-default {
       padding: 2px 6px;
     }
@@ -87,12 +91,20 @@
       background-color: var(--rs-red-100);
     }
 
+    &-default&-equal {
+      background-color: var(--rs-primary-100);
+    }
+
     &-subtle&-up {
       color: var(--rs-green-600);
     }
 
     &-subtle&-down {
       color: var(--rs-red-600);
+    }
+
+    &-subtle&-equal {
+      color: var(--rs-primary-600);
     }
   }
 

--- a/src/Stat/test/StatTrendSpec.tsx
+++ b/src/Stat/test/StatTrendSpec.tsx
@@ -6,10 +6,16 @@ import StatTrend from '../StatTrend';
 describe('StatTrend', () => {
   testStandardProps(<StatTrend />);
 
-  it('Should render a trend indicator', () => {
+  it('Should render a up trend indicator', () => {
     render(<StatTrend indicator="up">100</StatTrend>);
 
     expect(screen.getByText('100')).to.have.class('rs-stat-trend-up');
+  });
+
+  it('Should render a equal trend indicator', () => {
+    render(<StatTrend indicator="equal">100</StatTrend>);
+
+    expect(screen.getByText('100')).to.have.class('rs-stat-trend-equal');
   });
 
   it('Should render as subtle appearance', () => {


### PR DESCRIPTION
Added an equal indicator to the StatTrend component so that flat trends can also be represented. This new trend indicator displays an = icon and uses the primary color scheme.