### PR TITLE
fix(DatePicker): calculate disabled months correctly

### DIFF
--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -359,7 +359,7 @@ const DatePicker = forwardRef<'div', DatePickerProps>((props: DatePickerProps, r
 
   /**
    * Check whether the month is disabled.
-   * If any day in the month is disabled, the entire month is disabled
+   * If every day in the month is disabled, the entire month is disabled.
    */
   const isMonthDisabled = (date: Date): boolean => {
     return isEveryDateInMonth(date.getFullYear(), date.getMonth(), isDateDisabled);

--- a/src/DatePicker/test/DatePicker.spec.tsx
+++ b/src/DatePicker/test/DatePicker.spec.tsx
@@ -1160,7 +1160,7 @@ describe('DatePicker', () => {
           shouldDisableDate={date => {
             const month = date.getMonth();
             const year = date.getFullYear();
-            return month === 0 && year === 2024;
+            return month <= 5 && year === 2024;
           }}
           onSelect={onSelect}
           format="yyyy-MM"
@@ -1168,12 +1168,18 @@ describe('DatePicker', () => {
         />
       );
 
-      const gridcell = screen.getByRole('gridcell', { name: 'Jan 2024' });
+      const january = screen.getByRole('gridcell', { name: 'Jan 2024' });
+      const april = screen.getByRole('gridcell', { name: 'Apr 2024' });
+      const june = screen.getByRole('gridcell', { name: 'Jun 2024' });
+      const july = screen.getByRole('gridcell', { name: 'Jul 2024' });
 
-      expect(gridcell).to.have.class('disabled');
-      expect(gridcell).to.have.attribute('aria-disabled', 'true');
+      expect(january).to.have.class('disabled');
+      expect(april).to.have.class('disabled');
+      expect(june).to.have.class('disabled');
+      expect(july).not.to.have.class('disabled');
+      expect(june).to.have.attribute('aria-disabled', 'true');
 
-      fireEvent.click(gridcell);
+      fireEvent.click(june);
 
       expect(onSelect).not.toHaveBeenCalled();
     });

--- a/src/internals/utils/date/plainDate.ts
+++ b/src/internals/utils/date/plainDate.ts
@@ -77,7 +77,7 @@ export function plainYearMonthToString(yearMonth: PlainYearMonth): string {
  * @see https://tc39.es/proposal-temporal/docs/plainyearmonth.html#daysInMonth
  */
 function getDaysInMonth(yearMonth: PlainYearMonth): number {
-  return new Date(yearMonth.year, yearMonth.month - 1, 0).getDate();
+  return new Date(yearMonth.year, yearMonth.month, 0).getDate();
 }
 
 export function isEveryDayInMonth(

--- a/src/internals/utils/date/test/plainDate.spec.ts
+++ b/src/internals/utils/date/test/plainDate.spec.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect } from 'vitest';
-import { isSameDay, addDays } from '../plainDate';
+import { describe, test, expect, vi } from 'vitest';
+import { isSameDay, addDays, isEveryDayInMonth } from '../plainDate';
 
 describe('isSameDay', () => {
   test('should return true if year, month, day all match', () => {
@@ -26,5 +26,21 @@ describe('addDays', () => {
     expect(addDays(date, 31)).toEqual({ year: 2025, month: 9, day: 9 });
     // Cross-year
     expect(addDays(date, 365)).toEqual({ year: 2026, month: 8, day: 9 });
+  });
+});
+
+describe('isEveryDayInMonth', () => {
+  test.each([
+    [2023, 2, 28],
+    [2024, 2, 29],
+    [2024, 4, 30],
+    [2024, 6, 30],
+    [2024, 7, 31]
+  ])('should check every day in %i-%i', (year, month, daysInMonth) => {
+    const predicate = vi.fn(() => true);
+
+    expect(isEveryDayInMonth({ year, month }, predicate)).toBe(true);
+    expect(predicate).toHaveBeenCalledTimes(daysInMonth);
+    expect(predicate).toHaveBeenLastCalledWith({ year, month, day: daysInMonth });
   });
 });


### PR DESCRIPTION
## Summary

- calculate the number of days from the current 1-based `PlainYearMonth` instead of the previous month
- prevent overflow dates such as April 31 and June 31 from making fully disabled months appear selectable
- align the DatePicker month-disable comment with the existing all-days-disabled behavior
- add utility coverage for leap years, February, 30-day months, and 31-day months, plus a DatePicker regression for January through June

## Test plan

- `npx vitest run src/internals/utils/date/test/plainDate.spec.ts src/DatePicker/test/DatePicker.spec.tsx` (140 passed, 1 skipped)
- `npx vitest run src/Calendar/test` (149 passed)
- `npm run lint:ts`
- `npm run format:check`

Closes #4594