### PR TITLE
feat(build): export SCSS source files to npm package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -80,6 +80,12 @@ function copyDocs() {
   return gulp.src(['./README.md', './CHANGELOG.md', './LICENSE']).pipe(gulp.dest(libRoot));
 }
 
+function copyScssFiles() {
+  return gulp
+    .src([`${srcRoot}/**/*.scss`])
+    .pipe(gulp.dest(libRoot));
+}
+
 function createPkgFile(done) {
   delete pkg.devDependencies;
   delete pkg.files;
@@ -87,6 +93,8 @@ function createPkgFile(done) {
   pkg.main = 'cjs/index.js';
   pkg.module = 'esm/index.js';
   pkg.typings = 'esm/index.d.ts';
+  pkg.sass = 'styles/index.scss';
+  pkg.style = 'dist/rsuite.css';
   pkg.scripts = {
     prepublishOnly: 'node ../scripts/validate-builds.js'
   };
@@ -104,6 +112,6 @@ exports.dev = gulp.series(clean, buildCjs, watch);
 exports.build = gulp.series(
   clean,
   gulp.parallel(buildCjs, buildEsm),
-  gulp.parallel(copyTypescriptDeclarationFiles, copyDocs, createPkgFile),
+  gulp.parallel(copyTypescriptDeclarationFiles, copyDocs, copyScssFiles, createPkgFile),
   buildDirectories
 );

--- a/package.json
+++ b/package.json
@@ -84,8 +84,6 @@
     "umd",
     "src"
   ],
-  "sass": "src/styles/index.scss",
-  "style": "lib/styles/index.css",
   "devDependencies": {
     "@babel/cli": "^7.26.4",
     "@babel/core": "^7.26.0",


### PR DESCRIPTION
- Add copyScssFiles function to copy all SCSS files to lib directory
- Set sass field to 'styles/index.scss' in lib/package.json
- Add validation tests for SCSS files in validateBuilds.spec.ts
- Fixes #4437