### PR TITLE
feat(Modal): add support for bodyFill

### DIFF
--- a/docs/pages/components/modal/en-US/index.md
+++ b/docs/pages/components/modal/en-US/index.md
@@ -64,6 +64,12 @@ Embed forms within a Modal, suitable for data collection and submission operatio
 
 <!--{include:`form.md`}-->
 
+### Custom layout
+
+Create a custom Modal with a split-panel layout, featuring a branded left side and a form on the right side.
+
+<!--{include:`custom-layout.md`}-->
+
 ### useDialog
 
 For common dialog scenarios, you can use [useDialog](/components/use-dialog) to simplify dialog usage.
@@ -115,6 +121,7 @@ On mobile devices, the Modal's maximum width will stretch to fill the screen whi
 | autoFocus         | boolean `(true)`                                                   | When set to true, the Modal is opened and is automatically focused on its own, accessible to screen readers                                                                            |
 | backdrop          | unions: boolean \| 'static'                                        | When set to true, the Modal will display the background when it is opened. Clicking on the background will close the Modal. If you do not want to close the Modal, set it to 'static'. |
 | backdropClassName | string                                                             | Add an optional extra class name to .modal-backdrop It could end up looking like class="modal-backdrop foo-modal-backdrop in".                                                         |
+| bodyFill          | boolean                                                            | Remove default padding from the dialog and body so the content can occupy the full height. Useful for creating custom layouts with full-width/height content.                          |
 | centered          | boolean                                                            | Align the modal vertically in the center of the page.                                                                                                                                  |
 | children          | ReactNode                                                          | Modal content                                                                                                                                                                          |
 | classPrefix       | string `('modal')`                                                 | The prefix of the component CSS class                                                                                                                                                  |

--- a/docs/pages/components/modal/fragments/custom-layout.md
+++ b/docs/pages/components/modal/fragments/custom-layout.md
@@ -1,0 +1,125 @@
+<!--start-code-->
+
+```js
+import {
+  Modal,
+  Button,
+  ButtonToolbar,
+  PasswordInput,
+  Form,
+  HStack,
+  Text,
+  Box,
+  Image,
+  IconButton,
+  Link
+} from 'rsuite';
+
+import CloseIcon from '@rsuite/icons/Close';
+
+const App = () => {
+  const [open, setOpen] = React.useState(false);
+  const [formValue, setFormValue] = React.useState({
+    username: '',
+    password: ''
+  });
+
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  const handleSubmit = () => {
+    console.log('Form submitted:', formValue);
+    handleClose();
+  };
+
+  return (
+    <>
+      <ButtonToolbar>
+        <Button onClick={handleOpen}>Open Custom Modal</Button>
+      </ButtonToolbar>
+
+      <Modal open={open} onClose={handleClose} size="lg" bodyFill>
+        <Modal.Body>
+          <HStack align="normal">
+            <Box
+              bg="linear-gradient(135deg, #2c3e75 0%, #1a2850 100%)"
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              position="relative"
+              width="50%"
+            >
+              <Image
+                src="/images/react-suite.png"
+                alt="Logo"
+                height={120}
+                filter="brightness(0) invert(1)"
+              />
+            </Box>
+
+            <Box
+              flex={1}
+              p={50}
+              minHeight={500}
+              display="flex"
+              flexDirection="column"
+              justifyContent="center"
+            >
+              <IconButton
+                onClick={handleClose}
+                style={{
+                  position: 'absolute',
+                  top: 10,
+                  right: 10,
+                  cursor: 'pointer'
+                }}
+                icon={<CloseIcon />}
+                appearance="subtle"
+                aria-label="Close"
+              />
+
+              <div>
+                <Text size="2xl" mb={4}>
+                  Welcome back
+                </Text>
+                <Text muted mb={20}>
+                  Sign in to continue.
+                </Text>
+
+                <Form fluid formValue={formValue} onChange={setFormValue}>
+                  <Form.Group controlId="username">
+                    <Form.ControlLabel>Username</Form.ControlLabel>
+                    <Form.Control name="username" placeholder="Enter your username" size="lg" />
+                  </Form.Group>
+
+                  <Form.Group controlId="password">
+                    <Form.ControlLabel>Password</Form.ControlLabel>
+                    <Form.Control
+                      accepter={PasswordInput}
+                      name="password"
+                      placeholder="Enter your password"
+                      size="lg"
+                    />
+                  </Form.Group>
+                  <Button appearance="primary" block size="lg" onClick={handleSubmit} mt={20}>
+                    Sign in
+                  </Button>
+                </Form>
+
+                <HStack mt={20} justify="center">
+                  <Text>Don&apos;t have an account?</Text>
+                  <Link href="#">Create one</Link>
+                </HStack>
+              </div>
+            </Box>
+          </HStack>
+        </Modal.Body>
+      </Modal>
+    </>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/modal/index.tsx
+++ b/docs/pages/components/modal/index.tsx
@@ -6,6 +6,7 @@ import ImportGuide from '@/components/ImportGuide';
 import {
   ButtonToolbar,
   Button,
+  IconButton,
   Modal,
   Toggle,
   SegmentedControl,
@@ -16,10 +17,15 @@ import {
   Form,
   Input,
   SelectPicker,
-  HStack,
   Textarea,
-  Text
+  HStack,
+  Text,
+  Box,
+  Image,
+  Link
 } from 'rsuite';
+import CloseIcon from '@rsuite/icons/Close';
+
 const inDocsComponents = {
   'import-guide': () => <ImportGuide components={['Modal']} />,
   'example-responsive': () => <Simulation example="responsive" componentName="modal" />
@@ -33,6 +39,7 @@ export default function Page() {
         Loader,
         ButtonToolbar,
         Button,
+        IconButton,
         Modal,
         Toggle,
         SegmentedControl,
@@ -40,12 +47,16 @@ export default function Page() {
         Input,
         HStack,
         Text,
+        Link,
+        Box,
+        Image,
         Textarea,
         SelectPicker,
         RemindFillIcon,
         PasswordInput,
         PasswordStrengthMeter,
-        Placeholder
+        Placeholder,
+        CloseIcon
       }}
     />
   );

--- a/docs/pages/components/modal/zh-CN/index.md
+++ b/docs/pages/components/modal/zh-CN/index.md
@@ -64,6 +64,12 @@
 
 <!--{include:`form.md`}-->
 
+### 自定义布局
+
+创建一个自定义的 Modal,采用分栏布局设计,左侧展示品牌信息,右侧为登录表单。
+
+<!--{include:`custom-layout.md`}-->
+
 ### 使用 useDialog
 
 对于常见的对话框场景，可以使用 [useDialog](/zh/components/use-dialog) 来简化对话框的使用。
@@ -115,6 +121,7 @@
 | autoFocus         | boolean `(true)`                                                   | 当设置为 true, Modal 被打开是自动焦点移到其自身,辅助屏幕阅读器容易访问                               |
 | backdrop          | unions: boolean \| 'static'                                        | 当设置为 true，Modal 打开时会显示背景，点击背景会关闭 Modal，如果不想关闭 Modal，可以设置为 'static' |
 | backdropClassName | string                                                             | 应用于 backdrop DOM 节点的 css class                                                                 |
+| bodyFill          | boolean                                                            | 移除对话框和主体的默认内边距，使内容可以占据全部高度。适用于创建全宽/全高内容的自定义布局。          |
 | centered          | boolean                                                            | 将模态框在页面垂直方向上居中对齐。                                                                   |
 | children          | ReactNode                                                          | Modal 的内容                                                                                         |
 | classPrefix       | string `('modal')`                                                 | 组件 CSS 类的前缀                                                                                    |

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -57,6 +57,12 @@ export interface ModalProps
 
   /** Custom close button, used when rendered as a Drawer */
   closeButton?: React.ReactNode | boolean;
+
+  /**
+   * Remove default padding from the dialog and body so the content can occupy the full height.
+   * Useful for creating custom layouts with full-width/height content like split panels or image galleries.
+   */
+  bodyFill?: boolean;
 }
 
 const Subcomponents = {
@@ -81,6 +87,7 @@ const Modal = forwardRef<'div', ModalProps, typeof Subcomponents>((props, ref) =
     'aria-describedby': ariaDescribedby,
     backdropClassName,
     backdrop = true,
+    bodyFill,
     className,
     classPrefix = 'modal',
     centered,
@@ -106,7 +113,10 @@ const Modal = forwardRef<'div', ModalProps, typeof Subcomponents>((props, ref) =
   const inClass = { in: open && !animation };
   const { merge, prefix } = useStyles(classPrefix);
   const [shake, setShake] = useState(false);
-  const classes = merge(className, prefix({ full, [size]: modalSizes.includes(size) }));
+  const classes = merge(
+    className,
+    prefix({ full, fill: bodyFill, [size]: modalSizes.includes(size) })
+  );
   const dialogRef = useRef<HTMLElement>(null);
   const transitionEndListener = useRef<{ off: () => void } | null>(null);
 

--- a/src/Modal/styles/index.scss
+++ b/src/Modal/styles/index.scss
@@ -61,6 +61,14 @@
     }
   }
 
+  &.rs-modal-fill {
+    .rs-modal-dialog,
+    .rs-modal-body {
+      margin: 0;
+      padding: 0;
+    }
+  }
+
   // Actual modal
   .rs-modal-dialog {
     position: relative;

--- a/src/Modal/test/Modal.spec.tsx
+++ b/src/Modal/test/Modal.spec.tsx
@@ -268,6 +268,43 @@ describe('Modal', () => {
     });
   });
 
+  describe('bodyFill', () => {
+    it('Should have .rs-modal-fill class when bodyFill=true', () => {
+      render(
+        <Modal open bodyFill>
+          <Modal.Body>Content</Modal.Body>
+        </Modal>
+      );
+
+      expect(screen.getByRole('dialog')).to.have.class('rs-modal-fill');
+    });
+
+    it('Should remove padding from dialog and body when bodyFill=true', () => {
+      render(
+        <Modal open bodyFill>
+          <Modal.Body>Content</Modal.Body>
+        </Modal>
+      );
+
+      const dialog = screen.getByRole('document');
+      const body = screen.getByText('Content');
+
+      expect(dialog).to.have.style('padding', '0px');
+      expect(body).to.have.style('margin', '0px');
+      expect(body).to.have.style('padding', '0px');
+    });
+
+    it('Should not have .rs-modal-fill class when bodyFill is not set', () => {
+      render(
+        <Modal open>
+          <Modal.Body>Content</Modal.Body>
+        </Modal>
+      );
+
+      expect(screen.getByRole('dialog')).to.not.have.class('rs-modal-fill');
+    });
+  });
+
   describe('a11y', () => {
     it('Should render an ARIA dialog with given title as its accessible name', () => {
       const title = 'Attention';


### PR DESCRIPTION
This pull request introduces a new `bodyFill` prop to the `Modal` component, enabling the creation of custom, full-bleed layouts by removing default padding and margins from the modal dialog and body. The documentation is updated with a new example demonstrating a split-panel modal layout, and tests are added to ensure the new feature works as intended.

**Modal component enhancements:**

- Added a new `bodyFill` prop to `Modal`, which removes default padding from the dialog and body, allowing content to occupy the full modal area. This is useful for building custom layouts such as split panels or image galleries. (`src/Modal/Modal.tsx` [[1]](diffhunk://#diff-1be7e63e7570ebe66e4559909557f52a74c7eaef41906bb9e6078e0d376201c3R60-R65) [[2]](diffhunk://#diff-1be7e63e7570ebe66e4559909557f52a74c7eaef41906bb9e6078e0d376201c3R90) [[3]](diffhunk://#diff-1be7e63e7570ebe66e4559909557f52a74c7eaef41906bb9e6078e0d376201c3L109-R119)
- Updated modal styles to apply zero padding and margin when `bodyFill` is enabled, using the `.rs-modal-fill` class. (`src/Modal/styles/index.scss` [src/Modal/styles/index.scssR64-R71](diffhunk://#diff-b599dcd71307279f9232b943ebf682f77515896c0b8f80bdf22cfd3092765a15R64-R71))

**Documentation updates:**

- Added a new section and example in both English and Chinese documentation pages demonstrating a custom split-panel modal layout using the new `bodyFill` prop. (`docs/pages/components/modal/en-US/index.md` [[1]](diffhunk://#diff-fdcfadd7dc168282891c7d407952cc77c72b7fddc5a6dbba25e19a86022aa885R67-R72) [[2]](diffhunk://#diff-fdcfadd7dc168282891c7d407952cc77c72b7fddc5a6dbba25e19a86022aa885R124); `docs/pages/components/modal/zh-CN/index.md` [[3]](diffhunk://#diff-2d765b6dca31c066d23d55d18bd8b9f364bfc74531e6e6083e3def5ceee4de3eR67-R72) [[4]](diffhunk://#diff-2d765b6dca31c066d23d55d18bd8b9f364bfc74531e6e6083e3def5ceee4de3eR124); `docs/pages/components/modal/fragments/custom-layout.md` [[5]](diffhunk://#diff-21701674b1f36f57abd51ad6d69743c44b6546874f3679acc868e5dfcedee6f3R1-R125)
- Updated imports in the documentation code to support the new example. (`docs/pages/components/modal/index.tsx` [[1]](diffhunk://#diff-aa249359517ba54767c5f05ae4678cc68f757b0838639115104dbd40c5f6741bR9) [[2]](diffhunk://#diff-aa249359517ba54767c5f05ae4678cc68f757b0838639115104dbd40c5f6741bL19-R28) [[3]](diffhunk://#diff-aa249359517ba54767c5f05ae4678cc68f757b0838639115104dbd40c5f6741bR42-R59)

**Testing:**

- Added tests to verify that enabling `bodyFill` applies the correct class and removes padding/margins from the modal dialog and body, and that the class is not present when `bodyFill` is not set. (`src/Modal/test/Modal.spec.tsx` [src/Modal/test/Modal.spec.tsxR271-R307](diffhunk://#diff-f9866a31a8918ec4917ed48868c0d73c0b45e5644b8b92992fd057c06b5e0765R271-R307))