### PR TITLE
(feat) Stat.Trend - add number type to trend indicator props

### DIFF
--- a/docs/pages/components/stat/en-US/index.md
+++ b/docs/pages/components/stat/en-US/index.md
@@ -86,12 +86,12 @@ Used to display statistical data with a title and its corresponding value, empha
 
 ### `<Stat.Trend>`
 
-| Property    | Type `(Default)`          | Description                           |
-| ----------- | ------------------------- | ------------------------------------- |
-| as          | elementType `('span')`    | HTML tag of the component             |
-| children    | ReactNode                 | The children of the component         |
-| classPrefix | string `('stat-trend')`   | The prefix of the component CSS class |
-| indicator   | 'up' \| 'down' \| 'equal' | The trend indicator of the component  |
+| Property    | Type `(Default)`                    | Description                           |
+| ----------- | ----------------------------------- | ------------------------------------- |
+| as          | elementType `('span')`              | HTML tag of the component             |
+| children    | ReactNode                           | The children of the component         |
+| classPrefix | string `('stat-trend')`             | The prefix of the component CSS class |
+| indicator   | 'up' \| 'down' \| 'equal' \| number | The trend indicator of the component  |
 
 ### `<Stat.HelpText>`
 

--- a/docs/pages/components/stat/zh-CN/index.md
+++ b/docs/pages/components/stat/zh-CN/index.md
@@ -84,12 +84,12 @@
 
 ### `<Stat.Trend>`
 
-| 属性        | 类型 `(默认值)`           | 描述                |
-| ----------- | ------------------------- | ------------------- |
-| as          | elementType `('span')`    | 组件的 HTML 标签    |
-| children    | ReactNode                 | 组件的子元素        |
-| classPrefix | string `('stat-trend')`   | 组件 CSS 类名的前缀 |
-| indicator   | 'up' \| 'down' \| 'equal' | 组件的趋势指示器    |
+| 属性        | 类型 `(默认值)`                     | 描述                |
+| ----------- | ----------------------------------- | ------------------- |
+| as          | elementType `('span')`              | 组件的 HTML 标签    |
+| children    | ReactNode                           | 组件的子元素        |
+| classPrefix | string `('stat-trend')`             | 组件 CSS 类名的前缀 |
+| indicator   | 'up' \| 'down' \| 'equal' \| number | 组件的趋势指示器    |
 
 ### `<Stat.HelpText>`
 

--- a/src/Stat/StatTrend.tsx
+++ b/src/Stat/StatTrend.tsx
@@ -43,7 +43,7 @@ const ArrowEqual = (props: React.SVGProps<SVGSVGElement>) => {
 };
 
 interface StatTrendProps extends WithAsProps {
-  indicator?: 'up' | 'down' | 'equal';
+  indicator?: 'up' | 'down' | 'equal' | number;
   appearance?: 'default' | 'subtle';
 }
 
@@ -58,11 +58,20 @@ const StatTrend: RsRefForwardingComponent<'dd', StatTrendProps> = React.forwardR
       children,
       ...rest
     } = props;
+    
+    let indicatorResolved = indicator;
+    if (typeof indicatorResolved === 'number') {
+      if (indicatorResolved > 0) {
+        indicatorResolved = 'up';
+      } else if (indicatorResolved < 0) {
+        indicatorResolved = 'down';
+      }
+    }
 
     const { merge, prefix, withClassPrefix } = useClassNames(classPrefix);
-    const classes = merge(className, withClassPrefix(appearance, indicator));
+    const classes = merge(className, withClassPrefix(appearance, indicatorResolved));
     const IndicatorIcon =
-      indicator === 'up' ? ArrowUp : indicator === 'down' ? ArrowDown : ArrowEqual;
+      indicatorResolved === 'up' ? ArrowUp : indicator === 'down' ? ArrowDown : ArrowEqual;
 
     return (
       <Component ref={ref} className={classes} {...rest}>


### PR DESCRIPTION
Stat.Trend property indicator should take a number directly, which represents the trend direction: < 0 for down, > 0 for up, o for equal. This will allows the component to be created from source data (which almost alwasy consists of the current numeric value, and some previous value: see example below) rather than the user having to evaluate the tri-state string.

`
<Stat bordered>
  <Stat.Label>Revenue</Stat.Label>
  <HStack spacing={10}>
    <Stat.Value>{currentValue}</Stat.Value>
    <Stat.Trend indicator={currentValue - previousValue}>{Math.round(100*(currentValue - previousValue)/previousValue)}%</Stat.Trend>
  </HStack>
</Stat>
`