### PR TITLE
fix(pagination): reorder group layout styles

### DIFF
--- a/src/Pagination/styles/_pagination-group.scss
+++ b/src/Pagination/styles/_pagination-group.scss
@@ -7,6 +7,10 @@
   --rs-pagination-font-size-lg: var(--rs-font-size-md);
   --rs-pagination-group-gap: calc(var(--rs-spacing) * 2.5);
 
+  display: flex;
+  align-items: center;
+  gap: var(--rs-pagination-group-gap);
+
   &-total,
   &-skip {
     font-size: var(--rs-pagination-font-size-md);
@@ -22,10 +26,6 @@
       }
     }
   }
-
-  display: flex;
-  align-items: center;
-  gap: var(--rs-pagination-group-gap);
 
   &-grow {
     flex-grow: 1;


### PR DESCRIPTION
This pull request makes a minor adjustment to the layout styling in the `src/Pagination/styles/_pagination-group.scss` file. The main change is moving the flexbox display and alignment properties from a lower block to a higher level in the SCSS hierarchy, which will help ensure consistent layout for the pagination group.

Layout and styling adjustment:

* Moved the `display: flex`, `align-items: center`, and `gap` properties from a lower block up to the root of the pagination group styles to standardize the layout structure. [[1]](diffhunk://#diff-62d187d94d696abda0976615cd3ba4ecf3f7d742b70fb8d1a6165d927d4d1c2dR10-R13) [[2]](diffhunk://#diff-62d187d94d696abda0976615cd3ba4ecf3f7d742b70fb8d1a6165d927d4d1c2dL26-L29)