### PR TITLE
fix(nav): ensure subtle vertical layout flex

### DIFF
--- a/src/Nav/styles/index.scss
+++ b/src/Nav/styles/index.scss
@@ -306,6 +306,9 @@
 
   // Vertical
   &[data-direction='vertical'] {
+    display: flex;
+    flex-direction: column;
+
     // Waterline
     .rs-nav-bar {
       width: 2px;

--- a/src/Nav/test/Nav.styles.spec.tsx
+++ b/src/Nav/test/Nav.styles.spec.tsx
@@ -23,6 +23,14 @@ describe('Nav styles', () => {
     expect(screen.getByRole('button')).to.have.style('background-color', 'rgba(0, 0, 0, 0)');
   });
 
+  it('Should render subtle vertical Nav as flex column layout', () => {
+    render(<Nav vertical appearance="subtle" data-testid="nav-vertical" />);
+
+    const nav = screen.getByTestId('nav-vertical');
+    expect(nav).to.have.style('display', 'flex');
+    expect(nav).to.have.style('flex-direction', 'column');
+  });
+
   describe('Issue #2678', () => {
     it('Height of <Nav.Menu> should be consistent with that of <Nav.Item> (36px)', () => {
       render(


### PR DESCRIPTION
This pull request updates the vertical navigation (`Nav`) component to use a flex column layout, ensuring more consistent and predictable styling. It also adds a test to verify the new flex behavior.

Layout improvements:

* Updated the `[data-direction='vertical']` selector in `index.scss` to apply `display: flex` and `flex-direction: column`, making vertical navigation items stack in a column using flexbox.

Testing:

* Added a test in `Nav.styles.spec.tsx` to confirm that a subtle vertical `Nav` renders with `display: flex` and `flex-direction: column`.