### PR TITLE
feat(picker): align badge size with picker size

### DIFF
--- a/src/CheckPicker/CheckPicker.tsx
+++ b/src/CheckPicker/CheckPicker.tsx
@@ -93,6 +93,7 @@ const CheckPicker = forwardRef<'div', CheckPickerProps>(
       searchable = true,
       sticky,
       style,
+      size,
       toggleAs,
       value: valueProp,
       valueKey = 'value',
@@ -268,6 +269,7 @@ const CheckPicker = forwardRef<'div', CheckPickerProps>(
           valueKey={valueKey}
           labelKey={labelKey}
           prefix={prefix}
+          badgeSize={size}
         />
       );
     }
@@ -389,6 +391,7 @@ const CheckPicker = forwardRef<'div', CheckPickerProps>(
           placement={placement}
           inputValue={value}
           focusItemValue={focusItemValue}
+          size={size}
           {...rest}
         >
           {selectedElement || locale?.placeholder}

--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -106,6 +106,7 @@ const CheckTreePicker = forwardRef<'div', CheckTreePickerProps>((props, ref) => 
     showIndentLine,
     searchable = true,
     style,
+    size,
     valueKey = 'value',
     value: controlledValue,
     virtualized = false,
@@ -313,6 +314,7 @@ const CheckTreePicker = forwardRef<'div', CheckTreePickerProps>((props, ref) => 
         prefix={prefix}
         cascade={cascade}
         locale={locale}
+        badgeSize={size}
       />
     );
     if (isFunction(renderValue)) {
@@ -359,6 +361,7 @@ const CheckTreePicker = forwardRef<'div', CheckTreePickerProps>((props, ref) => 
         placement={placement}
         inputValue={value}
         focusItemValue={focusItemValue}
+        size={size}
         {...rest}
       >
         {selectedElement || locale?.placeholder}

--- a/src/MultiCascader/MultiCascader.tsx
+++ b/src/MultiCascader/MultiCascader.tsx
@@ -102,6 +102,7 @@ const MultiCascader = forwardRef<'div', MultiCascaderProps>(
       renderValue,
       searchable = true,
       style,
+      size,
       toggleAs,
       uncheckableItemValues = emptyArray,
       value: valueProp,
@@ -338,6 +339,7 @@ const MultiCascader = forwardRef<'div', MultiCascaderProps>(
           prefix={prefix}
           cascade={cascade}
           locale={locale}
+          badgeSize={size}
         />
       );
     }
@@ -398,6 +400,7 @@ const MultiCascader = forwardRef<'div', MultiCascaderProps>(
           active={active}
           placement={placement}
           inputValue={value}
+          size={size}
           {...rest}
         >
           {selectedElement || locale?.placeholder}

--- a/src/internals/Picker/SelectedElement.tsx
+++ b/src/internals/Picker/SelectedElement.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import Badge from '../../Badge';
 import { reactToString } from '@/internals/utils';
 import { PickerLocale } from '../../locales';
+import type { Size } from '@/internals/types';
 
 export interface SelectedElementProps {
+  badgeSize?: Size;
   selectedItems: any[];
   valueKey: string;
   labelKey: string;
@@ -23,7 +25,8 @@ const SelectedElement = (props: SelectedElementProps) => {
     childrenKey = 'children',
     countable,
     cascade,
-    locale
+    locale,
+    badgeSize
   } = props;
 
   const count = selectedItems.length;
@@ -64,6 +67,7 @@ const SelectedElement = (props: SelectedElementProps) => {
           className={prefix('value-count')}
           title={`${count}`}
           content={count > 99 ? '99+' : count}
+          size={badgeSize}
         />
       ) : null}
     </React.Fragment>


### PR DESCRIPTION
This pull request introduces a new `size` prop to the `CheckPicker`, `CheckTreePicker`, and `MultiCascader` components, and ensures that this prop is passed down to the badge element that displays the count of selected items. This allows for consistent sizing of badges across these components based on the picker size.

**Support for size prop in picker components:**

* Added a `size` prop to `CheckPicker`, `CheckTreePicker`, and `MultiCascader`, and passed it to their respective badge elements for consistent badge sizing. (`src/CheckPicker/CheckPicker.tsx`, `src/CheckTreePicker/CheckTreePicker.tsx`, `src/MultiCascader/MultiCascader.tsx`) [[1]](diffhunk://#diff-24415b62298f3c3b22e4dd6a7c6043b14459e23907b0086a567f4088fea97900R96) [[2]](diffhunk://#diff-24415b62298f3c3b22e4dd6a7c6043b14459e23907b0086a567f4088fea97900R272) [[3]](diffhunk://#diff-24415b62298f3c3b22e4dd6a7c6043b14459e23907b0086a567f4088fea97900R394) [[4]](diffhunk://#diff-8b045fcb92febebcc963e692968b0df8c8c6aa3739fff8f6c70531df07bcad5bR109) [[5]](diffhunk://#diff-8b045fcb92febebcc963e692968b0df8c8c6aa3739fff8f6c70531df07bcad5bR317) [[6]](diffhunk://#diff-8b045fcb92febebcc963e692968b0df8c8c6aa3739fff8f6c70531df07bcad5bR364) [[7]](diffhunk://#diff-c1d8638909b4e501d226bc3e43d5bdf1d3cbcf512a554c4c4a87d649696fe2a9R105) [[8]](diffhunk://#diff-c1d8638909b4e501d226bc3e43d5bdf1d3cbcf512a554c4c4a87d649696fe2a9R342) [[9]](diffhunk://#diff-c1d8638909b4e501d226bc3e43d5bdf1d3cbcf512a554c4c4a87d649696fe2a9R403)

**Badge and selected element improvements:**

* Updated the `SelectedElement` component to accept a new `badgeSize` prop (typed as `Size`) and use it when rendering the `Badge`, ensuring the badge size matches the picker size. (`src/internals/Picker/SelectedElement.tsx`) [[1]](diffhunk://#diff-256937350c6dc327992d4e6edf059311f7e550fd2e80be8d12ca18d266d994efR5-R8) [[2]](diffhunk://#diff-256937350c6dc327992d4e6edf059311f7e550fd2e80be8d12ca18d266d994efL26-R29) [[3]](diffhunk://#diff-256937350c6dc327992d4e6edf059311f7e550fd2e80be8d12ca18d266d994efR70)