### PR TITLE
feat(locales): add Norwegian Nynorsk (nn_NO) locale

### DIFF
--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -15,6 +15,7 @@ export { default as itIT } from './it_IT';
 export { default as kkKZ } from './kk_KZ';
 export { default as koKR } from './ko_KR';
 export { default as nbNO } from './nb_NO';
+export { default as nnNO } from './nn_NO';
 export { default as nlNL } from './nl_NL';
 export { default as ptBR } from './pt_BR';
 export { default as ruRU } from './ru_RU';

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -14,6 +14,7 @@ export { default as huHU } from './hu_HU';
 export { default as itIT } from './it_IT';
 export { default as kkKZ } from './kk_KZ';
 export { default as koKR } from './ko_KR';
+export { default as nbNO } from './nb_NO';
 export { default as nlNL } from './nl_NL';
 export { default as ptBR } from './pt_BR';
 export { default as ruRU } from './ru_RU';

--- a/src/locales/nb_NO.ts
+++ b/src/locales/nb_NO.ts
@@ -1,0 +1,100 @@
+import { nb } from 'date-fns/locale/nb';
+
+const DateTimeFormats = {
+  sunday: 'Sø',
+  monday: 'Ma',
+  tuesday: 'Ti',
+  wednesday: 'On',
+  thursday: 'To',
+  friday: 'Fr',
+  saturday: 'Lø',
+  ok: 'OK',
+  today: 'I dag',
+  yesterday: 'I går',
+  now: 'Nå',
+  hours: 'Timer',
+  minutes: 'Minutter',
+  seconds: 'Sekunder',
+  /**
+   * Format of the string is based on Unicode Technical Standard #35:
+   * https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
+   **/
+  formattedMonthPattern: 'MMM yyyy',
+  formattedDayPattern: 'dd MMM yyyy',
+  shortDateFormat: 'dd.MM.yyyy',
+  shortTimeFormat: 'HH:mm',
+  dateLocale: nb as any
+};
+
+const Combobox = {
+  noResultsText: 'Ingen resultater funnet',
+  placeholder: 'Velg',
+  searchPlaceholder: 'Søk',
+  checkAll: 'Alle'
+};
+
+const CreatableComboBox = {
+  ...Combobox,
+  newItem: 'Nytt element',
+  createOption: 'Opprett alternativ "{0}"'
+};
+
+export default {
+  code: 'nb-NO',
+  common: {
+    loading: 'Laster...',
+    emptyMessage: 'Fant ingen data',
+    remove: 'Fjern',
+    clear: 'Tøm'
+  },
+  Plaintext: {
+    unfilled: 'Ikke utfylt',
+    notSelected: 'Ikke valgt',
+    notUploaded: 'Ikke lastet opp'
+  },
+  Pagination: {
+    more: 'Mer',
+    prev: 'Forrige',
+    next: 'Neste',
+    first: 'Første',
+    last: 'Siste',
+    limit: '{0} / side',
+    total: 'Totalt antall rader: {0}',
+    skip: 'Gå til {0}'
+  },
+  DateTimeFormats,
+  Calendar: DateTimeFormats,
+  DatePicker: DateTimeFormats,
+  DateRangePicker: {
+    ...DateTimeFormats,
+    last7Days: 'Siste 7 dager'
+  },
+  Combobox,
+  InputPicker: CreatableComboBox,
+  TagPicker: CreatableComboBox,
+  Uploader: {
+    inited: 'Klar',
+    progress: 'Laster opp',
+    error: 'Feil',
+    complete: 'Fullført',
+    emptyFile: 'Tom',
+    upload: 'Last opp',
+    removeFile: 'Fjern fil'
+  },
+  CloseButton: {
+    closeLabel: 'Lukk'
+  },
+  Breadcrumb: {
+    expandText: 'Vis sti'
+  },
+  Toggle: {
+    on: 'PÅ',
+    off: 'AV'
+  },
+  Dialog: {
+    alert: 'Varsel',
+    confirm: 'Bekreft',
+    ok: 'OK',
+    cancel: 'Avbryt'
+  }
+};

--- a/src/locales/nn_NO.ts
+++ b/src/locales/nn_NO.ts
@@ -1,0 +1,100 @@
+import { nn } from 'date-fns/locale/nn';
+
+const DateTimeFormats = {
+  sunday: 'Su',
+  monday: 'Må',
+  tuesday: 'Ty',
+  wednesday: 'On',
+  thursday: 'To',
+  friday: 'Fr',
+  saturday: 'La',
+  ok: 'OK',
+  today: 'I dag',
+  yesterday: 'I går',
+  now: 'No',
+  hours: 'Timar',
+  minutes: 'Minutt',
+  seconds: 'Sekund',
+  /**
+   * Format of the string is based on Unicode Technical Standard #35:
+   * https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
+   **/
+  formattedMonthPattern: 'MMM yyyy',
+  formattedDayPattern: 'dd MMM yyyy',
+  shortDateFormat: 'dd.MM.yyyy',
+  shortTimeFormat: 'HH:mm',
+  dateLocale: nn as any
+};
+
+const Combobox = {
+  noResultsText: 'Ingen resultat funne',
+  placeholder: 'Vel',
+  searchPlaceholder: 'Søk',
+  checkAll: 'Alle'
+};
+
+const CreatableComboBox = {
+  ...Combobox,
+  newItem: 'Nytt element',
+  createOption: 'Opprett alternativ "{0}"'
+};
+
+export default {
+  code: 'nn-NO',
+  common: {
+    loading: 'Lastar...',
+    emptyMessage: 'Fann ingen data',
+    remove: 'Fjern',
+    clear: 'Tøm'
+  },
+  Plaintext: {
+    unfilled: 'Ikkje utfylt',
+    notSelected: 'Ikkje vald',
+    notUploaded: 'Ikkje lasta opp'
+  },
+  Pagination: {
+    more: 'Meir',
+    prev: 'Førre',
+    next: 'Neste',
+    first: 'Første',
+    last: 'Siste',
+    limit: '{0} / side',
+    total: 'Totalt tal rader: {0}',
+    skip: 'Gå til {0}'
+  },
+  DateTimeFormats,
+  Calendar: DateTimeFormats,
+  DatePicker: DateTimeFormats,
+  DateRangePicker: {
+    ...DateTimeFormats,
+    last7Days: 'Siste 7 dagar'
+  },
+  Combobox,
+  InputPicker: CreatableComboBox,
+  TagPicker: CreatableComboBox,
+  Uploader: {
+    inited: 'Klar',
+    progress: 'Lastar opp',
+    error: 'Feil',
+    complete: 'Fullført',
+    emptyFile: 'Tom',
+    upload: 'Last opp',
+    removeFile: 'Fjern fil'
+  },
+  CloseButton: {
+    closeLabel: 'Lukk'
+  },
+  Breadcrumb: {
+    expandText: 'Vis sti'
+  },
+  Toggle: {
+    on: 'PÅ',
+    off: 'AV'
+  },
+  Dialog: {
+    alert: 'Varsel',
+    confirm: 'Stadfest',
+    ok: 'OK',
+    cancel: 'Avbryt'
+  }
+};


### PR DESCRIPTION
Follow-up to the Norwegian Bokmål (`nb_NO`) locale: adds Norwegian **Nynorsk** (`nn_NO`), the other official written standard of Norwegian.

- New `src/locales/nn_NO.ts`, mirroring the structure of `nb_NO`/`sv_SE` (uses the `nn` date-fns locale, Nynorsk date formats and weekday abbreviations, translated component strings).
- Registers `nnNO` in `src/locales/index.ts` (right after `nbNO`).

Disclosure: prepared with AI assistance and reviewed by me as a native Norwegian speaker.