### PR TITLE
docs(toolbar): add v5 entry to toolbar menu

### DIFF
--- a/docs/components/layout/PageToolbar/PageToolbar.tsx
+++ b/docs/components/layout/PageToolbar/PageToolbar.tsx
@@ -32,6 +32,12 @@ function PageToolbar({ designHash, routerId }: PageToolbarProps) {
 
   const versions = [
     {
+      id: 'v5',
+      name: locales?.common?.v5,
+      version: '5.83.3',
+      url: 'https://v5.rsuitejs.com/'
+    },
+    {
       id: 'v4',
       name: locales?.common?.v4,
       version: '4.11.1',

--- a/docs/locales/en-US/index.ts
+++ b/docs/locales/en-US/index.ts
@@ -47,6 +47,7 @@ export default {
     v2: '2.x',
     v3: '3.x',
     v4: '4.x',
+    v5: '5.x',
     v5Features: 'Upgrade to v5',
     notFount: 'Page not found',
     goHomePage: 'Return to homepage.',

--- a/docs/locales/zh-CN/index.ts
+++ b/docs/locales/zh-CN/index.ts
@@ -46,6 +46,7 @@ export default {
     v2: '2.x',
     v3: '3.x',
     v4: '4.x',
+    v5: '5.x',
     v5Features: '升级到 v5',
     notFount: '该页面无法显示',
     goHomePage: '返回首页',


### PR DESCRIPTION
This pull request adds support for version 5 (v5) of the documentation site, updating both the UI and localization files to include references to v5 alongside previous versions.
