### PR TITLE
fix(picker): expose responsive prop on CheckPicker and SelectPicker

### DIFF
--- a/src/CheckPicker/CheckPicker.tsx
+++ b/src/CheckPicker/CheckPicker.tsx
@@ -90,6 +90,7 @@ const CheckPicker = forwardRef<'div', CheckPickerProps>(
       popupAutoWidth = true,
       popupClassName,
       popupStyle,
+      responsive,
       searchable = true,
       sticky,
       style,
@@ -365,6 +366,7 @@ const CheckPicker = forwardRef<'div', CheckPickerProps>(
         id={id}
         multiple
         pickerType="check"
+        responsive={responsive}
         block={block}
         disabled={disabled}
         appearance={appearance}

--- a/src/SelectPicker/SelectPicker.tsx
+++ b/src/SelectPicker/SelectPicker.tsx
@@ -36,6 +36,14 @@ import type {
 } from '@/internals/types';
 
 export interface SelectProps<T> extends ListboxProps, PopupProps, DeprecatedMenuProps {
+  /**
+   * Whether the popup is responsive. When `true` (the default), the popup
+   * automatically switches to a full-width Drawer at the `xs` breakpoint.
+   * Set to `false` to always render the popup in place, e.g. when the
+   * picker is already inside another mobile-specific overlay.
+   */
+  responsive?: boolean;
+
   /** Set group condition key in data */
   groupBy?: string;
 
@@ -125,6 +133,7 @@ const SelectPicker = forwardRef<'div', SelectPickerProps>(
       popupAutoWidth = true,
       popupClassName,
       popupStyle,
+      responsive,
       searchable = true,
       style,
       toggleAs,
@@ -352,6 +361,7 @@ const SelectPicker = forwardRef<'div', SelectPickerProps>(
         as={as}
         id={id}
         pickerType="select"
+        responsive={responsive}
         block={block}
         disabled={disabled}
         appearance={appearance}


### PR DESCRIPTION
PickerToggleTrigger already accepts a responsive prop (defaulting to true) that controls whether the popup auto-switches to a full-width Drawer at the xs breakpoint, but CheckPicker and SelectPicker never threaded it through - it silently fell into the rest spread and never reached PickerToggleTrigger, so it was impossible to opt a picker out of the mobile Drawer behavior.

This is useful when a picker is already nested inside another mobile-specific overlay (e.g. a filter panel rendered as a Modal or Drawer), where a second full-width Drawer popping up on top reads as broken rather than helpful.

Fixes https://github.com/rsuite/rsuite/issues/4592