### PR TITLE
docs: update component thumbnails with new visual design

### DIFF
--- a/docs/components/overview/ComponentThumbnail.tsx
+++ b/docs/components/overview/ComponentThumbnail.tsx
@@ -63,6 +63,7 @@ const getSvgForComponent = (componentId: string): React.ReactNode => {
     textarea: <thumbnails.Textarea />,
     'check-tree': <thumbnails.CheckTree />,
     'multi-cascade-tree': <thumbnails.MultiCascadeTree />,
+    'segmented-control': <thumbnails.SegmentedControl />,
 
     // Data Pickers components
     cascader: <thumbnails.Cascader />,
@@ -111,6 +112,8 @@ const getSvgForComponent = (componentId: string): React.ReactNode => {
     'dom-helper': <thumbnails.DOMHelper />,
     'use-media-query': <thumbnails.Hooks />,
     'use-breakpoint-value': <thumbnails.Hooks />,
+    'use-dialog': <thumbnails.Hooks />,
+    'use-toaster': <thumbnails.Hooks />,
 
     // Status components
     badge: <thumbnails.Badge />,

--- a/docs/components/thumbnails/buttons.tsx
+++ b/docs/components/thumbnails/buttons.tsx
@@ -7,24 +7,15 @@ export const Button: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
       x="10"
-      y="30"
+      y="28"
       width="60"
-      height="20"
+      height="24"
       rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
-    <text
-      x="40"
-      y="45"
-      fontSize="12"
-      textAnchor="middle"
-      fill="var(--rs-thumbnail-color-high)"
-      fontWeight="bold"
-    >
-      Button
-    </text>
+    <rect x="25" y="38" width="30" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -33,12 +24,10 @@ export const Button: React.FC = () => (
  */
 export const IconButton: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect
-      x="25"
-      y="25"
-      width="30"
-      height="30"
-      rx="15"
+    <circle
+      cx="40"
+      cy="40"
+      r="16"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
@@ -48,6 +37,7 @@ export const IconButton: React.FC = () => (
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
       strokeLinecap="round"
+      strokeLinejoin="round"
     />
   </svg>
 );
@@ -57,57 +47,37 @@ export const IconButton: React.FC = () => (
  */
 export const ButtonGroup: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Left button */}
-    <rect x="20" y="30" width="13.33" height="20" rx="4" fill="var(--rs-thumbnail-bg-secondary)" />
-
-    {/* Middle button - Active */}
-    <rect
-      x="33.33"
-      y="30"
-      width="13.34"
-      height="20"
-      rx="0"
-      fill="var(--rs-thumbnail-color-primary)"
-    />
-
-    {/* Right button */}
-    <rect
-      x="46.67"
-      y="30"
-      width="13.33"
-      height="20"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-    />
-
-    {/* Divider lines */}
-    <line
-      x1="33.33"
-      y1="30"
-      x2="33.33"
-      y2="50"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <line
-      x1="46.67"
-      y1="30"
-      x2="46.67"
-      y2="50"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-
-    {/* Simple ButtonGroup */}
-    <rect
-      x="20"
-      y="30"
-      width="40"
-      height="20"
-      rx="4"
-      fill="none"
+    <path
+      d="M15 30H65V50H15V30Z"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
+      fill="none"
+      rx="4"
+    />
+    <path
+      d="M16 30H32V50H16C16 50 16 30 16 30Z"
+      fill="var(--rs-thumbnail-bg-secondary)"
+    />
+    <path
+      d="M32 30H48V50H32V30Z"
+      fill="var(--rs-thumbnail-color-primary)"
+    />
+    <path
+      d="M48 30H64C64 30 64 50 64 50H48V30Z"
+      fill="var(--rs-thumbnail-bg-secondary)"
+    />
+    <path d="M32 30V50" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M48 30V50" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+
+    <rect
+      x="15"
+      y="30"
+      width="50"
+      height="20"
+      rx="4"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+      fill="none"
     />
   </svg>
 );

--- a/docs/components/thumbnails/dataDisplay.tsx
+++ b/docs/components/thumbnails/dataDisplay.tsx
@@ -6,56 +6,59 @@ import React from 'react';
 export const Accordion: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="15"
-      rx="4"
+      x="10"
+      y="16"
+      width="60"
+      height="14"
+      rx="2"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
     <path
-      d="M55 22.5L50 17.5L45 22.5"
+      d="M60 19L64 23L60 27"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="1.5"
       strokeLinecap="round"
       strokeLinejoin="round"
     />
     <rect
-      x="15"
-      y="32.5"
-      width="50"
-      height="15"
-      rx="4"
-      fill="transparent"
+      x="10"
+      y="34"
+      width="60"
+      height="14"
+      rx="2"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
     <path
-      d="M45 40L50 45L55 40"
+      d="M60 37L64 41L60 45"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="1.5"
       strokeLinecap="round"
       strokeLinejoin="round"
     />
     <rect
-      x="15"
-      y="50"
-      width="50"
-      height="15"
-      rx="4"
-      fill="transparent"
+      x="10"
+      y="52"
+      width="60"
+      height="14"
+      rx="2"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
     <path
-      d="M45 57.5L50 62.5L55 57.5"
+      d="M60 55L64 59L60 63"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="1.5"
       strokeLinecap="round"
       strokeLinejoin="round"
     />
+    <rect x="16" y="21" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="16" y="39" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="16" y="57" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -70,35 +73,17 @@ export const Carousel: React.FC = () => (
       width="60"
       height="40"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
-    <rect
-      x="20"
-      y="30"
-      width="40"
-      height="20"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <circle cx="35" cy="55" r="2" fill="var(--rs-primary-300)" />
-    <circle cx="40" cy="55" r="2" fill="var(--rs-thumbnail-color-primary)" />
-    <circle cx="45" cy="55" r="2" fill="var(--rs-primary-300)" />
-    <path
-      d="M15 40L5 40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M65 40L75 40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <circle cx="34" cy="52" r="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.3" />
+    <circle cx="40" cy="52" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="46" cy="52" r="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.3" />
+    <path d="M16 40L20 36" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
+    <path d="M16 40L20 44" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
+    <path d="M64 40L60 36" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
+    <path d="M64 40L60 44" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
   </svg>
 );
 
@@ -108,66 +93,26 @@ export const Carousel: React.FC = () => (
 export const List: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="10"
+      y="10"
+      width="60"
+      height="60"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <line
-      x1="15"
-      y1="30"
-      x2="65"
-      y2="30"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <line
-      x1="15"
-      y1="45"
-      x2="65"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <line
-      x1="15"
-      y1="60"
-      x2="65"
-      y2="60"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <circle cx="25" cy="22.5" r="3" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="35"
-      y1="22.5"
-      x2="55"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <circle cx="25" cy="37.5" r="3" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="35"
-      y1="37.5"
-      x2="55"
-      y2="37.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <circle cx="25" cy="52.5" r="3" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="35"
-      y1="52.5"
-      x2="55"
-      y2="52.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <path d="M10 30H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M10 50H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+
+    <circle cx="20" cy="20" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="28" y="18" width="32" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+
+    <circle cx="20" cy="40" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="28" y="38" width="32" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+
+    <circle cx="20" cy="60" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="28" y="58" width="32" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -176,34 +121,16 @@ export const List: React.FC = () => (
  */
 export const Timeline: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <line x1="30" y1="15" x2="30" y2="65" stroke="var(--rs-primary-300)" strokeWidth="2" />
-    <circle cx="30" cy="20" r="5" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="35"
-      y1="20"
-      x2="60"
-      y2="20"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <circle cx="30" cy="40" r="5" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="35"
-      y1="40"
-      x2="55"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <circle cx="30" cy="60" r="5" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="35"
-      y1="60"
-      x2="50"
-      y2="60"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <line x1="28" y1="16" x2="28" y2="64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" opacity="0.3" />
+
+    <circle cx="28" cy="20" r="4" fill="var(--rs-thumbnail-bg-secondary)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <rect x="40" y="18" width="32" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+
+    <circle cx="28" cy="40" r="4" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="40" y="38" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+
+    <circle cx="28" cy="60" r="4" fill="var(--rs-thumbnail-bg-secondary)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <rect x="40" y="58" width="20" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -213,35 +140,19 @@ export const Timeline: React.FC = () => (
 export const Panel: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
-      rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-    />
-    <rect
-      x="15"
-      y="15"
-      width="50"
-      height="15"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
       rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <line
-      x1="25"
-      y1="22.5"
-      x2="55"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line x1="25" y1="40" x2="55" y2="40" stroke="var(--rs-primary-300)" strokeWidth="1.5" />
-    <line x1="25" y1="50" x2="45" y2="50" stroke="var(--rs-primary-300)" strokeWidth="1.5" />
+    <path d="M10 32H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <rect x="18" y="22" width="20" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="18" y="40" width="44" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="18" y="50" width="30" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -250,40 +161,19 @@ export const Panel: React.FC = () => (
  */
 export const Card: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Simple card without header/footer */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="16"
+      y="16"
+      width="48"
+      height="48"
       rx="4"
-      fill="transparent"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-
-    {/* Card content */}
-    <line
-      x1="25"
-      y1="25"
-      x2="55"
-      y2="25"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line x1="25" y1="35" x2="45" y2="35" stroke="var(--rs-primary-300)" strokeWidth="1.5" />
-
-    {/* Card image/content area */}
-    <rect
-      x="25"
-      y="42"
-      width="30"
-      height="15"
-      rx="2"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
+    <rect x="22" y="46" width="36" height="12" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.1" />
+    <rect x="22" y="22" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="22" y="30" width="16" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -292,72 +182,19 @@ export const Card: React.FC = () => (
  */
 export const Stat: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Stat card container */}
     <rect
-      x="15"
+      x="10"
       y="20"
-      width="50"
+      width="60"
       height="40"
       rx="4"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-
-    {/* Title */}
-    <line
-      x1="20"
-      y1="30"
-      x2="40"
-      y2="30"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Main statistic area - represented by a bold line */}
-    <line
-      x1="20"
-      y1="42"
-      x2="35"
-      y2="42"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="3"
-      strokeLinecap="round"
-    />
-
-    {/* Secondary info */}
-    <line
-      x1="40"
-      y1="42"
-      x2="55"
-      y2="42"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Divider */}
-    <line
-      x1="20"
-      y1="50"
-      x2="55"
-      y2="50"
-      stroke="var(--rs-thumbnail-bg-secondary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-
-    {/* Bottom content */}
-    <line
-      x1="20"
-      y1="55"
-      x2="50"
-      y2="55"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <rect x="18" y="28" width="20" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="18" y="38" width="28" height="6" rx="3" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="18" y="50" width="44" height="2" rx="1" fill="var(--rs-thumbnail-color-primary)" opacity="0.2" />
   </svg>
 );
 
@@ -367,37 +204,16 @@ export const Stat: React.FC = () => (
 export const Tag: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="20"
-      y="30"
-      width="40"
-      height="20"
-      rx="10"
+      x="14"
+      y="28"
+      width="52"
+      height="24"
+      rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <line
-      x1="30"
-      y1="40"
-      x2="45"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <circle
-      cx="55"
-      cy="40"
-      r="3"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <path
-      d="M53 38L57 42M57 38L53 42"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
+    <rect x="22" y="38" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M52 36L56 40L52 44" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
   </svg>
 );

--- a/docs/components/thumbnails/dataEntry.tsx
+++ b/docs/components/thumbnails/dataEntry.tsx
@@ -5,32 +5,26 @@ import React from 'react';
  */
 export const PasswordInput: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Outer input box */}
     <rect
-      x="15"
-      y="30"
-      width="50"
-      height="20"
+      x="10"
+      y="28"
+      width="60"
+      height="24"
       rx="4"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
-    {/* Password dots */}
-    <circle cx="26" cy="40" r="2" fill="var(--rs-thumbnail-color-primary)" />
-    <circle cx="34" cy="40" r="2" fill="var(--rs-thumbnail-color-primary)" />
-    <circle cx="42" cy="40" r="2" fill="var(--rs-thumbnail-color-primary)" />
-    {/* Eye icon (simple) */}
-    <ellipse
-      cx="55"
-      cy="40"
-      rx="5"
-      ry="3"
+    <circle cx="20" cy="40" r="3" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="30" cy="40" r="3" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="40" cy="40" r="3" fill="var(--rs-thumbnail-color-primary)" />
+    <path
+      d="M54 40C54 40 57 36 60 36C63 36 66 40 66 40C66 40 63 44 60 44C57 44 54 40 54 40Z"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="1.5"
       fill="none"
     />
-    <circle cx="55" cy="40" r="1.2" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="60" cy="40" r="1.5" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -40,17 +34,17 @@ export const PasswordInput: React.FC = () => (
 export const Checkbox: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="25"
-      y="25"
-      width="30"
-      height="30"
+      x="24"
+      y="24"
+      width="32"
+      height="32"
       rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
     <path
-      d="M32 40L38 46L50 34"
+      d="M32 40L38 46L48 34"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="3"
       strokeLinecap="round"
@@ -67,12 +61,12 @@ export const Radio: React.FC = () => (
     <circle
       cx="40"
       cy="40"
-      r="15"
+      r="16"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
-    <circle cx="40" cy="40" r="6" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="40" cy="40" r="8" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -82,23 +76,17 @@ export const Radio: React.FC = () => (
 export const Input: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="30"
-      width="50"
-      height="20"
+      x="10"
+      y="28"
+      width="60"
+      height="24"
       rx="4"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
-    <line
-      x1="20"
-      y1="40"
-      x2="30"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-    />
+    <rect x="18" y="38" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="62" y="36" width="2" height="8" rx="1" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -108,40 +96,20 @@ export const Input: React.FC = () => (
 export const Textarea: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
+      x="10"
       y="20"
-      width="50"
+      width="60"
       height="40"
       rx="4"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
-    {/* Simulate multiple lines of text */}
-    <line
-      x1="20"
-      y1="32"
-      x2="55"
-      y2="32"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="20"
-      y1="40"
-      x2="55"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="20"
-      y1="48"
-      x2="45"
-      y2="48"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <rect x="18" y="30" width="30" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="18" y="40" width="44" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="18" y="50" width="20" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M62 52L66 56" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
+    <path d="M58 56L66 56L66 48" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
   </svg>
 );
 
@@ -151,52 +119,20 @@ export const Textarea: React.FC = () => (
 export const NumberInput: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="30"
-      width="50"
-      height="20"
+      x="10"
+      y="28"
+      width="60"
+      height="24"
       rx="4"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
-    <text x="25" y="44" fill="var(--rs-thumbnail-color-primary)" fontSize="14" fontWeight="bold">
-      123
-    </text>
-
-    {/* Up/Down arrows */}
-    <rect
-      x="55"
-      y="30"
-      width="10"
-      height="20"
-      rx="2"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <path
-      d="M58 35L60 33L62 35"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M58 45L60 47L62 45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="55"
-      y1="40"
-      x2="65"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
+    <rect x="18" y="38" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M56 28V52" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M56 40H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M60 35L63 32L66 35" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M60 45L63 48L66 45" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
   </svg>
 );
 
@@ -206,22 +142,20 @@ export const NumberInput: React.FC = () => (
 export const Toggle: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="20"
-      y="30"
-      width="40"
-      height="20"
-      rx="10"
+      x="16"
+      y="28"
+      width="48"
+      height="24"
+      rx="12"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
     <circle
-      cx="50"
+      cx="52"
       cy="40"
       r="8"
       fill="var(--rs-thumbnail-color-primary)"
-      stroke="white"
-      strokeWidth="1.5"
     />
   </svg>
 );
@@ -232,41 +166,28 @@ export const Toggle: React.FC = () => (
 export const AutoComplete: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="20"
-      width="50"
-      height="15"
+      x="10"
+      y="16"
+      width="60"
+      height="24"
       rx="4"
-      fill="transparent"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
     <rect
-      x="15"
-      y="35"
-      width="50"
-      height="25"
+      x="10"
+      y="44"
+      width="60"
+      height="28"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="1.5"
     />
-    <line
-      x1="20"
-      y1="45"
-      x2="40"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="20"
-      y1="55"
-      x2="35"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <rect x="18" y="26" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="18" y="52" width="30" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="18" y="60" width="40" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -275,29 +196,13 @@ export const AutoComplete: React.FC = () => (
  */
 export const Slider: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <line
-      x1="15"
-      y1="40"
-      x2="65"
-      y2="40"
-      stroke="var(--rs-primary-200)"
-      strokeWidth="4"
-      strokeLinecap="round"
-    />
-    <line
-      x1="15"
-      y1="40"
-      x2="35"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="4"
-      strokeLinecap="round"
-    />
+    <rect x="10" y="38" width="60" height="4" rx="2" fill="var(--rs-thumbnail-bg-secondary)" />
+    <rect x="10" y="38" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
     <circle
-      cx="35"
+      cx="34"
       cy="40"
       r="8"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
@@ -310,33 +215,19 @@ export const Slider: React.FC = () => (
 export const InlineEdit: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="30"
-      width="50"
-      height="20"
+      x="10"
+      y="28"
+      width="60"
+      height="24"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeDasharray="2 1"
+      strokeWidth="2"
+      strokeDasharray="4 4"
     />
-    <line
-      x1="20"
-      y1="40"
-      x2="40"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <rect x="18" y="38" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
     <path
-      d="M50 35L55 35L55 40L60 40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M50 45L55 45L55 40L60 40"
+      d="M52 35L62 35M62 35V45M62 35L52 45"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="1.5"
       strokeLinecap="round"
@@ -351,22 +242,25 @@ export const InlineEdit: React.FC = () => (
 export const Rate: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
-      d="M20 40L23 46L30 47L25 52L26 59L20 56L14 59L15 52L10 47L17 46L20 40Z"
-      fill="var(--rs-yellow-500)"
-      stroke="var(--rs-yellow-700)"
-      strokeWidth="1"
-    />
-    <path
-      d="M40 40L43 46L50 47L45 52L46 59L40 56L34 59L35 52L30 47L37 46L40 40Z"
-      fill="var(--rs-yellow-500)"
-      stroke="var(--rs-yellow-700)"
-      strokeWidth="1"
-    />
-    <path
-      d="M60 40L63 46L70 47L65 52L66 59L60 56L54 59L55 52L50 47L57 46L60 40Z"
-      fill="var(--rs-thumbnail-bg)"
+      d="M20 30L23.5 37L31 38L25.5 43.5L27 51L20 47.5L13 51L14.5 43.5L9 38L16.5 37L20 30Z"
+      fill="var(--rs-thumbnail-color-primary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M40 30L43.5 37L51 38L45.5 43.5L47 51L40 47.5L33 51L34.5 43.5L29 38L36.5 37L40 30Z"
+      fill="var(--rs-thumbnail-color-primary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M60 30L63.5 37L71 38L65.5 43.5L67 51L60 47.5L53 51L54.5 43.5L49 38L56.5 37L60 30Z"
+      fill="none"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
     />
   </svg>
 );
@@ -377,47 +271,33 @@ export const Rate: React.FC = () => (
 export const TagInput: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="30"
-      width="50"
-      height="20"
+      x="10"
+      y="28"
+      width="60"
+      height="24"
       rx="4"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="20"
-      y="35"
-      width="15"
-      height="10"
-      rx="5"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
+      strokeWidth="2"
+    />
+    <rect
+      x="16"
+      y="34"
+      width="20"
+      height="12"
+      rx="3"
+      fill="var(--rs-thumbnail-color-primary)"
     />
     <rect
       x="40"
-      y="35"
-      width="15"
-      height="10"
-      rx="5"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
+      y="34"
+      width="20"
+      height="12"
+      rx="3"
+      fill="var(--rs-thumbnail-color-primary)"
     />
-    <path
-      d="M30 40L25 40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-    <path
-      d="M50 40L45 40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
+    <path d="M28 40L32 40" stroke="var(--rs-thumbnail-bg-secondary)" strokeWidth="1.5" strokeLinecap="round" />
+    <path d="M52 40L56 40" stroke="var(--rs-thumbnail-bg-secondary)" strokeWidth="1.5" strokeLinecap="round" />
   </svg>
 );
 
@@ -427,28 +307,22 @@ export const TagInput: React.FC = () => (
 export const Uploader: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="16"
+      y="16"
+      width="48"
+      height="48"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeDasharray="4 2"
+      strokeWidth="2"
+      strokeDasharray="4 4"
     />
     <path
-      d="M40 25L40 45M30 35L40 25L50 35"
+      d="M40 28V52M30 38L40 28L50 38"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
-    />
-    <path
-      d="M25 55L55 55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
     />
   </svg>
 );
@@ -459,63 +333,30 @@ export const Uploader: React.FC = () => (
 export const RadioTile: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="25"
-      width="20"
-      height="30"
+      x="12"
+      y="24"
+      width="24"
+      height="32"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
     <rect
-      x="45"
-      y="25"
-      width="20"
-      height="30"
+      x="44"
+      y="24"
+      width="24"
+      height="32"
       rx="4"
-      fill="transparent"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
+      strokeDasharray="4 2"
     />
-    <circle cx="20" cy="30" r="2" fill="var(--rs-thumbnail-color-primary)" />
-    <circle cx="50" cy="30" r="2" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1" />
-    <line
-      x1="20"
-      y1="40"
-      x2="30"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="20"
-      y1="45"
-      x2="25"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="50"
-      y1="40"
-      x2="60"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="50"
-      y1="45"
-      x2="55"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <circle cx="24" cy="34" r="3" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="56" cy="34" r="3" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <rect x="18" y="44" width="12" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="50" y="44" width="12" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -524,106 +365,23 @@ export const RadioTile: React.FC = () => (
  */
 export const CascadeTree: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Single panel with divider */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-
-    {/* Vertical divider line */}
-    <line
-      x1="40"
-      y1="15"
-      x2="40"
-      y2="65"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-
-    {/* First level items (left side) */}
-    <line
-      x1="20"
-      y1="25"
-      x2="35"
-      y2="25"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <rect
-      x="20"
-      y="32"
-      width="15"
-      height="8"
-      rx="2"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="1"
-    />
-    <line
-      x1="20"
-      y1="45"
-      x2="35"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="20"
-      y1="55"
-      x2="30"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Second level items (right side) */}
-    <line
-      x1="45"
-      y1="25"
-      x2="60"
-      y2="25"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <rect
-      x="45"
-      y="32"
-      width="15"
-      height="8"
-      rx="2"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="1"
-    />
-    <line
-      x1="45"
-      y1="45"
-      x2="60"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="45"
-      y1="55"
-      x2="55"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <line x1="40" y1="16" x2="40" y2="64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <rect x="16" y="24" width="16" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="16" y="34" width="12" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="16" y="44" width="14" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="46" y="24" width="16" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="46" y="34" width="12" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="46" y="44" width="14" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -632,111 +390,36 @@ export const CascadeTree: React.FC = () => (
  */
 export const Tree: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Tree container */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <circle cx="20" cy="28" r="3" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="28" y="26" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+
+    <circle cx="28" cy="40" r="3" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="36" y="38" width="20" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+
+    <circle cx="28" cy="52" r="3" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="36" y="50" width="20" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+
+    <path
+      d="M20 31V40H25"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="1.5"
+      fill="none"
     />
-
-    {/* Root node */}
-    <circle cx="22.5" cy="24.5" r="2" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="30"
-      y1="24.5"
-      x2="45"
-      y2="24.5"
+    <path
+      d="M20 40V52H25"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* First child level */}
-    <circle cx="27.5" cy="34.5" r="2" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="35"
-      y1="34.5"
-      x2="50"
-      y2="34.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Second child */}
-    <circle cx="27.5" cy="44.5" r="2" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="35"
-      y1="44.5"
-      x2="50"
-      y2="44.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Grandchild */}
-    <circle cx="32.5" cy="54.5" r="2" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="40"
-      y1="54.5"
-      x2="55"
-      y2="54.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Connection lines */}
-    <line
-      x1="22.5"
-      y1="27"
-      x2="22.5"
-      y2="54.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="22.5"
-      y1="34.5"
-      x2="25.5"
-      y2="34.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="22.5"
-      y1="44.5"
-      x2="25.5"
-      y2="44.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="27.5"
-      y1="47"
-      x2="27.5"
-      y2="54.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="27.5"
-      y1="54.5"
-      x2="30.5"
-      y2="54.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
+      fill="none"
     />
   </svg>
 );
@@ -746,147 +429,45 @@ export const Tree: React.FC = () => (
  */
 export const CheckTree: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Tree container */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
+    <rect x="18" y="26" width="6" height="6" rx="1" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="30" y="27" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
 
-    {/* Root node with checkbox */}
+    <rect x="26" y="38" width="6" height="6" rx="1" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="38" y="39" width="20" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+
     <rect
-      x="20"
-      y="22"
-      width="5"
-      height="5"
+      x="26"
+      y="50"
+      width="6"
+      height="6"
       rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="30"
-      y1="24.5"
-      x2="45"
-      y2="24.5"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="1.5"
-      strokeLinecap="round"
     />
+    <rect x="38" y="51" width="20" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
 
-    {/* First child level with checkboxes */}
-    <rect
-      x="25"
-      y="32"
-      width="5"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="35"
-      y1="34.5"
-      x2="50"
-      y2="34.5"
+    <path
+      d="M21 32V41H26"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="1.5"
-      strokeLinecap="round"
+      fill="none"
     />
-
-    {/* Second child with unchecked box */}
-    <rect
-      x="25"
-      y="42"
-      width="5"
-      height="5"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="35"
-      y1="44.5"
-      x2="50"
-      y2="44.5"
+    <path
+      d="M21 41V53H26"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Grandchild with unchecked box */}
-    <rect
-      x="30"
-      y="52"
-      width="5"
-      height="5"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="40"
-      y1="54.5"
-      x2="55"
-      y2="54.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Connection lines */}
-    <line
-      x1="22.5"
-      y1="27"
-      x2="22.5"
-      y2="54.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="22.5"
-      y1="34.5"
-      x2="25"
-      y2="34.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="22.5"
-      y1="44.5"
-      x2="25"
-      y2="44.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="27.5"
-      y1="47"
-      x2="27.5"
-      y2="54.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="27.5"
-      y1="54.5"
-      x2="30"
-      y2="54.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
+      fill="none"
     />
   </svg>
 );
@@ -896,203 +477,70 @@ export const CheckTree: React.FC = () => (
  */
 export const MultiCascadeTree: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Single panel with divider */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
+    <line x1="40" y1="16" x2="40" y2="64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
 
-    {/* Vertical divider line */}
-    <line
-      x1="40"
-      y1="15"
-      x2="40"
-      y2="65"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
+    {/* Left Panel */}
+    <rect x="14" y="24" width="6" height="6" rx="1" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <rect x="24" y="25" width="12" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
 
-    {/* First level items with checkboxes (left side) */}
+    <rect x="14" y="36" width="6" height="6" rx="1" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="24" y="37" width="12" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+
+    <rect x="14" y="48" width="6" height="6" rx="1" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <rect x="24" y="49" width="12" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+
+    {/* Right Panel */}
+    <rect x="44" y="24" width="6" height="6" rx="1" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <rect x="54" y="25" width="12" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+
+    <rect x="44" y="36" width="6" height="6" rx="1" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="54" y="37" width="12" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+
+    <rect x="44" y="48" width="6" height="6" rx="1" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <rect x="54" y="49" width="12" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+  </svg>
+);
+
+/**
+ * SegmentedControl component thumbnail
+ */
+export const SegmentedControl: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="20"
-      y="22"
-      width="5"
-      height="5"
-      rx="1"
-      fill="transparent"
+      x="10"
+      y="28"
+      width="60"
+      height="24"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
+      strokeWidth="2"
     />
-    <line
-      x1="28"
-      y1="24.5"
-      x2="35"
-      y2="24.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
     <rect
-      x="20"
+      x="14"
       y="32"
-      width="5"
-      height="5"
-      rx="1"
+      width="24"
+      height="16"
+      rx="2"
       fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
     />
-    <path
-      d="M21 34L22 35L24 33"
-      stroke="white"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="28"
-      y1="34.5"
-      x2="35"
-      y2="34.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
     <rect
-      x="20"
-      y="42"
-      width="5"
-      height="5"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="28"
-      y1="44.5"
-      x2="35"
-      y2="44.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    <rect
-      x="20"
-      y="52"
-      width="5"
-      height="5"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="28"
-      y1="54.5"
-      x2="35"
-      y2="54.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Second level items with checkboxes (right side) */}
-    <rect
-      x="45"
-      y="22"
-      width="5"
-      height="5"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="53"
-      y1="24.5"
-      x2="60"
-      y2="24.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    <rect
-      x="45"
+      x="42"
       y="32"
-      width="5"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <path
-      d="M46 34L47 35L49 33"
-      stroke="white"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="53"
-      y1="34.5"
-      x2="60"
-      y2="34.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    <rect
-      x="45"
-      y="42"
-      width="5"
-      height="5"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="53"
-      y1="44.5"
-      x2="60"
-      y2="44.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    <rect
-      x="45"
-      y="52"
-      width="5"
-      height="5"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="53"
-      y1="54.5"
-      x2="60"
-      y2="54.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
+      width="24"
+      height="16"
+      rx="2"
+      fill="none"
     />
   </svg>
 );
@@ -1102,46 +550,49 @@ export const MultiCascadeTree: React.FC = () => (
  */
 export const PinInput: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* PinInput segments */}
     <rect
       x="10"
-      y="30"
-      width="12"
-      height="20"
+      y="28"
+      width="14"
+      height="24"
       rx="4"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
     <rect
-      x="25"
-      y="30"
-      width="12"
-      height="20"
+      x="28"
+      y="28"
+      width="14"
+      height="24"
       rx="4"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
     <rect
-      x="40"
-      y="30"
-      width="12"
-      height="20"
+      x="46"
+      y="28"
+      width="14"
+      height="24"
       rx="4"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
     <rect
-      x="55"
-      y="30"
-      width="12"
-      height="20"
+      x="64"
+      y="28"
+      width="14"
+      height="24"
       rx="4"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
+    <circle cx="17" cy="40" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="35" cy="40" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="53" cy="40" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="71" cy="40" r="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );

--- a/docs/components/thumbnails/dataGrid.tsx
+++ b/docs/components/thumbnails/dataGrid.tsx
@@ -6,65 +6,23 @@ import React from 'react';
 export const BasicTable: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="20"
-      width="50"
-      height="40"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
       rx="4"
-      fill="transparent"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <rect
-      x="15"
-      y="20"
-      width="50"
-      height="10"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="15"
-      y1="30"
-      x2="65"
-      y2="30"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="15"
-      y1="40"
-      x2="65"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="15"
-      y1="50"
-      x2="65"
-      y2="50"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="32"
-      y1="20"
-      x2="32"
-      y2="60"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="49"
-      y1="20"
-      x2="49"
-      y2="60"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <path d="M10 32H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M10 48H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M30 16V64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M50 16V64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+
+    <rect x="14" y="22" width="12" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="34" y="22" width="12" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="54" y="22" width="12" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -74,91 +32,23 @@ export const BasicTable: React.FC = () => (
 export const VirtualTable: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="20"
-      width="50"
-      height="40"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
       rx="4"
-      fill="transparent"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <rect
-      x="15"
-      y="20"
-      width="50"
-      height="10"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="15"
-      y1="30"
-      x2="65"
-      y2="30"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="15"
-      y1="36"
-      x2="65"
-      y2="36"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <line
-      x1="15"
-      y1="42"
-      x2="65"
-      y2="42"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <line
-      x1="15"
-      y1="48"
-      x2="65"
-      y2="48"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <line
-      x1="15"
-      y1="54"
-      x2="65"
-      y2="54"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <line
-      x1="32"
-      y1="20"
-      x2="32"
-      y2="60"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="49"
-      y1="20"
-      x2="49"
-      y2="60"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect x="62" y="35" width="3" height="10" rx="1.5" fill="var(--rs-thumbnail-color-primary)" />
-    <rect
-      x="62"
-      y="35"
-      width="3"
-      height="10"
-      rx="1.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
+    <path d="M10 28H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M10 40H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M10 52H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+
+    <path d="M30 16V64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M50 16V64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+
+    <rect x="66" y="24" width="4" height="32" rx="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -167,221 +57,32 @@ export const VirtualTable: React.FC = () => (
  */
 export const TreeTable: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Table container */}
     <rect
-      x="15"
-      y="20"
-      width="50"
-      height="40"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
       rx="4"
-      fill="transparent"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
+    <path d="M10 32H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M10 48H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
 
-    {/* Table header */}
-    <rect
-      x="15"
-      y="20"
-      width="50"
-      height="10"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <path d="M30 16V64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M50 16V64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
 
-    {/* Horizontal lines */}
-    <line
-      x1="15"
-      y1="30"
-      x2="65"
-      y2="30"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="15"
-      y1="40"
-      x2="65"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <line
-      x1="15"
-      y1="50"
-      x2="65"
-      y2="50"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
+    <circle cx="16" cy="24" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="20" y="23" width="8" height="2" rx="1" fill="var(--rs-thumbnail-color-primary)" />
 
-    {/* Vertical lines */}
-    <line
-      x1="32"
-      y1="20"
-      x2="32"
-      y2="60"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="49"
-      y1="20"
-      x2="49"
-      y2="60"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <circle cx="20" cy="40" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="24" y="39" width="4" height="2" rx="1" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M16 26V40H18" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" fill="none" />
 
-    {/* Tree structure - First level */}
-    <circle
-      cx="20"
-      cy="35"
-      r="1.5"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-    <path
-      d="M22 35H26"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-    <rect
-      x="26"
-      y="33"
-      width="3"
-      height="3"
-      rx="0.5"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-
-    {/* Tree structure - Second level (expanded) */}
-    <path
-      d="M20 35V45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeDasharray="1 1"
-    />
-    <circle
-      cx="20"
-      cy="45"
-      r="1.5"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-    <path
-      d="M22 45H26"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-    <rect
-      x="26"
-      y="43"
-      width="3"
-      height="3"
-      rx="0.5"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-
-    {/* Tree structure - Third level */}
-    <path
-      d="M20 45V55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeDasharray="1 1"
-    />
-    <circle
-      cx="20"
-      cy="55"
-      r="1.5"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-    <path
-      d="M22 55H26"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-    <rect
-      x="26"
-      y="53"
-      width="3"
-      height="3"
-      rx="0.5"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-
-    {/* Data in other columns */}
-    <line
-      x1="36"
-      y1="35"
-      x2="45"
-      y2="35"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="53"
-      y1="35"
-      x2="60"
-      y2="35"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    <line
-      x1="36"
-      y1="45"
-      x2="45"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="53"
-      y1="45"
-      x2="60"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    <line
-      x1="36"
-      y1="55"
-      x2="45"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="53"
-      y1="55"
-      x2="60"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <circle cx="20" cy="56" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="24" y="55" width="4" height="2" rx="1" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M16 40V56H18" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" fill="none" />
   </svg>
 );
 
@@ -391,87 +92,23 @@ export const TreeTable: React.FC = () => (
 export const StickyTable: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="20"
-      width="50"
-      height="40"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
       rx="4"
-      fill="transparent"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <rect
-      x="15"
-      y="20"
-      width="50"
-      height="10"
-      rx="4"
-      fill="var(--rs-thumbnail-color-high)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="15"
-      y="30"
-      width="17"
-      height="30"
-      rx="0"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="15"
-      y1="30"
-      x2="65"
-      y2="30"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="15"
-      y1="40"
-      x2="65"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="15"
-      y1="50"
-      x2="65"
-      y2="50"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="32"
-      y1="20"
-      x2="32"
-      y2="60"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="49"
-      y1="20"
-      x2="49"
-      y2="60"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <path
-      d="M15 15L15 20M65 15L65 20"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeDasharray="1 1"
-    />
-    <path
-      d="M10 20L15 20M70 20L65 20"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeDasharray="1 1"
-    />
+    <path d="M10 32H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M10 48H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+
+    <path d="M30 16V64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M50 16V64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+
+    <rect x="10" y="16" width="60" height="16" rx="4" fill="var(--rs-thumbnail-bg-secondary)" opacity="0.3" />
+    <rect x="10" y="16" width="20" height="48" rx="4" fill="var(--rs-thumbnail-bg-secondary)" opacity="0.3" />
   </svg>
 );
 
@@ -481,87 +118,23 @@ export const StickyTable: React.FC = () => (
 export const EditableTable: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="20"
-      width="50"
-      height="40"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
       rx="4"
-      fill="transparent"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <rect
-      x="15"
-      y="20"
-      width="50"
-      height="10"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="15"
-      y1="30"
-      x2="65"
-      y2="30"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="15"
-      y1="40"
-      x2="65"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="15"
-      y1="50"
-      x2="65"
-      y2="50"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="32"
-      y1="20"
-      x2="32"
-      y2="60"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="49"
-      y1="20"
-      x2="49"
-      y2="60"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="32"
-      y="40"
-      width="17"
-      height="10"
-      rx="2"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <path
-      d="M36 45L40 45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M42 45L44 45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <path d="M10 32H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M10 48H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+
+    <path d="M30 16V64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M50 16V64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+
+    <rect x="34" y="36" width="12" height="8" rx="1" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M36 40H44" stroke="var(--rs-thumbnail-bg)" strokeWidth="1.5" strokeLinecap="round" />
   </svg>
 );
 
@@ -570,244 +143,24 @@ export const EditableTable: React.FC = () => (
  */
 export const FilterableTable: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Table container */}
     <rect
-      x="15"
-      y="20"
-      width="50"
-      height="40"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
       rx="4"
-      fill="transparent"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
+    <path d="M10 32H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M10 48H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
 
-    {/* Table header */}
-    <rect
-      x="15"
-      y="20"
-      width="50"
-      height="10"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <path d="M30 16V64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M50 16V64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
 
-    {/* Horizontal lines */}
-    <line
-      x1="15"
-      y1="30"
-      x2="65"
-      y2="30"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="15"
-      y1="40"
-      x2="65"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <line
-      x1="15"
-      y1="50"
-      x2="65"
-      y2="50"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-
-    {/* Vertical lines */}
-    <line
-      x1="32"
-      y1="20"
-      x2="32"
-      y2="60"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="49"
-      y1="20"
-      x2="49"
-      y2="60"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-
-    {/* Filter icons in header */}
-    {/* First column filter */}
-    <rect
-      x="22"
-      y="23"
-      width="6"
-      height="4"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-    />
-    <path
-      d="M24 23L26 26L28 23"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-
-    {/* Second column filter */}
-    <rect
-      x="39"
-      y="23"
-      width="6"
-      height="4"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-    />
-    <path
-      d="M41 23L43 26L45 23"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-
-    {/* Third column filter */}
-    <rect
-      x="56"
-      y="23"
-      width="6"
-      height="4"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-    />
-    <path
-      d="M58 23L60 26L62 23"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-
-    {/* Filter dropdown for first column (shown open) */}
-    <rect
-      x="18"
-      y="30"
-      width="12"
-      height="8"
-      rx="2"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      filter="url(#shadow)"
-    />
-    <line
-      x1="20"
-      y1="33"
-      x2="28"
-      y2="33"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-    />
-    <line
-      x1="20"
-      y1="35"
-      x2="28"
-      y2="35"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-    />
-    <circle cx="21" cy="33" r="0.75" fill="var(--rs-thumbnail-color-primary)" />
-
-    {/* Table data */}
-    <line
-      x1="20"
-      y1="45"
-      x2="28"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-    <line
-      x1="37"
-      y1="45"
-      x2="45"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-    <line
-      x1="54"
-      y1="45"
-      x2="62"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-
-    <line
-      x1="20"
-      y1="55"
-      x2="28"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-    <line
-      x1="37"
-      y1="55"
-      x2="45"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-    <line
-      x1="54"
-      y1="55"
-      x2="62"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-
-    {/* Shadow filter for dropdown */}
-    <defs>
-      <filter
-        id="shadow"
-        x="17"
-        y="29"
-        width="14"
-        height="10"
-        filterUnits="userSpaceOnUse"
-        colorInterpolationFilters="sRGB"
-      >
-        <feFlood floodOpacity="0" result="BackgroundImageFix" />
-        <feColorMatrix
-          in="SourceAlpha"
-          type="matrix"
-          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-        />
-        <feOffset dy="1" />
-        <feGaussianBlur stdDeviation="0.5" />
-        <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0" />
-        <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow" />
-        <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape" />
-      </filter>
-    </defs>
+    <path d="M22 22L24 26L26 22H22Z" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M42 22L44 26L46 22H42Z" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M62 22L64 26L66 22H62Z" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );

--- a/docs/components/thumbnails/dataPickers.tsx
+++ b/docs/components/thumbnails/dataPickers.tsx
@@ -5,120 +5,33 @@ import React from 'react';
  */
 export const CheckPicker: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Toggle button */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="15"
+      x="10"
+      y="16"
+      width="60"
+      height="14"
+      rx="2"
+      fill="none"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <path d="M58 21L62 25L66 21" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+
+    <rect
+      x="10"
+      y="34"
+      width="60"
+      height="32"
       rx="4"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <path
-      d="M55 22.5L53 19.5L57 19.5"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="20"
-      y1="22.5"
-      x2="45"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <rect x="14" y="40" width="6" height="6" rx="1" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M24 43H64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
 
-    {/* Dropdown menu */}
-    <rect
-      x="15"
-      y="30"
-      width="50"
-      height="40"
-      rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-
-    {/* Menu items with checkboxes */}
-    <rect
-      x="20"
-      y="37"
-      width="5"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <path
-      d="M21 39L22 40L24 38"
-      stroke="white"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="30"
-      y1="39.5"
-      x2="55"
-      y2="39.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    <rect
-      x="20"
-      y="47"
-      width="5"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <path
-      d="M21 49L22 50L24 48"
-      stroke="white"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="30"
-      y1="49.5"
-      x2="50"
-      y2="49.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    <rect
-      x="20"
-      y="57"
-      width="5"
-      height="5"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="30"
-      y1="59.5"
-      x2="45"
-      y2="59.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <rect x="14" y="52" width="6" height="6" rx="1" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M24 55H64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
   </svg>
 );
 
@@ -127,190 +40,35 @@ export const CheckPicker: React.FC = () => (
  */
 export const CheckTreePicker: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Toggle button */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="15"
+      x="10"
+      y="16"
+      width="60"
+      height="14"
+      rx="2"
+      fill="none"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <path d="M58 21L62 25L66 21" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+
+    <rect
+      x="10"
+      y="34"
+      width="60"
+      height="36"
       rx="4"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <path
-      d="M55 22.5L53 19.5L57 19.5"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="20"
-      y1="22.5"
-      x2="45"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <rect x="14" y="40" width="6" height="6" rx="1" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M26 43H64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
 
-    {/* CheckTree dropdown */}
-    <rect
-      x="15"
-      y="30"
-      width="50"
-      height="40"
-      rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <path d="M17 46V55H22" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" fill="none" />
 
-    {/* Root node with checkbox */}
-    <rect
-      x="20"
-      y="35"
-      width="5"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <path
-      d="M21 37L22 38L24 36"
-      stroke="white"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="30"
-      y1="37.5"
-      x2="45"
-      y2="37.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* First child level with checkbox */}
-    <rect
-      x="25"
-      y="45"
-      width="5"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <path
-      d="M26 47L27 48L29 46"
-      stroke="white"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="35"
-      y1="47.5"
-      x2="50"
-      y2="47.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Second child with unchecked box */}
-    <rect
-      x="25"
-      y="55"
-      width="5"
-      height="5"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="35"
-      y1="57.5"
-      x2="50"
-      y2="57.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Grandchild with unchecked box */}
-    <rect
-      x="30"
-      y="65"
-      width="5"
-      height="5"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="40"
-      y1="67.5"
-      x2="55"
-      y2="67.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Connection lines */}
-    <line
-      x1="22.5"
-      y1="40"
-      x2="22.5"
-      y2="67.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="22.5"
-      y1="47.5"
-      x2="25"
-      y2="47.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="22.5"
-      y1="57.5"
-      x2="25"
-      y2="57.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="27.5"
-      y1="60"
-      x2="27.5"
-      y2="67.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="27.5"
-      y1="67.5"
-      x2="30"
-      y2="67.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
+    <rect x="22" y="52" width="6" height="6" rx="1" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M34 55H64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
   </svg>
 );
 
@@ -319,79 +77,31 @@ export const CheckTreePicker: React.FC = () => (
  */
 export const InputPicker: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Toggle button */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="15"
+      x="10"
+      y="16"
+      width="60"
+      height="14"
+      rx="2"
+      fill="none"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <path d="M58 21L62 25L66 21" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+
+    <rect
+      x="10"
+      y="34"
+      width="60"
+      height="32"
       rx="4"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <path
-      d="M55 22.5L53 19.5L57 19.5"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="20"
-      y1="22.5"
-      x2="35"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-
-    {/* Dropdown menu */}
-    <rect
-      x="15"
-      y="30"
-      width="50"
-      height="40"
-      rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-
-    {/* Menu items */}
-    <rect
-      x="20"
-      y="37"
-      width="40"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-
-    <rect
-      x="20"
-      y="47"
-      width="35"
-      height="5"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-
-    <rect
-      x="20"
-      y="57"
-      width="30"
-      height="5"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
+    <rect x="14" y="40" width="52" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="14" y="48" width="40" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="14" y="56" width="46" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -400,86 +110,33 @@ export const InputPicker: React.FC = () => (
  */
 export const SelectPicker: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Toggle button */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="15"
+      x="10"
+      y="16"
+      width="60"
+      height="14"
+      rx="2"
+      fill="none"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <path d="M58 21L62 25L66 21" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+
+    <rect
+      x="10"
+      y="34"
+      width="60"
+      height="32"
       rx="4"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <path
-      d="M55 22.5L53 19.5L57 19.5"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="20"
-      y1="22.5"
-      x2="40"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <rect x="14" y="40" width="52" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M60 40L64 42L60 44" stroke="var(--rs-thumbnail-bg-secondary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
 
-    {/* Dropdown menu */}
-    <rect
-      x="15"
-      y="30"
-      width="50"
-      height="40"
-      rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-
-    {/* Menu items - highlighted item */}
-    <rect
-      x="20"
-      y="37"
-      width="40"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="25"
-      y1="39.5"
-      x2="55"
-      y2="39.5"
-      stroke="white"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Regular items */}
-    <line
-      x1="20"
-      y1="47.5"
-      x2="50"
-      y2="47.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="20"
-      y1="57.5"
-      x2="45"
-      y2="57.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <rect x="14" y="48" width="40" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="14" y="56" width="46" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -488,81 +145,34 @@ export const SelectPicker: React.FC = () => (
  */
 export const TagPicker: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Toggle button */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="15"
+      x="10"
+      y="16"
+      width="60"
+      height="14"
+      rx="2"
+      fill="none"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <rect x="14" y="20" width="16" height="6" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="34" y="20" width="12" height="6" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M58 21L62 25L66 21" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+
+    <rect
+      x="10"
+      y="34"
+      width="60"
+      height="32"
       rx="4"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <path
-      d="M55 22.5L53 19.5L57 19.5"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <rect
-      x="20"
-      y="20"
-      width="15"
-      height="5"
-      rx="2.5"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
+      strokeWidth="2"
     />
-
-    {/* Dropdown menu */}
-    <rect
-      x="15"
-      y="30"
-      width="50"
-      height="40"
-      rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-
-    {/* Menu items */}
-    <rect
-      x="20"
-      y="37"
-      width="40"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-
-    <rect
-      x="20"
-      y="47"
-      width="35"
-      height="5"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-
-    <rect
-      x="20"
-      y="57"
-      width="30"
-      height="5"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
+    <rect x="14" y="40" width="52" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <path d="M60 40L64 42L60 44" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    <rect x="14" y="48" width="40" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="14" y="56" width="46" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -571,140 +181,35 @@ export const TagPicker: React.FC = () => (
  */
 export const TreePicker: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Toggle button */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="15"
-      rx="4"
-      fill="transparent"
+      x="10"
+      y="16"
+      width="60"
+      height="14"
+      rx="2"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <path
-      d="M55 22.5L53 19.5L57 19.5"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="20"
-      y1="22.5"
-      x2="40"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <path d="M58 21L62 25L66 21" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
 
-    {/* Tree dropdown */}
     <rect
-      x="15"
-      y="30"
-      width="50"
-      height="40"
+      x="10"
+      y="34"
+      width="60"
+      height="36"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
+    <circle cx="16" cy="40" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M22 40H64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
 
-    {/* Root node */}
-    <circle cx="22.5" cy="37.5" r="2" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="30"
-      y1="37.5"
-      x2="45"
-      y2="37.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <path d="M16 42V52H22" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" fill="none" />
 
-    {/* First child level */}
-    <circle cx="27.5" cy="47.5" r="2" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="35"
-      y1="47.5"
-      x2="50"
-      y2="47.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Second child */}
-    <circle cx="27.5" cy="57.5" r="2" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="35"
-      y1="57.5"
-      x2="50"
-      y2="57.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Grandchild */}
-    <circle cx="32.5" cy="67.5" r="2" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="40"
-      y1="67.5"
-      x2="55"
-      y2="67.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Connection lines */}
-    <line
-      x1="22.5"
-      y1="40"
-      x2="22.5"
-      y2="67.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="22.5"
-      y1="47.5"
-      x2="25.5"
-      y2="47.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="22.5"
-      y1="57.5"
-      x2="25.5"
-      y2="57.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="27.5"
-      y1="60"
-      x2="27.5"
-      y2="67.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="27.5"
-      y1="67.5"
-      x2="30.5"
-      y2="67.5"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
+    <circle cx="26" cy="52" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M32 52H64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
   </svg>
 );
 
@@ -713,206 +218,43 @@ export const TreePicker: React.FC = () => (
  */
 export const MultiCascader: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Toggle button */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="15"
+      x="10"
+      y="16"
+      width="60"
+      height="14"
+      rx="2"
+      fill="none"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <path d="M58 21L62 25L66 21" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+
+    <rect
+      x="10"
+      y="34"
+      width="60"
+      height="36"
       rx="4"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <path
-      d="M55 22.5L53 19.5L57 19.5"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="20"
-      y1="22.5"
-      x2="45"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <path d="M40 34V70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
 
-    {/* Dropdown menu - single container */}
-    <rect
-      x="15"
-      y="30"
-      width="50"
-      height="40"
-      rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    {/* Left */}
+    <rect x="14" y="40" width="6" height="6" rx="1" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M26 43H36" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
 
-    {/* Vertical divider line */}
-    <line
-      x1="40"
-      y1="30"
-      x2="40"
-      y2="70"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
+    <rect x="14" y="52" width="6" height="6" rx="1" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M26 55H36" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
 
-    {/* Left side items with checkboxes */}
-    <rect
-      x="20"
-      y="37"
-      width="5"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <path
-      d="M21 39L22 40L24 38"
-      stroke="white"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="30"
-      y1="39.5"
-      x2="35"
-      y2="39.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    {/* Right */}
+    <rect x="44" y="40" width="6" height="6" rx="1" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M56 43H66" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
 
-    <rect
-      x="20"
-      y="47"
-      width="5"
-      height="5"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="30"
-      y1="49.5"
-      x2="35"
-      y2="49.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    <rect
-      x="20"
-      y="57"
-      width="5"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <path
-      d="M21 59L22 60L24 58"
-      stroke="white"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="30"
-      y1="59.5"
-      x2="35"
-      y2="59.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Right side items with checkboxes (second level) */}
-    <rect
-      x="45"
-      y="37"
-      width="5"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <path
-      d="M46 39L47 40L49 38"
-      stroke="white"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="55"
-      y1="39.5"
-      x2="60"
-      y2="39.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    <rect
-      x="45"
-      y="47"
-      width="5"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <path
-      d="M46 49L47 50L49 48"
-      stroke="white"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="55"
-      y1="49.5"
-      x2="60"
-      y2="49.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    <rect
-      x="45"
-      y="57"
-      width="5"
-      height="5"
-      rx="1"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="55"
-      y1="59.5"
-      x2="60"
-      y2="59.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <rect x="44" y="52" width="6" height="6" rx="1" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M56 55H66" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
   </svg>
 );
 
@@ -921,133 +263,36 @@ export const MultiCascader: React.FC = () => (
  */
 export const Cascader: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Toggle button */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="15"
+      x="10"
+      y="16"
+      width="60"
+      height="14"
+      rx="2"
+      fill="none"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <path d="M58 21L62 25L66 21" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+
+    <rect
+      x="10"
+      y="34"
+      width="60"
+      height="36"
       rx="4"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <path
-      d="M55 22.5L53 19.5L57 19.5"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <line
-      x1="20"
-      y1="22.5"
-      x2="45"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <path d="M40 34V70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
 
-    {/* Dropdown menu - single container */}
-    <rect
-      x="15"
-      y="30"
-      width="50"
-      height="40"
-      rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    {/* Left */}
+    <rect x="14" y="40" width="22" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="14" y="52" width="22" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
 
-    {/* Vertical divider line */}
-    <line
-      x1="40"
-      y1="30"
-      x2="40"
-      y2="70"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-
-    {/* Left side items */}
-    <line
-      x1="20"
-      y1="40"
-      x2="35"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <rect
-      x="20"
-      y="45"
-      width="15"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="20"
-      y1="55"
-      x2="30"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="20"
-      y1="65"
-      x2="25"
-      y2="65"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Right side items (second level) */}
-    <line
-      x1="45"
-      y1="40"
-      x2="60"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="45"
-      y1="50"
-      x2="55"
-      y2="50"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <rect
-      x="45"
-      y="55"
-      width="15"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <line
-      x1="45"
-      y1="65"
-      x2="50"
-      y2="65"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    {/* Right */}
+    <rect x="44" y="40" width="22" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="44" y="52" width="22" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );

--- a/docs/components/thumbnails/dateTime.tsx
+++ b/docs/components/thumbnails/dateTime.tsx
@@ -6,116 +6,37 @@ import React from 'react';
 export const Calendar: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="10"
+      x="10"
+      y="16"
+      width="60"
+      height="12"
       rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="25"
-      y1="35"
-      x2="25"
-      y2="35"
-      stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
-      strokeLinecap="round"
     />
-    <line
-      x1="35"
-      y1="35"
-      x2="35"
-      y2="35"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="45"
-      y1="35"
-      x2="45"
-      y2="35"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="55"
-      y1="35"
-      x2="55"
-      y2="35"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="25"
-      y1="45"
-      x2="25"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="35"
-      y1="45"
-      x2="35"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <circle cx="45" cy="45" r="3" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="55"
-      y1="45"
-      x2="55"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="25"
-      y1="55"
-      x2="25"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="35"
-      y1="55"
-      x2="35"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="45"
-      y1="55"
-      x2="45"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
+
+    <circle cx="26" cy="38" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="40" cy="38" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="54" cy="38" r="2" fill="var(--rs-thumbnail-color-primary)" />
+
+    <circle cx="26" cy="48" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="40" cy="48" r="2" fill="var(--rs-thumbnail-bg)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <circle cx="54" cy="48" r="2" fill="var(--rs-thumbnail-color-primary)" />
+
+    <circle cx="26" cy="58" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="40" cy="58" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="54" cy="58" r="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -124,124 +45,23 @@ export const Calendar: React.FC = () => (
  */
 export const DateInput: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Input container */}
     <rect
-      x="15"
-      y="30"
-      width="50"
-      height="20"
+      x="10"
+      y="28"
+      width="60"
+      height="24"
       rx="4"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-
-    {/* Date format: --/--/---- using lines */}
-    {/* First -- */}
-    <line
-      x1="22"
-      y1="40"
-      x2="25"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="27"
-      y1="40"
-      x2="30"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* First / */}
-    <path
-      d="M32 38L34 42"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-
-    {/* Second -- */}
-    <line
-      x1="36"
-      y1="40"
-      x2="39"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="41"
-      y1="40"
-      x2="44"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Second / */}
-    <path
-      d="M46 38L48 42"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-
-    {/* Year ---- */}
-    <line
-      x1="50"
-      y1="40"
-      x2="53"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Calendar icon - centered vertically */}
-    <rect
-      x="55"
-      y="37.5"
-      width="5"
-      height="5"
-      rx="1"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
+      strokeWidth="2"
     />
-    <line
-      x1="56"
-      y1="35.5"
-      x2="56"
-      y2="39.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-    />
-    <line
-      x1="59"
-      y1="35.5"
-      x2="59"
-      y2="39.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-    />
-    <line
-      x1="55"
-      y1="40.5"
-      x2="60"
-      y2="40.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-    />
+
+    {/* YYYY-MM-DD abstract */}
+    <rect x="16" y="38" width="16" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M34 36L36 44" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
+    <rect x="38" y="38" width="8" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M48 36L50 44" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
+    <rect x="52" y="38" width="8" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -250,248 +70,37 @@ export const DateInput: React.FC = () => (
  */
 export const DatePicker: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Toggle button part (similar to DateInput) */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="15"
-      rx="4"
-      fill="transparent"
+      x="10"
+      y="16"
+      width="60"
+      height="14"
+      rx="2"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
+    <rect x="14" y="21" width="16" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
 
-    {/* Date format: --/--/---- using lines */}
-    <line
-      x1="22"
-      y1="22.5"
-      x2="25"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="27"
-      y1="22.5"
-      x2="30"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* First / */}
-    <path
-      d="M32 20.5L34 24.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-
-    {/* Second -- */}
-    <line
-      x1="36"
-      y1="22.5"
-      x2="39"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="41"
-      y1="22.5"
-      x2="44"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Calendar icon */}
     <rect
-      x="55"
-      y="20"
-      width="5"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-    />
-    <line
-      x1="56"
-      y1="18"
-      x2="56"
-      y2="22"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-    />
-    <line
-      x1="59"
-      y1="18"
-      x2="59"
-      y2="22"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-    />
-    <line
-      x1="55"
-      y1="23"
-      x2="60"
-      y2="23"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-    />
-
-    {/* Calendar panel part (similar to Calendar) */}
-    <rect
-      x="15"
-      y="30"
-      width="50"
-      height="35"
-      rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="15"
-      y="30"
-      width="50"
-      height="8"
+      x="10"
+      y="34"
+      width="60"
+      height="36"
       rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
+    <rect x="10" y="34" width="60" height="8" rx="4" fill="var(--rs-thumbnail-color-primary)" opacity="0.1" />
 
-    {/* Calendar days */}
-    <line
-      x1="22"
-      y1="45"
-      x2="22"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="30"
-      y1="45"
-      x2="30"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="38"
-      y1="45"
-      x2="38"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="46"
-      y1="45"
-      x2="46"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="54"
-      y1="45"
-      x2="54"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
+    <circle cx="26" cy="50" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="40" cy="50" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="54" cy="50" r="2" fill="var(--rs-thumbnail-color-primary)" />
 
-    <line
-      x1="22"
-      y1="52"
-      x2="22"
-      y2="52"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="30"
-      y1="52"
-      x2="30"
-      y2="52"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <circle cx="38" cy="52" r="3" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="46"
-      y1="52"
-      x2="46"
-      y2="52"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="54"
-      y1="52"
-      x2="54"
-      y2="52"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-
-    <line
-      x1="22"
-      y1="59"
-      x2="22"
-      y2="59"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="30"
-      y1="59"
-      x2="30"
-      y2="59"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="38"
-      y1="59"
-      x2="38"
-      y2="59"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="46"
-      y1="59"
-      x2="46"
-      y2="59"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
+    <circle cx="26" cy="60" r="2" fill="var(--rs-thumbnail-color-primary)" />
+    <circle cx="40" cy="60" r="2" fill="var(--rs-thumbnail-bg)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <circle cx="54" cy="60" r="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -501,66 +110,18 @@ export const DatePicker: React.FC = () => (
 export const DateRangeInput: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="30"
-      width="50"
-      height="20"
+      x="10"
+      y="28"
+      width="60"
+      height="24"
       rx="4"
-      fill="transparent"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <path
-      d="M20 40H25"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M28 40H30"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M33 40H35"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M40 40H40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M45 40H50"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M53 40H55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M58 40H60"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="40"
-      y1="35"
-      x2="40"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
+    <rect x="14" y="38" width="16" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M34 40H46" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
+    <rect x="50" y="38" width="16" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -570,278 +131,31 @@ export const DateRangeInput: React.FC = () => (
 export const DateTimeRangePicker: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="20"
-      width="50"
-      height="15"
+      x="10"
+      y="16"
+      width="60"
+      height="14"
+      rx="2"
+      fill="none"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <rect x="14" y="21" width="16" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+
+    <rect
+      x="10"
+      y="34"
+      width="60"
+      height="36"
       rx="4"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <path
-      d="M55 27.5L50 32.5L45 27.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M25 27.5H40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <rect
-      x="15"
-      y="35"
-      width="50"
-      height="30"
-      rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="17"
-      y="37"
-      width="23"
-      height="26"
-      rx="2"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <rect
-      x="40"
-      y="37"
-      width="23"
-      height="26"
-      rx="2"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <rect
-      x="17"
-      y="37"
-      width="23"
-      height="6"
-      rx="2"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
+      strokeWidth="2"
     />
-    <rect
-      x="40"
-      y="37"
-      width="23"
-      height="6"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <line
-      x1="20"
-      y1="47"
-      x2="20"
-      y2="47"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="25"
-      y1="47"
-      x2="25"
-      y2="47"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="30"
-      y1="47"
-      x2="30"
-      y2="47"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="35"
-      y1="47"
-      x2="35"
-      y2="47"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="20"
-      y1="52"
-      x2="20"
-      y2="52"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="25"
-      y1="52"
-      x2="25"
-      y2="52"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <circle cx="30" cy="52" r="2" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="35"
-      y1="52"
-      x2="35"
-      y2="52"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="20"
-      y1="57"
-      x2="20"
-      y2="57"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="25"
-      y1="57"
-      x2="25"
-      y2="57"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="30"
-      y1="57"
-      x2="30"
-      y2="57"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="35"
-      y1="57"
-      x2="35"
-      y2="57"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="43"
-      y1="47"
-      x2="43"
-      y2="47"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="48"
-      y1="47"
-      x2="48"
-      y2="47"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="53"
-      y1="47"
-      x2="53"
-      y2="47"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="58"
-      y1="47"
-      x2="58"
-      y2="47"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="43"
-      y1="52"
-      x2="43"
-      y2="52"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="48"
-      y1="52"
-      x2="48"
-      y2="52"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="53"
-      y1="52"
-      x2="53"
-      y2="52"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <circle cx="58" cy="52" r="2" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="43"
-      y1="57"
-      x2="43"
-      y2="57"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="48"
-      y1="57"
-      x2="48"
-      y2="57"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="53"
-      y1="57"
-      x2="53"
-      y2="57"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="58"
-      y1="57"
-      x2="58"
-      y2="57"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <path d="M40 34V70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+
+    <rect x="14" y="44" width="22" height="16" rx="2" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeDasharray="2 2" />
+    <rect x="44" y="44" width="22" height="16" rx="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -850,314 +164,32 @@ export const DateTimeRangePicker: React.FC = () => (
  */
 export const TimeRangePicker: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Toggle button part */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="15"
+      x="10"
+      y="16"
+      width="60"
+      height="14"
+      rx="2"
+      fill="none"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <rect x="14" y="21" width="16" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+
+    <rect
+      x="10"
+      y="34"
+      width="60"
+      height="32"
       rx="4"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-
-    {/* Time format: --:-- to --:-- */}
-    <line
-      x1="20"
-      y1="22.5"
-      x2="23"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="25"
-      y1="22.5"
-      x2="28"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* First colon : */}
-    <circle cx="30" cy="20.5" r="1" fill="var(--rs-thumbnail-color-primary)" />
-    <circle cx="30" cy="24.5" r="1" fill="var(--rs-thumbnail-color-primary)" />
-
-    {/* First time minutes */}
-    <line
-      x1="32"
-      y1="22.5"
-      x2="35"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* To symbol */}
-    <line
-      x1="37"
-      y1="22.5"
-      x2="39"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Second time hours */}
-    <line
-      x1="41"
-      y1="22.5"
-      x2="44"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Second colon : */}
-    <circle cx="46" cy="20.5" r="1" fill="var(--rs-thumbnail-color-primary)" />
-    <circle cx="46" cy="24.5" r="1" fill="var(--rs-thumbnail-color-primary)" />
-
-    {/* Second time minutes */}
-    <line
-      x1="48"
-      y1="22.5"
-      x2="51"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Clock icon */}
-    <circle
-      cx="58"
-      cy="22.5"
-      r="3"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
+      strokeWidth="2"
     />
-    <line
-      x1="58"
-      y1="22.5"
-      x2="60"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-    />
-    <line
-      x1="58"
-      y1="22.5"
-      x2="58"
-      y2="20.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-    />
+    <path d="M40 34V66" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
 
-    {/* Time panel */}
-    <rect
-      x="15"
-      y="30"
-      width="50"
-      height="35"
-      rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-
-    {/* Vertical divider line */}
-    <line
-      x1="40"
-      y1="30"
-      x2="40"
-      y2="65"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-
-    {/* Left side - start time */}
-    {/* Hours column */}
-    <rect
-      x="18"
-      y="35"
-      width="8"
-      height="25"
-      rx="2"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-    />
-    <line
-      x1="20"
-      y1="40"
-      x2="24"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-    <rect
-      x="20"
-      y="45"
-      width="4"
-      height="4"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <text x="22" y="48" fontSize="4" textAnchor="middle" fill="transparent" fontWeight="bold">
-      9
-    </text>
-    <line
-      x1="20"
-      y1="55"
-      x2="24"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-
-    {/* Minutes column */}
-    <rect
-      x="28"
-      y="35"
-      width="8"
-      height="25"
-      rx="2"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-    />
-    <line
-      x1="30"
-      y1="40"
-      x2="34"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-    <rect
-      x="30"
-      y="45"
-      width="4"
-      height="4"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <text x="32" y="48" fontSize="4" textAnchor="middle" fill="transparent" fontWeight="bold">
-      00
-    </text>
-    <line
-      x1="30"
-      y1="55"
-      x2="34"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-
-    {/* Right side - end time */}
-    {/* Hours column */}
-    <rect
-      x="44"
-      y="35"
-      width="8"
-      height="25"
-      rx="2"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-    />
-    <line
-      x1="46"
-      y1="40"
-      x2="50"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-    <rect
-      x="46"
-      y="45"
-      width="4"
-      height="4"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <text x="48" y="48" fontSize="4" textAnchor="middle" fill="transparent" fontWeight="bold">
-      5
-    </text>
-    <line
-      x1="46"
-      y1="55"
-      x2="50"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-
-    {/* Minutes column */}
-    <rect
-      x="54"
-      y="35"
-      width="8"
-      height="25"
-      rx="2"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-    />
-    <line
-      x1="56"
-      y1="40"
-      x2="60"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-    <rect
-      x="56"
-      y="45"
-      width="4"
-      height="4"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="0.5"
-    />
-    <text x="58" y="48" fontSize="4" textAnchor="middle" fill="transparent" fontWeight="bold">
-      30
-    </text>
-    <line
-      x1="56"
-      y1="55"
-      x2="60"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
+    <rect x="14" y="44" width="22" height="12" rx="2" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeDasharray="2 2" />
+    <rect x="44" y="44" width="22" height="12" rx="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -1166,261 +198,39 @@ export const TimeRangePicker: React.FC = () => (
  */
 export const DateRangePicker: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Toggle button part */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="15"
-      rx="4"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-
-    {/* Date format: --/--/---- to --/--/---- */}
-    <line
-      x1="20"
-      y1="22.5"
-      x2="23"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M25 20.5L27 24.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-    <line
-      x1="29"
-      y1="22.5"
-      x2="32"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* To symbol */}
-    <line
-      x1="35"
-      y1="22.5"
-      x2="37"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Second date */}
-    <line
-      x1="40"
-      y1="22.5"
-      x2="43"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M45 20.5L47 24.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-    />
-    <line
-      x1="49"
-      y1="22.5"
-      x2="52"
-      y2="22.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Calendar icon */}
-    <rect
-      x="55"
-      y="20"
-      width="5"
-      height="5"
-      rx="1"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-    />
-    <line
-      x1="56"
-      y1="18"
-      x2="56"
-      y2="22"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-    />
-    <line
-      x1="59"
-      y1="18"
-      x2="59"
-      y2="22"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-    />
-    <line
-      x1="55"
-      y1="23"
-      x2="60"
-      y2="23"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.75"
-      strokeLinecap="round"
-    />
-
-    {/* Calendar panel part - single container with divider */}
-    <rect
-      x="15"
-      y="30"
-      width="50"
-      height="35"
-      rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="15"
-      y="30"
-      width="50"
-      height="8"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-
-    {/* Vertical divider line */}
-    <line
-      x1="40"
-      y1="30"
-      x2="40"
-      y2="65"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-
-    {/* Left calendar - start date */}
-    <line
-      x1="22"
-      y1="45"
-      x2="22"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="30"
-      y1="45"
-      x2="30"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <circle cx="22" cy="52" r="3" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="30"
-      y1="52"
-      x2="30"
-      y2="52"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="22"
-      y1="59"
-      x2="22"
-      y2="59"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="30"
-      y1="59"
-      x2="30"
-      y2="59"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-
-    {/* Right calendar - end date */}
-    <line
-      x1="48"
-      y1="45"
-      x2="48"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="56"
-      y1="45"
-      x2="56"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="48"
-      y1="52"
-      x2="48"
-      y2="52"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="56"
-      y1="52"
-      x2="56"
-      y2="52"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <circle cx="56" cy="59" r="3" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="48"
-      y1="59"
-      x2="48"
-      y2="59"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-
-    {/* Date range highlight */}
-    <rect
-      x="25"
-      y="52"
-      width="30"
-      height="6"
+      x="10"
+      y="16"
+      width="60"
+      height="14"
       rx="2"
+      fill="none"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
+    />
+    <rect x="14" y="21" width="16" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+
+    <rect
+      x="10"
+      y="34"
+      width="60"
+      height="36"
+      rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-      strokeDasharray="1 1"
+      strokeWidth="2"
     />
+    <path d="M40 34V70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+
+    {/* Left Calendar */}
+    <rect x="14" y="44" width="22" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="14" y="52" width="22" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="14" y="60" width="22" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+
+    {/* Right Calendar */}
+    <rect x="44" y="44" width="22" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="44" y="52" width="22" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="44" y="60" width="22" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 

--- a/docs/components/thumbnails/default.tsx
+++ b/docs/components/thumbnails/default.tsx
@@ -6,14 +6,15 @@ import React from 'react';
 export const Default: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="10"
+      y="10"
+      width="60"
+      height="60"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
+      strokeDasharray="4 4"
     />
     <path
       d="M30 40H50M40 30V50"

--- a/docs/components/thumbnails/disclosure.tsx
+++ b/docs/components/thumbnails/disclosure.tsx
@@ -7,98 +7,60 @@ import React from 'react';
  */
 export const DisclosureAccordion: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* First panel - expanded */}
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="15"
-      rx="4"
+      x="10"
+      y="16"
+      width="60"
+      height="14"
+      rx="2"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <line
-      x1="25"
-      y1="22.5"
-      x2="40"
-      y2="22.5"
+    <path
+      d="M60 19L64 23L60 27"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="1.5"
       strokeLinecap="round"
+      strokeLinejoin="round"
     />
-
-    {/* Indicator for expanded panel */}
-    <circle
-      cx="53"
-      cy="22.5"
-      r="3"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="0.5"
-    />
-
-    {/* Second panel - collapsed */}
     <rect
-      x="15"
-      y="32.5"
-      width="50"
-      height="15"
-      rx="4"
-      fill="transparent"
+      x="10"
+      y="34"
+      width="60"
+      height="14"
+      rx="2"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <line
-      x1="25"
-      y1="40"
-      x2="40"
-      y2="40"
+    <path
+      d="M60 37L64 41L60 45"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="1.5"
       strokeLinecap="round"
+      strokeLinejoin="round"
     />
-
-    {/* Indicator for collapsed panel */}
-    <circle
-      cx="53"
-      cy="40"
-      r="3"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-
-    {/* Third panel - collapsed */}
     <rect
-      x="15"
-      y="50"
-      width="50"
-      height="15"
-      rx="4"
-      fill="transparent"
+      x="10"
+      y="52"
+      width="60"
+      height="14"
+      rx="2"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <line
-      x1="25"
-      y1="57.5"
-      x2="40"
-      y2="57.5"
+    <path
+      d="M60 55L64 59L60 63"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="1.5"
       strokeLinecap="round"
+      strokeLinejoin="round"
     />
-
-    {/* Indicator for collapsed panel */}
-    <circle
-      cx="53"
-      cy="57.5"
-      r="3"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
+    <rect x="16" y="21" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="16" y="39" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="16" y="57" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -108,90 +70,24 @@ export const DisclosureAccordion: React.FC = () => (
 export const Tabs: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="25"
-      width="50"
-      height="40"
+      x="10"
+      y="28"
+      width="60"
+      height="36"
       rx="4"
-      fill="transparent"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <rect
-      x="15"
-      y="15"
-      width="15"
-      height="10"
-      rx="4 4 0 0"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="30"
-      y="15"
-      width="15"
-      height="10"
-      rx="4 4 0 0"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="45"
-      y="15"
-      width="15"
-      height="10"
-      rx="4 4 0 0"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="22.5"
-      y1="20"
-      x2="22.5"
-      y2="20"
-      stroke="white"
-      strokeWidth="3"
-      strokeLinecap="round"
-    />
-    <line
-      x1="37.5"
-      y1="20"
-      x2="37.5"
-      y2="20"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="3"
-      strokeLinecap="round"
-    />
-    <line
-      x1="52.5"
-      y1="20"
-      x2="52.5"
-      y2="20"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="3"
-      strokeLinecap="round"
-    />
-    <line
-      x1="25"
-      y1="40"
-      x2="55"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="25"
-      y1="50"
-      x2="45"
-      y2="50"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <path d="M10 28H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M10 40H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+
+    <path d="M10 28V20C10 17.7909 11.7909 16 14 16H26C28.2091 16 30 17.7909 30 20V28" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M30 28V22C30 19.7909 31.7909 18 34 18H46C48.2091 18 50 19.7909 50 22V28" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" opacity="0.5" />
+    <path d="M50 28V22C50 19.7909 51.7909 18 54 18H66C68.2091 18 70 19.7909 70 22V28" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" opacity="0.5" />
+
+    <rect x="16" y="46" width="32" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="16" y="54" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -201,50 +97,19 @@ export const Tabs: React.FC = () => (
 export const VisuallyHidden: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="30"
-      width="50"
-      height="20"
+      x="10"
+      y="28"
+      width="60"
+      height="24"
       rx="4"
-      fill="transparent"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeDasharray="3 2"
+      strokeWidth="2"
+      strokeDasharray="4 4"
     />
-    <circle
-      cx="40"
-      cy="40"
-      r="10"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeDasharray="3 2"
-    />
-    <path
-      d="M30 40L50 40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeDasharray="3 2"
-    />
-    <path
-      d="M40 30L40 50"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeDasharray="3 2"
-    />
-    <path
-      d="M30 30L50 50"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M50 30L30 50"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <path d="M25 40L35 40" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <circle cx="40" cy="40" r="8" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M45 40L55 40" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M34 34L46 46" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
   </svg>
 );

--- a/docs/components/thumbnails/form.tsx
+++ b/docs/components/thumbnails/form.tsx
@@ -6,45 +6,19 @@ import React from 'react';
 export const Form: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="10"
+      y="10"
+      width="60"
+      height="60"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
-    <rect
-      x="20"
-      y="20"
-      width="40"
-      height="10"
-      rx="2"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="20"
-      y="35"
-      width="40"
-      height="10"
-      rx="2"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="20"
-      y="50"
-      width="15"
-      height="10"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <rect x="18" y="18" width="44" height="8" rx="2" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <rect x="18" y="32" width="44" height="8" rx="2" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <rect x="18" y="46" width="44" height="8" rx="2" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <rect x="42" y="58" width="20" height="6" rx="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -54,46 +28,20 @@ export const Form: React.FC = () => (
 export const FormValidation: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="10"
+      y="10"
+      width="60"
+      height="60"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="20"
-      y="20"
-      width="40"
-      height="10"
-      rx="2"
-      fill="transparent"
-      stroke="var(--rs-red-500)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="20"
-      y="35"
-      width="40"
-      height="10"
-      rx="2"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="20"
-      y="50"
-      width="15"
-      height="10"
-      rx="2"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <line x1="20" y1="33" x2="35" y2="33" stroke="var(--rs-red-500)" strokeWidth="1.5" />
+    <rect x="18" y="18" width="44" height="8" rx="2" fill="none" stroke="var(--rs-red-500)" strokeWidth="1.5" />
+    <path d="M18 29H38" stroke="var(--rs-red-500)" strokeWidth="1.5" strokeLinecap="round" />
+
+    <rect x="18" y="34" width="44" height="8" rx="2" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <rect x="42" y="58" width="20" height="6" rx="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -103,80 +51,23 @@ export const FormValidation: React.FC = () => (
 export const Schema: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="10"
+      y="10"
+      width="60"
+      height="60"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="20"
-      y="20"
-      width="40"
-      height="10"
-      rx="2"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
+      strokeWidth="2"
     />
-    <rect
-      x="20"
-      y="35"
-      width="40"
-      height="10"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <rect
-      x="20"
-      y="50"
-      width="40"
-      height="10"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <path
-      d="M25 25L30 25L35 25"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M25 40L30 40L35 40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M25 55L30 55L35 55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M45 25L50 25L55 25"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M45 40L50 40L55 40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M45 55L50 55L55 55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+
+    <rect x="18" y="20" width="8" height="8" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M30 24H58" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
+
+    <rect x="18" y="36" width="8" height="8" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M30 40H58" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
+
+    <rect x="18" y="52" width="8" height="8" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M30 56H58" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
   </svg>
 );

--- a/docs/components/thumbnails/layout.tsx
+++ b/docs/components/thumbnails/layout.tsx
@@ -1,35 +1,25 @@
 import React from 'react';
 
 /**
- * Box 组件缩略图
+ * Box component thumbnail
  */
 export const Box: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="16"
+      y="16"
+      width="48"
+      height="48"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-    />
-    <rect
-      x="25"
-      y="25"
-      width="30"
-      height="30"
-      rx="2"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
   </svg>
 );
 
 /**
- * Center 组件缩略图
+ * Center component thumbnail
  */
 export const Center: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -41,145 +31,62 @@ export const Center: React.FC = () => (
       rx="4"
       fill="var(--rs-thumbnail-bg)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeDasharray="4 2"
+      strokeWidth="2"
+      strokeDasharray="4 4"
     />
     <rect
-      x="25"
-      y="25"
-      width="30"
-      height="30"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      x="28"
+      y="28"
+      width="24"
+      height="24"
+      rx="4"
+      fill="var(--rs-thumbnail-color-primary)"
     />
-    <line
-      x1="40"
-      y1="10"
-      x2="40"
-      y2="25"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="40"
-      y1="55"
-      x2="40"
-      y2="70"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="10"
-      y1="40"
-      x2="25"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="55"
-      y1="40"
-      x2="70"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
+    <path d="M40 10V28" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeDasharray="2 2" />
+    <path d="M40 52V70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeDasharray="2 2" />
+    <path d="M10 40H28" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeDasharray="2 2" />
+    <path d="M52 40H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeDasharray="2 2" />
   </svg>
 );
 
 /**
- * Divider 组件缩略图
+ * Divider component thumbnail
  */
 export const Divider: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect
-      x="15"
-      y="20"
-      width="50"
-      height="10"
-      rx="2"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="15"
-      y1="40"
-      x2="65"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-    />
-    <rect
-      x="15"
-      y="50"
-      width="50"
-      height="10"
-      rx="2"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
+    <rect x="20" y="24" width="40" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <path d="M10 40H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <rect x="20" y="52" width="40" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
 /**
- * Frame 组件缩略图
+ * Frame component thumbnail
  */
 export const Frame: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
       x="10"
-      y="10"
+      y="12"
       width="60"
-      height="60"
+      height="56"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
-    <rect
-      x="10"
-      y="10"
-      width="60"
-      height="12"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="10"
-      y="58"
-      width="60"
-      height="12"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="10"
-      y="22"
-      width="15"
-      height="36"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <path d="M10 24H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M10 56H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <path d="M26 24V56" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <rect x="14" y="16" width="20" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="30" y="28" width="20" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="30" y="36" width="30" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="30" y="44" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
 /**
- * Grid 组件缩略图
+ * Grid component thumbnail
  */
 export const Grid: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -189,56 +96,52 @@ export const Grid: React.FC = () => (
       width="60"
       height="60"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeDasharray="4 2"
+      strokeWidth="2"
+      strokeDasharray="4 4"
     />
     <rect
-      x="15"
-      y="15"
-      width="25"
-      height="25"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="45"
-      y="15"
+      x="16"
+      y="16"
       width="20"
-      height="25"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="15"
-      y="45"
-      width="15"
       height="20"
       rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      fill="var(--rs-thumbnail-color-primary)"
+      opacity="0.8"
     />
     <rect
-      x="35"
-      y="45"
-      width="30"
+      x="44"
+      y="16"
+      width="20"
       height="20"
       rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      fill="var(--rs-thumbnail-color-primary)"
+      opacity="0.6"
+    />
+    <rect
+      x="16"
+      y="44"
+      width="20"
+      height="20"
+      rx="2"
+      fill="var(--rs-thumbnail-color-primary)"
+      opacity="0.4"
+    />
+    <rect
+      x="44"
+      y="44"
+      width="20"
+      height="20"
+      rx="2"
+      fill="var(--rs-thumbnail-color-primary)"
+      opacity="0.2"
     />
   </svg>
 );
 
 /**
- * Stack 组件缩略图
+ * Stack component thumbnail
  */
 export const Stack: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -248,40 +151,13 @@ export const Stack: React.FC = () => (
       width="60"
       height="60"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeDasharray="4 2"
+      strokeWidth="2"
+      strokeDasharray="4 4"
     />
-    <rect
-      x="20"
-      y="15"
-      width="40"
-      height="15"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="20"
-      y="35"
-      width="40"
-      height="10"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="20"
-      y="50"
-      width="40"
-      height="15"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <rect x="20" y="20" width="40" height="10" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="20" y="35" width="40" height="10" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.6" />
+    <rect x="20" y="50" width="40" height="10" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.3" />
   </svg>
 );

--- a/docs/components/thumbnails/media.tsx
+++ b/docs/components/thumbnails/media.tsx
@@ -5,16 +5,18 @@ import React from 'react';
  */
 export const Avatar: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <circle
-      cx="40"
-      cy="40"
-      r="20"
+    <rect
+      x="10"
+      y="16"
+      width="60"
+      height="48"
+      rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
-    <circle cx="40" cy="35" r="7" fill="var(--rs-thumbnail-color-primary)" />
-    <path d="M25 55C30 45 50 45 55 55" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <circle cx="40" cy="34" r="8" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M26 54C26 46 32 46 40 46C48 46 54 46 54 54" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinecap="round" />
   </svg>
 );
 
@@ -23,68 +25,17 @@ export const Avatar: React.FC = () => (
  */
 export const Icon: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect
-      x="15"
-      y="15"
-      width="20"
-      height="20"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <path
-      d="M20 25H30M25 20V30"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
+    <rect x="16" y="16" width="20" height="20" rx="4" fill="var(--rs-thumbnail-bg-secondary)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M22 26H30M26 22V30" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinecap="round" />
 
-    <rect
-      x="45"
-      y="15"
-      width="20"
-      height="20"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <circle cx="55" cy="25" r="5" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <rect x="44" y="16" width="20" height="20" rx="4" fill="var(--rs-thumbnail-bg-secondary)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <circle cx="54" cy="26" r="4" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
 
-    <rect
-      x="15"
-      y="45"
-      width="20"
-      height="20"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <path
-      d="M20 55L30 55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
+    <rect x="16" y="44" width="20" height="20" rx="4" fill="var(--rs-thumbnail-bg-secondary)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M22 54H30" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinecap="round" />
 
-    <rect
-      x="45"
-      y="45"
-      width="20"
-      height="20"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <path
-      d="M50 50L60 60M60 50L50 60"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
+    <rect x="44" y="44" width="20" height="20" rx="4" fill="var(--rs-thumbnail-bg-secondary)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M49 49L59 59M59 49L49 59" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinecap="round" />
   </svg>
 );
 
@@ -94,17 +45,17 @@ export const Icon: React.FC = () => (
 export const Image: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="20"
-      width="50"
-      height="40"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
     />
-    <circle cx="30" cy="35" r="5" fill="var(--rs-thumbnail-color-primary)" />
-    <path d="M15 50L30 40L40 50L65 35" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
-    <path d="M40 50L50 45L65 55" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <circle cx="30" cy="32" r="6" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M10 52L26 40L40 50L60 36L70 42" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinejoin="round" />
+    <path d="M40 64L50 56L70 64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinejoin="round" />
   </svg>
 );

--- a/docs/components/thumbnails/misc.tsx
+++ b/docs/components/thumbnails/misc.tsx
@@ -13,7 +13,7 @@ export const Animation: React.FC = () => (
       rx="4"
       fill="var(--rs-thumbnail-bg)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
     <rect
       x="45"
@@ -23,34 +23,28 @@ export const Animation: React.FC = () => (
       rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      opacity="0.7"
-    />
-    <path
-      d="M35 40H45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeDasharray="2 1"
+      strokeWidth="2"
+      opacity="0.5"
     />
     <path
       d="M38 35L42 40L38 45"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
     />
     <path
       d="M15 60C15 60 20 55 25 60C30 65 35 60 35 60"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
       strokeLinecap="round"
     />
     <path
       d="M45 60C45 60 50 55 55 60C60 65 65 60 65 60"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
       strokeLinecap="round"
+      opacity="0.5"
     />
   </svg>
 );
@@ -62,98 +56,22 @@ export const CustomProvider: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
       x="10"
-      y="20"
+      y="16"
       width="60"
-      height="40"
+      height="48"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <rect
-      x="15"
-      y="25"
-      width="50"
-      height="10"
-      rx="2"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <rect
-      x="15"
-      y="40"
-      width="20"
-      height="15"
-      rx="2"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <rect
-      x="40"
-      y="40"
-      width="25"
-      height="15"
-      rx="2"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <path
-      d="M25 30L30 30"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M35 30L40 30"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M45 30L55 30"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M25 47.5L25 47.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="3"
-      strokeLinecap="round"
-    />
-    <path
-      d="M52.5 47.5L52.5 47.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="3"
-      strokeLinecap="round"
-    />
-    <path
-      d="M40 15L40 10"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M40 70L40 65"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M75 40L70 40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M10 40L5 40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <rect x="16" y="24" width="48" height="8" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="16" y="38" width="20" height="12" rx="2" fill="var(--rs-thumbnail-bg-secondary)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <rect x="42" y="38" width="22" height="12" rx="2" fill="var(--rs-thumbnail-bg-secondary)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+
+    <path d="M40 16V12" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinecap="round" />
+    <path d="M40 68V64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinecap="round" />
+    <path d="M70 40H66" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinecap="round" />
+    <path d="M14 40H10" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinecap="round" />
   </svg>
 );
 
@@ -163,35 +81,24 @@ export const CustomProvider: React.FC = () => (
 export const DOMHelper: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <path
-      d="M25 25L35 35L25 45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M55 25L45 35L55 45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M35 55L45 25"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <circle cx="26" cy="30" r="4" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M26 34V50" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M26 50L16 60" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M26 50L36 60" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+
+    <circle cx="54" cy="30" r="4" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M54 34V50" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M54 50L44 60" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M54 50L64 60" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
   </svg>
 );
 
@@ -201,56 +108,14 @@ export const DOMHelper: React.FC = () => (
 export const Hooks: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
-      d="M25 30C25 25.5817 28.5817 22 33 22C37.4183 22 41 25.5817 41 30V50C41 54.4183 44.5817 58 49 58C53.4183 58 57 54.4183 57 50"
+      d="M28 20C28 17.7909 29.7909 16 32 16H48C50.2091 16 52 17.7909 52 20V60C52 62.2091 50.2091 64 48 64H32C29.7909 64 28 62.2091 28 60V20Z"
       stroke="var(--rs-thumbnail-color-primary)"
       strokeWidth="2"
-      strokeLinecap="round"
     />
-    <rect
-      x="15"
-      y="30"
-      width="20"
-      height="20"
-      rx="2"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="45"
-      y="30"
-      width="20"
-      height="20"
-      rx="2"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <path
-      d="M25 40L35 40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M45 40L55 40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M25 35L30 40L25 45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M55 35L50 40L55 45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
+    <rect x="14" y="28" width="16" height="24" rx="2" fill="var(--rs-thumbnail-bg-secondary)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M22 36L26 40L22 44" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+
+    <rect x="50" y="28" width="16" height="24" rx="2" fill="var(--rs-thumbnail-bg-secondary)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M58 36L54 40L58 44" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
   </svg>
 );

--- a/docs/components/thumbnails/navigation.tsx
+++ b/docs/components/thumbnails/navigation.tsx
@@ -11,63 +11,22 @@ export const Affix: React.FC = () => (
       width="60"
       height="60"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeDasharray="4 2"
+      strokeWidth="2"
+      strokeDasharray="4 4"
     />
     <rect
-      x="20"
-      y="20"
-      width="40"
-      height="15"
+      x="16"
+      y="16"
+      width="48"
+      height="14"
       rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      fill="var(--rs-thumbnail-color-primary)"
     />
-    <line
-      x1="10"
-      y1="20"
-      x2="15"
-      y2="20"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="10"
-      y1="35"
-      x2="15"
-      y2="35"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="65"
-      y1="20"
-      x2="70"
-      y2="20"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="65"
-      y1="35"
-      x2="70"
-      y2="35"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M25 27.5L35 27.5M45 27.5L55 27.5"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <path d="M16 40H64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeDasharray="2 2" />
+    <path d="M16 50H64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeDasharray="2 2" />
+    <path d="M16 60H64" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeDasharray="2 2" />
   </svg>
 );
 
@@ -76,51 +35,13 @@ export const Affix: React.FC = () => (
  */
 export const Breadcrumb: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* First item */}
-    <rect
-      x="5"
-      y="25"
-      width="18"
-      height="25"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <rect x="10" y="34" width="16" height="12" rx="2" fill="var(--rs-thumbnail-bg-secondary)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M30 36L34 40L30 44" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
 
-    {/* First separator */}
-    <text x="28" y="42" fontSize="16" textAnchor="middle" fill="var(--rs-gray-500)">
-      ›
-    </text>
+    <rect x="38" y="34" width="16" height="12" rx="2" fill="var(--rs-thumbnail-bg-secondary)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M58 36L62 40L58 44" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
 
-    {/* Second item */}
-    <rect
-      x="32"
-      y="25"
-      width="18"
-      height="25"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-
-    {/* Second separator */}
-    <text x="55" y="42" fontSize="16" textAnchor="middle" fill="var(--rs-gray-500)">
-      ›
-    </text>
-
-    {/* Third item */}
-    <rect
-      x="59"
-      y="25"
-      width="18"
-      height="25"
-      rx="4"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="1.5"
-    />
+    <rect x="66" y="34" width="12" height="12" rx="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -129,70 +50,30 @@ export const Breadcrumb: React.FC = () => (
  */
 export const Dropdown: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Dropdown button */}
     <rect
-      x="20"
-      y="15"
-      width="40"
-      height="15"
+      x="16"
+      y="16"
+      width="48"
+      height="20"
       rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
+    <path d="M54 24L50 28L46 24" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
 
-    {/* Dropdown arrow */}
-    <path
-      d="M52 22.5L50 19.5L54 19.5"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-
-    {/* Dropdown menu */}
     <rect
-      x="20"
-      y="30"
-      width="40"
-      height="35"
+      x="16"
+      y="40"
+      width="48"
+      height="28"
       rx="4"
-      fill="transparent"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-
-    {/* Menu items */}
-    <rect x="22" y="32" width="36" height="8" rx="2" fill="var(--rs-thumbnail-bg)" />
-    <line
-      x1="25"
-      y1="36"
-      x2="55"
-      y2="36"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    <line
-      x1="25"
-      y1="45"
-      x2="55"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="25"
-      y1="54"
-      x2="45"
-      y2="54"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <rect x="22" y="46" width="36" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="22" y="56" width="28" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -201,27 +82,8 @@ export const Dropdown: React.FC = () => (
  */
 export const Link: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Link text */}
-    <text
-      x="40"
-      y="40"
-      fontSize="12"
-      textAnchor="middle"
-      fill="var(--rs-thumbnail-color-primary)"
-      textDecoration="underline"
-    >
-      Visit Page
-    </text>
-
-    {/* Underline */}
-    <line
-      x1="20"
-      y1="42"
-      x2="60"
-      y2="42"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
+    <rect x="20" y="38" width="40" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M20 48H60" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
   </svg>
 );
 
@@ -231,53 +93,20 @@ export const Link: React.FC = () => (
 export const Menu: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
-      rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="15"
-      y="15"
-      width="50"
-      height="10"
+      x="10"
+      y="10"
+      width="60"
+      height="60"
       rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <line
-      x1="20"
-      y1="35"
-      x2="60"
-      y2="35"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="20"
-      y1="45"
-      x2="60"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="20"
-      y1="55"
-      x2="60"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <rect x="20" y="25" width="10" height="5" rx="1" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="18" y="22" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M62 24L58 28L62 32" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+
+    <rect x="18" y="38" width="44" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="18" y="54" width="36" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -286,67 +115,24 @@ export const Menu: React.FC = () => (
  */
 export const Nav: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M10 32H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" opacity="0.3" />
+
+    <rect x="16" y="24" width="16" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M16 32H32" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+
+    <rect x="40" y="24" width="12" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="60" y="24" width="14" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+
     <rect
       x="10"
-      y="20"
+      y="38"
       width="60"
-      height="10"
-      rx="2"
-      fill="var(--rs-thumbnail-bg)"
+      height="28"
+      rx="4"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect x="15" y="20" width="15" height="10" rx="2" fill="var(--rs-thumbnail-color-primary)" />
-    <rect
-      x="35"
-      y="20"
-      width="15"
-      height="10"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <rect
-      x="55"
-      y="20"
-      width="10"
-      height="10"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <rect
-      x="10"
-      y="35"
-      width="60"
-      height="25"
-      rx="2"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="20"
-      y1="45"
-      x2="60"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-      strokeDasharray="2 1"
-    />
-    <line
-      x1="20"
-      y1="55"
-      x2="50"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeLinecap="round"
-      strokeDasharray="2 1"
+      strokeWidth="2"
+      strokeDasharray="4 4"
     />
   </svg>
 );
@@ -358,45 +144,28 @@ export const Navbar: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
       x="10"
-      y="15"
+      y="16"
       width="60"
-      height="15"
-      rx="2"
+      height="16"
+      rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <rect x="15" y="17.5" width="15" height="10" rx="1" fill="var(--rs-thumbnail-color-primary)" />
-    <rect
-      x="35"
-      y="17.5"
-      width="10"
-      height="10"
-      rx="1"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <rect
-      x="50"
-      y="17.5"
-      width="10"
-      height="10"
-      rx="1"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
+    <rect x="16" y="22" width="12" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="48" y="22" width="8" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="60" y="22" width="4" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+
     <rect
       x="10"
-      y="35"
+      y="38"
       width="60"
-      height="30"
-      rx="2"
-      fill="var(--rs-thumbnail-bg)"
+      height="28"
+      rx="4"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeDasharray="2 1"
+      strokeWidth="2"
+      strokeDasharray="4 4"
     />
   </svg>
 );
@@ -412,75 +181,16 @@ export const Sidenav: React.FC = () => (
       width="60"
       height="60"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <rect
-      x="10"
-      y="10"
-      width="20"
-      height="60"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect x="10" y="10" width="20" height="10" rx="4" fill="var(--rs-thumbnail-color-primary)" />
-    <line
-      x1="15"
-      y1="30"
-      x2="25"
-      y2="30"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="15"
-      y1="40"
-      x2="25"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="15"
-      y1="50"
-      x2="25"
-      y2="50"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="40"
-      y1="25"
-      x2="60"
-      y2="25"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="40"
-      y1="35"
-      x2="55"
-      y2="35"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="40"
-      y1="45"
-      x2="50"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <path d="M30 10V70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+
+    <rect x="16" y="20" width="8" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="16" y="30" width="8" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="16" y="40" width="8" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="16" y="60" width="8" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -489,52 +199,15 @@ export const Sidenav: React.FC = () => (
  */
 export const Steps: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <circle
-      cx="20"
-      cy="40"
-      r="10"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="1.5"
-    />
-    <text x="20" y="44" fontSize="12" textAnchor="middle" fill="transparent" fontWeight="bold">
-      1
-    </text>
-    <line
-      x1="30"
-      y1="40"
-      x2="40"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-    />
-    <circle
-      cx="50"
-      cy="40"
-      r="10"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <text
-      x="50"
-      y="44"
-      fontSize="12"
-      textAnchor="middle"
-      fill="var(--rs-thumbnail-color-primary)"
-      fontWeight="bold"
-    >
-      2
-    </text>
-    <line
-      x1="60"
-      y1="40"
-      x2="70"
-      y2="40"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="2"
-      strokeDasharray="2 1"
-    />
+    <circle cx="20" cy="40" r="10" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M16 40L19 43L24 37" stroke="var(--rs-thumbnail-bg-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+
+    <path d="M30 40H40" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+
+    <circle cx="50" cy="40" r="9" fill="var(--rs-thumbnail-bg-secondary)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M50 36V44M46 40H54" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinecap="round" />
+
+    <path d="M60 40H70" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeDasharray="2 2" />
   </svg>
 );
 
@@ -543,101 +216,14 @@ export const Steps: React.FC = () => (
  */
 export const Pagination: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Left arrow button */}
-    <rect
-      x="10"
-      y="30"
-      width="10"
-      height="20"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <polyline
-      points="16,35 12,40 16,45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      fill="none"
-    />
+    <rect x="10" y="28" width="12" height="24" rx="2" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M17 36L13 40L17 44" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
 
-    {/* Page buttons */}
-    <rect
-      x="25"
-      y="30"
-      width="10"
-      height="20"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <text
-      x="30"
-      y="44"
-      fontSize="12"
-      textAnchor="middle"
-      fill="var(--rs-thumbnail-color-primary)"
-      fontWeight="bold"
-    >
-      1
-    </text>
+    <rect x="26" y="28" width="12" height="24" rx="2" fill="var(--rs-thumbnail-color-primary)" />
 
-    <rect
-      x="40"
-      y="30"
-      width="10"
-      height="20"
-      rx="2"
-      fill="var(--rs-thumbnail-color-primary)"
-      stroke="var(--rs-thumbnail-color-high)"
-      strokeWidth="1.5"
-    />
-    <text x="45" y="44" fontSize="12" textAnchor="middle" fill="transparent" fontWeight="bold">
-      2
-    </text>
+    <rect x="42" y="28" width="12" height="24" rx="2" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
 
-    <rect
-      x="55"
-      y="30"
-      width="10"
-      height="20"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <text
-      x="60"
-      y="44"
-      fontSize="12"
-      textAnchor="middle"
-      fill="var(--rs-thumbnail-color-primary)"
-      fontWeight="bold"
-    >
-      3
-    </text>
-
-    {/* Right arrow button */}
-    <rect
-      x="70"
-      y="30"
-      width="10"
-      height="20"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <polyline
-      points="74,35 78,40 74,45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      fill="none"
-    />
+    <rect x="58" y="28" width="12" height="24" rx="2" fill="none" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M63 36L67 40L63 44" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
   </svg>
 );

--- a/docs/components/thumbnails/overlays.tsx
+++ b/docs/components/thumbnails/overlays.tsx
@@ -6,96 +6,29 @@ import React from 'react';
 export const Drawer: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="14"
-      y="14"
-      width="52"
-      height="52"
-      rx="6"
-      fill="var(--rs-thumbnail-bg)"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
+      rx="4"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
+      strokeDasharray="4 4"
     />
-    <path
-      d="M14 20
-         Q14 14 20 14
-         L36 14
-         L36 66
-         L20 66
-         Q14 66 14 60
-         Z"
+    <rect
+      x="40"
+      y="16"
+      width="30"
+      height="48"
+      rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <path
-      d="M14 20
-         Q14 14 20 14
-         L36 14
-         Q36 14 36 20
-         L36 24
-         L14 24
-         Z"
-      fill="var(--rs-thumbnail-color-primary)"
-      fillOpacity="0.07"
-      stroke="none"
-    />
-    <rect
-      x="18"
-      y="18"
-      width="14"
-      height="2.5"
-      rx="1.25"
-      fill="var(--rs-thumbnail-color-primary)"
-      fillOpacity="0.5"
-    />
-    <rect
-      x="18"
-      y="28"
-      width="14"
-      height="2"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      fillOpacity="0.15"
-    />
-    <rect
-      x="18"
-      y="36"
-      width="10"
-      height="2"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      fillOpacity="0.15"
-    />
-    <line
-      x1="38"
-      y1="24"
-      x2="60"
-      y2="24"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.2"
-      strokeDasharray="3 2"
-      opacity="0.5"
-    />
-    <line
-      x1="38"
-      y1="34"
-      x2="60"
-      y2="34"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.2"
-      strokeDasharray="3 2"
-      opacity="0.5"
-    />
-    <line
-      x1="38"
-      y1="44"
-      x2="60"
-      y2="44"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.2"
-      strokeDasharray="3 2"
-      opacity="0.5"
-    />
+    <rect x="46" y="24" width="18" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="46" y="34" width="12" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+    <rect x="46" y="44" width="14" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -104,112 +37,21 @@ export const Drawer: React.FC = () => (
  */
 export const Modal: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Overlay */}
-    <rect x="6" y="6" width="68" height="68" rx="8" fill="var(--rs-gray-300)" fillOpacity="0.55" />
+    <rect x="10" y="16" width="60" height="48" rx="4" fill="var(--rs-thumbnail-color-primary)" opacity="0.1" />
 
-    {/* Dialog shadow */}
-    <rect x="18" y="19" width="44" height="38" rx="8" fill="black" opacity="0.10" />
-
-    {/* Dialog */}
     <rect
-      x="16"
-      y="16"
-      width="48"
-      height="40"
-      rx="8"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-
-    {/* Header */}
-    <rect
-      x="16"
-      y="16"
-      width="48"
-      height="10"
-      rx="8 8 0 0"
+      x="20"
+      y="26"
+      width="40"
+      height="28"
+      rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.2"
+      strokeWidth="2"
     />
-    {/* Title bar */}
-    <rect
-      x="22"
-      y="20"
-      width="20"
-      height="3"
-      rx="1.5"
-      fill="var(--rs-thumbnail-color-primary)"
-      fillOpacity="0.4"
-    />
-    {/* Close button */}
-    <circle
-      cx="56"
-      cy="21"
-      r="2.2"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.2"
-    />
-    <path
-      d="M55 20L57 22M57 20L55 22"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.2"
-      strokeLinecap="round"
-    />
-
-    {/* Body content lines */}
-    <rect
-      x="22"
-      y="28"
-      width="28"
-      height="2.2"
-      rx="1.1"
-      fill="var(--rs-thumbnail-color-primary)"
-      fillOpacity="0.13"
-    />
-    <rect
-      x="22"
-      y="33"
-      width="24"
-      height="2"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      fillOpacity="0.13"
-    />
-    <rect
-      x="22"
-      y="38"
-      width="18"
-      height="2"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      fillOpacity="0.13"
-    />
-
-    {/* Footer */}
-    <rect
-      x="16"
-      y="46"
-      width="48"
-      height="10"
-      rx="0 0 8 8"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.2"
-    />
-    {/* Footer button */}
-    <rect
-      x="46"
-      y="49"
-      width="14"
-      height="4"
-      rx="2"
-      fill="var(--rs-thumbnail-color-primary)"
-      fillOpacity="0.14"
-      stroke="none"
-    />
+    <path d="M20 36H60" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
+    <rect x="26" y="30" width="12" height="3" rx="1.5" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="26" y="42" width="28" height="3" rx="1.5" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -218,45 +60,21 @@ export const Modal: React.FC = () => (
  */
 export const Popover: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Popover content */}
     <rect
-      x="10"
-      y="15"
-      width="60"
-      height="35"
-      rx="8"
-      fill="transparent"
+      x="14"
+      y="22"
+      width="52"
+      height="30"
+      rx="4"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
+    <path d="M36 52L40 56L44 52" fill="var(--rs-thumbnail-bg-secondary)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M37 52H43" stroke="var(--rs-thumbnail-bg-secondary)" strokeWidth="2" />
 
-    {/* Content lines */}
-    <line
-      x1="20"
-      y1="30"
-      x2="60"
-      y2="30"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="20"
-      y1="40"
-      x2="50"
-      y2="40"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Arrow - pointing down */}
-    <polygon
-      points="40,55 35,50 45,50"
-      fill="transparent"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
+    <rect x="22" y="30" width="36" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="22" y="38" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
@@ -265,37 +83,16 @@ export const Popover: React.FC = () => (
  */
 export const Tooltip: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Tooltip */}
     <rect
-      x="10"
-      y="20"
-      width="60"
-      height="25"
+      x="18"
+      y="28"
+      width="44"
+      height="20"
       rx="4"
-      fill="var(--rs-gray-800)"
-      stroke="var(--rs-gray-900)"
-      strokeWidth="1.5"
+      fill="var(--rs-thumbnail-color-primary)"
     />
-
-    {/* Tooltip text */}
-    <circle cx="25" cy="32.5" r="2.5" fill="transparent" />
-    <line
-      x1="30"
-      y1="32.5"
-      x2="55"
-      y2="32.5"
-      stroke="white"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-
-    {/* Arrow - pointing down */}
-    <polygon
-      points="40,50 35,45 45,45"
-      fill="var(--rs-gray-800)"
-      stroke="var(--rs-gray-900)"
-      strokeWidth="1.5"
-    />
+    <path d="M36 48L40 52L44 48" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="26" y="36" width="28" height="4" rx="2" fill="var(--rs-thumbnail-bg)" />
   </svg>
 );
 
@@ -304,73 +101,13 @@ export const Tooltip: React.FC = () => (
  */
 export const Whisper: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* Popover shadow */}
-    <rect x="20" y="23" width="40" height="18" rx="9" fill="black" opacity="0.13" />
-    {/* Popover bubble */}
-    <rect
-      x="18"
-      y="17"
-      width="44"
-      height="20"
-      rx="9"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    {/* Popover arrow */}
-    <polygon
-      points="40,37 46,47 34,47"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    {/* Title line */}
-    <rect
-      x="26"
-      y="24"
-      width="20"
-      height="3"
-      rx="1.5"
-      fill="var(--rs-thumbnail-color-primary)"
-      fillOpacity="0.18"
-    />
-    {/* Content lines */}
-    <rect
-      x="26"
-      y="29"
-      width="14"
-      height="2"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      fillOpacity="0.13"
-    />
-    <rect
-      x="26"
-      y="33"
-      width="10"
-      height="2"
-      rx="1"
-      fill="var(--rs-thumbnail-color-primary)"
-      fillOpacity="0.13"
-    />
-    {/* Trigger button with icon */}
-    <circle
-      cx="40"
-      cy="58"
-      r="8"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="37"
-      y="55"
-      width="6"
-      height="6"
-      rx="3"
-      fill="var(--rs-thumbnail-color-primary)"
-      fillOpacity="0.35"
-    />
+    <rect x="18" y="22" width="44" height="20" rx="4" fill="var(--rs-thumbnail-bg-secondary)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" />
+    <path d="M36 42L40 46L44 42" fill="var(--rs-thumbnail-bg-secondary)" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M37 42H43" stroke="var(--rs-thumbnail-bg-secondary)" strokeWidth="2" />
+
+    <rect x="26" y="30" width="28" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
+
+    <circle cx="40" cy="56" r="6" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
@@ -380,64 +117,27 @@ export const Whisper: React.FC = () => (
 export const ModalIntegrations: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
+      strokeDasharray="4 4"
     />
+
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="10"
+      x="24"
+      y="28"
+      width="32"
+      height="24"
       rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <rect
-      x="20"
-      y="30"
-      width="20"
-      height="15"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <rect
-      x="45"
-      y="30"
-      width="15"
-      height="15"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <rect
-      x="20"
-      y="50"
-      width="15"
-      height="10"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
-    <rect
-      x="40"
-      y="50"
-      width="20"
-      height="10"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-    />
+    <path d="M24 36H56" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" />
   </svg>
 );

--- a/docs/components/thumbnails/status.tsx
+++ b/docs/components/thumbnails/status.tsx
@@ -1,33 +1,30 @@
 import React from 'react';
 
 /**
- * Badge
+ * Badge component thumbnail
  */
 export const Badge: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
       x="20"
-      y="25"
-      width="30"
-      height="30"
+      y="26"
+      width="32"
+      height="32"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <circle cx="46" cy="25" r="10" fill="var(--rs-red-500)" stroke="white" strokeWidth="2" />
-    <text x="46" y="29" fontSize="10" textAnchor="middle" fill="transparent" fontWeight="bold">
-      5
-    </text>
+    <circle cx="54" cy="24" r="8" fill="var(--rs-red-500)" stroke="var(--rs-bg-card)" strokeWidth="2" />
   </svg>
 );
 
 /**
- * Loader
+ * Loader component thumbnail
  */
 export const Loader: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <circle cx="40" cy="40" r="20" stroke="var(--rs-primary-200)" strokeWidth="4" />
+    <circle cx="40" cy="40" r="20" stroke="var(--rs-thumbnail-bg-secondary)" strokeWidth="4" />
     <path
       d="M40 20C51.0457 20 60 28.9543 60 40"
       stroke="var(--rs-thumbnail-color-primary)"
@@ -38,217 +35,133 @@ export const Loader: React.FC = () => (
 );
 
 /**
- * Message
+ * Message component thumbnail
  */
 export const Message: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
       x="10"
-      y="25"
+      y="24"
       width="60"
-      height="30"
+      height="32"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-    />
-    <circle
-      cx="25"
-      cy="40"
-      r="8"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="40"
-      y1="35"
-      x2="60"
-      y2="35"
-      stroke="var(--rs-primary-300)"
       strokeWidth="2"
-      strokeLinecap="round"
     />
-    <line
-      x1="40"
-      y1="45"
-      x2="55"
-      y2="45"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
+    <circle cx="22" cy="40" r="6" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="34" y="34" width="28" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="34" y="42" width="20" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.5" />
   </svg>
 );
 
 /**
- * Notification
+ * Notification component thumbnail
  */
 export const Notification: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="14"
+      y="16"
+      width="52"
+      height="48"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-    />
-    <rect
-      x="20"
-      y="20"
-      width="40"
-      height="10"
-      rx="2"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <line
-      x1="20"
-      y1="40"
-      x2="60"
-      y2="40"
-      stroke="var(--rs-primary-300)"
       strokeWidth="2"
-      strokeLinecap="round"
     />
-    <line
-      x1="20"
-      y1="50"
-      x2="50"
-      y2="50"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
+    <rect x="20" y="24" width="28" height="6" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <path d="M20 38H58" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
+    <path d="M20 46H58" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
+    <path d="M20 54H48" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="1.5" strokeLinecap="round" />
   </svg>
 );
 
 /**
- * Progress
+ * Progress component thumbnail
  */
 export const Progress: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="35"
-      width="50"
-      height="10"
-      rx="5"
+      x="10"
+      y="36"
+      width="60"
+      height="8"
+      rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
+      strokeWidth="2"
     />
-    <rect x="15" y="35" width="30" height="10" rx="5" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="14" y="38" width="30" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
 /**
- * Placeholder
+ * Placeholder component thumbnail
  */
 export const Placeholder: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="15"
-      y="15"
-      width="50"
-      height="50"
+      x="10"
+      y="16"
+      width="60"
+      height="48"
       rx="4"
-      fill="var(--rs-thumbnail-bg)"
+      fill="none"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeDasharray="4 2"
+      strokeWidth="2"
+      strokeDasharray="4 4"
     />
+    <rect x="16" y="24" width="48" height="8" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.3" />
+    <rect x="16" y="38" width="48" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.2" />
+    <rect x="16" y="46" width="36" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.2" />
+    <rect x="16" y="54" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.2" />
+  </svg>
+);
+
+/**
+ * Toaster component thumbnail
+ */
+export const Toaster: React.FC = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="20"
-      y="20"
-      width="40"
-      height="10"
-      rx="2"
+      x="16"
+      y="16"
+      width="48"
+      height="20"
+      rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
+      strokeWidth="2"
     />
     <rect
-      x="20"
-      y="35"
-      width="40"
-      height="5"
-      rx="2"
+      x="22"
+      y="36"
+      width="36"
+      height="12"
+      rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
+      strokeWidth="2"
+      opacity="0.6"
     />
     <rect
-      x="20"
-      y="45"
-      width="30"
-      height="5"
-      rx="2"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
-    />
-    <rect
-      x="20"
-      y="55"
+      x="30"
+      y="48"
       width="20"
-      height="5"
-      rx="2"
+      height="12"
+      rx="4"
       fill="var(--rs-thumbnail-bg-secondary)"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1"
-      strokeDasharray="2 1"
+      strokeWidth="2"
+      opacity="0.3"
     />
   </svg>
 );
 
 /**
- * Toaster
+ * ProgressCircle component thumbnail
  */
-export const Toaster: React.FC = () => (
-  <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect
-      x="15"
-      y="15"
-      width="50"
-      height="20"
-      rx="4"
-      fill="var(--rs-thumbnail-bg-secondary)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-    />
-    <rect
-      x="25"
-      y="35"
-      width="30"
-      height="15"
-      rx="4"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeDasharray="2 1"
-    />
-    <rect
-      x="35"
-      y="50"
-      width="10"
-      height="15"
-      rx="2"
-      fill="var(--rs-thumbnail-bg)"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeDasharray="2 1"
-    />
-  </svg>
-);
-
 export const ProgressCircle: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <circle
@@ -256,19 +169,15 @@ export const ProgressCircle: React.FC = () => (
       cy="40"
       r="20"
       stroke="var(--rs-thumbnail-bg-secondary)"
-      strokeWidth="5"
+      strokeWidth="4"
       fill="transparent"
     />
-
     <path
-      d="M 40,40 m 0,-20 a 20,20 0 1 1 0,40 a 20,20 0 1 1 0,-40"
+      d="M40 20C51.0457 20 60 28.9543 60 40C60 51.0457 51.0457 60 40 60"
       stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="5"
+      strokeWidth="4"
       strokeLinecap="round"
-      strokeDasharray="125.6 188.4"
       fill="transparent"
     />
-
-    <circle cx="40" cy="40" r="12" fill="var(--rs-thumbnail-bg)" />
   </svg>
 );

--- a/docs/components/thumbnails/typography.tsx
+++ b/docs/components/thumbnails/typography.tsx
@@ -1,168 +1,74 @@
 import React from 'react';
 
 /**
- * Heading 组件缩略图
+ * Heading component thumbnail
  */
 export const Heading: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <text x="20" y="30" fontSize="16" fill="var(--rs-thumbnail-color-high)" fontWeight="bold">
-      H1
-    </text>
-    <text x="20" y="45" fontSize="14" fill="var(--rs-thumbnail-color-high)" fontWeight="bold">
-      H2
-    </text>
-    <text x="20" y="58" fontSize="12" fill="var(--rs-thumbnail-color-high)" fontWeight="bold">
-      H3
-    </text>
-    <line
-      x1="40"
-      y1="30"
-      x2="60"
-      y2="30"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="3"
-      strokeLinecap="round"
-    />
-    <line
-      x1="40"
-      y1="45"
-      x2="55"
-      y2="45"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="40"
-      y1="58"
-      x2="50"
-      y2="58"
-      stroke="var(--rs-primary-300)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
+    <rect x="16" y="24" width="48" height="8" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="16" y="38" width="36" height="6" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.8" />
+    <rect x="16" y="50" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.6" />
   </svg>
 );
 
 /**
- * Highlight 组件缩略图
+ * Highlight component thumbnail
  */
 export const Highlight: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect
-      x="20"
-      y="30"
-      width="40"
-      height="20"
+      x="14"
+      y="32"
+      width="52"
+      height="16"
       rx="2"
-      fill="var(--rs-yellow-100)"
-      stroke="var(--rs-yellow-500)"
-      strokeWidth="1.5"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
     />
-    <text
-      x="40"
-      y="45"
-      fontSize="12"
-      textAnchor="middle"
-      fill="var(--rs-yellow-700)"
-      fontWeight="bold"
-    >
-      Text
-    </text>
+    <rect x="20" y="38" width="40" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
   </svg>
 );
 
 /**
- * Kbd 组件缩略图
+ * Kbd component thumbnail
  */
 export const Kbd: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    {/* First key with padding */}
     <rect
-      x="15"
-      y="25"
-      width="22"
-      height="22"
+      x="14"
+      y="24"
+      width="32"
+      height="32"
       rx="4"
-      fill="var(--rs-gray-100)"
-      stroke="var(--rs-gray-500)"
-      strokeWidth="1.5"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
     />
-    <text
-      x="26"
-      y="39"
-      fontSize="12"
-      textAnchor="middle"
-      fill="var(--rs-gray-700)"
-      fontWeight="bold"
-    >
-      A
-    </text>
+    <path d="M24 46L30 34L36 46" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M26 42H34" stroke="var(--rs-thumbnail-color-primary)" strokeWidth="2" strokeLinecap="round" />
 
-    {/* Second key with padding */}
     <rect
-      x="45"
-      y="25"
-      width="22"
-      height="22"
+      x="54"
+      y="24"
+      width="12"
+      height="32"
       rx="4"
-      fill="var(--rs-gray-100)"
-      stroke="var(--rs-gray-500)"
-      strokeWidth="1.5"
+      fill="var(--rs-thumbnail-bg-secondary)"
+      stroke="var(--rs-thumbnail-color-primary)"
+      strokeWidth="2"
     />
-    <text
-      x="56"
-      y="39"
-      fontSize="10"
-      textAnchor="middle"
-      fill="var(--rs-gray-700)"
-      fontWeight="bold"
-    >
-      Ctrl
-    </text>
   </svg>
 );
 
 /**
- * Text 组件缩略图
+ * Text component thumbnail
  */
 export const Text: React.FC = () => (
   <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <line
-      x1="20"
-      y1="25"
-      x2="60"
-      y2="25"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />
-    <line
-      x1="20"
-      y1="35"
-      x2="55"
-      y2="35"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="20"
-      y1="45"
-      x2="50"
-      y2="45"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="20"
-      y1="55"
-      x2="40"
-      y2="55"
-      stroke="var(--rs-thumbnail-color-primary)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-    />
+    <rect x="16" y="24" width="48" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" />
+    <rect x="16" y="34" width="40" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.8" />
+    <rect x="16" y="44" width="44" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.6" />
+    <rect x="16" y="54" width="24" height="4" rx="2" fill="var(--rs-thumbnail-color-primary)" opacity="0.4" />
   </svg>
 );


### PR DESCRIPTION
This pull request updates and refines the SVG thumbnails for various UI components in the documentation, focusing on improving visual consistency, clarity, and alignment with the design system. It also adds thumbnails for new hooks and components. The changes are grouped into improvements to component mapping and significant visual updates to the thumbnails themselves.

**Component and Hook Thumbnail Mapping Updates:**

* Added SVG thumbnail mappings for the `segmented-control` component and the `use-dialog` and `use-toaster` hooks in `ComponentThumbnail.tsx`. [[1]](diffhunk://#diff-d23d843912544bb8ae53b71d5765fe508b008561f9b0b043b8a100be576c771fR66) [[2]](diffhunk://#diff-d23d843912544bb8ae53b71d5765fe508b008561f9b0b043b8a100be576c771fR115-R116)

**Visual and Structural Updates to Thumbnails:**

_Buttons:_
* Updated the `Button` thumbnail to a more abstract representation, removing the text label and using rectangles for a cleaner look.
* Changed the `IconButton` thumbnail from a rounded rectangle to a circle, improving visual consistency, and added `strokeLinejoin="round"` for better rendering. [[1]](diffhunk://#diff-3a2bed2a242a42fe78659ff091172d6d07a613dcb12c4f90e291f8923f6224c0L36-R30) [[2]](diffhunk://#diff-3a2bed2a242a42fe78659ff091172d6d07a613dcb12c4f90e291f8923f6224c0R40)
* Redesigned the `ButtonGroup` thumbnail to use paths for a more accurate depiction of grouped buttons and improved border rendering.

_Data Display Components:_
* Refactored the thumbnails for `Accordion`, `Carousel`, `List`, `Timeline`, `Panel`, `Card`, `Stat`, and `Tag` to use consistent sizing, spacing, and opacity. These changes enhance readability, align with the design system, and provide a more modern appearance. [[1]](diffhunk://#diff-5a580091ed54343a18e7d73a4c78311713e477c59d33c07f639cea02fc8fd4eeL9-R61) [[2]](diffhunk://#diff-5a580091ed54343a18e7d73a4c78311713e477c59d33c07f639cea02fc8fd4eeL73-R86) [[3]](diffhunk://#diff-5a580091ed54343a18e7d73a4c78311713e477c59d33c07f639cea02fc8fd4eeL111-R115) [[4]](diffhunk://#diff-5a580091ed54343a18e7d73a4c78311713e477c59d33c07f639cea02fc8fd4eeL179-R133) [[5]](diffhunk://#diff-5a580091ed54343a18e7d73a4c78311713e477c59d33c07f639cea02fc8fd4eeL216-R155) [[6]](diffhunk://#diff-5a580091ed54343a18e7d73a4c78311713e477c59d33c07f639cea02fc8fd4eeL253-R176) [[7]](diffhunk://#diff-5a580091ed54343a18e7d73a4c78311713e477c59d33c07f639cea02fc8fd4eeL295-R197) [[8]](diffhunk://#diff-5a580091ed54343a18e7d73a4c78311713e477c59d33c07f639cea02fc8fd4eeL370-R217)

_Default Thumbnail:_
* Updated the default thumbnail to use a dashed border and adjusted its size and fill for consistency with other thumbnails.