### PR TITLE
build(deps): bump rsuite-table from 5.19.1 to 5.19.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "prop-types": "^15.8.1",
         "react-use-set": "^1.0.0",
         "react-window": "^1.8.8",
-        "rsuite-table": "^5.19.1",
+        "rsuite-table": "^5.19.2",
         "schema-typed": "^2.4.2"
       },
       "devDependencies": {
@@ -19592,6 +19592,7 @@
     },
     "node_modules/react-is": {
       "version": "17.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
@@ -20356,19 +20357,17 @@
       }
     },
     "node_modules/rsuite-table": {
-      "version": "5.19.1",
-      "license": "MIT",
+      "version": "5.19.2",
+      "resolved": "https://registry.npmjs.org/rsuite-table/-/rsuite-table-5.19.2.tgz",
+      "integrity": "sha512-0mnAuvTlDjNGo3FTWqIMdlCP2+gx8NJiMYJnGvOoYMt/kcxRsWzayQRrywc2cvnHTEOjMIQFi2uHYfie0irAHg==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@juggle/resize-observer": "^3.3.1",
-        "@rsuite/icons": "^1.0.0",
         "classnames": "^2.3.1",
         "dom-lib": "^3.3.1",
-        "lodash": "^4.17.21",
-        "react-is": "^17.0.2"
+        "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "prop-types": "^15.7.2",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
       }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "prop-types": "^15.8.1",
     "react-use-set": "^1.0.0",
     "react-window": "^1.8.8",
-    "rsuite-table": "^5.19.1",
+    "rsuite-table": "^5.19.2",
     "schema-typed": "^2.4.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
This pull request includes a minor version update to the `rsuite-table` dependency in the `package.json` file. The version was incremented from `^5.19.1` to `^5.19.2` to ensure compatibility with the latest features or fixes.