### PR TITLE
fix(TimeDropdown): guard +12 hour offset on showMeridiem in 24h mode

### DIFF
--- a/src/Calendar/TimeDropdown/TimeDropdown.tsx
+++ b/src/Calendar/TimeDropdown/TimeDropdown.tsx
@@ -49,14 +49,14 @@ const TimeDropdown = forwardRef<'div', TimeDropdownProps>((props: TimeDropdownPr
 
   const handleClick = useEventCallback((type: TimeType, d: number, event: React.MouseEvent) => {
     const nextTime = {
-      hour: (time.hours ?? 0) + (time.meridiem === 'PM' ? 12 : 0),
+      hour: (time.hours ?? 0) + (showMeridiem && time.meridiem === 'PM' ? 12 : 0),
       minute: time.minutes ?? 0,
       second: time.seconds ?? 0
     } satisfies PlainTime;
 
     switch (type) {
       case 'hours':
-        nextTime.hour = time.meridiem === 'PM' ? d + 12 : d;
+        nextTime.hour = showMeridiem && time.meridiem === 'PM' ? d + 12 : d;
         break;
       case 'minutes':
         nextTime.minute = d;
@@ -71,7 +71,7 @@ const TimeDropdown = forwardRef<'div', TimeDropdownProps>((props: TimeDropdownPr
 
   const handleClickMeridiem = useEventCallback((meridiem: 'AM' | 'PM', event: React.MouseEvent) => {
     const nextTime = {
-      hour: (time.hours ?? 0) + (time.meridiem === 'PM' ? 12 : 0),
+      hour: (time.hours ?? 0) + (showMeridiem && time.meridiem === 'PM' ? 12 : 0),
       minute: time.minutes ?? 0,
       second: time.seconds ?? 0
     } satisfies PlainTime;

--- a/src/Calendar/test/CalendarTimeDropdown.spec.tsx
+++ b/src/Calendar/test/CalendarTimeDropdown.spec.tsx
@@ -124,6 +124,54 @@ describe('Calendar - TimeDropdown', () => {
     });
   });
 
+  it('Should not add 12 to hour >= 12 when clicking minutes in 24h mode', () => {
+    const onChangeTime = vi.fn();
+
+    render(
+      <CalendarProvider
+        value={{
+          onChangeTime,
+          date: new Date(2024, 0, 1, 13, 0, 0),
+          format: 'HH:mm',
+          locale: en_US.Calendar,
+          isoWeek: false,
+          weekStart: 0
+        }}
+      >
+        <TimeDropdown showMeridiem={false} />
+      </CalendarProvider>
+    );
+
+    fireEvent.click(screen.getByRole('option', { name: '30 minutes', hidden: true }));
+
+    expect(onChangeTime).toHaveBeenCalledTimes(1);
+    expect(onChangeTime.mock.calls[0][0].hour).to.equal(13);
+  });
+
+  it('Should not add 12 to hour when clicking hours >= 12 in 24h mode', () => {
+    const onChangeTime = vi.fn();
+
+    render(
+      <CalendarProvider
+        value={{
+          onChangeTime,
+          date: new Date(2024, 0, 1, 13, 0, 0),
+          format: 'HH:mm',
+          locale: en_US.Calendar,
+          isoWeek: false,
+          weekStart: 0
+        }}
+      >
+        <TimeDropdown showMeridiem={false} />
+      </CalendarProvider>
+    );
+
+    fireEvent.click(screen.getByRole('option', { name: '13 hours', hidden: true }));
+
+    expect(onChangeTime).toHaveBeenCalledTimes(1);
+    expect(onChangeTime.mock.calls[0][0].hour).to.equal(13);
+  });
+
   it('Should not render hours hidden by `hideHours`', () => {
     const hideHours = vi.fn(h => {
       return h > 10;


### PR DESCRIPTION
## Summary

- In 24h mode (`showMeridiem=false`), clicking minutes/seconds or an hour ≥ 12 incorrectly added 12 to the hour (e.g. 13:xx → 01:xx), because `time.meridiem` is set unconditionally by `getClockTime` even when not in 12h mode
- Fixed by gating the `+12` offset on `showMeridiem` in both `handleClick` and `handleClickMeridiem`
- Added two regression tests to `CalendarTimeDropdown.spec.tsx` covering the two broken code paths

Fixes #4526

## Test plan

- [ ] `M=Calendar npm run test` — all 149 tests pass
- [ ] Manual: open a TimePicker in 24h format with a time ≥ 13:00, click minutes/seconds — hour must stay unchanged
- [ ] Manual: 12h mode (AM/PM) still toggles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)