### PR TITLE
feat(locales): add Norwegian Bokmål (nb_NO) locale

### DIFF
--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -14,6 +14,7 @@ export { default as huHU } from './hu_HU';
 export { default as itIT } from './it_IT';
 export { default as kkKZ } from './kk_KZ';
 export { default as koKR } from './ko_KR';
+export { default as nbNO } from './nb_NO';
 export { default as nlNL } from './nl_NL';
 export { default as ptBR } from './pt_BR';
 export { default as ruRU } from './ru_RU';

--- a/src/locales/nb_NO.ts
+++ b/src/locales/nb_NO.ts
@@ -1,0 +1,100 @@
+import { nb } from 'date-fns/locale/nb';
+
+const DateTimeFormats = {
+  sunday: 'Sø',
+  monday: 'Ma',
+  tuesday: 'Ti',
+  wednesday: 'On',
+  thursday: 'To',
+  friday: 'Fr',
+  saturday: 'Lø',
+  ok: 'OK',
+  today: 'I dag',
+  yesterday: 'I går',
+  now: 'Nå',
+  hours: 'Timer',
+  minutes: 'Minutter',
+  seconds: 'Sekunder',
+  /**
+   * Format of the string is based on Unicode Technical Standard #35:
+   * https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
+   **/
+  formattedMonthPattern: 'MMM yyyy',
+  formattedDayPattern: 'dd MMM yyyy',
+  shortDateFormat: 'dd.MM.yyyy',
+  shortTimeFormat: 'HH:mm',
+  dateLocale: nb as any
+};
+
+const Combobox = {
+  noResultsText: 'Ingen resultater funnet',
+  placeholder: 'Velg',
+  searchPlaceholder: 'Søk',
+  checkAll: 'Alle'
+};
+
+const CreatableComboBox = {
+  ...Combobox,
+  newItem: 'Nytt element',
+  createOption: 'Opprett alternativ "{0}"'
+};
+
+export default {
+  code: 'nb-NO',
+  common: {
+    loading: 'Laster...',
+    emptyMessage: 'Fant ingen data',
+    remove: 'Fjern',
+    clear: 'Tøm'
+  },
+  Plaintext: {
+    unfilled: 'Ikke utfylt',
+    notSelected: 'Ikke valgt',
+    notUploaded: 'Ikke lastet opp'
+  },
+  Pagination: {
+    more: 'Mer',
+    prev: 'Forrige',
+    next: 'Neste',
+    first: 'Første',
+    last: 'Siste',
+    limit: '{0} / side',
+    total: 'Totalt antall rader: {0}',
+    skip: 'Gå til {0}'
+  },
+  DateTimeFormats,
+  Calendar: DateTimeFormats,
+  DatePicker: DateTimeFormats,
+  DateRangePicker: {
+    ...DateTimeFormats,
+    last7Days: 'Siste 7 dager'
+  },
+  Combobox,
+  InputPicker: CreatableComboBox,
+  TagPicker: CreatableComboBox,
+  Uploader: {
+    inited: 'Klar',
+    progress: 'Laster opp',
+    error: 'Feil',
+    complete: 'Fullført',
+    emptyFile: 'Tom',
+    upload: 'Last opp',
+    removeFile: 'Fjern fil'
+  },
+  CloseButton: {
+    closeLabel: 'Lukk'
+  },
+  Breadcrumb: {
+    expandText: 'Vis sti'
+  },
+  Toggle: {
+    on: 'PÅ',
+    off: 'AV'
+  },
+  Dialog: {
+    alert: 'Varsel',
+    confirm: 'Bekreft',
+    ok: 'OK',
+    cancel: 'Avbryt'
+  }
+};


### PR DESCRIPTION
Adds a Norwegian Bokmål (`nb-NO`) locale, which was missing.

- New `src/locales/nb_NO.ts`, following the structure of the existing locales (uses the `nb` date-fns locale, Norwegian date/time formats, weekday abbreviations, and translated component strings).
- Registers it in `src/locales/index.ts` as `nbNO` (placed before `nlNL`).

Mirrors `en_GB`/`sv_SE` exactly in shape, so all keys are present.

Disclosure: prepared with AI assistance and reviewed by me as a native Norwegian (Bokmål) speaker — happy to adjust any wording.