### PR TITLE
feat(DateInput): support AM/PM toggle with 'a' and 'p' keys

### DIFF
--- a/src/DateInput/DateInput.tsx
+++ b/src/DateInput/DateInput.tsx
@@ -191,6 +191,27 @@ const DateInput = forwardRef<typeof Input, DateInputProps>((props, ref) => {
     }
   });
 
+  const onAmPmToggle = useEventCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+    const input = event.target as HTMLInputElement;
+    const key = event.key.toLowerCase();
+
+    // Only handle 'a' or 'p' keys when the selected pattern is 'a' (AM/PM)
+    if (selectedState.selectedPattern === 'a' && (key === 'a' || key === 'p')) {
+      const currentHour = dateField.hour || 0;
+      const isAM = currentHour < 12;
+      const isPM = currentHour >= 12;
+
+      // Toggle AM/PM based on the key pressed
+      // 'a' key -> set to AM, 'p' key -> set to PM
+      if ((key === 'a' && isPM) || (key === 'p' && isAM)) {
+        const state = getInputSelectedState({ ...keyPressOptions, input });
+        setSelectedState(state);
+        setDateOffset('a', 1, date => handleChange(date, event));
+        setSelectionRange(state.selectionStart, state.selectionEnd);
+      }
+    }
+  });
+
   const handleClick = useEventCallback((event: React.MouseEvent<HTMLInputElement>) => {
     const input = event.target as HTMLInputElement;
     const state = getInputSelectedState({ ...keyPressOptions, input });
@@ -222,6 +243,7 @@ const DateInput = forwardRef<typeof Input, DateInputProps>((props, ref) => {
     onSegmentValueChange,
     onSegmentValueChangeWithNumericKeys,
     onSegmentValueRemove,
+    onAmPmToggle,
     onKeyDown
   });
 

--- a/src/DateInput/hooks/useKeyboardInputEvent.ts
+++ b/src/DateInput/hooks/useKeyboardInputEvent.ts
@@ -3,6 +3,7 @@ interface KeyboardEventOptions {
   onSegmentValueChange?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
   onSegmentValueChangeWithNumericKeys?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
   onSegmentValueRemove?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  onAmPmToggle?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
   onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
@@ -11,6 +12,7 @@ export function useKeyboardInputEvent({
   onSegmentValueChange,
   onSegmentValueChangeWithNumericKeys,
   onSegmentValueRemove,
+  onAmPmToggle,
   onKeyDown
 }: KeyboardEventOptions) {
   return (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -35,6 +37,20 @@ export function useKeyboardInputEvent({
       case key.match(/\d/)?.input:
         // Allow numeric keys to be entered
         onSegmentValueChangeWithNumericKeys?.(event);
+        event.preventDefault();
+        break;
+
+      case 'a':
+      case 'p':
+      case 'A':
+      case 'P':
+        // Determine whether the Ctrl or Command key is pressed, does not affect user copy and paste
+        if (event.ctrlKey || event.metaKey) {
+          break;
+        }
+
+        // Handle AM/PM toggle with 'a' or 'p' keys
+        onAmPmToggle?.(event);
         event.preventDefault();
         break;
 

--- a/src/DateInput/test/DateInput.spec.tsx
+++ b/src/DateInput/test/DateInput.spec.tsx
@@ -400,6 +400,39 @@ describe('DateInput', () => {
       });
     });
 
+    it('Should toggle AM/PM by typing "a" key', () => {
+      testContinuousKeyPress({
+        format: 'aa',
+        defaultValue: new Date('2023-10-01 13:00:00'),
+        keySequences: [
+          { key: 'a', expected: 'AM' },
+          { key: 'a', expected: 'AM' } // Should remain AM when already AM
+        ]
+      });
+    });
+
+    it('Should toggle AM/PM by typing "p" key', () => {
+      testContinuousKeyPress({
+        format: 'aa',
+        defaultValue: new Date('2023-10-01 01:00:00'),
+        keySequences: [
+          { key: 'p', expected: 'PM' },
+          { key: 'p', expected: 'PM' } // Should remain PM when already PM
+        ]
+      });
+    });
+
+    it('Should toggle AM/PM with "a" and "p" keys in full format', () => {
+      testContinuousKeyPress({
+        format: 'HH:mm aa',
+        defaultValue: new Date('2023-10-01 13:30:00'),
+        keySequences: [
+          { key: '{arrowright}{arrowright}a', expected: '01:30 AM' },
+          { key: '{arrowright}{arrowright}p', expected: '13:30 PM' }
+        ]
+      });
+    });
+
     it('Should show correct AM/PM by changing the hour', () => {
       testContinuousKeyPress({
         format: 'HH aa',

--- a/src/DateRangeInput/DateRangeInput.tsx
+++ b/src/DateRangeInput/DateRangeInput.tsx
@@ -253,6 +253,27 @@ const DateRangeInput = React.forwardRef((props: DateRangeInputProps, ref) => {
     }
   });
 
+  const onAmPmToggle = useEventCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+    const input = event.target as HTMLInputElement;
+    const key = event.key.toLowerCase();
+
+    // Only handle 'a' or 'p' keys when the selected pattern is 'a' (AM/PM)
+    if (selectedState.selectedPattern === 'a' && (key === 'a' || key === 'p')) {
+      const currentHour = getActiveState().dateField.hour || 0;
+      const isAM = currentHour < 12;
+      const isPM = currentHour >= 12;
+
+      // Toggle AM/PM based on the key pressed
+      // 'a' key -> set to AM, 'p' key -> set to PM
+      if ((key === 'a' && isPM) || (key === 'p' && isAM)) {
+        const state = getInputSelectedState({ ...keyPressOptions, input });
+        setSelectedState(state);
+        getActiveState().setDateOffset('a', 1, date => handleChange(date, event));
+        setSelectionRange(state.selectionStart, state.selectionEnd);
+      }
+    }
+  });
+
   const handleClick = useEventCallback((event: React.MouseEvent<HTMLInputElement>) => {
     const input = event.target as HTMLInputElement;
 
@@ -306,6 +327,7 @@ const DateRangeInput = React.forwardRef((props: DateRangeInputProps, ref) => {
     onSegmentValueChange,
     onSegmentValueChangeWithNumericKeys,
     onSegmentValueRemove,
+    onAmPmToggle,
     onKeyDown
   });
 

--- a/src/DateRangeInput/test/DateRangeInput.spec.tsx
+++ b/src/DateRangeInput/test/DateRangeInput.spec.tsx
@@ -397,6 +397,39 @@ describe('DateRangeInput', () => {
       });
     });
 
+    it('Should toggle AM/PM by typing "a" key', () => {
+      testContinuousKeyPress({
+        format: 'aa',
+        defaultValue: [new Date('2023-10-01 13:00:00'), null],
+        keySequences: [
+          { key: 'a', expected: 'AM ~ aa' },
+          { key: 'a', expected: 'AM ~ aa' } // Should remain AM when already AM
+        ]
+      });
+    });
+
+    it('Should toggle AM/PM by typing "p" key', () => {
+      testContinuousKeyPress({
+        format: 'aa',
+        defaultValue: [new Date('2023-10-01 01:00:00'), null],
+        keySequences: [
+          { key: 'p', expected: 'PM ~ aa' },
+          { key: 'p', expected: 'PM ~ aa' } // Should remain PM when already PM
+        ]
+      });
+    });
+
+    it('Should toggle AM/PM with "a" and "p" keys in full format', () => {
+      testContinuousKeyPress({
+        format: 'HH:mm aa',
+        defaultValue: [new Date('2023-10-01 13:30:00'), null],
+        keySequences: [
+          { key: '{arrowright}{arrowright}a', expected: '01:30 AM ~ HH:mm aa' },
+          { key: '{arrowright}{arrowright}p', expected: '13:30 PM ~ HH:mm aa' }
+        ]
+      });
+    });
+
     it('Should show correct AM/PM by changing the hour', () => {
       testContinuousKeyPress({
         format: 'HH aa',


### PR DESCRIPTION
https://github.com/rsuite/rsuite/issues/4399

- Add onAmPmToggle handler in DateInput component
- Add onAmPmToggle handler in DateRangeInput component
- Update useKeyboardInputEvent to allow 'a' and 'p' keys for AM/PM field
- Add unit tests for AM/PM toggle functionality in both components
- Pressing 'a' key switches to AM when in PM
- Pressing 'p' key switches to PM when in AM

