### PR TITLE
fix(sidenav): ensure dropdown menu display matches collapse state

### DIFF
--- a/src/Sidenav/styles/index.scss
+++ b/src/Sidenav/styles/index.scss
@@ -119,6 +119,14 @@
     .rs-dropdown-item-collapse-icon {
       transform: rotate(90deg);
     }
+
+    > .rs-dropdown-menu.rs-dropdown-menu-collapse-out {
+      display: none;
+    }
+
+    > .rs-dropdown-menu.rs-dropdown-menu-collapse-in {
+      display: flex;
+    }
   }
 
   .rs-dropdown-item {

--- a/src/Sidenav/test/Sidenav.styles.spec.tsx
+++ b/src/Sidenav/test/Sidenav.styles.spec.tsx
@@ -3,7 +3,7 @@ import Nav from '../../Nav';
 import Dropdown from '../../Dropdown';
 import Sidenav from '../Sidenav';
 import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { getDefaultPalette } from '@test/utils';
 
 import '../styles/index.scss';
@@ -27,6 +27,44 @@ describe('Sidenav styles', () => {
     );
 
     expect(screen.getByText('Child Item')).to.have.style('display', 'flex');
+  });
+
+  it('Should hide collapsed dropdown menu by default', () => {
+    render(
+      <Sidenav>
+        <Nav>
+          <Dropdown title="Dropdown">
+            <Dropdown.Item>Dropdown Item</Dropdown.Item>
+          </Dropdown>
+        </Nav>
+      </Sidenav>
+    );
+
+    const dropdownMenu = screen.getByText('Dropdown Item').closest('ul');
+    expect(dropdownMenu).to.have.class('rs-dropdown-menu-collapse-out');
+    expect(dropdownMenu).to.have.style('display', 'none');
+  });
+
+  it('Should display expanded dropdown menu', async () => {
+    render(
+      <Sidenav>
+        <Nav>
+          <Dropdown title="Dropdown">
+            <Dropdown.Item>Dropdown Item</Dropdown.Item>
+          </Dropdown>
+        </Nav>
+      </Sidenav>
+    );
+
+    fireEvent.click(screen.getByText('Dropdown'));
+
+    const dropdownMenu = screen.getByText('Dropdown Item').closest('ul');
+
+    await waitFor(() => {
+      expect(dropdownMenu).to.have.class('rs-dropdown-menu-collapse-in');
+    });
+
+    expect(dropdownMenu).to.have.style('display', 'flex');
   });
 
   describe('Default', () => {


### PR DESCRIPTION
This pull request improves the behavior and test coverage of the Sidenav dropdown menu, specifically ensuring that collapsed and expanded states are styled and tested correctly. The main changes include updating the SCSS to control the display of dropdown menus based on their state and adding tests to verify this behavior.

**Styling improvements for dropdown menu states:**

* Updated `index.scss` to set `display: none` for `.rs-dropdown-menu-collapse-out` (collapsed menus) and `display: flex` for `.rs-dropdown-menu-collapse-in` (expanded menus), ensuring proper visibility control of dropdown menus.

**Test enhancements for dropdown menu behavior:**

* Added tests in `Sidenav.styles.spec.tsx` to verify that collapsed dropdown menus are hidden by default and expanded dropdown menus are displayed when triggered.
* Updated test imports to include `fireEvent` and `waitFor` from `@testing-library/react`, supporting the new interaction-based tests.