### PR TITLE
docs(timeline): replace p tags with Text component in align example

### DIFF
--- a/docs/pages/components/timeline/fragments/align.md
+++ b/docs/pages/components/timeline/fragments/align.md
@@ -1,29 +1,29 @@
 <!--start-code-->
 
 ```js
-import { Timeline, Grid, Row, Col } from 'rsuite';
+import { Timeline, Grid, Row, Col, Text } from 'rsuite';
 
 const AlignTimeline = ({ align }) => (
   <Timeline align={align}>
     <Timeline.Item>
-      <p>2018-03-01</p>
-      <p>Your order starts processing</p>
+      <Text>2018-03-01</Text>
+      <Text>Your order starts processing</Text>
     </Timeline.Item>
     <Timeline.Item>
-      <p>2018-03-02</p>
-      <p>Order out of stock</p>
+      <Text>2018-03-02</Text>
+      <Text>Order out of stock</Text>
     </Timeline.Item>
     <Timeline.Item>
-      <p>2018-03-10</p>
-      <p>Arrival</p>
+      <Text>2018-03-10</Text>
+      <Text>Arrival</Text>
     </Timeline.Item>
     <Timeline.Item>
-      <p>2018-03-12</p>
-      <p>Order out of the library</p>
+      <Text>2018-03-12</Text>
+      <Text>Order out of the library</Text>
     </Timeline.Item>
     <Timeline.Item>
-      <p>2018-03-15</p>
-      <p>Sending you a piece</p>
+      <Text>2018-03-15</Text>
+      <Text>Sending you a piece</Text>
     </Timeline.Item>
   </Timeline>
 );


### PR DESCRIPTION
This pull request updates the usage example for the `Timeline` component in the documentation to use the `Text` component from `rsuite` instead of HTML `<p>` tags. This change helps standardize text rendering and aligns with best practices for using library components.

Documentation improvements:

* Replaced all `<p>` tags with `Text` components in the `Timeline` example within `align.md` for consistency and to leverage `rsuite`'s text styling.
* Updated the import statement to include `Text` from `rsuite`.