### PR TITLE
fix(InputPicker): ignore Enter during IME composition when selecting an item

### DIFF
--- a/src/InputPicker/InputPicker.tsx
+++ b/src/InputPicker/InputPicker.tsx
@@ -369,6 +369,11 @@ const InputPicker = forwardRef<'div', InputPickerProps>((props, ref) => {
   });
 
   const handleMenuItemKeyPress = useEventCallback((event: React.KeyboardEvent) => {
+    // When composing, ignore the keypress event.
+    if (event.nativeEvent.isComposing) {
+      return;
+    }
+
     if (!focusItemValue || !controlledData) {
       return;
     }

--- a/src/InputPicker/test/InputPicker.spec.tsx
+++ b/src/InputPicker/test/InputPicker.spec.tsx
@@ -296,6 +296,15 @@ describe('InputPicker', () => {
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
+  it('Should not call `onChange` when Enter is pressed during IME composition', () => {
+    const onChange = vi.fn();
+    render(<InputPicker defaultOpen data={data} onChange={onChange} defaultValue={'Kariane'} />);
+
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter', isComposing: true });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('Should call onBlur callback', () => {
     const onBlur = vi.fn();
     render(<InputPicker data={[]} onBlur={onBlur} />);


### PR DESCRIPTION
### What

`InputPicker` already ignores the Enter key while an IME is composing in its tag-input handler (`handleTagKeyPress`), but the single-select handler (`handleMenuItemKeyPress`) is missing the same guard. So in a single-select `InputPicker`, pressing Enter to confirm an IME conversion also selects the focused option and closes the menu.

### Steps to reproduce

1. Render a single-select `InputPicker` and open it.
2. With a CJK IME (Japanese/Chinese/Korean), type in the search box to filter the list. An option becomes focused.
3. Press Enter to confirm the IME conversion candidate.

Expected: Enter only commits the composing text in the input; the picker stays open.
Actual: `onChange` fires, the focused option is selected, and the menu closes.

### Fix

Bail out of `handleMenuItemKeyPress` when `event.nativeEvent.isComposing` is true, mirroring the guard that already exists in `handleTagKeyPress` a few lines above.

### Test

Added a case next to the existing "Should call `onChange` by key=Enter" test, with the same setup but `isComposing: true` on the keydown, asserting `onChange` is not called. Without the guard it fails (`onChange` is called once); with it the full `InputPicker` suite passes.
