### PR TITLE
fix(styles): use CSS variable for html font-size to allow customization

### DIFF
--- a/docs/pages/guide/css-variables/themes.json
+++ b/docs/pages/guide/css-variables/themes.json
@@ -12,6 +12,12 @@
     "category": "typography"
   },
   {
+    "name": "--rs-html-font-size",
+    "value": "16px",
+    "type": "font-size",
+    "category": "typography"
+  },
+  {
     "name": "--rs-font-size-4xs",
     "value": "0.375rem",
     "type": "font-size",

--- a/src/Progress/styles/_progress-line.scss
+++ b/src/Progress/styles/_progress-line.scss
@@ -15,6 +15,7 @@
   align-items: center;
   width: 100%;
   gap: calc(var(--rs-spacing) * 3);
+  font-size: var(--rs-font-size-sm);
 
   &:where([data-status='active']) {
     .rs-progress-line-stroke {

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -18,20 +18,3 @@
     box-sizing: border-box;
   }
 }
-
-// Document-level styles
-// 1. Remove tap highlight on iOS devices
-// 2. Set base font size for rem calculations
-html {
-  -webkit-tap-highlight-color: transparent; // 1
-  font-size: 16px; // 2
-}
-
-// Base typography and document styles
-body {
-  font-family: var(--rs-font-family-base);
-  font-size: var(--rs-font-size-sm);
-  line-height: var(--rs-line-height-md);
-  color: var(--rs-text-primary);
-  background-color: var(--rs-body);
-}

--- a/src/styles/_css-reset.scss
+++ b/src/styles/_css-reset.scss
@@ -1,3 +1,11 @@
+// Document-level styles
+// 1. Remove tap highlight on iOS devices
+// 2. Set base font size for rem calculations (customizable via --rs-html-font-size)
+html {
+  -webkit-tap-highlight-color: transparent; // 1
+  font-size: var(--rs-html-font-size); // 2
+}
+
 body {
   // Remove default margin.
   margin: 0;
@@ -5,6 +13,13 @@ body {
   // Optimize for the retina screen
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  // Base typography and document styles
+  font-family: var(--rs-font-family-base);
+  font-size: var(--rs-font-size-sm);
+  line-height: var(--rs-line-height-md);
+  color: var(--rs-text-primary);
+  background-color: var(--rs-body);
 }
 
 // Address `[hidden]` styling not present in IE 10.

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -4,6 +4,9 @@
 @use 'color-modes/high-contrast' as high-contrast-theme;
 
 :root {
+  // HTML base font size (used for rem calculations)
+  --rs-html-font-size: 16px;
+
   // Font family
   --rs-font-family-base: -apple-system, BlinkMacSystemFont, Arial, Helvetica, 'PingFang SC',
     'Hiragino Sans GB', 'Microsoft YaHei', STXihei, sans-serif;


### PR DESCRIPTION
- Add --rs-html-font-size CSS variable (default: 16px)
- Replace hardcoded 16px with var(--rs-html-font-size) in html element
- Update CSS variables documentation

This allows users to customize the base font size without recompiling  
```scss
:root {
  --rs-html-font-size: 14px;
}
```
Fixes #4466