### PR TITLE
fix(docs): repair online sandbox examples

### DIFF
--- a/docs/components/CodeView/CodeView.tsx
+++ b/docs/components/CodeView/CodeView.tsx
@@ -12,7 +12,7 @@ import AdCarbonInline from '../AdCarbon/AdCarbonInline';
 import { Divider, IconButton, Tooltip, Whisper, Placeholder } from 'rsuite';
 import { TransparentIcon, CodesandboxIcon, StackBlitzIcon } from '@/components/icons';
 import { useApp } from '@/hooks/useApp';
-import { html, css, dependencies as codeDependencies } from './utils';
+import { viteHtml, css, dependencies as codeDependencies, createVitePackageJson } from './utils';
 
 export interface CustomCodeViewProps {
   className?: string;
@@ -85,20 +85,29 @@ const CodeView = (props: CustomCodeViewProps) => {
 
   const openStackBlitz = useCallback(() => {
     const depsFiles = {};
+    const projectDependencies = { ...codeDependencies, ...sandboxDependencies };
 
     sandboxFiles?.forEach(file => {
-      depsFiles[file.name] = file.content;
+      depsFiles[`src/${file.name}`] = file.content;
     });
 
     const project: Project = {
       title: 'rsuite example',
       description: 'Example from rsuitejs.com',
-      template: 'create-react-app',
-      dependencies: { ...codeDependencies, ...sandboxDependencies },
-      files: { 'index.js': code, 'index.html': html, 'styles.css': css, ...depsFiles }
+      template: 'node',
+      files: {
+        'package.json': createVitePackageJson(projectDependencies),
+        'index.html': viteHtml,
+        'src/index.jsx': code,
+        'src/styles.css': css,
+        ...depsFiles
+      }
     };
 
-    stackBlitzSDK.openProject(project);
+    stackBlitzSDK.openProject(project, {
+      openFile: 'src/index.jsx',
+      startScript: 'dev'
+    });
   }, [code, sandboxFiles, sandboxDependencies]);
 
   const withWhisper = useCallback(

--- a/docs/components/CodeView/utils.ts
+++ b/docs/components/CodeView/utils.ts
@@ -1,9 +1,29 @@
 export const html = '<div id="root"></div>';
+export const viteHtml = `${html}\n<script type="module" src="/src/index.jsx"></script>`;
 export const css = '@import "rsuite/dist/rsuite.css";\n\n#root{ padding: 10px; }';
 export const dependencies = {
-  react: '^17.0.0 || ^18.0.0',
-  'react-dom': '^17.0.0 || ^18.0.0',
+  react: '^18.0.0',
+  'react-dom': '^18.0.0',
   rsuite: 'latest',
   '@rsuite/icons': 'latest',
   '@babel/runtime': '^7.8.4'
 };
+
+export function createVitePackageJson(projectDependencies: Record<string, string>) {
+  return JSON.stringify(
+    {
+      name: 'rsuite-example',
+      private: true,
+      version: '0.0.0',
+      scripts: {
+        dev: 'vite --host 0.0.0.0'
+      },
+      dependencies: projectDependencies,
+      devDependencies: {
+        vite: '^7.0.0'
+      }
+    },
+    null,
+    2
+  );
+}


### PR DESCRIPTION
fix: https://github.com/rsuite/rsuite/issues/4587

This pull request updates the StackBlitz integration in the `CodeView` component to use Vite instead of Create React App, improving the developer experience and aligning with modern React tooling. It also updates dependency versions and adds utility functions to support this migration.

**StackBlitz integration migration to Vite:**

* Updated the StackBlitz project template from `create-react-app` to `node` and restructured the project files to use a Vite-compatible setup, including moving source files to the `src/` directory and updating file references.
* Added the `viteHtml` template and a `createVitePackageJson` utility function to generate the necessary `index.html` and `package.json` files for Vite projects.
* Changed the default opened file in StackBlitz to `src/index.jsx` and set the start script to `dev` for Vite.

**Dependency updates:**

* Updated the default React and ReactDOM dependencies to require version 18 or higher, ensuring compatibility with the latest features and Vite.

**Code organization:**

* Refactored imports in `CodeView.tsx` to include the new Vite-related utilities.