### PR TITLE
fix(DatePicker): align OK button to right when no ranges

### DIFF
--- a/docs/pages/components/date-range-picker/fragments/format.md
+++ b/docs/pages/components/date-range-picker/fragments/format.md
@@ -14,9 +14,14 @@ const App = () => (
     <DateRangePicker format="yyyy年MM月dd日" />
     <DateRangePicker format="MM/dd/yyyy HH:mm" />
     <DateRangePicker format="MM/dd/yyyy hh:mm aa" showMeridiem />
-    <DateRangePicker format="MMM yyyy" caretAs={BsCalendar2MonthFill} />
-    <DateRangePicker format="HH:mm:ss" caretAs={FaClock} />
-    <DateRangePicker format="dd MMM yyyy hh:mm:ss aa" showMeridiem caretAs={FaCalendar} />
+    <DateRangePicker format="MMM yyyy" caretAs={BsCalendar2MonthFill} ranges={[]} />
+    <DateRangePicker format="HH:mm:ss" caretAs={FaClock} ranges={[]} />
+    <DateRangePicker
+      format="dd MMM yyyy hh:mm:ss aa"
+      showMeridiem
+      caretAs={FaCalendar}
+      ranges={[]}
+    />
   </Stack>
 );
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/DatePicker/Toolbar.tsx
+++ b/src/DatePicker/Toolbar.tsx
@@ -62,8 +62,11 @@ const Toolbar: ToolbarComponent = React.forwardRef<HTMLDivElement, ToolbarProps>
 
   const classes = merge(className, withPrefix());
 
+  // If there are no ranges, the ok button should be aligned to the right
+  const justify = ranges?.length === 0 ? 'flex-end' : 'space-between';
+
   return (
-    <Stack ref={ref} className={classes} justify="space-between" align="flex-start" {...rest}>
+    <Stack ref={ref} className={classes} justify={justify} align="flex-start" {...rest}>
       <PredefinedRanges
         wrap
         className={prefix('ranges')}

--- a/src/DatePicker/test/Toolbar.spec.tsx
+++ b/src/DatePicker/test/Toolbar.spec.tsx
@@ -85,4 +85,12 @@ describe('DatePicker - Toolbar', () => {
 
     expect(screen.getByTestId('daterange-predefined-bottom')).to.have.attr('data-wrap', 'true');
   });
+
+  it('Should have a style "justify-content: flex-end" when ranges is empty', () => {
+    const { container } = render(
+      <Toolbar calendarDate={new Date(2021, 11, 24)} ranges={[]} locale={{}} />
+    );
+
+    expect(container.firstChild).to.have.style('justify-content', 'flex-end');
+  });
 });


### PR DESCRIPTION
This pull request improves the behavior and documentation of the `DateRangePicker` and its `Toolbar` component to better handle cases where no predefined ranges are provided. The main focus is on ensuring that the UI aligns the "OK" button to the right when the `ranges` prop is empty, and updating documentation and tests accordingly.

**UI Alignment Improvements:**

* Updated the `Toolbar` component in `src/DatePicker/Toolbar.tsx` to align the "OK" button to the right (`flex-end`) when the `ranges` prop is empty, instead of the default `space-between` alignment.

**Documentation Updates:**

* Modified the examples in `docs/pages/components/date-range-picker/fragments/format.md` to explicitly pass `ranges={[]}` for cases without predefined ranges, ensuring documentation matches the new behavior.

**Testing Enhancements:**

* Added a unit test in `src/DatePicker/test/Toolbar.spec.tsx` to verify that the `Toolbar` correctly applies `justify-content: flex-end` when `ranges` is empty.