### PR TITLE
chore(examples): update CDN example to use rsuite 5.70.1

### DIFF
--- a/examples/cdn/README.md
+++ b/examples/cdn/README.md
@@ -1,10 +1,15 @@
 ### Using CDN
 
-Add `script` and `link` tags in your browser and use the global variable `rsuite`. We provide relevant file in rsuite's npm package. You can also download these files directly from [![cdnjs][cdnjs-badge]][cdnjs-home]、[![jsDelivr][jsdelivr-badge]][jsdelivr-home] or [UNPKG][unpkg-home] .
+Add `script` and `link` tags in your browser and use the global variable `rsuite`. We provide relevant files in the rsuite npm package. You can also download these files directly from [![cdnjs][cdnjs-badge]][cdnjs-home], [![jsDelivr][jsdelivr-badge]][jsdelivr-home] or [UNPKG][unpkg-home].
 
-### CDN 引用
+**Current Version**: This example uses rsuite 5.70.1 with React 18.
 
-您也可以在浏览器中使用 `script` 和 `link` 标签直接引入文件，并使用全局变量 `rsuite`。我们在 npm 发布包内 `rsiute/dist` 目录提供了相关的文件。您也可以通过 [![cdnjs][cdnjs-badge]][cdnjs-home]、[![jsDelivr][jsdelivr-badge]][jsdelivr-home] 或 [UNPKG][unpkg-home] 进行下载。
+**Note**: rsuite 6.x is not recommended for CDN/UMD usage in production environments. The UMD build requires additional webpack configuration (adding `react-dom/client` to externals). For production use with rsuite 6.x, we recommend using a build tool (Webpack, Vite, etc.) instead of CDN.
+
+For more examples using build tools, see:
+- [with-vite](../with-vite)
+- [with-nextjs-app](../with-nextjs-app)
+- [with-typescript](../with-typescript)
 
 [cdnjs-badge]: https://img.shields.io/cdnjs/v/rsuite.svg?style=flat-square
 [cdnjs-home]: https://cdnjs.com/libraries/rsuite

--- a/examples/cdn/index.html
+++ b/examples/cdn/index.html
@@ -6,35 +6,39 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>React Suite CDN example</title>
-  <script src="https://cdn.bootcss.com/react/15.4.1/react.js"></script>
-  <script src="https://cdn.bootcss.com/react/15.4.1/react-dom.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/rsuite/3.2.9/rsuite.min.js"></script>
-  <script src="https://cdn.bootcss.com/babel-core/5.8.38/browser.js"></script>
-  <link href="https://cdn.jsdelivr.net/npm/rsuite@3.2.9/dist/styles/rsuite.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/rsuite@5.70.1/dist/rsuite.min.css">
 </head>
 
 <body>
   <div id="example"></div>
+  
+  <!-- React 18 UMD builds -->
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  
+  <!-- rsuite 5.70.1 -->
+  <script src="https://cdn.jsdelivr.net/npm/rsuite@5.70.1/dist/rsuite.min.js"></script>
+  
+  <!-- Babel -->
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  
   <script type="text/babel">
     const { Button } = rsuite;
-    const Hello = React.createClass({
-      getDefaultProps: function() {
-        return {
-          text: 'Hello, world'
-        }
-      },
-      onclick: function(e) {
-        console.log('click', e)
-      },
-      render: function() {
-        return (
-          <div style={{ padding:20 }}>
-            <Button onClick={this.onclick}> {this.props.text} </Button>
-          </div>
-        ); 
-      }
-    })
-    ReactDOM.render(<Hello /> , document.getElementById('example'));
+    
+    function Hello({ text = 'Hello, world' }) {
+      const handleClick = (e) => {
+        console.log('click', e);
+      };
+      
+      return (
+        <div style={{ padding: 20 }}>
+          <Button onClick={handleClick}>{text}</Button>
+        </div>
+      );
+    }
+    
+    const root = ReactDOM.createRoot(document.getElementById('example'));
+    root.render(<Hello />);
   </script>
 
 </body>


### PR DESCRIPTION
- Revert CDN example to use rsuite 5.70.1 with React 18
- Update README.md to English-only documentation
- Add note about rsuite 6.x UMD build requirements
- Recommend build tools for production use with rsuite 6.x
- Add links to other example projects using build tools