### PR TITLE
fix(Textarea): improve onChange type definition

### DIFF
--- a/src/Textarea/Textarea.tsx
+++ b/src/Textarea/Textarea.tsx
@@ -4,6 +4,7 @@ import InputBase, { InputBaseCommonProps } from '@/internals/InputBase';
 import { forwardRef, mergeStyles } from '@/internals/utils';
 import { useStyles, useCustom } from '@/internals/hooks';
 import type {
+  PrependParameters,
   SanitizedTextareaProps,
   PropsWithoutChange,
   FormControlBaseProps,
@@ -44,6 +45,11 @@ export interface TextareaProps
    * Called when Enter key is pressed
    */
   onPressEnter?: React.KeyboardEventHandler<HTMLTextAreaElement>;
+
+  /**
+   * The callback function in which value is changed.
+   */
+  onChange?: PrependParameters<React.ChangeEventHandler<HTMLTextAreaElement>, [value: string]>;
 }
 
 const Textarea = forwardRef<'textarea', TextareaProps>((props, ref) => {

--- a/src/Textarea/test/Textarea.test.tsx
+++ b/src/Textarea/test/Textarea.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import Textarea from '../Textarea';
+
+// onChange should be rewritten with the type
+<Textarea
+  onChange={(value: string, event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    console.log(value, event);
+  }}
+/>;


### PR DESCRIPTION
This pull request introduces support for a new `onChange` prop in the `Textarea` component, allowing consumers to access both the new value and the original change event when handling input changes. 