### PR TITLE
fix(webpack): add react-dom/client external for UMD builds

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,12 @@ module.exports = {
       commonjs2: 'react-dom',
       commonjs: 'react-dom',
       amd: 'react-dom'
+    },
+    'react-dom/client': {
+      root: 'ReactDOM',
+      commonjs2: 'react-dom/client',
+      commonjs: 'react-dom/client',
+      amd: 'react-dom/client'
     }
   },
   module: {


### PR DESCRIPTION
- Add 'react-dom/client' to webpack externals configuration
- Fixes UMD build compatibility with React 18
- Resolves 'Cannot read properties of undefined' error in browser environments
- Enables rsuite 6.x to work properly with CDN/UMD builds