### PR TITLE
fix: Progress.Circle properties do not include width (#4352)

### DIFF
--- a/docs/pages/components/progress/en-US/index.md
+++ b/docs/pages/components/progress/en-US/index.md
@@ -56,3 +56,4 @@ Display the current progress of an operation flow.
 | strokeWidth   | number `(6)`                                                 | Line width                               |
 | trailColor    | string                                                       | Trail color                              |
 | trailWidth    | number `(6)`                                                 | Trail width                              |
+| width         | number `(50)`                                                | Circle diameter                          |

--- a/docs/pages/components/progress/en-US/index.md
+++ b/docs/pages/components/progress/en-US/index.md
@@ -56,4 +56,4 @@ Display the current progress of an operation flow.
 | strokeWidth   | number `(6)`                                                 | Line width                               |
 | trailColor    | string                                                       | Trail color                              |
 | trailWidth    | number `(6)`                                                 | Trail width                              |
-| width         | number `(50)`                                                | Circle diameter                          |
+| width         | number                                                       | Circle diameter                          |

--- a/docs/pages/components/progress/zh-CN/index.md
+++ b/docs/pages/components/progress/zh-CN/index.md
@@ -56,4 +56,4 @@
 | strokeWidth   | number `(6)`                                                 | 线条宽度                           |
 | trailColor    | string                                                       | 背景颜色                           |
 | trailWidth    | number `(6)`                                                 | 背景宽度                           |
-| width         | number `(50)`                                                | 圆直径                             |
+| width         | number                                                       | 圆直径                             |

--- a/docs/pages/components/progress/zh-CN/index.md
+++ b/docs/pages/components/progress/zh-CN/index.md
@@ -56,3 +56,4 @@
 | strokeWidth   | number `(6)`                                                 | 线条宽度                           |
 | trailColor    | string                                                       | 背景颜色                           |
 | trailWidth    | number `(6)`                                                 | 背景宽度                           |
+| width         | number `(50)`                                                | 圆直径                             |

--- a/examples/with-flow/flow-typed/npm/rsuite_v3.x.x.js
+++ b/examples/with-flow/flow-typed/npm/rsuite_v3.x.x.js
@@ -1005,6 +1005,7 @@ declare module "rsuite" {
     percent?: number,
     strokeWidth?: number,
     trailWidth?: number,
+    width?: number,
     gapDegree?: number,
     gapPosition?: "top" | "bottom" | "left" | "right",
     showInfo?: boolean,
@@ -1020,6 +1021,7 @@ declare module "rsuite" {
     strokeWidth?: number,
     trailColor?: string,
     trailWidth?: number,
+    width?: number,
     showInfo?: boolean,
     status?: "success" | "fail" | "active"
   }> {}

--- a/src/Progress/ProgressCircle.tsx
+++ b/src/Progress/ProgressCircle.tsx
@@ -52,7 +52,7 @@ const ProgressCircle: RsRefForwardingComponent<'div', ProgressCircleProps> = Rea
       as: Component = 'div',
       strokeWidth = 6,
       trailWidth = 6,
-      width = 50,
+      width,
       percent = 0,
       strokeLinecap = 'round',
       className,

--- a/src/Progress/ProgressCircle.tsx
+++ b/src/Progress/ProgressCircle.tsx
@@ -25,6 +25,9 @@ export interface ProgressCircleProps extends WithAsProps {
   /** Tail width */
   trailWidth?: number;
 
+  /** Diameter of the circle */
+  width?: number;
+
   /** Circular progress bar degree */
   gapDegree?: number;
 
@@ -49,6 +52,7 @@ const ProgressCircle: RsRefForwardingComponent<'div', ProgressCircleProps> = Rea
       as: Component = 'div',
       strokeWidth = 6,
       trailWidth = 6,
+      width = 50,
       percent = 0,
       strokeLinecap = 'round',
       className,
@@ -140,7 +144,7 @@ const ProgressCircle: RsRefForwardingComponent<'div', ProgressCircleProps> = Rea
       >
         {showInfo ? <span className={prefix('circle-info')}>{info}</span> : null}
 
-        <svg className={prefix('svg')} viewBox="0 0 100 100" {...rest}>
+        <svg className={prefix('svg')} viewBox="0 0 100 100" width={width} {...rest}>
           <path
             className={prefix('trail')}
             d={pathString}
@@ -171,6 +175,7 @@ ProgressCircle.propTypes = {
   percent: PropTypes.number,
   strokeWidth: PropTypes.number,
   trailWidth: PropTypes.number,
+  width: PropTypes.number,
   gapDegree: PropTypes.number,
   gapPosition: oneOf(['top', 'bottom', 'left', 'right']),
   showInfo: PropTypes.bool,


### PR DESCRIPTION
Fixed Issue #4352: Progress.Circle properties do not include width - it's use is required but results in typescript error TS2322 