### PR TITLE
fix(Breadcrumb): move default size to css and update docs

### DIFF
--- a/docs/pages/components/breadcrumb/fragments/background.md
+++ b/docs/pages/components/breadcrumb/fragments/background.md
@@ -6,7 +6,7 @@ import { GoHomeFill } from 'react-icons/go';
 
 const App = () => (
   <Box bg="var(--rs-placeholder)" p="12px 20px">
-    <Breadcrumb>
+    <Breadcrumb aria-label="breadcrumb">
       <Breadcrumb.Item icon={<GoHomeFill />}>Home</Breadcrumb.Item>
       <Breadcrumb.Item>Components</Breadcrumb.Item>
       <Breadcrumb.Item active>Breadcrumb</Breadcrumb.Item>

--- a/docs/pages/components/breadcrumb/fragments/basic.md
+++ b/docs/pages/components/breadcrumb/fragments/basic.md
@@ -4,7 +4,7 @@
 import { Breadcrumb } from 'rsuite';
 
 const App = () => (
-  <Breadcrumb>
+  <Breadcrumb aria-label="breadcrumb">
     <Breadcrumb.Item>Home</Breadcrumb.Item>
     <Breadcrumb.Item>Components</Breadcrumb.Item>
     <Breadcrumb.Item active>Breadcrumb</Breadcrumb.Item>

--- a/docs/pages/components/breadcrumb/fragments/dropdown.md
+++ b/docs/pages/components/breadcrumb/fragments/dropdown.md
@@ -5,7 +5,7 @@ import ArrowDownLineIcon from '@rsuite/icons/ArrowDownLine';
 import { Breadcrumb, Dropdown, HStack } from 'rsuite';
 
 const App = () => (
-  <Breadcrumb>
+  <Breadcrumb aria-label="breadcrumb">
     <Breadcrumb.Item>Home</Breadcrumb.Item>
     <Breadcrumb.Item>
       <Dropdown

--- a/docs/pages/components/breadcrumb/fragments/icons.md
+++ b/docs/pages/components/breadcrumb/fragments/icons.md
@@ -5,7 +5,7 @@ import { Breadcrumb } from 'rsuite';
 import { GoHomeFill } from 'react-icons/go';
 
 const App = () => (
-  <Breadcrumb>
+  <Breadcrumb aria-label="breadcrumb">
     <Breadcrumb.Item icon={<GoHomeFill />}>Home</Breadcrumb.Item>
     <Breadcrumb.Item>Components</Breadcrumb.Item>
     <Breadcrumb.Item active>Breadcrumb</Breadcrumb.Item>

--- a/docs/pages/components/breadcrumb/fragments/max-items.md
+++ b/docs/pages/components/breadcrumb/fragments/max-items.md
@@ -5,6 +5,7 @@ import { Breadcrumb } from 'rsuite';
 
 const App = () => (
   <Breadcrumb
+    aria-label="breadcrumb"
     maxItems={5}
     onExpand={() => {
       console.log('call onExpand');

--- a/docs/pages/components/breadcrumb/fragments/separator.md
+++ b/docs/pages/components/breadcrumb/fragments/separator.md
@@ -6,7 +6,7 @@ import { Breadcrumb, VStack } from 'rsuite';
 import { MdArrowRightAlt } from 'react-icons/md';
 
 const BreadcrumbBox = ({ separator }) => (
-  <Breadcrumb separator={separator}>
+  <Breadcrumb aria-label="breadcrumb" separator={separator}>
     <Breadcrumb.Item as={Link} href="/">
       Home
     </Breadcrumb.Item>

--- a/docs/pages/components/breadcrumb/fragments/size.md
+++ b/docs/pages/components/breadcrumb/fragments/size.md
@@ -4,7 +4,7 @@
 import { Breadcrumb, VStack } from 'rsuite';
 
 const BreadcrumbBox = ({ size }) => (
-  <Breadcrumb size={size}>
+  <Breadcrumb aria-label="breadcrumb" size={size}>
     <Breadcrumb.Item>Home</Breadcrumb.Item>
     <Breadcrumb.Item>Products</Breadcrumb.Item>
     <Breadcrumb.Item>Electronics</Breadcrumb.Item>

--- a/docs/pages/components/breadcrumb/fragments/with-router.md
+++ b/docs/pages/components/breadcrumb/fragments/with-router.md
@@ -5,7 +5,7 @@ import { Breadcrumb } from 'rsuite';
 import Link from 'next/link';
 
 const App = () => (
-  <Breadcrumb>
+  <Breadcrumb aria-label="breadcrumb">
     <Breadcrumb.Item as={Link} href="/">
       Home
     </Breadcrumb.Item>

--- a/src/Breadcrumb/Breadcrumb.tsx
+++ b/src/Breadcrumb/Breadcrumb.tsx
@@ -64,7 +64,7 @@ const Breadcrumb = forwardRef<'ol', BreadcrumbProps, typeof Subcomponents>(
       ellipsis = '...',
       maxItems = 5,
       separator = '/',
-      size = 'md',
+      size,
       locale,
       onExpand,
       ...rest

--- a/src/Breadcrumb/styles/index.scss
+++ b/src/Breadcrumb/styles/index.scss
@@ -10,7 +10,7 @@
   --rs-breadcrumb-size-sm: var(--rs-font-size-xs);
   --rs-breadcrumb-size-md: var(--rs-font-size-sm);
   --rs-breadcrumb-size-lg: var(--rs-font-size-md);
-  --rs-breadcrumb-size: var(--rs-breadcrumb-size-sm);
+  --rs-breadcrumb-size: var(--rs-breadcrumb-size-md);
 
   font-size: var(--rs-breadcrumb-size);
   color: var(--rs-text-secondary);

--- a/src/Breadcrumb/test/Breadcrumb.styles.spec.tsx
+++ b/src/Breadcrumb/test/Breadcrumb.styles.spec.tsx
@@ -11,4 +11,10 @@ describe('Breadcrumb styles', () => {
 
     expect(container.firstChild).to.have.style('padding', '0px');
   });
+
+  it('Should have correct default size', () => {
+    const { container } = render(<Breadcrumb />);
+
+    expect(container.firstChild).to.have.style('font-size', '14px');
+  });
 });


### PR DESCRIPTION
This pull request makes accessibility improvements to the Breadcrumb component examples in the documentation and adjusts the default sizing for the Breadcrumb component. The most important changes are grouped below:

**Accessibility improvements in documentation:**

* Added the `aria-label="breadcrumb"` attribute to all `Breadcrumb` examples in the documentation to improve accessibility and clarify the navigation role for assistive technologies. [[1]](diffhunk://#diff-7fdc1facfa7ab2fdb910e4f4d80ffdf554b496f463f7ccb86384491b2e95977aL7-R7) [[2]](diffhunk://#diff-755f4fa4f3184a38bfef83d29f47a911fc618890daea178d2007f2c72b28c2acL9-R9) [[3]](diffhunk://#diff-a057cce027c664d90be3ad242618520ea85c76c9d5d86f49a30751a0e3a4dc6eL8-R8) [[4]](diffhunk://#diff-908489d4cc0c110dd6efda777460c765a1ba85c737ff23c1e6b407ca00f31548L8-R8) [[5]](diffhunk://#diff-a6b15eb57e204dddd4909b67c8a212571a31bce3317f6d51d7a02f07d858b653R8) [[6]](diffhunk://#diff-e88d3d53a889987676e644b550002b22e687d59d84990af4f9177efde3288b33L9-R9) [[7]](diffhunk://#diff-414d468a6ac1d8c43a81c95b5bdcfd5e83766eca65eea8fd1a1b2741880e6c45L7-R7) [[8]](diffhunk://#diff-785d708ca98f4811587935e4409e1a1677df2a42aa73c549a3df799413f97239L8-R8)

**Breadcrumb component sizing updates:**

* Changed the default value for the `size` prop in the `Breadcrumb` component from `'md'` to `undefined`, allowing the CSS variable to control the default size.
* Updated the default CSS variable for breadcrumb size from small to medium (`--rs-breadcrumb-size-md`), making the default font size `14px`.
* Added a unit test to verify that the default font size for the `Breadcrumb` component is `14px`.