### PR TITLE
fix(picker): expose responsive control for all pickers

### DIFF
--- a/docs/pages/components/cascader/en-US/index.md
+++ b/docs/pages/components/cascader/en-US/index.md
@@ -52,6 +52,8 @@ This tree allows the use of the `getChildren` option and the length of the child
 
 ## Responsive
 
+On extra-small screens, the popup is displayed as a full-width Drawer by default. Set `responsive={false}` to keep a positioned popup, such as when the picker is already inside a Modal or Drawer.
+
 <!--{include:<example-responsive>}-->
 
 ## Accessibility
@@ -122,6 +124,7 @@ This tree allows the use of the `getChildren` option and the length of the child
 | renderSearchItem   | (node: ReactNode, items: [Option][item][]) => ReactNode                           | Custom render function for search result items              |
 | renderTreeNode     | (node: ReactNode, item: [Option][item]) => ReactNode                              | Custom render function for tree nodes                       |
 | renderValue        | (value: string, selectedPaths: [Option][item][], selected:ReactNode) => ReactNode | Custom render function for selected items                   |
+| responsive         | boolean `(true)`                                                                  | Whether to display the popup as a full-width Drawer on extra-small screens |
 | searchable         | boolean `(true)`                                                                  | Whether the component is searchable                         |
 | size               | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`                                             | Size of the component                                       |
 | toggleAs           | ElementType `('a')`                                                               | Custom element for the component                            |

--- a/docs/pages/components/cascader/zh-CN/index.md
+++ b/docs/pages/components/cascader/zh-CN/index.md
@@ -52,6 +52,8 @@
 
 ## 响应式
 
+在超小屏幕上，弹出层默认显示为全宽 Drawer。当选择器已经位于 Modal 或 Drawer 中时，可设置 `responsive={false}` 保持定位浮层，避免嵌套遮罩。
+
 <!--{include:<example-responsive>}-->
 
 ## 可访问性
@@ -122,6 +124,7 @@
 | renderSearchItem   | (node: ReactNode, items: [Option][item][]) => ReactNode                          | 自定义渲染搜索结果选项                             |
 | renderTreeNode     | (node: ReactNode, item: [Option][item]) => ReactNode                             | 自定义选项                                         |
 | renderValue        | (value:string, selectedPaths: [Option][item][], selected:ReactNode) => ReactNode | 自定义被选中的选项                                 |
+| responsive         | boolean `(true)`                                                                 | 是否在超小屏幕上将弹出层显示为全宽 Drawer          |
 | searchable         | boolean `(true)`                                                                 | 可以搜索                                           |
 | size               | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`                                            | 设置组件尺寸                                       |
 | toggleAs           | ElementType `('a')`                                                              | 为组件自定义元素类型                               |

--- a/docs/pages/components/check-picker/en-US/index.md
+++ b/docs/pages/components/check-picker/en-US/index.md
@@ -81,6 +81,8 @@ Customize a select all function.
 
 ## Responsive
 
+On extra-small screens, the popup is displayed as a full-width Drawer by default. Set `responsive={false}` to keep a positioned popup, such as when the picker is already inside a Modal or Drawer.
+
 <!--{include:<example-responsive>}-->
 
 ## Accessibility
@@ -150,6 +152,7 @@ Customize a select all function.
 | renderOption       | (label: ReactNode, item:[Option][item]) => ReactNode                              | Custom render function for options                          |
 | renderOptionGroup  | (title: ReactNode, item:[Option][item]) => ReactNode                              | Custom render function for option groups                    |
 | renderValue        | (value: [Value][value], items: [Option][item][], selected:ReactNode) => ReactNode | Custom render function for selected items                   |
+| responsive         | boolean `(true)`                                                                  | Whether to display the popup as a full-width Drawer on extra-small screens |
 | searchable         | boolean `(true)`                                                                  | Whether to display search input box                         |
 | searchBy           | (keyword: string, label: ReactNode, item: Option) => boolean                      | Custom search function                                      |
 | size               | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`                                             | Size of the picker                                          |

--- a/docs/pages/components/check-picker/zh-CN/index.md
+++ b/docs/pages/components/check-picker/zh-CN/index.md
@@ -81,6 +81,8 @@
 
 ## 响应式
 
+在超小屏幕上，弹出层默认显示为全宽 Drawer。当选择器已经位于 Modal 或 Drawer 中时，可设置 `responsive={false}` 保持定位浮层，避免嵌套遮罩。
+
 <!--{include:<example-responsive>}-->
 
 ## 可访问性
@@ -150,6 +152,7 @@
 | renderOption       | (label: ReactNode, item: [Option][item]) => ReactNode                 | 自定义选项                           |
 | renderOptionGroup  | (title: ReactNode, item: [Option][item]) => ReactNode                 | 自定义选项组                         |
 | renderValue        | (value: [Value][value], items: any[],selected:ReactNode) => ReactNode | 自定义被选中的选项                   |
+| responsive         | boolean `(true)`                                                      | 是否在超小屏幕上将弹出层显示为全宽 Drawer |
 | searchable         | boolean `(true)`                                                      | 可以搜索                             |
 | searchBy           | (keyword: string, label: ReactNode, item: [Option][item]) => boolean  | 自定义搜索规则                       |
 | size               | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`                                 | 设置组件尺寸                         |

--- a/docs/pages/components/check-tree-picker/en-US/index.md
+++ b/docs/pages/components/check-tree-picker/en-US/index.md
@@ -52,6 +52,8 @@ The cascade attribute can set whether or not CheckTreePicker can consider the ca
 
 ## Responsive
 
+On extra-small screens, the popup is displayed as a full-width Drawer by default. Set `responsive={false}` to keep a positioned popup, such as when the picker is already inside a Modal or Drawer.
+
 <!--{include:<example-responsive>}-->
 
 ## Accessibility
@@ -141,6 +143,7 @@ The cascade attribute can set whether or not CheckTreePicker can consider the ca
 | renderTreeIcon          | (item:[TreeNode][node], expanded: boolean) => ReactNode                                        | Custom render tree node icon                                |
 | renderTreeNode          | (item:[TreeNode][node]) => ReactNode                                                           | Custom render tree node                                     |
 | renderValue             | (values:string[], checkedItems:[TreeNode][node][],selectedElement: ReactNode) => ReactNode     | Custom render selected items                                |
+| responsive              | boolean `(true)`                                                                               | Whether to display the popup as a full-width Drawer on extra-small screens |
 | searchable              | boolean `(true)`                                                                               | Whether display search input box                            |
 | searchBy                | (keyword: string, label: ReactNode, item: [TreeNode][node]) => boolean                         | Custom search method                                        |
 | showIndentLine          | boolean                                                                                        | Whether to show the indent line                             |

--- a/docs/pages/components/check-tree-picker/zh-CN/index.md
+++ b/docs/pages/components/check-tree-picker/zh-CN/index.md
@@ -52,6 +52,8 @@
 
 ## 响应式
 
+在超小屏幕上，弹出层默认显示为全宽 Drawer。当选择器已经位于 Modal 或 Drawer 中时，可设置 `responsive={false}` 保持定位浮层，避免嵌套遮罩。
+
 <!--{include:<example-responsive>}-->
 
 ## 可访问性
@@ -141,6 +143,7 @@
 | renderTreeIcon          | (item:[TreeNode][node], expanded: boolean) => ReactNode                                        | 自定义渲染树节点图标                   |
 | renderTreeNode          | (item:[TreeNode][node]) => ReactNode                                                           | 自定义渲染树节点                       |
 | renderValue             | (values:string[], checkedItems:[TreeNode][node][],selectedElement: ReactNode) => ReactNode     | 自定义渲染值                           |
+| responsive              | boolean `(true)`                                                                               | 是否在超小屏幕上将弹出层显示为全宽 Drawer |
 | searchable              | boolean `(true)`                                                                               | 是否显示搜索框                         |
 | searchBy                | (keyword: string, label: ReactNode, item: [TreeNode][node]) => boolean                         | 自定义搜索方法                         |
 | showIndentLine          | boolean                                                                                        | 是否显示缩进线                         |

--- a/docs/pages/components/date-picker/en-US/index.md
+++ b/docs/pages/components/date-picker/en-US/index.md
@@ -116,6 +116,8 @@ If you only need to meet the simple date selection function, you can use the nat
 
 ## Responsive
 
+On extra-small screens, the popup is displayed as a full-width Drawer by default. Set `responsive={false}` to keep a positioned popup, such as when the picker is already inside a Modal or Drawer.
+
 <!--{include:<example-responsive>}-->
 
 ## Accessibility
@@ -189,6 +191,7 @@ Has keyboard interaction for the DateInput component by default.
 | ranges                | [Range[]](#code-ts-range-code)                         | Custom shortcut options                                                                                          |             |
 | renderCell            | (date: Date) => ReactNode                              | Custom calendar cell rendering                                                                                   | ![][5.54.0] |
 | renderValue           | (date: Date, format: string) => string                 | Custom render value                                                                                              |             |
+| responsive            | boolean `(true)`                                       | Whether to display the popup as a full-width Drawer on extra-small screens                                       |             |
 | shouldDisableDate     | (date:Date) => boolean                                 | Disabled date                                                                                                    |             |
 | shouldDisableHour     | (hour:number, date:Date) => boolean                    | Disabled hours                                                                                                   |             |
 | shouldDisableMinute   | (minute:number, date:Date) => boolean                  | Disabled minutes                                                                                                 |             |

--- a/docs/pages/components/date-picker/zh-CN/index.md
+++ b/docs/pages/components/date-picker/zh-CN/index.md
@@ -114,6 +114,8 @@ DatePicker 是一个高度可定制的组件，用户可以输入或选择不同
 
 ## 响应式
 
+在超小屏幕上，弹出层默认显示为全宽 Drawer。当选择器已经位于 Modal 或 Drawer 中时，可设置 `responsive={false}` 保持定位浮层，避免嵌套遮罩。
+
 <!--{include:<example-responsive>}-->
 
 ## 可访问性
@@ -189,6 +191,7 @@ DatePicker 是一个高度可定制的组件，用户可以输入或选择不同
 | ranges                | [Range[]](#code-ts-range-code)                         | 快捷项配置                                                            |             |
 | renderCell            | (date: Date) => ReactNode                              | 自定义渲染日历单元格                                                  | ![][5.54.0] |
 | renderValue           | (date: Date) => ReactNode                              | 自定义渲染值                                                          |             |
+| responsive            | boolean `(true)`                                       | 是否在超小屏幕上将弹出层显示为全宽 Drawer                             |             |
 | shouldDisableDate     | (date:Date) => boolean                                 | 禁用日期                                                              |             |
 | shouldDisableHour     | (hour:number, date:Date) => boolean                    | 禁用小时                                                              |             |
 | shouldDisableMinute   | (minute:number, date:Date) => boolean                  | 禁用分钟                                                              |             |

--- a/docs/pages/components/date-range-picker/en-US/index.md
+++ b/docs/pages/components/date-range-picker/en-US/index.md
@@ -120,6 +120,8 @@ const { combine, allowedMaxDays, beforeToday } = DateRangePicker;
 
 ## Responsive
 
+On extra-small screens, the popup is displayed as a full-width Drawer by default. Set `responsive={false}` to keep a positioned popup, such as when the picker is already inside a Modal or Drawer.
+
 <!--{include:<example-responsive>}-->
 
 ## Accessibility
@@ -189,6 +191,7 @@ Has keyboard interaction for the DateRangeInput component by default.
 | renderCell           | (date: Date) => ReactNode                                       | Custom calendar cell rendering                                                                                   | ![][5.77.0] |
 | renderTitle          | (date: Date, calendarKey: 'start' \| 'end') => ReactNode                                       | Custom render for month's title                                                                                  |             |
 | renderValue          | (date: [Date, Date], format: string) => string                  | Custom render value                                                                                              |             |
+| responsive           | boolean `(true)`                                                | Whether to display the popup as a full-width Drawer on extra-small screens                                       |             |
 | shouldDisableDate    | [DisabledDateFunction](#code-ts-disabled-date-function-code)    | Disabled date                                                                                                    |             |
 | showHeader           | boolean `(true)`                                                | Whether to display the formatted date range at the header of the calendar                                        | ![][5.52.0] |
 | showMeridiem         | boolean                                                         | Display hours in 12 format                                                                                       |             |

--- a/docs/pages/components/date-range-picker/zh-CN/index.md
+++ b/docs/pages/components/date-range-picker/zh-CN/index.md
@@ -122,6 +122,8 @@ const { combine, allowedMaxDays, beforeToday } = DateRangePicker;
 
 ## 响应式
 
+在超小屏幕上，弹出层默认显示为全宽 Drawer。当选择器已经位于 Modal 或 Drawer 中时，可设置 `responsive={false}` 保持定位浮层，避免嵌套遮罩。
+
 <!--{include:<example-responsive>}-->
 
 ## 可访问性
@@ -192,6 +194,7 @@ const { combine, allowedMaxDays, beforeToday } = DateRangePicker;
 | renderCell           | (date: Date) => ReactNode                                       | 自定义渲染日历面板上的日期单元格                                             | ![][5.77.0] |
 | renderTitle          | (date: Date, calendarKey: 'start' \| 'end') => ReactNode                                       | 自定义渲染日历面板上的月份标题                                               |             |
 | renderValue          | (date: [Date, Date], format: string) => string                  | 自定义渲染值                                                                 |             |
+| responsive           | boolean `(true)`                                                | 是否在超小屏幕上将弹出层显示为全宽 Drawer                                |             |
 | shouldDisableDate    | [DisabledDateFunction](#code-ts-disabled-date-function-code)    | 禁用日期                                                                     |             |
 | showHeader           | boolean `(true)`                                                | 是否在日历面板的头部显示格式化的日期范围                                     | ![][5.52.0] |
 | showMeridiem         | boolean                                                         | 显示 12 小时制的时间格式                                                     |             |

--- a/docs/pages/components/input-picker/en-US/index.md
+++ b/docs/pages/components/input-picker/en-US/index.md
@@ -46,7 +46,7 @@ Single item selector with text box input.
 
 ## Responsive
 
-On small screen devices, the selection list will be converted to a popup selector. To maintain the component's search functionality, this will only take effect when `searchable={false}` is set.
+By default, the popup becomes a full-width Drawer on extra-small screens only when `searchable={false}`. Set `responsive` to force a searchable Drawer, or `responsive={false}` to always keep a positioned popup.
 
 <!--{include:<example-responsive>}-->
 
@@ -115,6 +115,7 @@ On small screen devices, the selection list will be converted to a popup selecto
 | renderOption              | (label: ReactNode, item: [Option][item]) => ReactNode                | Custom render function for options                       |
 | renderOptionGroup         | (groupTitle: ReactNode, item: [Option][item]) => ReactNode           | Custom render function for option groups                 |
 | renderValue               | (value:string, item: [Option][item],selected:ReactNode) => ReactNode | Custom render function for selected value                |
+| responsive                | boolean                                                              | Controls the responsive Drawer; defaults to `!searchable` when omitted |
 | searchable                | boolean `(true)`                                                     | Whether the component is searchable                      |
 | searchBy                  | (keyword: string, label: ReactNode, item: [Option][item]) => boolean | Custom search function                                   |
 | shouldDisplayCreateOption | (searchKeyword: string, filteredData: InputOption[]) => boolean      | Function to determine whether to display "Create option" |

--- a/docs/pages/components/input-picker/examples/responsive.tsx
+++ b/docs/pages/components/input-picker/examples/responsive.tsx
@@ -23,7 +23,7 @@ const data = [
 const App = () => {
   return (
     <Box p={20}>
-      <InputPicker data={data} block searchable={false} />
+      <InputPicker data={data} block responsive />
     </Box>
   );
 };

--- a/docs/pages/components/input-picker/zh-CN/index.md
+++ b/docs/pages/components/input-picker/zh-CN/index.md
@@ -46,7 +46,7 @@
 
 ## 响应式
 
-在小屏幕设备上，选择列表将被转换为弹出式选择器。 为了不影响组件的搜索功能，只有在设置 `searchable={false}` 时，才会生效。
+默认仅在 `searchable={false}` 时，弹出层会在超小屏幕上转换为全宽 Drawer。设置 `responsive` 可强制启用支持搜索的 Drawer；设置 `responsive={false}` 则始终保持定位浮层。
 
 <!--{include:<example-responsive>}-->
 
@@ -118,6 +118,7 @@
 | renderOption              | (label: ReactNode, item: [Option][item]) => ReactNode                 | 自定义选项                                         |
 | renderOptionGroup         | (title: ReactNode, item: [Option][item]) => ReactNode                 | 自定义选项组                                       |
 | renderValue               | (value: string, item: [Option][item],selected:ReactNode) => ReactNode | 自定义渲染被选中的选项                             |
+| responsive                | boolean                                                               | 控制响应式 Drawer；省略时默认为 `!searchable`      |
 | searchable                | boolean `(true)`                                                      | 可以搜索                                           |
 | searchBy                  | (keyword: string, label: ReactNode, item: [Option][item]) => boolean  | 自定义搜索规则                                     |
 | shouldDisplayCreateOption | (searchKeyword: string, filteredData: InputOption[]) => boolean       | 自定义何时显示/隐藏"新建选项"操作                  |

--- a/docs/pages/components/multi-cascader/en-US/index.md
+++ b/docs/pages/components/multi-cascader/en-US/index.md
@@ -58,6 +58,8 @@ The `MultiCascader` component is used to select multiple values from cascading o
 
 ## Responsive
 
+On extra-small screens, the popup is displayed as a full-width Drawer by default. Set `responsive={false}` to keep a positioned popup, such as when the picker is already inside a Modal or Drawer.
+
 <!--{include:<example-responsive>}-->
 
 ## Accessibility
@@ -129,6 +131,7 @@ The `MultiCascader` component is used to select multiple values from cascading o
 | renderExtraFooter     | () => ReactNode                                                                           | Custom render extra footer                                                      |
 | renderTreeNode        | (node: ReactNode, item: [Option][item]) => ReactNode                                      | Custom render tree node                                                         |
 | renderValue           | (value: string, selectedItems: [Option][item][], selectedElement: ReactNode) => ReactNode | Custom render selected items                                                    |
+| responsive            | boolean `(true)`                                                                          | Whether to display the popup as a full-width Drawer on extra-small screens      |
 | searchable            | boolean `(true)`                                                                          | Whether can be searched                                                         |
 | size                  | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`                                                     | A picker can have different sizes                                               |
 | toggleAs              | ElementType `('a')`                                                                       | You can use a custom element for this component                                 |

--- a/docs/pages/components/multi-cascader/zh-CN/index.md
+++ b/docs/pages/components/multi-cascader/zh-CN/index.md
@@ -58,6 +58,8 @@
 
 ## 响应式
 
+在超小屏幕上，弹出层默认显示为全宽 Drawer。当选择器已经位于 Modal 或 Drawer 中时，可设置 `responsive={false}` 保持定位浮层，避免嵌套遮罩。
+
 <!--{include:<example-responsive>}-->
 
 ## 可访问性
@@ -128,6 +130,7 @@
 | renderExtraFooter     | () => ReactNode                                                                           | 自定义额外页脚的渲染方式。                     |
 | renderTreeNode        | (node: ReactNode, item: [Option][item]) => ReactNode                                      | 自定义树节点的渲染方式。                       |
 | renderValue           | (value: string, selectedItems: [Option][item][], selectedElement: ReactNode) => ReactNode | 自定义已选项的渲染方式。                       |
+| responsive            | boolean `(true)`                                                                          | 是否在超小屏幕上将弹出层显示为全宽 Drawer。    |
 | searchable            | boolean `(true)`                                                                          | 是否启用搜索功能。                             |
 | size                  | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`                                                     | 设置选择器的大小。                             |
 | toggleAs              | ElementType `('a')`                                                                       | 使用自定义元素作为组件。                       |

--- a/docs/pages/components/select-picker/en-US/index.md
+++ b/docs/pages/components/select-picker/en-US/index.md
@@ -77,6 +77,8 @@ Clicking a loading picker won't open its options menu.
 
 ## Responsive
 
+On extra-small screens, the popup is displayed as a full-width Drawer by default. Set `responsive={false}` to keep a positioned popup, such as when the picker is already inside a Modal or Drawer.
+
 <!--{include:<example-responsive>}-->
 
 ## Accessibility
@@ -144,6 +146,7 @@ Clicking a loading picker won't open its options menu.
 | renderOption       | (label: ReactNode, item: [Option][item]) => ReactNode                          | Custom render function for options                      |
 | renderOptionGroup  | (title: ReactNode, item: [Option][item]) => ReactNode                          | Custom render function for option groups                |
 | renderValue        | (value: [Value][value], item: [Option][item], selected:ReactNode) => ReactNode | Custom render function for selected value               |
+| responsive         | boolean `(true)`                                                               | Whether to display the popup as a full-width Drawer on extra-small screens |
 | searchable         | boolean `(true)`                                                               | Whether the component is searchable                     |
 | searchBy           | (keyword:string, label:ReactNode, item: [Option][item]) => boolean             | Custom search function                                  |
 | size               | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`                                          | Size of the component                                   |

--- a/docs/pages/components/select-picker/zh-CN/index.md
+++ b/docs/pages/components/select-picker/zh-CN/index.md
@@ -77,6 +77,8 @@
 
 ## 响应式
 
+在超小屏幕上，弹出层默认显示为全宽 Drawer。当选择器已经位于 Modal 或 Drawer 中时，可设置 `responsive={false}` 保持定位浮层，避免嵌套遮罩。
+
 <!--{include:<example-responsive>}-->
 
 ## 可访问性
@@ -144,6 +146,7 @@
 | renderOption       | (label: ReactNode, item: [Option][item]) => ReactNode                         | 自定义选项                                         |
 | renderOptionGroup  | (title: ReactNode, item: [Option][item]) => ReactNode                         | 自定义选项组                                       |
 | renderValue        | (value: [Value][value], item: [Option][item],selected:ReactNode) => ReactNode | 自定义渲染被选中的选项                             |
+| responsive         | boolean `(true)`                                                              | 是否在超小屏幕上将弹出层显示为全宽 Drawer          |
 | searchable         | boolean `(true)`                                                              | 可以搜索                                           |
 | searchBy           | (keyword: string, label: ReactNode, item: [Option][item]) => boolean          | 自定义搜索规则                                     |
 | size               | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`                                         | 设置组件尺寸                                       |

--- a/docs/pages/components/tag-picker/en-US/index.md
+++ b/docs/pages/components/tag-picker/en-US/index.md
@@ -56,7 +56,7 @@ Implement async search and loading of options using the `onSearch` callback.
 
 ## Responsive
 
-On small screen devices, the selection list will be converted to a popup selector. To maintain the component's search functionality, this will only take effect when `searchable={false}` is set.
+By default, the popup becomes a full-width Drawer on extra-small screens only when `searchable={false}`. Set `responsive` to force a searchable Drawer, or `responsive={false}` to always keep a positioned popup.
 
 <!--{include:<example-responsive>}-->
 
@@ -127,6 +127,7 @@ On small screen devices, the selection list will be converted to a popup selecto
 | renderOption       | (label:ReactNode, item: [Option][item]) => ReactNode                     | Custom render function for options                      |
 | renderOptionGroup  | (groupTitle: ReactNode, item: [Option][item]) => ReactNode               | Custom render function for option groups                |
 | renderValue        | (value: string[], items:[Option][item][], tags:ReactNode[]) => ReactNode | Custom render function for selected items               |
+| responsive         | boolean                                                                  | Controls the responsive Drawer; defaults to `!searchable` when omitted |
 | searchable         | boolean `(true)`                                                         | Whether the component is searchable                     |
 | searchBy           | (keyword: string, label: ReactNode, item: [Option][item]) => boolean     | Custom search rules                                     |
 | size               | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`                                    | The size of the component                               |

--- a/docs/pages/components/tag-picker/examples/responsive.tsx
+++ b/docs/pages/components/tag-picker/examples/responsive.tsx
@@ -23,7 +23,7 @@ const data = [
 const App = () => {
   return (
     <Box p={20}>
-      <TagPicker data={data} block searchable={false} />
+      <TagPicker data={data} block responsive />
     </Box>
   );
 };

--- a/docs/pages/components/tag-picker/zh-CN/index.md
+++ b/docs/pages/components/tag-picker/zh-CN/index.md
@@ -56,7 +56,7 @@
 
 ## 响应式
 
-在小屏幕设备上，选择列表将被转换为弹出式选择器。 为了不影响组件的搜索功能，只有在设置 `searchable={false}` 时，才会生效。
+默认仅在 `searchable={false}` 时，弹出层会在超小屏幕上转换为全宽 Drawer。设置 `responsive` 可强制启用支持搜索的 Drawer；设置 `responsive={false}` 则始终保持定位浮层。
 
 <!--{include:<example-responsive>}-->
 
@@ -126,6 +126,7 @@
 | renderOption       | (label: ReactNode, item: [Option][item]) => ReactNode                      | 自定义选项渲染函数             |
 | renderOptionGroup  | (groupTitle: ReactNode, item: [Option][item]) => ReactNode                 | 自定义选项组渲染函数           |
 | renderValue        | (value: string[], items: [Option][item][], tags: ReactNode[]) => ReactNode | 自定义选中项渲染函数           |
+| responsive         | boolean                                                                    | 控制响应式 Drawer；省略时默认为 `!searchable` |
 | searchable         | boolean `(true)`                                                           | 是否可以搜索                   |
 | searchBy           | (keyword: string, label: ReactNode, item: [Option][item]) => boolean       | 自定义搜索匹配函数             |
 | size               | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`                                      | 设置组件尺寸                   |

--- a/docs/pages/components/time-picker/en-US/index.md
+++ b/docs/pages/components/time-picker/en-US/index.md
@@ -50,6 +50,8 @@ TimePicker is a component that allows users to select a time value.
 
 ## Responsive
 
+On extra-small screens, the popup is displayed as a full-width Drawer by default. Set `responsive={false}` to keep a positioned popup, such as when the picker is already inside a Modal or Drawer.
+
 <!--{include:<example-responsive>}-->
 
 ## Accessibility
@@ -103,6 +105,7 @@ Has all ARIA properties of the DateInput component by default.
 | preventOverflow     | boolean                                                         | Prevent floating element overflow                                                   |
 | ranges              | [Range[]](#code-ts-range-code) ([Ranges](#code-ts-ranges-code)) | Shortcut config                                                                     |
 | renderValue         | (date: Date, format: string) => string                          | Custom render value                                                                 |
+| responsive          | boolean `(true)`                                                | Whether to display the popup as a full-width Drawer on extra-small screens          |
 | shouldDisableHour   | (hour:number, date:Date) => boolean                             | Disabled hours                                                                      |
 | shouldDisableMinute | (minute:number, date:Date) => boolean                           | Disabled minutes                                                                    |
 | shouldDisableSecond | (second:number, date:Date) => boolean                           | Disabled seconds                                                                    |

--- a/docs/pages/components/time-picker/zh-CN/index.md
+++ b/docs/pages/components/time-picker/zh-CN/index.md
@@ -50,6 +50,8 @@ TimePicker 是一个允许用户选择时间值的组件。
 
 ## 响应式
 
+在超小屏幕上，弹出层默认显示为全宽 Drawer。当选择器已经位于 Modal 或 Drawer 中时，可设置 `responsive={false}` 保持定位浮层，避免嵌套遮罩。
+
 <!--{include:<example-responsive>}-->
 
 ## 可访问性
@@ -103,6 +105,7 @@ TimePicker 是一个允许用户选择时间值的组件。
 | preventOverflow     | boolean                                                         | 防止浮动元素溢出                                   |
 | ranges              | [Range[]](#code-ts-range-code) ([Ranges](#code-ts-ranges-code)) | 快捷项配置                                         |
 | renderValue         | (date: Date) => ReactNode                                       | 自定义渲染值                                       |
+| responsive          | boolean `(true)`                                                | 是否在超小屏幕上将弹出层显示为全宽 Drawer          |
 | shouldDisableHour   | (hour:number, date:Date) => boolean                             | 禁用小时                                           |
 | shouldDisableMinute | (minute:number, date:Date) => boolean                           | 禁用分钟                                           |
 | shouldDisableSecond | (second:number, date:Date) => boolean                           | 禁用秒                                             |

--- a/docs/pages/components/time-range-picker/en-US/index.md
+++ b/docs/pages/components/time-range-picker/en-US/index.md
@@ -50,6 +50,8 @@ The TimeRangePicker component is used to select a time range.
 
 ## Responsive
 
+On extra-small screens, the popup is displayed as a full-width Drawer by default. Set `responsive={false}` to keep a positioned popup, such as when the picker is already inside a Modal or Drawer.
+
 <!--{include:<example-responsive>}-->
 
 ## Accessibility
@@ -103,6 +105,7 @@ Has all ARIA properties of the DateRangeInput component by default.
 | preventOverflow | boolean                                                | Prevent floating element overflow                                                   |             |
 | ranges          | [Range[]](#code-ts-range-code) ([])                    | Set predefined date ranges the user can select from.                                |             |
 | renderValue     | (date: [Date, Date], format: string) => string         | Custom render value                                                                 |             |
+| responsive      | boolean `(true)`                                       | Whether to display the popup as a full-width Drawer on extra-small screens          |             |
 | showHeader      | boolean `(true)`                                       | Whether to display the formatted date range at the header of the calendar           | ![][5.52.0] |
 | showMeridiem    | boolean                                                | Display hours in 12 format                                                          |             |
 | size            | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`                  | A picker can have different sizes                                                   |             |

--- a/docs/pages/components/time-range-picker/zh-CN/index.md
+++ b/docs/pages/components/time-range-picker/zh-CN/index.md
@@ -48,7 +48,9 @@ TimePicker 是一个允许用户选择时间值的组件。
 
 <!--{include:`controlled.md`}-->
 
-### 响应式
+## 响应式
+
+在超小屏幕上，弹出层默认显示为全宽 Drawer。当选择器已经位于 Modal 或 Drawer 中时，可设置 `responsive={false}` 保持定位浮层，避免嵌套遮罩。
 
 <!--{include:<example-responsive>}-->
 
@@ -102,6 +104,7 @@ TimePicker 是一个允许用户选择时间值的组件。
 | placement       | [Placement](#code-ts-placement-code) `('bottomStart')` | 显示位置                                           |
 | preventOverflow | boolean                                                | 防止浮动元素溢出                                   |
 | renderValue     | (date: [Date, Date], format: string) => string         | 自定义渲染值                                       |
+| responsive      | boolean `(true)`                                       | 是否在超小屏幕上将弹出层显示为全宽 Drawer          |
 | showMeridiem    | boolean                                                | 显示 12 小时制的时间格式                           |
 | size            | 'lg' \| 'md' \| 'sm' \| 'xs' `('md')`                  | 设置组件尺寸                                       |
 | value           | [Date, Date]                                           | 当前值（受控）                                     |

--- a/docs/pages/components/tree-picker/en-US/index.md
+++ b/docs/pages/components/tree-picker/en-US/index.md
@@ -72,6 +72,8 @@ Use `onlyLeafSelectable` to control the selection of leaf nodes.
 
 ## Responsive
 
+On extra-small screens, the popup is displayed as a full-width Drawer by default. Set `responsive={false}` to keep a positioned popup, such as when the picker is already inside a Modal or Drawer.
+
 <!--{include:<example-responsive>}-->
 
 ## Accessibility
@@ -159,6 +161,7 @@ Use `onlyLeafSelectable` to control the selection of leaf nodes.
 | renderTreeIcon          | (node: [TreeNode][node], expanded: boolean) => ReactNode                                      | Custom render tree node icon                               |            |
 | renderTreeNode          | (node: [TreeNode][node]) => ReactNode                                                         | Custom render tree node                                    |            |
 | renderValue             | (value: string, node:[TreeNode][node], selected:ReactNode) => ReactNode                       | Custom render selected value                               |            |
+| responsive              | boolean `(true)`                                                                              | Whether to display the popup as a full-width Drawer on extra-small screens |            |
 | searchable              | boolean `(true)`                                                                              | Whether to show the search box                             |            |
 | searchBy                | (keyword: string, label: ReactNode, node: [TreeNode][node]) => boolean                        | Custom search method                                       |            |
 | showIndentLine          | boolean                                                                                       | Whether to show the indent line                            |            |

--- a/docs/pages/components/tree-picker/zh-CN/index.md
+++ b/docs/pages/components/tree-picker/zh-CN/index.md
@@ -72,7 +72,9 @@
 
 <!--{include:`only-leaf-selectable.md`}-->
 
-## Responsive
+## 响应式
+
+在超小屏幕上，弹出层默认显示为全宽 Drawer。当选择器已经位于 Modal 或 Drawer 中时，可设置 `responsive={false}` 保持定位浮层，避免嵌套遮罩。
 
 <!--{include:<example-responsive>}-->
 
@@ -161,6 +163,7 @@
 | renderTreeIcon          | (node: [TreeNode][node], expanded: boolean) => ReactNode                                      | 自定义渲染图标                         |            |
 | renderTreeNode          | (node: [TreeNode][node]) => ReactNode                                                         | 自定义渲染树节点                       |            |
 | renderValue             | (value:string, node:[TreeNode][node], selected:ReactNode) => ReactNode                        | 自定义渲染选中的值                     |            |
+| responsive              | boolean `(true)`                                                                              | 是否在超小屏幕上将弹出层显示为全宽 Drawer |            |
 | searchable              | boolean `(true)`                                                                              | 是否可以搜索                           |            |
 | searchBy                | (keyword: string, label: ReactNode, node: [TreeNode][node]) => boolean                        | 自定义搜索方法                         |            |
 | showIndentLine          | boolean                                                                                       | 是否显示缩进线                         |            |

--- a/docs/public/react/types/cascader.json
+++ b/docs/public/react/types/cascader.json
@@ -220,6 +220,12 @@
         "isRequired": false,
         "description": "Custom render function for selected items"
       },
+      "responsive": {
+        "type": "boolean",
+        "isRequired": false,
+        "description": "Whether to display the popup as a full-width Drawer on extra-small screens",
+        "defaultValue": "true"
+      },
       "searchable": {
         "type": "boolean",
         "isRequired": false,

--- a/docs/public/react/types/check-picker.json
+++ b/docs/public/react/types/check-picker.json
@@ -220,6 +220,12 @@
         "isRequired": false,
         "description": "Custom render function for selected items"
       },
+      "responsive": {
+        "type": "boolean",
+        "isRequired": false,
+        "description": "Whether to display the popup as a full-width Drawer on extra-small screens",
+        "defaultValue": "true"
+      },
       "searchable": {
         "type": "boolean",
         "isRequired": false,

--- a/docs/public/react/types/check-tree-picker.json
+++ b/docs/public/react/types/check-tree-picker.json
@@ -234,6 +234,12 @@
         "isRequired": false,
         "description": "Custom render selected items"
       },
+      "responsive": {
+        "type": "boolean",
+        "isRequired": false,
+        "description": "Whether to display the popup as a full-width Drawer on extra-small screens",
+        "defaultValue": "true"
+      },
       "searchable": {
         "type": "boolean",
         "isRequired": false,

--- a/docs/public/react/types/date-picker.json
+++ b/docs/public/react/types/date-picker.json
@@ -243,6 +243,12 @@
         "isRequired": false,
         "description": "Custom render value"
       },
+      "responsive": {
+        "type": "boolean",
+        "isRequired": false,
+        "description": "Whether to display the popup as a full-width Drawer on extra-small screens",
+        "defaultValue": "true"
+      },
       "shouldDisableDate": {
         "type": "(date:Date) => boolean",
         "isRequired": false,

--- a/docs/public/react/types/date-range-picker.json
+++ b/docs/public/react/types/date-range-picker.json
@@ -244,6 +244,12 @@
         "isRequired": false,
         "description": "Custom render value"
       },
+      "responsive": {
+        "type": "boolean",
+        "isRequired": false,
+        "description": "Whether to display the popup as a full-width Drawer on extra-small screens",
+        "defaultValue": "true"
+      },
       "shouldDisableDate": {
         "type": "DisabledDateFunction",
         "isRequired": false,

--- a/docs/public/react/types/input-picker.json
+++ b/docs/public/react/types/input-picker.json
@@ -213,6 +213,11 @@
         "isRequired": false,
         "description": "Custom render function for selected value"
       },
+      "responsive": {
+        "type": "boolean",
+        "isRequired": false,
+        "description": "Controls the responsive Drawer; defaults to `!searchable` when omitted"
+      },
       "searchable": {
         "type": "boolean",
         "isRequired": false,

--- a/docs/public/react/types/multi-cascader.json
+++ b/docs/public/react/types/multi-cascader.json
@@ -222,6 +222,12 @@
         "isRequired": false,
         "description": "Custom render selected items"
       },
+      "responsive": {
+        "type": "boolean",
+        "isRequired": false,
+        "description": "Whether to display the popup as a full-width Drawer on extra-small screens",
+        "defaultValue": "true"
+      },
       "searchable": {
         "type": "boolean",
         "isRequired": false,

--- a/docs/public/react/types/select-picker.json
+++ b/docs/public/react/types/select-picker.json
@@ -214,6 +214,12 @@
         "isRequired": false,
         "description": "Custom render function for selected value"
       },
+      "responsive": {
+        "type": "boolean",
+        "isRequired": false,
+        "description": "Whether to display the popup as a full-width Drawer on extra-small screens",
+        "defaultValue": "true"
+      },
       "searchable": {
         "type": "boolean",
         "isRequired": false,

--- a/docs/public/react/types/tag-picker.json
+++ b/docs/public/react/types/tag-picker.json
@@ -218,6 +218,11 @@
         "isRequired": false,
         "description": "Custom render function for selected items"
       },
+      "responsive": {
+        "type": "boolean",
+        "isRequired": false,
+        "description": "Controls the responsive Drawer; defaults to `!searchable` when omitted"
+      },
       "searchable": {
         "type": "boolean",
         "isRequired": false,

--- a/docs/public/react/types/time-picker.json
+++ b/docs/public/react/types/time-picker.json
@@ -182,6 +182,12 @@
         "isRequired": false,
         "description": "Custom render value"
       },
+      "responsive": {
+        "type": "boolean",
+        "isRequired": false,
+        "description": "Whether to display the popup as a full-width Drawer on extra-small screens",
+        "defaultValue": "true"
+      },
       "shouldDisableHour": {
         "type": "(hour:number, date:Date) => boolean",
         "isRequired": false,

--- a/docs/public/react/types/time-range-picker.json
+++ b/docs/public/react/types/time-range-picker.json
@@ -183,6 +183,12 @@
         "isRequired": false,
         "description": "Custom render value"
       },
+      "responsive": {
+        "type": "boolean",
+        "isRequired": false,
+        "description": "Whether to display the popup as a full-width Drawer on extra-small screens",
+        "defaultValue": "true"
+      },
       "showHeader": {
         "type": "boolean",
         "isRequired": false,

--- a/docs/public/react/types/tree-picker.json
+++ b/docs/public/react/types/tree-picker.json
@@ -229,6 +229,12 @@
         "isRequired": false,
         "description": "Custom render selected value"
       },
+      "responsive": {
+        "type": "boolean",
+        "isRequired": false,
+        "description": "Whether to display the popup as a full-width Drawer on extra-small screens",
+        "defaultValue": "true"
+      },
       "searchable": {
         "type": "boolean",
         "isRequired": false,

--- a/src/AutoComplete/AutoComplete.tsx
+++ b/src/AutoComplete/AutoComplete.tsx
@@ -35,7 +35,7 @@ import type {
 import type { BoxProps } from '@/internals/Box';
 
 export interface AutoCompleteProps<T = string>
-  extends FormControlPickerProps<T, any, Option | string>,
+  extends Omit<FormControlPickerProps<T, any, Option | string>, 'responsive'>,
     ListboxProps,
     PopupProps,
     BoxProps {

--- a/src/Cascader/Cascader.tsx
+++ b/src/Cascader/Cascader.tsx
@@ -100,6 +100,7 @@ const Cascader = forwardRef<'div', CascaderProps>(
       placement = 'bottomStart',
       popupClassName,
       popupStyle,
+      responsive,
       renderColumn,
       renderExtraFooter,
       renderSearchItem,
@@ -425,6 +426,7 @@ const Cascader = forwardRef<'div', CascaderProps>(
         as={as}
         id={id}
         pickerType="cascader"
+        responsive={responsive}
         block={block}
         disabled={disabled}
         appearance={appearance}

--- a/src/CheckPicker/CheckPicker.tsx
+++ b/src/CheckPicker/CheckPicker.tsx
@@ -90,6 +90,7 @@ const CheckPicker = forwardRef<'div', CheckPickerProps>(
       popupAutoWidth = true,
       popupClassName,
       popupStyle,
+      responsive,
       searchable = true,
       sticky,
       style,
@@ -365,6 +366,7 @@ const CheckPicker = forwardRef<'div', CheckPickerProps>(
         id={id}
         multiple
         pickerType="check"
+        responsive={responsive}
         block={block}
         disabled={disabled}
         appearance={appearance}

--- a/src/CheckPicker/test/CheckPicker.spec.tsx
+++ b/src/CheckPicker/test/CheckPicker.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import CheckPicker from '../CheckPicker';
 import Button from '../../Button';
+import Drawer from '../../Drawer';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { mockGroupData } from '@test/mocks/data-mock';
@@ -49,6 +50,20 @@ describe('CheckPicker', () => {
     value: ['Eugenia'],
     componentProps: { data },
     getUIElement: () => screen.getByRole('combobox')
+  });
+
+  it('Should render a positioned popup inside an existing Drawer when responsive=false', () => {
+    render(
+      <Drawer open>
+        <CheckPicker data={data} defaultOpen responsive={false} />
+      </Drawer>
+    );
+
+    const drawers = document.querySelectorAll('.rs-drawer');
+    const popup = screen.getByTestId('picker-popup');
+
+    expect(drawers).to.have.lengthOf(1);
+    expect(screen.getByTestId('drawer-wrapper')).to.contain(popup);
   });
 
   it('Should clean selected default value', () => {

--- a/src/CheckTreePicker/CheckTreePicker.tsx
+++ b/src/CheckTreePicker/CheckTreePicker.tsx
@@ -98,6 +98,7 @@ const CheckTreePicker = forwardRef<'div', CheckTreePickerProps>((props, ref) => 
     popupClassName,
     popupStyle,
     popupAutoWidth = true,
+    responsive,
     placement = 'bottomStart',
     treeHeight = 320,
     toggleAs,
@@ -331,6 +332,7 @@ const CheckTreePicker = forwardRef<'div', CheckTreePickerProps>((props, ref) => 
       as={as}
       id={id}
       pickerType="check-tree"
+      responsive={responsive}
       block={block}
       disabled={disabled}
       appearance={appearance}

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -284,6 +284,7 @@ const DatePicker = forwardRef<'div', DatePickerProps>((props: DatePickerProps, r
     label,
     popupClassName,
     popupStyle,
+    responsive,
     appearance = 'default',
     placement = 'bottomStart',
     oneTap,
@@ -675,6 +676,7 @@ const DatePicker = forwardRef<'div', DatePickerProps>((props: DatePickerProps, r
     <PickerToggleTrigger
       as={as}
       pickerType="date"
+      responsive={responsive}
       classPrefix={classPrefix}
       className={merge(className, { [prefix('error')]: invalidValue })}
       block={block}

--- a/src/DateRangePicker/DateRangePicker.tsx
+++ b/src/DateRangePicker/DateRangePicker.tsx
@@ -305,6 +305,7 @@ const DateRangePicker = forwardRef<'div', DateRangePickerProps, typeof StaticMet
       label,
       popupClassName,
       popupStyle,
+      responsive,
       oneTap,
       placeholder = '',
       placement = 'bottomStart',
@@ -1067,6 +1068,7 @@ const DateRangePicker = forwardRef<'div', DateRangePickerProps, typeof StaticMet
       <PickerToggleTrigger
         as={as}
         pickerType="date-range"
+        responsive={responsive}
         classPrefix={classPrefix}
         className={merge(className, { [prefix('error')]: invalidValue })}
         block={block}

--- a/src/InputPicker/InputPicker.tsx
+++ b/src/InputPicker/InputPicker.tsx
@@ -7,6 +7,7 @@ import isArray from 'lodash/isArray';
 import pick from 'lodash/pick';
 import Tag from '../Tag';
 import TextBox from './TextBox';
+import InputPickerPopup from './InputPickerPopup';
 import Stack, { StackProps } from '../Stack';
 import useInput from './hooks/useInput';
 import useData, { InputOption } from './hooks/useData';
@@ -116,6 +117,7 @@ const InputPicker = forwardRef<'div', InputPickerProps>((props, ref) => {
     popupClassName,
     popupStyle,
     popupAutoWidth = true,
+    responsive,
     listboxMaxHeight = 320,
     creatable,
     shouldDisplayCreateOption,
@@ -156,7 +158,7 @@ const InputPicker = forwardRef<'div', InputPickerProps>((props, ref) => {
     throw Error('`groupBy` can not be equal to `valueKey` and `labelKey`');
   }
 
-  const { trigger: triggerRef, root, target, overlay, list } = usePickerRef(ref);
+  const { trigger: triggerRef, root, target, overlay, list, searchInput } = usePickerRef(ref);
   const { prefix, merge } = useStyles(classPrefix);
   const [open, setOpen] = useControlled(controlledOpen, defaultOpen);
   const { inputRef, inputProps, focus, blur } = useInput({ multi, triggerRef });
@@ -478,6 +480,7 @@ const InputPicker = forwardRef<'div', InputPickerProps>((props, ref) => {
     trigger: triggerRef,
     target,
     overlay,
+    searchInput,
     loading,
     ...events,
     ...rest
@@ -486,6 +489,10 @@ const InputPicker = forwardRef<'div', InputPickerProps>((props, ref) => {
   const handleExited = useEventCallback(() => {
     setFocusItemValue(multi ? value?.[0] : value);
     resetSearch();
+
+    if (typeof requestAnimationFrame !== 'undefined') {
+      requestAnimationFrame(() => target.current?.focus?.());
+    }
   });
 
   const handleFocus = useEventCallback((event: React.FocusEvent) => {
@@ -627,17 +634,22 @@ const InputPicker = forwardRef<'div', InputPickerProps>((props, ref) => {
     );
 
     return (
-      <PickerPopup
+      <InputPickerPopup
         ref={mergeRefs(overlay, speakerRef)}
         autoWidth={popupAutoWidth}
         className={classes}
         style={mergedPopupStyle}
         target={triggerRef}
         onKeyDown={onPickerKeyDown}
+        searchable={searchable}
+        searchKeyword={searchKeyword}
+        searchPlaceholder={locale?.searchPlaceholder}
+        searchInput={searchInput}
+        onSearch={handleSearch}
       >
         {renderListbox ? renderListbox(listbox) : listbox}
         {renderExtraFooter?.()}
-      </PickerPopup>
+      </InputPickerPopup>
     );
   };
 
@@ -701,7 +713,7 @@ const InputPicker = forwardRef<'div', InputPickerProps>((props, ref) => {
       size={size}
       classPrefix={classPrefix}
       className={className}
-      responsive={searchable === false}
+      responsive={responsive ?? searchable === false}
       onClick={focus}
       onKeyDown={onPickerKeyDown}
       data-focus={open}

--- a/src/InputPicker/InputPickerPopup.tsx
+++ b/src/InputPicker/InputPickerPopup.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect } from 'react';
+import SearchBox from '@/internals/SearchBox';
+import PickerPopup, { type PickerPopupProps } from '@/internals/Picker/PickerPopup';
+import { useCombobox } from '@/internals/Picker';
+
+interface InputPickerPopupProps extends PickerPopupProps {
+  searchable?: boolean;
+  searchKeyword?: string;
+  searchPlaceholder?: string;
+  searchInput?: React.RefObject<HTMLInputElement | null>;
+  onSearch?: (value: string, event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const InputPickerPopup = React.forwardRef<HTMLDivElement, InputPickerPopupProps>((props, ref) => {
+  const {
+    children,
+    searchable,
+    searchKeyword,
+    searchPlaceholder,
+    searchInput,
+    onSearch,
+    ...popupProps
+  } = props;
+  const { breakpoint } = useCombobox();
+  const showSearchBox = searchable && breakpoint === 'xs';
+
+  useEffect(() => {
+    if (!showSearchBox || typeof requestAnimationFrame === 'undefined') {
+      return;
+    }
+
+    const animationFrame = requestAnimationFrame(() => {
+      searchInput?.current?.focus();
+    });
+
+    return () => cancelAnimationFrame(animationFrame);
+  }, [searchInput, showSearchBox]);
+
+  return (
+    <PickerPopup ref={ref} {...popupProps}>
+      {showSearchBox && (
+        <SearchBox
+          placeholder={searchPlaceholder}
+          value={searchKeyword}
+          inputRef={searchInput}
+          onChange={onSearch}
+        />
+      )}
+      {children}
+    </PickerPopup>
+  );
+});
+
+InputPickerPopup.displayName = 'InputPickerPopup';
+
+export default InputPickerPopup;

--- a/src/InputPicker/TextBox.tsx
+++ b/src/InputPicker/TextBox.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import TagList from './TagList';
 import InputSearch, { InputSearchProps } from './InputSearch';
+import { useCombobox } from '@/internals/Picker';
 import { useStyles } from '@/internals/hooks';
 
 interface TextBoxProps {
@@ -36,23 +37,25 @@ const TextBox = React.forwardRef((props: TextBoxProps, ref: React.Ref<HTMLDivEle
   } = props;
 
   const { prefix } = useStyles('picker');
+  const { breakpoint } = useCombobox();
 
   if (!multiple && disabled) {
     return null;
   }
 
-  const input = editable ? (
-    <InputSearch
-      {...inputProps}
-      tabIndex={-1}
-      readOnly={readOnly}
-      onBlur={onBlur}
-      onFocus={onFocus}
-      inputRef={inputRef}
-      onChange={onChange}
-      value={inputValue}
-    />
-  ) : null;
+  const input =
+    editable && breakpoint !== 'xs' ? (
+      <InputSearch
+        {...inputProps}
+        tabIndex={-1}
+        readOnly={readOnly}
+        onBlur={onBlur}
+        onFocus={onFocus}
+        inputRef={inputRef}
+        onChange={onChange}
+        value={inputValue}
+      />
+    ) : null;
 
   return (
     <div className={prefix`textbox`} ref={ref} {...rest}>

--- a/src/InputPicker/test/InputPicker.spec.tsx
+++ b/src/InputPicker/test/InputPicker.spec.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import InputPicker from '../InputPicker';
 import Button from '../../Button';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
-import { render, fireEvent, screen, within } from '@testing-library/react';
+import MatchMediaMock from '@test/mocks/matchmedia-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { mockGroupData } from '@test/mocks/data-mock';
 import { PickerHandle } from '@/internals/Picker';
 import {
@@ -22,7 +23,11 @@ describe('InputPicker', () => {
       return screen.getByRole('combobox');
     }
   });
-  testPickers(InputPicker, { virtualized: true });
+  testPickers(InputPicker, {
+    virtualized: true,
+    responsiveByDefault: false,
+    responsiveSearchable: true
+  });
   testControlledUnControlled(InputPicker, {
     componentProps: { data, defaultOpen: true },
     value: 'Eugenia',
@@ -48,6 +53,65 @@ describe('InputPicker', () => {
     value: 'Eugenia',
     componentProps: { data },
     getUIElement: () => screen.getByRole('combobox')
+  });
+
+  describe('Responsive searchable popup', () => {
+    let matchMedia: MatchMediaMock;
+    let initialMatchMedia: typeof window.matchMedia;
+    let initialWidth: number;
+    let initialHeight: number;
+
+    const resizeWindow = (width: number, height = 1000) => {
+      Object.assign(window, {
+        innerWidth: width,
+        innerHeight: height,
+        outerWidth: width,
+        outerHeight: height
+      }).dispatchEvent(new window.Event('resize'));
+    };
+
+    beforeEach(() => {
+      initialWidth = window.innerWidth;
+      initialHeight = window.innerHeight;
+      initialMatchMedia = window.matchMedia;
+      matchMedia = new MatchMediaMock();
+      resizeWindow(575);
+    });
+
+    afterEach(() => {
+      resizeWindow(initialWidth, initialHeight);
+      matchMedia.clear();
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: initialMatchMedia
+      });
+    });
+
+    it('Should search and select an option in a forced responsive Drawer', async () => {
+      const onChange = vi.fn();
+      const onSearch = vi.fn();
+
+      render(<InputPicker data={data} responsive onChange={onChange} onSearch={onSearch} />);
+
+      const combobox = screen.getByRole('combobox');
+      fireEvent.click(combobox);
+
+      const searchbox = screen.getByRole('searchbox');
+      await waitFor(() => expect(searchbox).to.have.focus);
+
+      fireEvent.change(searchbox, { target: { value: 'Lou' } });
+
+      expect(onSearch).toHaveBeenCalledWith('Lou', expect.any(Object));
+      expect(screen.queryByRole('option', { name: 'Eugenia' })).not.to.exist;
+      expect(screen.getByRole('option', { name: 'Louisa' })).to.exist;
+
+      fireEvent.keyDown(searchbox, { key: 'Enter' });
+
+      expect(onChange).toHaveBeenCalledWith('Louisa', expect.any(Object));
+      expect(combobox).to.have.text('Louisa');
+      await waitFor(() => expect(combobox).to.have.focus);
+    });
   });
 
   it('Should clean selected default value', () => {

--- a/src/MultiCascader/MultiCascader.tsx
+++ b/src/MultiCascader/MultiCascader.tsx
@@ -96,6 +96,7 @@ const MultiCascader = forwardRef<'div', MultiCascaderProps>(
       placement = 'bottomStart',
       popupClassName,
       popupStyle,
+      responsive,
       renderColumn,
       renderExtraFooter,
       renderTreeNode,
@@ -373,6 +374,7 @@ const MultiCascader = forwardRef<'div', MultiCascaderProps>(
         as={as}
         id={id}
         pickerType="multi-cascader"
+        responsive={responsive}
         block={block}
         disabled={disabled}
         appearance={appearance}

--- a/src/SelectPicker/SelectPicker.tsx
+++ b/src/SelectPicker/SelectPicker.tsx
@@ -125,6 +125,7 @@ const SelectPicker = forwardRef<'div', SelectPickerProps>(
       popupAutoWidth = true,
       popupClassName,
       popupStyle,
+      responsive,
       searchable = true,
       style,
       toggleAs,
@@ -352,6 +353,7 @@ const SelectPicker = forwardRef<'div', SelectPickerProps>(
         as={as}
         id={id}
         pickerType="select"
+        responsive={responsive}
         block={block}
         disabled={disabled}
         appearance={appearance}

--- a/src/TagPicker/test/TagPicker.spec.tsx
+++ b/src/TagPicker/test/TagPicker.spec.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import TagPicker from '../index';
 import Button from '../../Button';
-import { describe, expect, it, vi } from 'vitest';
+import MatchMediaMock from '@test/mocks/matchmedia-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockGroupData } from '@test/mocks/data-mock';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { PickerHandle } from '@/internals/Picker';
 
 import {
@@ -27,7 +28,11 @@ describe('TagPicker', () => {
     }
   });
 
-  testPickers(TagPicker, { virtualized: true });
+  testPickers(TagPicker, {
+    virtualized: true,
+    responsiveByDefault: false,
+    responsiveSearchable: true
+  });
 
   testControlledUnControlled(TagPicker, {
     componentProps: { data, defaultOpen: true },
@@ -53,6 +58,72 @@ describe('TagPicker', () => {
     value: ['Eugenia'],
     componentProps: { data },
     getUIElement: () => screen.getByRole('combobox')
+  });
+
+  describe('Responsive searchable popup', () => {
+    let matchMedia: MatchMediaMock;
+    let initialMatchMedia: typeof window.matchMedia;
+    let initialWidth: number;
+    let initialHeight: number;
+
+    const resizeWindow = (width: number, height = 1000) => {
+      Object.assign(window, {
+        innerWidth: width,
+        innerHeight: height,
+        outerWidth: width,
+        outerHeight: height
+      }).dispatchEvent(new window.Event('resize'));
+    };
+
+    beforeEach(() => {
+      initialWidth = window.innerWidth;
+      initialHeight = window.innerHeight;
+      initialMatchMedia = window.matchMedia;
+      matchMedia = new MatchMediaMock();
+      resizeWindow(575);
+    });
+
+    afterEach(() => {
+      resizeWindow(initialWidth, initialHeight);
+      matchMedia.clear();
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: initialMatchMedia
+      });
+    });
+
+    it('Should select and create tags in a forced responsive Drawer', async () => {
+      const onChange = vi.fn();
+      const onCreate = vi.fn();
+
+      render(
+        <TagPicker data={data} responsive creatable onChange={onChange} onCreate={onCreate} />
+      );
+
+      const combobox = screen.getByRole('combobox');
+      fireEvent.click(combobox);
+
+      const searchbox = screen.getByRole('searchbox');
+      await waitFor(() => expect(searchbox).to.have.focus);
+
+      fireEvent.change(searchbox, { target: { value: 'New tag' } });
+      fireEvent.keyDown(searchbox, { key: 'Enter' });
+
+      expect(onCreate).toHaveBeenCalledWith(
+        ['New tag'],
+        expect.objectContaining({ label: 'New tag', value: 'New tag' }),
+        expect.any(Object)
+      );
+
+      fireEvent.change(searchbox, { target: { value: 'Lou' } });
+      fireEvent.keyDown(searchbox, { key: 'Enter' });
+
+      expect(onChange).toHaveBeenLastCalledWith(['New tag', 'Louisa'], expect.any(Object));
+
+      fireEvent.keyDown(searchbox, { key: 'Escape' });
+      await waitFor(() => expect(combobox).to.have.focus);
+    });
   });
 
   it('Should clean selected default value', () => {

--- a/src/TreePicker/TreePicker.tsx
+++ b/src/TreePicker/TreePicker.tsx
@@ -98,6 +98,7 @@ const TreePicker = forwardRef<'div', TreePickerProps>((props, ref) => {
     popupClassName,
     popupStyle,
     popupAutoWidth = true,
+    responsive,
     treeHeight = 320,
     valueKey = 'value',
     virtualized = false,
@@ -295,6 +296,7 @@ const TreePicker = forwardRef<'div', TreePickerProps>((props, ref) => {
       as={as}
       id={id}
       pickerType="tree"
+      responsive={responsive}
       block={block}
       disabled={disabled}
       appearance={appearance}

--- a/src/internals/Overlay/OverlayTrigger.tsx
+++ b/src/internals/Overlay/OverlayTrigger.tsx
@@ -202,6 +202,11 @@ const OverlayTrigger = React.forwardRef(
       onBlur,
       onOpen,
       onClose,
+      onEnter,
+      onEntering,
+      onEntered,
+      onExit,
+      onExiting,
       onExited,
       ...rest
     } = props;
@@ -506,6 +511,11 @@ const OverlayTrigger = React.forwardRef(
             ? () => handleClose(undefined, OverlayCloseCause.ClickOutside) as any
             : undefined,
         onExited: createChainedFunction(followCursor ? handleExited : undefined, onExited),
+        onEnter,
+        onEntering,
+        onEntered,
+        onExit,
+        onExiting,
         placement,
         container: containerElement,
         open
@@ -567,6 +577,12 @@ const OverlayTrigger = React.forwardRef(
           <OverlayComponent
             open={open}
             onClose={handleClose}
+            onEnter={onEnter}
+            onEntering={onEntering}
+            onEntered={onEntered}
+            onExit={onExit}
+            onExiting={onExiting}
+            onExited={onExited}
             placement="bottom"
             speaker={speaker}
           />

--- a/src/internals/types/picker.ts
+++ b/src/internals/types/picker.ts
@@ -135,6 +135,12 @@ export interface PickerBaseProps<L = any>
   /** Format picker to appear inside a content block */
   block?: boolean;
 
+  /**
+   * Controls whether the popup adapts to a full-width Drawer on extra-small screens.
+   * When omitted, each picker uses its existing default behavior.
+   */
+  responsive?: boolean;
+
   /** Set the padding of the container. */
   containerPadding?: number;
 

--- a/test/cases/testPickers.tsx
+++ b/test/cases/testPickers.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import MatchMediaMock from '@test/mocks/matchmedia-mock';
+import CustomProvider from '@/CustomProvider';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 
 interface TestPickerOptions {
@@ -8,6 +10,8 @@ interface TestPickerOptions {
   role?: 'combobox' | 'textbox';
   ariaHaspopup?: 'listbox' | 'dialog' | 'grid' | 'menu' | 'tree';
   popupAutoWidth?: boolean;
+  responsiveByDefault?: boolean;
+  responsiveSearchable?: boolean;
 }
 
 const defaultData = [
@@ -21,11 +25,107 @@ export function testPickers(TestComponent: React.ComponentType<any>, options?: T
     virtualized,
     role = 'combobox',
     ariaHaspopup = 'listbox',
-    popupAutoWidth
+    popupAutoWidth,
+    responsiveByDefault = true,
+    responsiveSearchable = false
   } = options || {};
   const displayName = TestComponent.displayName;
 
   describe(`${displayName} - Common props for all pickers`, () => {
+    describe('Responsive popup', () => {
+      let matchMedia: MatchMediaMock;
+      let initialMatchMedia: typeof window.matchMedia;
+      let initialWidth: number;
+      let initialHeight: number;
+
+      const resizeWindow = (width: number, height = 1000) => {
+        Object.assign(window, {
+          innerWidth: width,
+          innerHeight: height,
+          outerWidth: width,
+          outerHeight: height
+        }).dispatchEvent(new window.Event('resize'));
+      };
+
+      beforeEach(() => {
+        initialWidth = window.innerWidth;
+        initialHeight = window.innerHeight;
+        initialMatchMedia = window.matchMedia;
+        matchMedia = new MatchMediaMock();
+        resizeWindow(575);
+      });
+
+      afterEach(() => {
+        resizeWindow(initialWidth, initialHeight);
+        matchMedia.clear();
+        Object.defineProperty(window, 'matchMedia', {
+          configurable: true,
+          writable: true,
+          value: initialMatchMedia
+        });
+      });
+
+      it('Should preserve the default responsive behavior', () => {
+        render(<TestComponent data={data} open />);
+
+        if (responsiveByDefault) {
+          expect(document.querySelector('.rs-drawer')).to.exist;
+        } else {
+          expect(document.querySelector('.rs-drawer')).not.to.exist;
+        }
+      });
+
+      if (responsiveSearchable) {
+        it('Should preserve the responsive default when search is disabled', () => {
+          render(<TestComponent data={data} open searchable={false} />);
+
+          expect(document.querySelector('.rs-drawer')).to.exist;
+        });
+      }
+
+      it('Should allow responsive behavior to be forced or disabled', () => {
+        const { unmount } = render(<TestComponent data={data} open responsive />);
+
+        expect(document.querySelector('.rs-drawer')).to.exist;
+        if (responsiveSearchable) {
+          expect(screen.getByRole('searchbox')).to.exist;
+        }
+
+        unmount();
+        render(<TestComponent data={data} open responsive={false} />);
+
+        expect(document.querySelector('.rs-drawer')).not.to.exist;
+        expect(screen.getByTestId('picker')).not.to.have.attr('responsive');
+      });
+
+      it('Should support a responsive default from CustomProvider', () => {
+        render(
+          <CustomProvider
+            components={{
+              [displayName as string]: {
+                defaultProps: { responsive: !responsiveByDefault }
+              }
+            }}
+          >
+            <TestComponent data={data} open />
+          </CustomProvider>
+        );
+
+        if (responsiveByDefault) {
+          expect(document.querySelector('.rs-drawer')).not.to.exist;
+        } else {
+          expect(document.querySelector('.rs-drawer')).to.exist;
+        }
+      });
+
+      it('Should only use a Drawer below the sm breakpoint', () => {
+        resizeWindow(576);
+        render(<TestComponent data={data} open responsive />);
+
+        expect(document.querySelector('.rs-drawer')).not.to.exist;
+      });
+    });
+
     it('Should render a picker', () => {
       const { container } = render(<TestComponent data={data} />);
 


### PR DESCRIPTION
## Summary

- expose `responsive` from the shared `PickerBaseProps` and explicitly thread it through all picker triggers
- preserve existing defaults while allowing positioned popups with `responsive={false}` inside Modal and Drawer overlays
- add a searchable responsive Drawer experience for InputPicker and TagPicker, including focus management, filtering, keyboard selection, and creatable tags
- keep AutoComplete non-responsive and exclude the prop from its public API
- update bilingual documentation, responsive examples, and generated API metadata for all 12 pickers

## Test plan

- `npx vitest run` for SelectPicker, CheckPicker, TreePicker, CheckTreePicker, Cascader, MultiCascader, DatePicker, DateRangePicker, TimePicker, TimeRangePicker, InputPicker, and TagPicker (1109 passed, 3 skipped)
- `npm run lint:ts`
- `npx eslint test/cases/testPickers.tsx`
- `npm run format:check`
- `npm --prefix docs run generate-types`
- generated API validation confirming the 12 pickers expose `responsive` and AutoComplete does not

Closes #4592