### PR TITLE
fix(modal): derive overflow height from DOM

### DIFF
--- a/src/Modal/utils.ts
+++ b/src/Modal/utils.ts
@@ -23,7 +23,6 @@ export const useBodyStyles = (
   const updateBodyStyles = useCallback(
     (_event?: EventInit, entering?: boolean) => {
       const dialog = ref.current;
-      const scrollHeight = dialog ? dialog.scrollHeight : 0;
 
       const styles: React.CSSProperties = {
         overflow: 'auto'
@@ -40,13 +39,35 @@ export const useBodyStyles = (
         headerHeight = headerDOM ? getHeight(headerDOM) + headerHeight : headerHeight;
         footerHeight = footerDOM ? getHeight(footerDOM) + footerHeight : footerHeight;
 
+        // Get the actual margin from the modal element itself (.rs-modal)
+        const computedStyle = window.getComputedStyle(dialog);
+        const marginTop = parseFloat(computedStyle.marginTop) || 0;
+        const marginBottom = parseFloat(computedStyle.marginBottom) || 0;
+        const dialogMargin = marginTop + marginBottom;
+
+        // Get padding from the wrapper if needed
+        const wrapper = dialog.parentElement;
+        let wrapperPadding = 0;
+        if (wrapper) {
+          const wrapperStyle = window.getComputedStyle(wrapper);
+          const paddingTop = parseFloat(wrapperStyle.paddingTop) || 0;
+          const paddingBottom = parseFloat(wrapperStyle.paddingBottom) || 0;
+          wrapperPadding = paddingTop + paddingBottom;
+        }
+
+        // Add extra space during entering animation (10px buffer)
+        const extraSpace = entering ? 10 : 0;
+
         /**
-         * Header height + Footer height + Dialog margin
+         * Header height + Footer height + Dialog margin + Wrapper padding + Extra space
          */
-        const excludeHeight = headerHeight + footerHeight + (entering ? 70 : 60);
+        const excludeHeight =
+          headerHeight + footerHeight + dialogMargin + wrapperPadding + extraSpace;
+
         const bodyHeight = getHeight(window) - excludeHeight;
-        const maxHeight = scrollHeight >= bodyHeight ? bodyHeight : scrollHeight;
-        styles.maxHeight = maxHeight;
+
+        // Always set maxHeight to available space, let browser handle content that's smaller
+        styles.maxHeight = bodyHeight;
       }
 
       setBodyStyles(styles);


### PR DESCRIPTION
This pull request enhances the calculation of the modal body’s maximum height to more accurately account for the modal’s margins, wrapper padding, and animation buffer. This ensures that the modal content fits better within the viewport, especially during animations and when the modal or its wrapper have custom styles.

**Improvements to modal body sizing:**

* The calculation for `maxHeight` in the modal body now includes the modal’s top and bottom margins, the wrapper’s top and bottom paddings, and an extra buffer during the entering animation for smoother transitions.
* The previous logic that relied on the modal’s scroll height to determine `maxHeight` has been removed, and the browser is now allowed to handle content that is smaller than the available space.