### PR TITLE
fix(pagination): align group text size with size prop

### DIFF
--- a/src/Pagination/styles/_pagination-group.scss
+++ b/src/Pagination/styles/_pagination-group.scss
@@ -1,10 +1,31 @@
 @use '../../internals/Box/styles/index' as box;
 
 .rs-pagination-group {
-  --pagination-group-gap: calc(var(--rs-spacing) * 2.5);
+  --rs-pagination-font-size-xs: var(--rs-font-size-xs);
+  --rs-pagination-font-size-sm: var(--rs-font-size-sm);
+  --rs-pagination-font-size-md: var(--rs-font-size-sm);
+  --rs-pagination-font-size-lg: var(--rs-font-size-md);
+  --rs-pagination-group-gap: calc(var(--rs-spacing) * 2.5);
+
+  &-total,
+  &-skip {
+    font-size: var(--rs-pagination-font-size-md);
+  }
+
+  $sizes: (xs, sm, md, lg);
+
+  @each $size in $sizes {
+    &[data-size='#{$size}'] {
+      .rs-pagination-group-total,
+      .rs-pagination-group-skip {
+        font-size: var(--rs-pagination-font-size-#{$size});
+      }
+    }
+  }
+
   display: flex;
   align-items: center;
-  gap: var(--pagination-group-gap);
+  gap: var(--rs-pagination-group-gap);
 
   &-grow {
     flex-grow: 1;

--- a/src/Pagination/test/PaginationGroup.styles.spec.tsx
+++ b/src/Pagination/test/PaginationGroup.styles.spec.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PaginationGroup, { PaginationGroupProps } from '../PaginationGroup';
+
+import '../styles/index.scss';
+
+describe('PaginationGroup styles', () => {
+  const FONT_SIZES: Record<NonNullable<PaginationGroupProps['size']>, string> = {
+    xs: '12px',
+    sm: '14px',
+    md: '14px',
+    lg: '16px'
+  };
+
+  const sizes: NonNullable<PaginationGroupProps['size']>[] = ['xs', 'sm', 'md', 'lg'];
+
+  sizes.forEach(size => {
+    it(`Should render the correct font-size for total and skip when size is ${size}`, () => {
+      render(
+        <PaginationGroup
+          layout={['total', 'skip']}
+          total={100}
+          size={size}
+          locale={{ total: 'Total Rows: {0}', skip: 'Go to {0} page' }}
+        />
+      );
+
+      expect(screen.getByText('Go to')).to.have.style('font-size', FONT_SIZES[size]);
+      expect(screen.getByText('Total Rows:')).to.have.style('font-size', FONT_SIZES[size]);
+    });
+  });
+});


### PR DESCRIPTION
This pull request enhances the `PaginationGroup` component's styling by making its font sizes responsive to the `size` prop and adds tests to ensure the correct font sizes are applied. The main changes are grouped into style improvements and test coverage.

**Style improvements:**

* Updated `src/Pagination/styles/_pagination-group.scss` to define font size CSS variables for each size (`xs`, `sm`, `md`, `lg`) and apply them to `.rs-pagination-group-total` and `.rs-pagination-group-skip` elements based on the `data-size` attribute. This ensures that the font size of these elements dynamically matches the component's `size` prop.

**Test coverage:**

* Added a new test file `src/Pagination/test/PaginationGroup.styles.spec.tsx` that renders the `PaginationGroup` with different `size` props and asserts that the `total` and `skip` elements receive the correct font sizes. This helps prevent regressions in the responsive font size behavior.