### PR TITLE
docs(uploader): refine custom file info layout

### DIFF
--- a/docs/pages/components/uploader/fragments/file-list-custom.md
+++ b/docs/pages/components/uploader/fragments/file-list-custom.md
@@ -22,10 +22,12 @@ const App = () => (
     action="//jsonplaceholder.typicode.com/posts/"
     renderFileInfo={(file, fileElement) => {
       return (
-        <>
+        <VStack spacing="1">
           <span>File Name: {file.name}</span>
-          <p>File URL: <a href={file.url}>{file.url}</a></p>
-        </>
+          <span>
+            File URL: <a href={file.url}>{file.url}</a>
+          </span>
+        </VStack>
       );
     }}
   >


### PR DESCRIPTION
This pull request makes a small change to the file list display in the uploader documentation example. It updates the layout to use a vertical stack (`VStack`) and changes the file URL display from a paragraph to a span for improved consistency and styling.

- UI update:
  * [`docs/pages/components/uploader/fragments/file-list-custom.md`](diffhunk://#diff-fa5b352a95e94799c5fbac1624b31b6e4138ea898d784bdf2655a2626d07563dL25-R30): Replaces the fragment wrapper with a `VStack` component and changes the file URL element from a `<p>` to a `<span>`.