### PR TITLE
fix: improve SegmentedControl styling across color modes

### DIFF
--- a/src/styles/color-modes/_dark.scss
+++ b/src/styles/color-modes/_dark.scss
@@ -305,12 +305,12 @@
     --rs-rate-color: var(--rs-yellow-500);
 
     // SegmentedControl
-    --rs-segmented-control-bg: var(--rs-gray-700);
-    --rs-segmented-control-border-color: var(--rs-border-primary);
+    --rs-segmented-control-bg: var(--rs-gray-900);
+    --rs-segmented-control-border-color: var(--rs-gray-900);
     --rs-segmented-control-item-active-color: var(--rs-text-primary);
     --rs-segmented-control-item-color: var(--rs-text-secondary);
     --rs-segmented-control-item-disabled-color: var(--rs-gray-500);
-    --rs-segmented-control-pill-indicator-bg: var(--rs-gray-800);
+    --rs-segmented-control-pill-indicator-bg: var(--rs-gray-700);
     --rs-segmented-control-underline-color: var(--rs-primary-500);
 
     // Slider

--- a/src/styles/color-modes/_high-contrast.scss
+++ b/src/styles/color-modes/_high-contrast.scss
@@ -310,12 +310,12 @@
     --rs-rate-color: var(--rs-primary-500);
 
     // SegmentedControl
-    --rs-segmented-control-bg: var(--rs-gray-700);
-    --rs-segmented-control-border-color: var(--rs-gray-600);
+    --rs-segmented-control-bg: var(--rs-gray-900);
+    --rs-segmented-control-border-color: var(--rs-gray-900);
     --rs-segmented-control-item-active-color: var(--rs-text-primary);
     --rs-segmented-control-item-color: var(--rs-text-secondary);
     --rs-segmented-control-item-disabled-color: var(--rs-gray-500);
-    --rs-segmented-control-pill-indicator-bg: var(--rs-gray-800);
+    --rs-segmented-control-pill-indicator-bg: var(--rs-gray-700);
     --rs-segmented-control-underline-color: var(--rs-primary-500);
 
     // Slider

--- a/src/styles/color-modes/_light.scss
+++ b/src/styles/color-modes/_light.scss
@@ -313,8 +313,8 @@
   --rs-rate-color: var(--rs-blue-500);
 
   // SegmentedControl
-  --rs-segmented-control-bg: var(--rs-gray-100);
-  --rs-segmented-control-border-color: var(--rs-border-primary);
+  --rs-segmented-control-bg: var(--rs-gray-50);
+  --rs-segmented-control-border-color: var(--rs-gray-50);
   --rs-segmented-control-item-active-color: var(--rs-text-primary);
   --rs-segmented-control-item-color: var(--rs-text-secondary);
   --rs-segmented-control-item-disabled-color: var(--rs-gray-400);


### PR DESCRIPTION
- Light mode: use gray-50 for better contrast and consistency
- Dark mode: use gray-900 for background and border, gray-700 for pill indicator
- High-contrast mode: use gray-900 for background and border, gray-700 for pill indicator

This improves visual consistency and contrast for the SegmentedControl component.