### PR TITLE
fix(FormGroup): label  within vertical form layout is wider than the its text 

### DIFF
--- a/src/FormGroup/styles/index.less
+++ b/src/FormGroup/styles/index.less
@@ -26,6 +26,7 @@
 .rs-form-vertical .rs-form-group {
   .rs-form-control-label {
     display: block;
+    width: fit-content;
   }
 
   .rs-form-help-text:not(.rs-form-help-text-tooltip) {


### PR DESCRIPTION
Before

https://github.com/user-attachments/assets/a66b05c1-0396-4ae3-a526-a98a5fa26b02

After

https://github.com/user-attachments/assets/d16101e5-7e31-4c09-a21a-e3f4781a41f7

