### PR TITLE
docs(jsonld): add breadcrumb structured data

### DIFF
--- a/docs/components/layout/Head.tsx
+++ b/docs/components/layout/Head.tsx
@@ -1,18 +1,25 @@
 import React from 'react';
 import NextHead from 'next/head';
 import { useRouter } from 'next/router';
+import { createBreadcrumbSchema, serializeJsonLd } from '@/utils/jsonld';
 
 interface HeadProps {
   description: string;
   title: string;
   children?: React.ReactNode;
+  /** Breadcrumb items for breadcrumb navigation JSON-LD schema */
+  breadcrumbs?: Array<{ name: string; url?: string }>;
 }
 
 export default function Head(props: HeadProps) {
-  const { description, title, children } = props;
+  const { description, title, children, breadcrumbs } = props;
   const pageTitle = `${title} - React Suite`;
 
   const router = useRouter();
+  const currentUrl = `https://rsuitejs.com${router.asPath}`;
+
+  // Generate breadcrumb JSON-LD schema if breadcrumbs are provided
+  const jsonLdSchema = breadcrumbs ? createBreadcrumbSchema(breadcrumbs) : null;
 
   return (
     <NextHead>
@@ -29,11 +36,19 @@ export default function Head(props: HeadProps) {
       {/* Facebook */}
       <meta property="og:type" content="website" />
       <meta property="og:title" content={title} />
-      <meta property="og:url" content={`https://rsuitejs.com${router.asPath}`} />
+      <meta property="og:url" content={currentUrl} />
       <meta property="og:description" content={description} />
       <meta property="og:image" content="https://rsuitejs.com/images/logo.png" />
       <meta property="og:ttl" content="604800" />
       <link rel="shortcut icon" href="/favicon.ico" />
+
+      {/* JSON-LD Structured Data */}
+      {jsonLdSchema && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLdSchema) }}
+        />
+      )}
 
       {children}
     </NextHead>

--- a/docs/components/layout/PageContent.tsx
+++ b/docs/components/layout/PageContent.tsx
@@ -43,11 +43,7 @@ const PageContent = (props: PageContentProps) => {
   const pathname = router.pathname;
   const id = pathname.match(new RegExp(`/${category}/(\\S*)`))?.[1];
 
-  const context = require(`../../pages${pathname}${localePath}/index.md`).default;
-  const title = getTitle(context);
-  const description = getDescription(context);
-  const pageHead = <Head title={title} description={description} />;
-
+  // Find component metadata first
   let component: MenuItem;
 
   components.forEach(group => {
@@ -57,6 +53,21 @@ const PageContent = (props: PageContentProps) => {
       }
     });
   });
+
+  const context = require(`../../pages${pathname}${localePath}/index.md`).default;
+  const title = getTitle(context);
+  const description = getDescription(context);
+
+  // Generate breadcrumbs for component pages
+  const breadcrumbs = component
+    ? [
+        { name: 'Home', url: 'https://rsuitejs.com' },
+        { name: 'Components', url: 'https://rsuitejs.com/components/overview' },
+        { name: component.name }
+      ]
+    : undefined;
+
+  const pageHead = <Head title={title} description={description} breadcrumbs={breadcrumbs} />;
 
   const designHash = component?.designHash;
   const fragments = context.split(/<!--{(\S+)}-->/);

--- a/docs/pages/_document.tsx
+++ b/docs/pages/_document.tsx
@@ -1,13 +1,38 @@
 import React from 'react';
 import { Html, Head, Main, NextScript } from 'next/document';
+import {
+  createOrganizationSchema,
+  createSoftwareApplicationSchema,
+  createSoftwareSourceCodeSchema,
+  serializeJsonLd
+} from '../utils/jsonld';
 
 export default function Document() {
+  // Generate global JSON-LD schemas
+  const organizationSchema = createOrganizationSchema();
+  const softwareAppSchema = createSoftwareApplicationSchema();
+  const sourceCodeSchema = createSoftwareSourceCodeSchema();
+
   return (
     <Html>
       <Head>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@alpha" />
         {/* Import CSS for nprogress */}
         <link rel="stylesheet" type="text/css" href="/css/nprogress.css" />
+
+        {/* Global JSON-LD Structured Data */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(organizationSchema) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(softwareAppSchema) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(sourceCodeSchema) }}
+        />
 
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-3VVC8ZNFF9"></script>
         <script

--- a/docs/utils/jsonld.ts
+++ b/docs/utils/jsonld.ts
@@ -1,0 +1,237 @@
+/**
+ * JSON-LD Schema.org utilities for RSuite documentation
+ * Provides structured data for better SEO and rich snippets
+ */
+
+export interface Organization {
+  '@context': 'https://schema.org';
+  '@type': 'Organization';
+  name: string;
+  url: string;
+  logo: string;
+  sameAs: string[];
+  description?: string;
+}
+
+export interface SoftwareApplication {
+  '@context': 'https://schema.org';
+  '@type': 'SoftwareApplication';
+  name: string;
+  applicationCategory: string;
+  operatingSystem: string;
+  offers?: {
+    '@type': 'Offer';
+    price: string;
+    priceCurrency: string;
+  };
+  aggregateRating?: {
+    '@type': 'AggregateRating';
+    ratingValue: string;
+    ratingCount: string;
+  };
+}
+
+export interface WebPage {
+  '@context': 'https://schema.org';
+  '@type': 'WebPage';
+  name: string;
+  description: string;
+  url: string;
+  inLanguage?: string;
+  isPartOf?: {
+    '@type': 'WebSite';
+    name: string;
+    url: string;
+  };
+}
+
+export interface Article {
+  '@context': 'https://schema.org';
+  '@type': 'Article' | 'TechArticle';
+  headline: string;
+  description: string;
+  url: string;
+  datePublished?: string;
+  dateModified?: string;
+  author?: {
+    '@type': 'Organization';
+    name: string;
+  };
+  publisher?: {
+    '@type': 'Organization';
+    name: string;
+    logo: {
+      '@type': 'ImageObject';
+      url: string;
+    };
+  };
+  inLanguage?: string;
+}
+
+export interface BreadcrumbList {
+  '@context': 'https://schema.org';
+  '@type': 'BreadcrumbList';
+  itemListElement: Array<{
+    '@type': 'ListItem';
+    position: number;
+    name: string;
+    item?: string;
+  }>;
+}
+
+export interface SoftwareSourceCode {
+  '@context': 'https://schema.org';
+  '@type': 'SoftwareSourceCode';
+  name: string;
+  description: string;
+  codeRepository: string;
+  programmingLanguage: string;
+  runtimePlatform: string;
+  author?: {
+    '@type': 'Organization';
+    name: string;
+  };
+}
+
+/**
+ * Generate Organization schema for RSuite
+ */
+export function createOrganizationSchema(): Organization {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: 'React Suite',
+    url: 'https://rsuitejs.com',
+    logo: 'https://rsuitejs.com/images/react-suite.png',
+    sameAs: [
+      'https://github.com/rsuite/rsuite',
+      'https://x.com/reactsuite',
+      'https://www.npmjs.com/package/rsuite',
+      'https://opencollective.com/rsuite'
+    ],
+    description:
+      'A suite of React components, sensible UI design, and a friendly development experience.'
+  };
+}
+
+/**
+ * Generate SoftwareApplication schema for RSuite
+ */
+export function createSoftwareApplicationSchema(): SoftwareApplication {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'React Suite',
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: 'Cross-platform',
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD'
+    }
+  };
+}
+
+/**
+ * Generate WebPage schema
+ */
+export function createWebPageSchema(options: {
+  title: string;
+  description: string;
+  url: string;
+  language?: string;
+}): WebPage {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: options.title,
+    description: options.description,
+    url: options.url,
+    inLanguage: options.language || 'en',
+    isPartOf: {
+      '@type': 'WebSite',
+      name: 'React Suite Documentation',
+      url: 'https://rsuitejs.com'
+    }
+  };
+}
+
+/**
+ * Generate Article schema for documentation pages
+ */
+export function createArticleSchema(options: {
+  title: string;
+  description: string;
+  url: string;
+  datePublished?: string;
+  dateModified?: string;
+  language?: string;
+}): Article {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: options.title,
+    description: options.description,
+    url: options.url,
+    datePublished: options.datePublished,
+    dateModified: options.dateModified,
+    author: {
+      '@type': 'Organization',
+      name: 'React Suite Team'
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'React Suite',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://rsuitejs.com/images/react-suite.png'
+      }
+    },
+    inLanguage: options.language || 'en'
+  };
+}
+
+/**
+ * Generate BreadcrumbList schema
+ */
+export function createBreadcrumbSchema(
+  items: Array<{ name: string; url?: string }>
+): BreadcrumbList {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: item.url
+    }))
+  };
+}
+
+/**
+ * Generate SoftwareSourceCode schema
+ */
+export function createSoftwareSourceCodeSchema(): SoftwareSourceCode {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareSourceCode',
+    name: 'React Suite',
+    description:
+      'A suite of React components, sensible UI design, and a friendly development experience.',
+    codeRepository: 'https://github.com/rsuite/rsuite',
+    programmingLanguage: 'TypeScript',
+    runtimePlatform: 'React',
+    author: {
+      '@type': 'Organization',
+      name: 'React Suite Team'
+    }
+  };
+}
+
+/**
+ * Serialize JSON-LD object to string for script tag
+ */
+export function serializeJsonLd(data: any): string {
+  return JSON.stringify(data, null, 0);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rsuite",
-  "version": "6.0.0-canary-20250904",
+  "version": "6.0.0-canary-20251029",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rsuite",
-      "version": "6.0.0-canary-20250904",
+      "version": "6.0.0-canary-20251029",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",


### PR DESCRIPTION
This pull request adds comprehensive JSON-LD structured data support to the RSuite documentation site to improve SEO and enable rich snippets in search engines. The main changes include introducing a new utility for generating Schema.org JSON-LD objects, embedding global and page-specific schemas, and supporting breadcrumb navigation data.

**Structured Data & SEO Enhancements:**

* Added a new utility module `docs/utils/jsonld.ts` that provides functions to generate Schema.org JSON-LD objects for organization, software application, software source code, web pages, articles, and breadcrumbs, along with a serializer for embedding these objects in script tags.
* Embedded global JSON-LD schemas for Organization, SoftwareApplication, and SoftwareSourceCode in the `<Head>` of every page via `docs/pages/_document.tsx`, ensuring search engines can recognize the site, app, and code repository.

**Page-Specific Structured Data:**

* Updated the `Head` component (`docs/components/layout/Head.tsx`) to accept a `breadcrumbs` prop and automatically generate and inject a breadcrumb JSON-LD schema when breadcrumbs are provided. Also refactored the Open Graph URL logic for consistency. [[1]](diffhunk://#diff-b644b42fdc2741050fbb66b8d628c34b3ffed4b1f1ae0904df4e7f945852753dR4-R22) [[2]](diffhunk://#diff-b644b42fdc2741050fbb66b8d628c34b3ffed4b1f1ae0904df4e7f945852753dL32-R52)
* In `PageContent` (`docs/components/layout/PageContent.tsx`), implemented logic to generate breadcrumbs for component pages and pass them to the `Head` component, enabling page-level breadcrumb structured data. [[1]](diffhunk://#diff-188b0f4bae66e633335913dd41eee7297eb26f6d17dce7e51f24638fd3fd76b6L46-R46) [[2]](diffhunk://#diff-188b0f4bae66e633335913dd41eee7297eb26f6d17dce7e51f24638fd3fd76b6R57-R71)