### PR TITLE
refactor(Calendar/CalendarBody): replace js Date with temporal-like PlainYearMonth and PlainDate

### DIFF
--- a/src/Calendar/CalendarBody.tsx
+++ b/src/Calendar/CalendarBody.tsx
@@ -22,10 +22,13 @@ const CalendarBody = forwardRef<'div', CalendarBodyProps>((props, ref) => {
   return (
     <Component {...rest} ref={ref} className={classes}>
       <Grid
-        rows={getWeekStartDates(thisMonthDate, {
-          weekStart,
-          locale: locale?.dateLocale
-        })}
+        rows={getWeekStartDates(
+          { year: date.getFullYear(), month: date.getMonth() + 1 },
+          {
+            weekStart,
+            locale: locale?.dateLocale
+          }
+        )}
         aria-label={formatDate(thisMonthDate, locale.formattedMonthPattern)}
       />
     </Component>

--- a/src/Calendar/CalendarContainer.tsx
+++ b/src/Calendar/CalendarContainer.tsx
@@ -10,7 +10,6 @@ import { forwardRef } from '@/internals/utils';
 import {
   startOfToday,
   disableTime,
-  isSameMonth,
   calendarOnlyProps,
   omitHideDisabledProps,
   DateMode,
@@ -267,7 +266,6 @@ const CalendarContainer = forwardRef<'div', CalendarProps>((props: CalendarProps
   const { mode, has } = useDateMode(format);
   const timeMode = calendarState === CalendarState.TIME || mode === DateMode.Time;
   const monthMode = calendarState === CalendarState.MONTH || mode === DateMode.Month;
-  const inSameThisMonthDate = (date: Date) => isSameMonth(calendarDate, date);
 
   const calendarClasses = merge(
     className,
@@ -299,7 +297,6 @@ const CalendarContainer = forwardRef<'div', CalendarProps>((props: CalendarProps
     monthDropdownProps,
     cellClassName,
     disabledDate: isDateDisabled,
-    inSameMonth: inSameThisMonthDate,
     onChangeMonth: handleChangeMonth,
     onChangeTime,
     onMouseMove,

--- a/src/Calendar/CalendarProvider.ts
+++ b/src/Calendar/CalendarProvider.ts
@@ -68,13 +68,6 @@ export interface CalendarInnerContextValue {
   disabledDate?: (date: Date, selectRangeValue?: Date[], type?: string) => boolean;
 
   /**
-   * A function that determines if a date is in the same month as the current date in the calendar.
-   * @param date - The date to check.
-   * @returns True if the date is in the same month, false otherwise.
-   */
-  inSameMonth?: (date: Date) => boolean;
-
-  /**
    * A callback function that is called when the month is changed in the calendar.
    * @param nextPageDate - The next page date.
    * @param event - The mouse event.

--- a/src/Calendar/Grid/Grid.tsx
+++ b/src/Calendar/Grid/Grid.tsx
@@ -4,10 +4,11 @@ import GridHeaderRow from './GridHeaderRow';
 import { forwardRef } from '@/internals/utils';
 import { useStyles } from '@/internals/hooks';
 import { WithAsProps } from '@/internals/types';
+import type { PlainDate } from '@/internals/utils/date';
 import { useCalendar } from '../hooks';
 
 export interface GridProps extends WithAsProps {
-  rows: any[];
+  rows: readonly PlainDate[];
 }
 
 const Grid = forwardRef<'div', GridProps>((props: GridProps, ref) => {
@@ -32,8 +33,8 @@ const Grid = forwardRef<'div', GridProps>((props: GridProps, ref) => {
       className={classes}
     >
       <GridHeaderRow />
-      {rows.map((week, index) => (
-        <GridRow key={index} weekendDate={week} rowIndex={index + 1} />
+      {rows.map((rowStartingDate, index) => (
+        <GridRow key={index} startingDate={rowStartingDate} rowIndex={index + 1} />
       ))}
     </Component>
   );

--- a/src/Calendar/Grid/GridRow.tsx
+++ b/src/Calendar/Grid/GridRow.tsx
@@ -1,21 +1,21 @@
 import React, { useCallback } from 'react';
 import GridCell from './GridCell';
 import { forwardRef } from '@/internals/utils';
-import {
-  isSameDay,
-  addDays,
-  isBefore,
-  isAfter,
-  format,
-  type PlainDate
-} from '@/internals/utils/date';
+import { format, type PlainDate } from '@/internals/utils/date';
 import { DATERANGE_DISABLED_TARGET } from '@/internals/constants';
 import { useStyles } from '@/internals/hooks';
 import { useCalendar } from '../hooks';
 import { WithAsProps } from '@/internals/types';
+import { addDays, compare, isSameDay } from '@/internals/utils/date/plainDate';
+
+/**
+ * A row in the calendar month view grid, i.e. a week of days.
+ */
 export interface GridRowProps extends WithAsProps {
-  /** The weekend: Sunday */
-  weekendDate?: Date;
+  /**
+   * The starting day of the row of dates.
+   */
+  startingDate: PlainDate;
 
   /** The index of the row */
   rowIndex?: number;
@@ -26,7 +26,7 @@ const GridRow = forwardRef<'div', GridRowProps>((props: GridRowProps, ref) => {
     as: Component = 'div',
     className,
     classPrefix = 'calendar-table',
-    weekendDate = new Date(),
+    startingDate,
     rowIndex,
     ...rest
   } = props;
@@ -39,7 +39,6 @@ const GridRow = forwardRef<'div', GridRowProps>((props: GridRowProps, ref) => {
     weekStart,
     showWeekNumbers,
     locale,
-    inSameMonth,
     disabledDate,
     onSelect
   } = useCalendar();
@@ -58,18 +57,21 @@ const GridRow = forwardRef<'div', GridRowProps>((props: GridRowProps, ref) => {
 
   const renderDays = () => {
     const days: React.ReactElement[] = [];
-    const [selectedStartDate, selectedEndDate] = dateRange || [];
-    const [hoverStartDate, hoverEndDate] = hoverRangeValue ?? [];
+    const [selectedStartDateJS, selectedEndDateJS] = dateRange || [];
+    const [hoverStartDateJS, hoverEndDateJS] = hoverRangeValue ?? [];
     const isRangeSelectionMode = typeof dateRange !== 'undefined';
 
     for (let i = 0; i < 7; i += 1) {
-      const thisDate = addDays(weekendDate, i);
-      const disabled = disabledDate?.(thisDate, dateRange, DATERANGE_DISABLED_TARGET.CALENDAR);
+      const thisDate = addDays(startingDate, i);
+      const thisDateJS = new Date(thisDate.year, thisDate.month - 1, thisDate.day);
+      const disabled = disabledDate?.(thisDateJS, dateRange, DATERANGE_DISABLED_TARGET.CALENDAR);
 
-      const unSameMonth = !inSameMonth?.(thisDate);
+      const unSameMonth =
+        selected.getFullYear() !== thisDate.year || selected.getMonth() + 1 !== thisDate.month;
+
       const rangeStart =
-        !unSameMonth && selectedStartDate && isSameDay(thisDate, selectedStartDate);
-      const rangeEnd = !unSameMonth && selectedEndDate && isSameDay(thisDate, selectedEndDate);
+        !unSameMonth && selectedStartDateJS && isSameDay(thisDate, selectedStartDateJS);
+      const rangeEnd = !unSameMonth && selectedEndDateJS && isSameDay(thisDate, selectedEndDateJS);
       const isSelected = isRangeSelectionMode
         ? rangeStart || rangeEnd
         : isSameDay(thisDate, selected);
@@ -78,35 +80,49 @@ const GridRow = forwardRef<'div', GridRowProps>((props: GridRowProps, ref) => {
       //           Calendar is not supposed to be reused this way
       let inRange = false;
       // for Selected
-      if (selectedStartDate && selectedEndDate) {
-        if (isBefore(thisDate, selectedEndDate) && isAfter(thisDate, selectedStartDate)) {
+      if (selectedStartDateJS && selectedEndDateJS) {
+        const selectedStartDate = {
+          year: selectedStartDateJS.getFullYear(),
+          month: selectedStartDateJS.getMonth() + 1,
+          day: selectedStartDateJS.getDate()
+        };
+        const selectedEndDate = {
+          year: selectedEndDateJS.getFullYear(),
+          month: selectedEndDateJS.getMonth() + 1,
+          day: selectedEndDateJS.getDate()
+        };
+        if (compare(thisDate, selectedEndDate) < 0 && compare(thisDate, selectedStartDate) > 0) {
           inRange = true;
         }
-        if (isBefore(thisDate, selectedStartDate) && isAfter(thisDate, selectedEndDate)) {
+        if (compare(thisDate, selectedStartDate) < 0 && compare(thisDate, selectedEndDate) > 0) {
           inRange = true;
         }
       }
 
       // for Hovering
-      if (!isSelected && hoverStartDate && hoverEndDate) {
-        if (!isAfter(thisDate, hoverEndDate) && !isBefore(thisDate, hoverStartDate)) {
+      if (!isSelected && hoverStartDateJS && hoverEndDateJS) {
+        const hoverStartDate = {
+          year: hoverStartDateJS.getFullYear(),
+          month: hoverStartDateJS.getMonth() + 1,
+          day: hoverStartDateJS.getDate()
+        };
+        const hoverEndDate = {
+          year: hoverEndDateJS.getFullYear(),
+          month: hoverEndDateJS.getMonth() + 1,
+          day: hoverEndDateJS.getDate()
+        };
+        if (compare(thisDate, hoverEndDate) <= 0 && compare(thisDate, hoverStartDate) >= 0) {
           inRange = true;
         }
-        if (!isAfter(thisDate, hoverStartDate) && !isBefore(thisDate, hoverEndDate)) {
+        if (compare(thisDate, hoverStartDate) <= 0 && compare(thisDate, hoverEndDate) >= 0) {
           inRange = true;
         }
       }
 
-      const thisDatePlain = {
-        year: thisDate.getFullYear(),
-        month: thisDate.getMonth() + 1,
-        day: thisDate.getDate()
-      };
-
       days.push(
         <GridCell
-          key={format(thisDate, 'yyyy-MM-dd')}
-          date={thisDatePlain}
+          key={format(thisDateJS, 'yyyy-MM-dd')}
+          date={thisDate}
           disabled={disabled}
           selected={isSelected}
           onSelect={handleSelect}
@@ -123,8 +139,8 @@ const GridRow = forwardRef<'div', GridRowProps>((props: GridRowProps, ref) => {
   const classes = merge(className, prefix('row'));
   const { firstWeekContainsDate } = locale?.dateLocale?.options ?? {};
   // ISO week starts on Monday
-  const date = isoWeek ? addDays(weekendDate, 1) : weekendDate;
-  const week = format(date, isoWeek ? 'I' : 'w', {
+  const date = isoWeek ? addDays(startingDate, 1) : startingDate;
+  const week = format(new Date(date.year, date.month - 1, date.day), isoWeek ? 'I' : 'w', {
     locale: locale?.dateLocale,
     firstWeekContainsDate,
     weekStartsOn: weekStart

--- a/src/Calendar/test/CalendarGridRow.spec.tsx
+++ b/src/Calendar/test/CalendarGridRow.spec.tsx
@@ -7,16 +7,24 @@ import { CalendarProvider } from '../CalendarProvider';
 import { testStandardProps } from '@test/cases';
 
 describe('Calendar-GridRow', () => {
-  testStandardProps(<GridRow />);
+  testStandardProps(<GridRow startingDate={{ year: 2025, month: 8, day: 4 }} />);
 
   it('Should render a div with `table-row` class', () => {
-    render(<GridRow />);
+    render(<GridRow startingDate={{ year: 2025, month: 8, day: 4 }} />);
     expect(screen.getByRole('row')).to.have.class('rs-calendar-table-row');
   });
 
   it('Should be active today', () => {
     const thisDate = new Date();
-    render(<GridRow weekendDate={thisDate} />);
+    render(
+      <GridRow
+        startingDate={{
+          year: thisDate.getFullYear(),
+          month: thisDate.getMonth() + 1,
+          day: thisDate.getDate()
+        }}
+      />
+    );
 
     expect(screen.getByTitle(`${format(thisDate, 'dd MMM yyyy')} (Today)`)).to.have.class(
       'rs-calendar-table-cell-is-today'
@@ -30,7 +38,7 @@ describe('Calendar-GridRow', () => {
       <CalendarProvider
         value={{ onSelect, date: thisDate, locale: {}, isoWeek: false, weekStart: 0 }}
       >
-        <GridRow weekendDate={thisDate} />
+        <GridRow startingDate={{ year: 2025, month: 6, day: 16 }} />
       </CalendarProvider>
     );
 
@@ -50,14 +58,13 @@ describe('Calendar-GridRow', () => {
           weekStart: 0
         }}
       >
-        <GridRow weekendDate={thisDate} />
+        <GridRow startingDate={{ year: 2022, month: 11, day: 2 }} />
       </CalendarProvider>
     );
     expect(screen.getByRole('rowheader')).to.have.text(format(thisDate, 'w'));
   });
 
   it('Should render a ISO week number', () => {
-    const thisDate = new Date(2022, 10, 2);
     render(
       <CalendarProvider
         value={{
@@ -67,7 +74,7 @@ describe('Calendar-GridRow', () => {
           locale: {}
         }}
       >
-        <GridRow weekendDate={thisDate} />
+        <GridRow startingDate={{ year: 2022, month: 11, day: 2 }} />
       </CalendarProvider>
     );
 
@@ -91,7 +98,13 @@ describe('Calendar-GridRow', () => {
           }
         }}
       >
-        <GridRow />
+        <GridRow
+          startingDate={{
+            year: thisDate.getFullYear(),
+            month: thisDate.getMonth() + 1,
+            day: thisDate.getDate()
+          }}
+        />
       </CalendarProvider>
     );
 
@@ -102,7 +115,7 @@ describe('Calendar-GridRow', () => {
 
   describe('Accessibility', () => {
     it('Should have a role attribute', () => {
-      render(<GridRow />);
+      render(<GridRow startingDate={{ year: 2025, month: 8, day: 4 }} />);
       expect(screen.getByRole('row')).to.have.attribute('role', 'row');
     });
   });

--- a/src/internals/utils/date/getWeekStartDates.ts
+++ b/src/internals/utils/date/getWeekStartDates.ts
@@ -1,19 +1,29 @@
-import { addDays } from 'date-fns/addDays';
 import { startOfWeek } from 'date-fns/startOfWeek';
 import type { Locale } from 'date-fns';
+import type { PlainDate, PlainYearMonth } from './types';
+import { addDays } from './plainDate';
 /**
  * Get the first days of weeks in a month。
- * @param firstDayOfMonth The first day of the month
+ * @param month The month
  * @param options.weekStart the index of the first day of the week (0 - Sunday)
  * @param options.isoWeek Whether to use ISO week
  * @returns A list of first days of weeks in a month
  */
 export function getWeekStartDates(
-  firstDayOfMonth: Date,
+  month: PlainYearMonth,
   options: { weekStart?: 0 | 1 | 2 | 3 | 4 | 5 | 6; locale?: Locale }
-): Date[] {
+): PlainDate[] {
   const { weekStart, locale } = options;
-  const firstDay = startOfWeek(firstDayOfMonth, { weekStartsOn: weekStart, locale });
+  const firstDayJs = startOfWeek(new Date(month.year, month.month - 1, 1), {
+    weekStartsOn: weekStart,
+    locale
+  });
+  const firstDay: PlainDate = {
+    year: firstDayJs.getFullYear(),
+    month: firstDayJs.getMonth() + 1,
+    day: firstDayJs.getDate()
+  };
+
   const days = [firstDay];
 
   for (let i = 1; i < 6; i++) {

--- a/src/internals/utils/date/plainDate.ts
+++ b/src/internals/utils/date/plainDate.ts
@@ -8,7 +8,12 @@ function toPlainDate(date: Date): PlainDate {
   };
 }
 
-function comparePlainDates(date1: PlainDate, date2: PlainDate): -1 | 0 | 1 {
+/**
+ * Resembles the behavior of `Temporal.PlainDate.compare`.
+ *
+ * @see https://tc39.es/proposal-temporal/docs/plaindatetime.html#compare
+ */
+export function compare(date1: PlainDate, date2: PlainDate): -1 | 0 | 1 {
   if (date1.year < date2.year) return -1;
   if (date1.year > date2.year) return 1;
   if (date1.month < date2.month) return -1;
@@ -18,6 +23,21 @@ function comparePlainDates(date1: PlainDate, date2: PlainDate): -1 | 0 | 1 {
   return 0;
 }
 
+/**
+ * Resembles the behavior of `Temporal.PlainDate.prototype.equals`.
+ *
+ * @see https://tc39.es/proposal-temporal/docs/plaindatetime.html#equals
+ */
+function equals(date1: PlainDate, date2: PlainDate): boolean {
+  return compare(date1, date2) === 0;
+}
+
 export function isSameDay(date: PlainDate, jsDate: Date): boolean {
-  return comparePlainDates(date, toPlainDate(jsDate)) === 0;
+  return equals(date, toPlainDate(jsDate));
+}
+
+export function addDays(date: PlainDate, days: number): PlainDate {
+  const jsDate = new Date(date.year, date.month - 1, date.day);
+  jsDate.setDate(jsDate.getDate() + days);
+  return toPlainDate(jsDate);
 }

--- a/src/internals/utils/date/test/getWeekStartDates.spec.ts
+++ b/src/internals/utils/date/test/getWeekStartDates.spec.ts
@@ -1,85 +1,60 @@
 import getWeekStartDates from '../getWeekStartDates';
 import { describe, expect, it } from 'vitest';
-import { parseISO, format } from 'date-fns';
 
 describe('internals/utils/date/getWeekStartDates', () => {
   it('Sunday is the first day of the week.', () => {
-    const weeks = getWeekStartDates(parseISO('2017-11-30'), { weekStart: 0 });
+    const weeks = getWeekStartDates({ year: 2017, month: 12 }, { weekStart: 0 });
     const dates = [
-      '2017-11-26',
-      '2017-12-03',
-      '2017-12-10',
-      '2017-12-17',
-      '2017-12-24',
-      '2017-12-31'
+      { year: 2017, month: 11, day: 26 },
+      { year: 2017, month: 12, day: 3 },
+      { year: 2017, month: 12, day: 10 },
+      { year: 2017, month: 12, day: 17 },
+      { year: 2017, month: 12, day: 24 },
+      { year: 2017, month: 12, day: 31 }
     ];
 
-    weeks.forEach((week, index) => {
-      expect(format(week, 'yyyy-MM-dd')).to.be.equal(dates[index]);
-    });
+    expect(weeks).to.deep.equal(dates);
   });
 
   it('Monday is the first day of the week.', () => {
-    const weeks = getWeekStartDates(parseISO('2017-11-30'), { weekStart: 1 });
+    const weeks = getWeekStartDates({ year: 2017, month: 12 }, { weekStart: 1 });
     const dates = [
-      '2017-11-27',
-      '2017-12-04',
-      '2017-12-11',
-      '2017-12-18',
-      '2017-12-25',
-      '2018-01-01'
+      { year: 2017, month: 11, day: 27 },
+      { year: 2017, month: 12, day: 4 },
+      { year: 2017, month: 12, day: 11 },
+      { year: 2017, month: 12, day: 18 },
+      { year: 2017, month: 12, day: 25 },
+      { year: 2018, month: 1, day: 1 }
     ];
 
-    weeks.forEach((week, index) => {
-      expect(format(week, 'yyyy-MM-dd')).to.be.equal(dates[index]);
-    });
-  });
-
-  it('Should be monday as the first day of the week.', () => {
-    const weeks = getWeekStartDates(parseISO('2017-11-30'), { weekStart: 1 });
-    const dates = [
-      '2017-11-27',
-      '2017-12-04',
-      '2017-12-11',
-      '2017-12-18',
-      '2017-12-25',
-      '2018-01-01'
-    ];
-
-    weeks.forEach((week, index) => {
-      expect(format(week, 'yyyy-MM-dd')).to.be.equal(dates[index]);
-    });
+    expect(weeks).to.deep.equal(dates);
   });
 
   it('Should be tuesday as the first day of the week.', () => {
-    const weeks = getWeekStartDates(parseISO('2017-11-30'), { weekStart: 2 });
+    const weeks = getWeekStartDates({ year: 2017, month: 12 }, { weekStart: 2 });
     const dates = [
-      '2017-11-28',
-      '2017-12-05',
-      '2017-12-12',
-      '2017-12-19',
-      '2017-12-26',
-      '2018-01-02'
+      { year: 2017, month: 11, day: 28 },
+      { year: 2017, month: 12, day: 5 },
+      { year: 2017, month: 12, day: 12 },
+      { year: 2017, month: 12, day: 19 },
+      { year: 2017, month: 12, day: 26 },
+      { year: 2018, month: 1, day: 2 }
     ];
 
-    weeks.forEach((week, index) => {
-      expect(format(week, 'yyyy-MM-dd')).to.be.equal(dates[index]);
-    });
+    expect(weeks).to.deep.equal(dates);
   });
 
   it('Should be saturday as the first day of the week.', () => {
-    const weeks = getWeekStartDates(parseISO('2017-11-30'), { weekStart: 6 });
+    const weeks = getWeekStartDates({ year: 2017, month: 12 }, { weekStart: 6 });
     const dates = [
-      '2017-11-25',
-      '2017-12-02',
-      '2017-12-09',
-      '2017-12-16',
-      '2017-12-23',
-      '2017-12-30'
+      { year: 2017, month: 11, day: 25 },
+      { year: 2017, month: 12, day: 2 },
+      { year: 2017, month: 12, day: 9 },
+      { year: 2017, month: 12, day: 16 },
+      { year: 2017, month: 12, day: 23 },
+      { year: 2017, month: 12, day: 30 }
     ];
 
-    weeks.forEach((week, index) => {
-      expect(format(week, 'yyyy-MM-dd')).to.be.equal(dates[index]);
-    });
+    expect(weeks).to.deep.equal(dates);
   });
 });

--- a/src/internals/utils/date/test/plainDate.spec.ts
+++ b/src/internals/utils/date/test/plainDate.spec.ts
@@ -1,0 +1,14 @@
+import { describe, test, expect } from 'vitest';
+import { addDays } from '../plainDate';
+
+describe('addDays', () => {
+  test('should add days to a PlainDate', () => {
+    const date = { year: 2025, month: 8, day: 9 };
+
+    expect(addDays(date, 1)).toEqual({ year: 2025, month: 8, day: 10 });
+    // Cross-month
+    expect(addDays(date, 31)).toEqual({ year: 2025, month: 9, day: 9 });
+    // Cross-year
+    expect(addDays(date, 365)).toEqual({ year: 2026, month: 8, day: 9 });
+  });
+});

--- a/src/internals/utils/date/types.ts
+++ b/src/internals/utils/date/types.ts
@@ -94,3 +94,13 @@ export type PlainDate = {
   readonly month: number;
   readonly day: number;
 };
+
+/**
+ * Resembles Temporal.PlainYearMonth
+ *
+ * @see https://tc39.es/proposal-temporal/docs/plainyearmonth.html
+ */
+export type PlainYearMonth = {
+  readonly year: number;
+  readonly month: number;
+};


### PR DESCRIPTION
## Summary

Refactor CalendarBody and GridRow components to use Temporal-like PlainYearMonth and PlainDate objects instead of JavaScript Date objects, in respect of RFC #4347. 

## Changes

* Update GridRow component to accept a required PlainDate as the starting date in the row, instead of an optional js Date object
* Update the Grid component to accept a list of PlainDate instead of Date to be passed to GridRow
* Update the `getWeekStartDates` util to accept PlainYearMonth and return PlainDate instead of js Dates to be passed to Grid by CalendarBody