### PR TITLE
fix(useDialog): separate handleClose and handleCancel behaviors

### DIFF
--- a/src/useDialog/Dialog.tsx
+++ b/src/useDialog/Dialog.tsx
@@ -54,7 +54,7 @@ const Dialog = forwardRef((props: DialogProps, ref) => {
     }
   }, [type]);
 
-  const handleClose = useCallback(
+  const handleCancel = useCallback(
     (result?: any) => {
       setIsOpen(false);
 
@@ -75,11 +75,13 @@ const Dialog = forwardRef((props: DialogProps, ref) => {
           return;
         }
       }
-      handleClose(value);
+      handleCancel(value);
     } else {
-      handleClose(true);
+      handleCancel(true);
     }
-  }, [type, inputValue, validate, handleClose]);
+  }, [type, inputValue, validate, handleCancel]);
+
+  const handleClose = useCallback(() => handleCancel(false), [handleCancel]);
 
   const handleInputKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/useDialog/test/Dialog.spec.tsx
+++ b/src/useDialog/test/Dialog.spec.tsx
@@ -74,7 +74,7 @@ describe('Dialog', () => {
     expect(onClose).toHaveBeenCalledWith(true);
   });
 
-  it('Should call onClose when clicking Cancel button', async () => {
+  it('Should call onClose with false when clicking Cancel button', async () => {
     const onClose = vi.fn();
     render(
       <Dialog
@@ -101,7 +101,7 @@ describe('Dialog', () => {
     // Wait for any state updates and animations
     await new Promise(resolve => setTimeout(resolve, 500));
 
-    expect(onClose).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledWith(false);
   });
 
   it('Should call onClose with input value when pressing Enter in prompt', async () => {


### PR DESCRIPTION
This pull request refactors the dialog closing logic in the `Dialog` component to clarify the distinction between canceling and closing actions. The main change is that clicking the Cancel button now triggers the `onClose` callback with a value of `false`, making the intent clearer and improving test reliability. 