### PR TITLE
docs(avatar): add Next.js Image integration example

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -258,6 +258,9 @@ module.exports = {
     remotePatterns: [
       {
         hostname: 'images.unsplash.com'
+      },
+      {
+        hostname: 'i.pravatar.cc'
       }
     ]
   }

--- a/docs/pages/components/avatar/en-US/index.md
+++ b/docs/pages/components/avatar/en-US/index.md
@@ -53,6 +53,12 @@ If there is an error loading the src of the avatar, there are 2 fallbacks:
 
 <!--{include:`badge.md`}-->
 
+### Integration with Next.js Image
+
+To leverage Next.js's image optimization and caching, you can pass the `next/image` component as a child of the `Avatar` component.
+
+<!--{include:`nextjs-image.md`}-->
+
 ## Props
 
 ### `<Avatar>`

--- a/docs/pages/components/avatar/fragments/nextjs-image.md
+++ b/docs/pages/components/avatar/fragments/nextjs-image.md
@@ -1,0 +1,22 @@
+<!--start-code-->
+
+```js
+import { Avatar } from 'rsuite';
+import Image from 'next/image';
+
+const App = () => (
+  <Avatar circle size="lg">
+    <Image
+      src="https://i.pravatar.cc/150?u=1"
+      alt="Avatar"
+      width={60}
+      height={60}
+      unoptimized
+    />
+  </Avatar>
+);
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+<!--end-code-->

--- a/docs/pages/components/avatar/index.tsx
+++ b/docs/pages/components/avatar/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Image from 'next/image';
 import { Avatar, AvatarGroup, Badge } from 'rsuite';
 import DefaultPage from '@/components/layout/Page';
 import ImportGuide from '@/components/ImportGuide';
@@ -13,7 +14,15 @@ export default function Page() {
   return (
     <DefaultPage
       inDocsComponents={inDocsComponents}
-      dependencies={{ Avatar, AvatarGroup, Badge, FaUserLarge, FcBusinessman, FcCustomerSupport }}
+      dependencies={{
+        Avatar,
+        AvatarGroup,
+        Badge,
+        FaUserLarge,
+        FcBusinessman,
+        FcCustomerSupport,
+        Image
+      }}
       sandboxDependencies={{ 'react-icons': 'latest' }}
     />
   );

--- a/docs/pages/components/avatar/zh-CN/index.md
+++ b/docs/pages/components/avatar/zh-CN/index.md
@@ -53,6 +53,12 @@
 
 <!--{include:`badge.md`}-->
 
+### 结合 Next.js Image 使用
+
+为了利用 Next.js 的图像优化和缓存功能，您可以将 `next/image` 组件作为 `Avatar` 组件的子组件传入。
+
+<!--{include:`nextjs-image.md`}-->
+
 ## Props
 
 ### `<Avatar>`


### PR DESCRIPTION
This pull request enhances the documentation and integration of the `Avatar` component with Next.js's `Image` component. The updates provide guidance and support for using Next.js image optimization with `Avatar`, including code examples and configuration changes to allow images from `i.pravatar.cc`.

**Documentation improvements:**

* Added sections in both English and Chinese documentation to explain how to use the `Avatar` component with Next.js's `Image` component for optimized image loading and caching. [[1]](diffhunk://#diff-a7f4a261a81a81df8e112400ecb0075e9c7ec6489cf1300c9a1cac207847f0f8R56-R61) [[2]](diffhunk://#diff-e8742b2d5c19996a11d0444bfdbfb9f8fc1f94600b8a45344eceed842237f2a5R56-R61)
* Introduced a reusable documentation fragment (`nextjs-image.md`) with a code example demonstrating the integration of `Avatar` and `next/image`.

**Code and configuration updates:**

* Imported `Image` from `next/image` in the avatar documentation example and added it to the dependencies for live code previews. [[1]](diffhunk://#diff-615eefdc60e7fed0fc882059bb6277faca3409aedbb3dd1cf86f688f7dc136f8R2) [[2]](diffhunk://#diff-615eefdc60e7fed0fc882059bb6277faca3409aedbb3dd1cf86f688f7dc136f8L16-R25)
* Updated the Next.js image configuration (`next.config.js`) to allow loading images from `i.pravatar.cc`, which is used in the new example.