### PR TITLE
fix(Uploader): prevent horizontal overflow and width increase

### DIFF
--- a/src/Uploader/styles/index.scss
+++ b/src/Uploader/styles/index.scss
@@ -109,6 +109,7 @@
       @include utils.ellipsis-basic;
 
       flex: 1 1 auto;
+      min-width: 0;
     }
 
     &-size {
@@ -169,6 +170,7 @@
 .rs-uploader[data-list-type='picture'] {
   display: inline-flex;
   flex-direction: row;
+  flex-wrap: wrap;
   gap: var(--rs-uploader-item-spacing);
 
   .rs-uploader-trigger-btn {
@@ -213,6 +215,7 @@
 
   .rs-uploader-file-items {
     display: inline-flex;
+    flex-wrap: wrap;
     gap: var(--rs-uploader-item-spacing);
   }
 


### PR DESCRIPTION
Picture mode (listType='picture'):
- Added flex-wrap: wrap to the container and file-items list to allow items to wrap when the container is narrower than the total width of all items, preventing horizontal scrollbar.

Text mode (listType='text'):
- Added min-width: 0 to .rs-uploader-file-item-title to override the flexbox default min-width: auto, allowing the file name to properly truncate with ellipsis instead of pushing the container beyond its parent width.

Closes #4536