### PR TITLE
docs(i18n): add missing supported locales

### DIFF
--- a/docs/pages/guide/i18n/en-US/index.md
+++ b/docs/pages/guide/i18n/en-US/index.md
@@ -33,11 +33,13 @@ return (
 | fa-IR               | Persian (Iran)                                   | `faIR`      |
 | fi-FI               | Finnish                                          | `fiFI`      |
 | fr-FR               | French                                           | `frFR`      |
+| gu-IN               | Gujarati                                         | `guIN`      |
 | hu-HU               | Hungarian                                        | `huHU`      |
 | it-IT               | Italian                                          | `itIT`      |
 | ja-JP               | Japanese                                         | `jaJP`      |
 | kk-KZ               | Kazakh                                           | `kkKZ`      |
 | ko-KR               | Korean                                           | `koKR`      |
+| nb-NO               | Norwegian Bokmål                                 | `nbNO`      |
 | ne-NP               | Nepali                                           | `neNP`      |
 | nl-NL               | Dutch                                            | `nlNL`      |
 | pl-PL               | Polish (Poland)                                  | `plPL`      |

--- a/docs/pages/guide/i18n/zh-CN/index.md
+++ b/docs/pages/guide/i18n/zh-CN/index.md
@@ -33,11 +33,13 @@ return (
 | fa-IR                | 波斯语 (伊朗)         | `faIR`   |
 | fi-FI                | 芬兰语                | `fiFI`   |
 | fr-FR                | 法语                  | `frFR`   |
+| gu-IN                | 古吉拉特语            | `guIN`   |
 | hu-HU                | 匈牙利语              | `huHU`   |
 | it-IT                | 意大利语              | `itIT`   |
 | ja-JP                | 日语                  | `jaJP`   |
 | kk-KZ                | 哈萨克语              | `kkKZ`   |
 | ko-KR                | 韩语/朝鲜语           | `koKR`   |
+| nb-NO                | 挪威博克马尔语        | `nbNO`   |
 | ne-NP                | 尼泊尔语              | `neNP`   |
 | nl-NL                | 荷兰语                | `nlNL`   |
 | pl-PL                | 波兰语（波兰）        | `plPL`   |


### PR DESCRIPTION
This pull request updates the language documentation to include two additional supported languages. The changes ensure that both the English and Chinese guides reflect the latest list of available languages.

**Documentation updates:**

* Added Gujarati (`gu-IN`, `guIN`) and Norwegian Bokmål (`nb-NO`, `nbNO`) to the list of supported languages in the English guide (`docs/pages/guide/i18n/en-US/index.md`).
* Added Gujarati (`gu-IN`, `guIN`) and Norwegian Bokmål (`nb-NO`, `nbNO`) to the list of supported languages in the Chinese guide (`docs/pages/guide/i18n/zh-CN/index.md`).