### PR TITLE
fix(panel): handle fragment header children safely

### DIFF
--- a/src/Panel/PanelHeader.tsx
+++ b/src/Panel/PanelHeader.tsx
@@ -3,6 +3,7 @@ import get from 'lodash/get';
 import AccordionButton from './AccordionButton';
 import Box, { BoxProps } from '@/internals/Box';
 import { useStyles } from '@/internals/hooks';
+import { isFragment } from '@/internals/utils';
 
 export interface PanelHeaderProps
   extends BoxProps,
@@ -38,8 +39,8 @@ const PanelHeader = (props: PanelHeaderProps) => {
 
   let headerElement: React.ReactNode;
 
-  if (!isValidElement(children) || Array.isArray(children)) {
-    headerElement = <span className={prefix('title')}>{children}</span>;
+  if (!isValidElement(children) || Array.isArray(children) || isFragment(children)) {
+    headerElement = <div className={prefix('title')}>{children}</div>;
   } else {
     const className = merge(prefix('title'), get(children, 'props.className'));
     headerElement = cloneElement<any>(children, { className });

--- a/src/Panel/test/Panel.spec.tsx
+++ b/src/Panel/test/Panel.spec.tsx
@@ -280,5 +280,26 @@ describe('Panel', () => {
 
       expect(screen.getByText('Test Header')).to.exist;
     });
+
+    it('Should handle React.Fragment as children', () => {
+      render(
+        <PanelHeader data-testid="panel-header">
+          <>
+            <div>Fragment</div>
+            <p>Content</p>
+          </>
+        </PanelHeader>
+      );
+
+      const titleWrapper = screen.getByTestId('panel-header').querySelector('.rs-panel-title');
+
+      // Fragment content should be wrapped by a div.rs-panel-title
+      expect(titleWrapper).to.exist;
+      expect(titleWrapper).to.have.tagName('div');
+      expect(titleWrapper).to.have.class('rs-panel-title');
+      // Ensure children of Fragment are rendered inside wrapper
+      expect(titleWrapper).to.contain.text('Fragment');
+      expect(titleWrapper).to.contain.text('Content');
+    });
   });
 });


### PR DESCRIPTION
This pull request improves the handling of React Fragments as children in the `PanelHeader` component, ensuring consistent rendering and wrapping of header content. It also adds a test to verify this new behavior.

Component enhancements:

* Updated `PanelHeader` to check for React Fragments using the new `isFragment` utility and wrap such children in a `div` with the correct class, ensuring consistent structure for all header content. [[1]](diffhunk://#diff-58c4468b54446aab499bca7f46597cefc9bb6eaedd22e7f8666a7f01faf9e26fR6) [[2]](diffhunk://#diff-58c4468b54446aab499bca7f46597cefc9bb6eaedd22e7f8666a7f01faf9e26fL41-R43)

Testing improvements:

* Added a unit test to confirm that when a React Fragment is passed as a child to `PanelHeader`, its content is correctly wrapped and rendered.