### PR TITLE
docs(card): adjust headers to use Text

### DIFF
--- a/docs/pages/components/card/fragments/basic.md
+++ b/docs/pages/components/card/fragments/basic.md
@@ -6,7 +6,11 @@ import { Card, Text } from 'rsuite';
 const App = () => {
   return (
     <Card width={320}>
-      <Card.Header as="h5">John Doe</Card.Header>
+      <Card.Header>
+        <Text size="lg" bold>
+          John Doe
+        </Text>
+      </Card.Header>
       <Card.Body>
         A passionate developer with a love for learning new technologies. Enjoys building innovative
         solutions and solving problems.

--- a/docs/pages/components/card/fragments/horizontal.md
+++ b/docs/pages/components/card/fragments/horizontal.md
@@ -13,7 +13,11 @@ const App = () => {
         style={{ objectFit: 'cover' }}
       />
       <VStack spacing={2}>
-        <Card.Header as="h5">Cream</Card.Header>
+        <Card.Header>
+          <Text size="lg" bold>
+            Cream
+          </Text>
+        </Card.Header>
         <Card.Body>
           Meet Shadow, a spirited little explorer with a heart full of adventure! This charming pup
           loves to roam the fields, soaking up the sights and sounds of nature.

--- a/docs/pages/components/card/fragments/hover-shadow.md
+++ b/docs/pages/components/card/fragments/hover-shadow.md
@@ -6,7 +6,11 @@ import { Card, Text } from 'rsuite';
 const App = () => {
   return (
     <Card width={320} shaded="hover">
-      <Card.Header as="h5">John Doe</Card.Header>
+      <Card.Header>
+        <Text size="lg" bold>
+          John Doe
+        </Text>
+      </Card.Header>
       <Card.Body>
         A passionate developer with a love for learning new technologies. Enjoys building innovative
         solutions and solving problems.

--- a/docs/pages/components/card/fragments/shadow.md
+++ b/docs/pages/components/card/fragments/shadow.md
@@ -6,7 +6,11 @@ import { Card, Text } from 'rsuite';
 const App = () => {
   return (
     <Card width={320} shaded>
-      <Card.Header as="h5">John Doe</Card.Header>
+      <Card.Header>
+        <Text size="lg" bold>
+          John Doe
+        </Text>
+      </Card.Header>
       <Card.Body>
         A passionate developer with a love for learning new technologies. Enjoys building innovative
         solutions and solving problems.

--- a/docs/pages/components/card/fragments/size.md
+++ b/docs/pages/components/card/fragments/size.md
@@ -7,7 +7,11 @@ const App = () => {
   return (
     <VStack spacing={10}>
       <Card size="sm">
-        <Card.Header as="h5">Card Header - Small</Card.Header>
+        <Card.Header>
+          <Text size="lg" bold>
+            Card Header - Small
+          </Text>
+        </Card.Header>
         <Card.Body>
           This is a small card with a brief description to highlight key information or content. It
           can be used for various purposes like displaying details, statistics, or any relevant
@@ -15,7 +19,11 @@ const App = () => {
         </Card.Body>
       </Card>
       <Card size="md">
-        <Card.Header as="h5">Card Header - Medium</Card.Header>
+        <Card.Header>
+          <Text size="lg" bold>
+            Card Header - Medium
+          </Text>
+        </Card.Header>
         <Card.Body>
           This is a medium card with a brief description to highlight key information or content. It
           can be used for various purposes like displaying details, statistics, or any relevant
@@ -23,7 +31,11 @@ const App = () => {
         </Card.Body>
       </Card>
       <Card size="lg">
-        <Card.Header as="h5">Card Header - Large</Card.Header>
+        <Card.Header>
+          <Text size="lg" bold>
+            Card Header - Large
+          </Text>
+        </Card.Header>
         <Card.Body>
           This is a large card with a brief description to highlight key information or content. It
           can be used for various purposes like displaying details, statistics, or any relevant

--- a/docs/pages/components/card/fragments/with-image.md
+++ b/docs/pages/components/card/fragments/with-image.md
@@ -10,7 +10,11 @@ const App = () => {
         src="https://images.unsplash.com/photo-1576606539605-b2a44fa58467?q=80&w=1974"
         alt="Shadow"
       />
-      <Card.Header as="h5">Shadow</Card.Header>
+      <Card.Header>
+        <Text size="lg" bold>
+          Shadow
+        </Text>
+      </Card.Header>
       <Card.Body>
         Meet Shadow, a spirited little explorer with a heart full of adventure! This charming pup
         loves to roam the fields, soaking up the sights and sounds of nature.


### PR DESCRIPTION
This pull request updates several Card component documentation examples to improve header styling consistency. Instead of passing the `as="h5"` prop to `Card.Header`, headers now use the `Text` component with explicit size and bold styling for better clarity and customization.

**Documentation improvements:**

* Updated all `Card.Header` usages in Card documentation fragments to wrap header text in a `Text` component with `size="lg"` and `bold` props, replacing the previous `as="h5"` prop for more explicit and flexible header styling. [[1]](diffhunk://#diff-6c5bd647dbee21ff9065ae720904bf898ada954a898b1a4046278a0eca55fd8eL9-R13) [[2]](diffhunk://#diff-81d4c1978e70c6e66fada8738812b6c4aa6c474017775448670081bfba3ab895L9-R13) [[3]](diffhunk://#diff-fa6c9dd19efff6b55555d30e03c0a5ec2ebfdf20d3afc0b9372c8d688d4c0366L9-R13) [[4]](diffhunk://#diff-7bbb1b05de7a803779934fc3bee2af6d4808818e7e1e3cd22061b84445818dbdL16-R20) [[5]](diffhunk://#diff-4fdf93de4af0c8fedf9ed67c9335c9f7b0d615b64b82c8f2b4efae982e29e8ebL13-R17) [[6]](diffhunk://#diff-0a42bd1b221b430a60bac8403c05b0a75567ad5e5d6e2486a28ba6cda3983586L10-R38)