### PR TITLE
feat(badge): add size variants and docs

### DIFF
--- a/docs/pages/components/badge/en-US/index.md
+++ b/docs/pages/components/badge/en-US/index.md
@@ -26,6 +26,12 @@ If the wrapped element is a circle, you can use the `shape` property `circle` to
 
 <!--{include:`shape.md`}-->
 
+### Sizes
+
+The Badge component supports different sizes through the `size` prop.
+
+<!--{include:`size.md`}-->
+
 ### Offset
 
 If the Badge position is not reasonable, you can use the `offset` property to make fine adjustments.
@@ -61,6 +67,7 @@ If the Badge position is not reasonable, you can use the `offset` property to ma
 | outline     | boolean`(true)`                                        | Whether to use outline mode                                                            | ![][6.0.0] |
 | placement   | [PlacementCorners](#code-ts-placement-corners-code)    | Set the position of the badge in the wrapped element                                   | ![][6.0.0] |
 | shape       | 'rectangle' \| 'circle'                                | The shape of the wrapped element                                                       | ![][6.0.0] |
+| size        | 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' `('md')` | Set the size of the badge                                                    |            |
 
 <!--{include:(_common/types/color.md)}-->
 <!--{include:(_common/types/placement-corners.md)}-->

--- a/docs/pages/components/badge/fragments/size.md
+++ b/docs/pages/components/badge/fragments/size.md
@@ -1,0 +1,39 @@
+<!--start-code-->
+
+```js
+import { Badge, Avatar, HStack } from 'rsuite';
+
+const App = () => (
+  <>
+    <HStack spacing={10} wrap>
+      <Badge content={6} size="xs">
+        <Avatar />
+      </Badge>
+      <Badge content={6} size="sm">
+        <Avatar />
+      </Badge>
+      <Badge content={6} size="md">
+        <Avatar />
+      </Badge>
+      <Badge content={6} size="lg">
+        <Avatar />
+      </Badge>
+      <Badge content={6} size="xl">
+        <Avatar />
+      </Badge>
+    </HStack>
+    <hr />
+    <HStack spacing={10} wrap>
+      <Badge content="Xsmall" size="xs" />
+      <Badge content="Small" size="sm" />
+      <Badge content="Medium" size="md" />
+      <Badge content="Large" size="lg" />
+      <Badge content="Xlarge" size="xl" />
+    </HStack>
+  </>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/badge/zh-CN/index.md
+++ b/docs/pages/components/badge/zh-CN/index.md
@@ -26,6 +26,12 @@
 
 <!--{include:`shape.md`}-->
 
+### 尺寸
+
+Badge 组件通过 `size` 属性支持不同的尺寸。
+
+<!--{include:`size.md`}-->
+
 ### 偏移
 
 如果 Badge 的位置不合理, 可以使用 `offset` 属性进行微调。
@@ -61,6 +67,7 @@
 | outline     | boolean`(true)`                                        | 是否为轮廓模式                                  | ![][6.0.0] |
 | placement   | [PlacementCorners](#code-ts-placement-corners-code)    | 设置标记在被包裹元素的位置                      | ![][6.0.0] |
 | shape       | 'rectangle' \| 'circle'                                | 被包裹元素的形状                                | ![][6.0.0] |
+| size        | 'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' `('md')` | 设置标记的尺寸                                  |            |
 
 <!--{include:(_common/types/color.md)}-->
 <!--{include:(_common/types/placement-corners.md)}-->

--- a/src/Badge/Badge.tsx
+++ b/src/Badge/Badge.tsx
@@ -8,7 +8,7 @@ import {
   isPresetColor,
   createColorVariables
 } from '@/internals/utils';
-import type { Color, PlacementCorners } from '@/internals/types';
+import type { Color, PlacementCorners, Size } from '@/internals/types';
 
 export interface BadgeProps extends BoxProps {
   /**
@@ -50,6 +50,11 @@ export interface BadgeProps extends BoxProps {
   shape?: 'rectangle' | 'circle';
 
   /**
+   * A badge can have different sizes
+   */
+  size?: Size;
+
+  /**
    * Define the horizontal and vertical offset of the badge relative to its wrapped element
    * @version 6.0.0
    */
@@ -81,6 +86,7 @@ const Badge = forwardRef<'div', BadgeProps>((props: BadgeProps, ref) => {
     outline = true,
     placement = 'topEnd',
     shape,
+    size = 'md',
     style,
     invisible,
     ...rest
@@ -111,9 +117,10 @@ const Badge = forwardRef<'div', BadgeProps>((props: BadgeProps, ref) => {
       ['data-outline']: outline,
       ['data-hidden']: invisible,
       ['data-independent']: !children,
-      ['data-placement']: children ? placement : undefined
+      ['data-placement']: children ? placement : undefined,
+      ['data-size']: size
     };
-  }, [color, shape, compact, isOneChar, outline, invisible, children, placement]);
+  }, [color, shape, compact, isOneChar, outline, invisible, children, placement, size]);
 
   if (!children) {
     return (

--- a/src/Badge/styles/_variables.scss
+++ b/src/Badge/styles/_variables.scss
@@ -1,9 +1,38 @@
 .rs-badge {
+  // Size variables (base md = 0.75rem)
+  --rs-badge-font-size-xs: 0.625rem; // 10px
+  --rs-badge-font-size-sm: 0.6875rem; // 11px
+  --rs-badge-font-size-md: 0.75rem; // 12px
+  --rs-badge-font-size-lg: 0.875rem; // 14px
+  --rs-badge-font-size-xl: 1rem; // 16px
+
+  --rs-badge-line-height-xs: 0.875rem; // 14px
+  --rs-badge-line-height-sm: 0.9375rem; // 15px
+  --rs-badge-line-height-md: 1rem; // 16px
+  --rs-badge-line-height-lg: 1.125rem; // 18px
+  --rs-badge-line-height-xl: 1.25rem; // 20px
+
+  // One char size variables (for single character badges)
+  --rs-badge-one-char-size-xs: 1rem; // 16px
+  --rs-badge-one-char-size-sm: 1.125rem; // 18px
+  --rs-badge-one-char-size-md: 1.25rem; // 20px
+  --rs-badge-one-char-size-lg: 1.5rem; // 24px
+  --rs-badge-one-char-size-xl: 1.75rem; // 28px
+
+  // Dot size variables (for empty badges)
+  --rs-badge-dot-size-xs: 0.375rem; // 6px
+  --rs-badge-dot-size-sm: 0.5rem; // 8px
+  --rs-badge-dot-size-md: 0.625rem; // 10px
+  --rs-badge-dot-size-lg: 0.75rem; // 12px
+  --rs-badge-dot-size-xl: 0.875rem; // 14px
+
   --rs-badge-offset-x: 5%;
   --rs-badge-offset-y: 5%;
   --rs-badge-move: var(--rs-badge-offset, 40%);
-  --rs-badge-one-char-size: 20px;
-  --rs-badge-dot-size: 10px;
+  --rs-badge-one-char-size: var(--rs-badge-one-char-size-md);
+  --rs-badge-dot-size: var(--rs-badge-dot-size-md);
+  --rs-badge-font-size: var(--rs-badge-font-size-md);
+  --rs-badge-line-height: var(--rs-badge-line-height-md);
 
   --rs-badge-transform-top-start: translate(calc(-1 * var(--rs-badge-move)), calc(-1 * var(--rs-badge-move)));
   --rs-badge-transform-top-end: translate(var(--rs-badge-move), calc(-1 * var(--rs-badge-move)));

--- a/src/Badge/styles/index.scss
+++ b/src/Badge/styles/index.scss
@@ -21,8 +21,8 @@
     background-color: var(--rs-badge-bg);
     color: var(--rs-badge-text);
     border-radius: var(--rs-radius-full);
-    font-size: var(--rs-font-size-xs);
-    line-height: 1rem;
+    font-size: var(--rs-badge-font-size);
+    line-height: var(--rs-badge-line-height);
     padding-inline: 0.3125rem;
     transition: opacity 0.3s ease-in-out;
   }
@@ -31,6 +31,7 @@
   &[data-one-char='true'][data-independent='true'] {
     width: var(--rs-badge-one-char-size);
     height: var(--rs-badge-one-char-size);
+    line-height: var(--rs-badge-one-char-size);
   }
 
   &-content {
@@ -95,5 +96,16 @@ $badge-spectrum: 'red', 'orange', 'yellow', 'green', 'cyan', 'blue', 'violet', '
 @each $color in $badge-spectrum {
   .rs-badge[data-color='#{$color}'] {
     --rs-badge-bg: var(--rs-#{$color}-500);
+  }
+}
+
+// Size classes
+$badge-sizes: 'xs', 'sm', 'md', 'lg', 'xl';
+@each $size in $badge-sizes {
+  .rs-badge[data-size='#{$size}'] {
+    --rs-badge-font-size: var(--rs-badge-font-size-#{$size});
+    --rs-badge-line-height: var(--rs-badge-line-height-#{$size});
+    --rs-badge-one-char-size: var(--rs-badge-one-char-size-#{$size});
+    --rs-badge-dot-size: var(--rs-badge-dot-size-#{$size});
   }
 }

--- a/src/Badge/test/Badge.spec.tsx
+++ b/src/Badge/test/Badge.spec.tsx
@@ -110,4 +110,18 @@ describe('Badge', () => {
       expect(container.firstChild).to.have.attr('data-placement', placement);
     });
   });
+
+  it('Should render with default size', () => {
+    const { container } = render(<Badge content={6} />);
+    expect(container.firstChild).to.have.attr('data-size', 'md');
+  });
+
+  it('Should render with custom size', () => {
+    const sizes: any = ['xs', 'sm', 'md', 'lg', 'xl'];
+
+    sizes.forEach(size => {
+      const { container } = render(<Badge content={6} size={size} />);
+      expect(container.firstChild).to.have.attr('data-size', size);
+    });
+  });
 });


### PR DESCRIPTION
This pull request adds support for different sizes to the `Badge` component, allowing users to specify the badge size via a new `size` prop. The implementation includes updates to the component logic, SCSS variables and styles, documentation in both English and Chinese, and comprehensive tests.

**Badge size support:**

* Added a new `size` prop to the `Badge` component (`src/Badge/Badge.tsx`) that accepts `'xs'`, `'sm'`, `'md'`, `'lg'`, or `'xl'`, defaulting to `'md'`. The prop is reflected in the rendered DOM as a `data-size` attribute. [[1]](diffhunk://#diff-6c71229a85da7e9dd8ba4c89707d315d1157e04b477afa2a2de14210d0246606L11-R11) [[2]](diffhunk://#diff-6c71229a85da7e9dd8ba4c89707d315d1157e04b477afa2a2de14210d0246606R52-R56) [[3]](diffhunk://#diff-6c71229a85da7e9dd8ba4c89707d315d1157e04b477afa2a2de14210d0246606R89) [[4]](diffhunk://#diff-6c71229a85da7e9dd8ba4c89707d315d1157e04b477afa2a2de14210d0246606L114-R123)
* Introduced new SCSS variables for badge font size, line height, one-char size, and dot size for each supported size, and added size-specific CSS rules to apply these variables based on the `data-size` attribute (`src/Badge/styles/_variables.scss`, `src/Badge/styles/index.scss`). [[1]](diffhunk://#diff-aa76182d3211733100eb6a6c0f0a1b552536fc6e04e1d2b4ecd2e2999b063f9eR2-R35) [[2]](diffhunk://#diff-b9985229a83a6d5c6a7f2dfd1b6c7f235d3a4a98a08674ae0744f6fec05fcd10L24-R25) [[3]](diffhunk://#diff-b9985229a83a6d5c6a7f2dfd1b6c7f235d3a4a98a08674ae0744f6fec05fcd10R34) [[4]](diffhunk://#diff-b9985229a83a6d5c6a7f2dfd1b6c7f235d3a4a98a08674ae0744f6fec05fcd10R101-R111)

**Documentation updates:**

* Updated the English and Chinese documentation to describe the new `size` prop, including usage examples and prop tables (`docs/pages/components/badge/en-US/index.md`, `docs/pages/components/badge/zh-CN/index.md`, `docs/pages/components/badge/fragments/size.md`). [[1]](diffhunk://#diff-2c2f67448b97b33c236ed43ef4e6146e7829502d992114ed2a26341ee7c9894aR29-R34) [[2]](diffhunk://#diff-2c2f67448b97b33c236ed43ef4e6146e7829502d992114ed2a26341ee7c9894aR70) [[3]](diffhunk://#diff-884082f20f019111d6cd0699951eb6dca80d8dbe6b532043b25613cf9f579b00R29-R34) [[4]](diffhunk://#diff-884082f20f019111d6cd0699951eb6dca80d8dbe6b532043b25613cf9f579b00R70) [[5]](diffhunk://#diff-a972a4d152b28dac77d0a41950dc15077f90bbeb79e7bd960e99674398eb96d5R1-R39)

**Testing:**

* Added tests to verify that the `Badge` renders with the correct `data-size` attribute for both the default and all custom sizes (`src/Badge/test/Badge.spec.tsx`).