### PR TITLE
chore: update Node.js version to 22.x in engines field

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -86,6 +86,6 @@
     "rtlcss-webpack-plugin": "^4.0.6"
   },
   "engines": {
-    "node": "^18.17.0"
+    "node": "22.x"
   }
 }


### PR DESCRIPTION
This pull request updates the required Node.js version for the documentation package to ensure compatibility with the latest runtime.

Dependency update:

* [`docs/package.json`](diffhunk://#diff-adfa337ce44dc2902621da20152a048dac41878cf3716dfc4cc56d03aa212a56L89-R89): Changed the Node.js engine requirement from `^18.17.0` to `22.x` to support newer Node.js features and improve consistency across environments.