### PR TITLE
fix(build): update prepublishOnly to use TypeScript validation test

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -42,7 +42,7 @@
         "react-icons": "^5.0.1",
         "react-json-tree": "^0.20.0",
         "react-select": "^5.5.9",
-        "rsuite": "^6.0.0-canary-20250702",
+        "rsuite": "^6.0.0-canary-20250805",
         "svg-sprite-loader": "^6.0.11",
         "svgo": "^2.3.1",
         "svgo-loader": "^3.0.3",
@@ -9796,9 +9796,9 @@
       }
     },
     "node_modules/rsuite": {
-      "version": "6.0.0-canary-20250702",
-      "resolved": "https://registry.npmjs.org/rsuite/-/rsuite-6.0.0-canary-20250702.tgz",
-      "integrity": "sha512-+ObAN/oj4ieypn/2BCiEYqQ+E4F4XG9I79T/6yCHWeqOMZkW15LXhF83gEG+A0g0N4vfKgJLUQaYnupS+KzUSw==",
+      "version": "6.0.0-canary-20250805",
+      "resolved": "https://registry.npmjs.org/rsuite/-/rsuite-6.0.0-canary-20250805.tgz",
+      "integrity": "sha512-Ug7NOv9MWDpR/tYz8pYu2jv6/Ho9FrBoDO+n0p4rRfoRkSlST8GdfNai1dLqY5Kpwayn85hGCXIhYAe6jDjmFg==",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@juggle/resize-observer": "^3.4.0",
@@ -9812,7 +9812,7 @@
         "react-textarea-autosize": "^8.5.9",
         "react-use-set": "^1.0.0",
         "react-window": "^1.8.11",
-        "rsuite-table": "^5.19.1",
+        "rsuite-table": "^5.19.2",
         "schema-typed": "^2.4.2"
       },
       "peerDependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -52,7 +52,7 @@
     "react-icons": "^5.0.1",
     "react-json-tree": "^0.20.0",
     "react-select": "^5.5.9",
-    "rsuite": "^6.0.0-canary-20250702",
+    "rsuite": "^6.0.0-canary-20250805",
     "svg-sprite-loader": "^6.0.11",
     "svgo": "^2.3.1",
     "svgo-loader": "^3.0.3",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -88,7 +88,7 @@ function createPkgFile(done) {
   pkg.module = 'esm/index.js';
   pkg.typings = 'esm/index.d.ts';
   pkg.scripts = {
-    prepublishOnly: '../node_modules/mocha/bin/_mocha ../test/validateBuilds.js'
+    prepublishOnly: 'node ../scripts/validate-builds.js'
   };
 
   writeFile(`${libRoot}/package.json`, JSON.stringify(pkg, null, 2) + '\n')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsuite",
-  "version": "6.0.0-canary-20250702",
+  "version": "6.0.0-canary-20250805",
   "description": "A suite of react components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/scripts/validate-builds.js
+++ b/scripts/validate-builds.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+/**
+ * Script to validate builds from the lib directory
+ * This is used in the prepublishOnly npm script
+ */
+
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Change to the project root directory (parent of lib)
+process.chdir(path.join(__dirname, '..'));
+
+try {
+  // Run the validation test using vitest
+  execSync('VITEST_RUNNING_POSTBUILD=true npx vitest run --environment=node test/validateBuilds.spec.ts', {
+    stdio: 'inherit'
+  });
+
+  console.log('✅ Build validation successful!');
+  process.exit(0);
+} catch (err) {
+  console.error('❌ Build validation failed:', err.message);
+  process.exit(1);
+}


### PR DESCRIPTION
Replaced the prepublish build validation script to use a new Node.js script (`scripts/validate-builds.js`) that runs Vitest instead of Mocha for post-build validation. The relevant command in `gulpfile.js` was updated accordingly. [[1]](diffhunk://#diff-25789e3ba4c2adf4a68996260eb693a441b4a834c38b76167a120f0b51b969f7L91-R91) [[2]](diffhunk://#diff-50c9abb520060a8c4c0475963dcf56263ff1c2d7a9af265b57a016474792d862R1-R25)