### PR TITLE
fix(Image): prevent SSR hydration mismatch

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -91,6 +91,10 @@ jobs:
           CI: true
           BROWSER: ${{ matrix.browser }}
 
+      - name: Run SSR hydration tests
+        if: ${{ matrix.browser == 'chromium' }}
+        run: npm run test:ssr
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.2.0
         with:

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:ci": "cross-env RUN_ENV=ci vitest --run --coverage",
     "test:component": "cross-env RUN_ENV=test vitest --run",
     "test:coverage": "cross-env RUN_ENV=test vitest --run --coverage",
+    "test:ssr": "cross-env RUN_ENV=ssr vitest --run",
     "prepare": "husky install",
     "release": "node scripts/release.js",
     "version": "npm run changelog && git add -A",

--- a/src/Image/test/Image.spec.tsx
+++ b/src/Image/test/Image.spec.tsx
@@ -3,6 +3,7 @@ import Image from '../Image';
 import { describe, expect, it } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { testStandardProps } from '@test/cases';
+import CustomProvider from '@/CustomProvider';
 
 describe('Image', () => {
   testStandardProps(<Image />);
@@ -80,6 +81,41 @@ describe('Image', () => {
   it('Should apply loading', () => {
     render(<Image src="https://placehold.co/300x200" loading="lazy" />);
     expect(screen.getByRole('img')).to.have.attr('loading', 'lazy');
+  });
+
+  it('Should not treat native image props as Box style props', () => {
+    render(
+      <CustomProvider>
+        <Image
+          alt="demo"
+          src="/demo.png"
+          srcSet="/demo.png 1x, /demo@2x.png 2x"
+          fit="cover"
+          position="top"
+          loading="lazy"
+        />
+      </CustomProvider>
+    );
+
+    const image = screen.getByRole('img');
+
+    expect(image).to.not.have.attr('data-rs');
+    expect(image.className).to.not.match(/\brs-box-/);
+    expect(image).to.have.attr('src', '/demo.png');
+    expect(image).to.have.attr('srcset', '/demo.png 1x, /demo@2x.png 2x');
+    expect(image).to.have.attr('loading', 'lazy');
+    expect(image).to.have.style('--rs-object-fit', 'cover');
+    expect(image).to.have.style('--rs-object-position', 'top');
+  });
+
+  it('Should enable Box styling when a supported style prop is provided', () => {
+    render(<Image src="/demo.png" transform="scale(1)" />);
+
+    const image = screen.getByRole('img');
+
+    expect(image).to.have.attr('data-rs', 'box');
+    expect(image.className).to.match(/\brs-box-/);
+    expect(image).to.have.attr('src', '/demo.png');
   });
 
   it('Should load fallback image when main image fails to load', async () => {

--- a/src/Image/test/Image.ssr.test.tsx
+++ b/src/Image/test/Image.ssr.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import type { AddressInfo } from 'node:net';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import { chromium, type Browser } from 'playwright';
+import react from '@vitejs/plugin-react';
+import { createServer, type ViteDevServer } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+import ImageHydrationFixture from './ImageHydrationFixture';
+import type { HydrationResult } from './ImageHydration.client';
+
+const transparentPng = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+  'base64'
+);
+
+describe('Image SSR hydration', () => {
+  let browser: Browser;
+  let server: ViteDevServer;
+  let serverMarkup: string;
+  let serverUrl: string;
+
+  beforeAll(async () => {
+    serverMarkup = renderToString(<ImageHydrationFixture />);
+
+    server = await createServer({
+      appType: 'custom',
+      configFile: false,
+      logLevel: 'silent',
+      plugins: [tsconfigPaths(), react()],
+      root: process.cwd(),
+      server: {
+        host: '127.0.0.1',
+        port: 0
+      }
+    });
+
+    server.middlewares.use(async (request, response, next) => {
+      if (request.url === '/demo.png' || request.url === '/demo@2x.png') {
+        response.statusCode = 200;
+        response.setHeader('Content-Type', 'image/png');
+        response.end(transparentPng);
+        return;
+      }
+
+      if (request.url !== '/') {
+        next();
+        return;
+      }
+
+      const html = await server.transformIndexHtml(
+        '/',
+        `<!doctype html>
+          <html>
+            <head><meta charset="UTF-8" /></head>
+            <body>
+              <div id="root">${serverMarkup}</div>
+              <script type="module" src="/src/Image/test/ImageHydration.client.tsx"></script>
+            </body>
+          </html>`
+      );
+
+      response.statusCode = 200;
+      response.setHeader('Content-Type', 'text/html');
+      response.end(html);
+    });
+
+    await server.listen();
+
+    const address = server.httpServer?.address() as AddressInfo;
+    serverUrl = `http://127.0.0.1:${address.port}`;
+    browser = await chromium.launch({ headless: true });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it('hydrates without changing Image attributes or reporting errors', async () => {
+    expect(serverMarkup).not.toContain('data-rs="box"');
+    expect(serverMarkup).not.toMatch(/\brs-box-/);
+
+    const page = await browser.newPage();
+    const consoleErrors: string[] = [];
+
+    page.on('console', message => {
+      if (message.type() === 'error') {
+        consoleErrors.push(message.text());
+      }
+    });
+
+    await page.goto(serverUrl);
+    await page.waitForFunction(() => Boolean(window.__RSUITE_HYDRATION_RESULT__));
+
+    const result = await page.evaluate(() => window.__RSUITE_HYDRATION_RESULT__ as HydrationResult);
+    const imageAttributes = await page.locator('img').evaluate(image => ({
+      className: image.className,
+      dataRs: image.getAttribute('data-rs'),
+      loading: image.getAttribute('loading'),
+      src: image.getAttribute('src'),
+      srcSet: image.getAttribute('srcset')
+    }));
+
+    expect(result.errors).toEqual([]);
+    expect(consoleErrors).toEqual([]);
+    expect(result.hydratedMarkup).toBe(result.initialMarkup);
+    expect(imageAttributes).toMatchObject({
+      dataRs: null,
+      loading: 'lazy',
+      src: '/demo.png',
+      srcSet: '/demo.png 1x, /demo@2x.png 2x'
+    });
+    expect(imageAttributes.className).not.toMatch(/\brs-box-/);
+
+    await page.close();
+  });
+});

--- a/src/Image/test/ImageHydration.client.tsx
+++ b/src/Image/test/ImageHydration.client.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import ImageHydrationFixture from './ImageHydrationFixture';
+
+export interface HydrationResult {
+  errors: string[];
+  initialMarkup: string;
+  hydratedMarkup: string;
+}
+
+declare global {
+  interface Window {
+    __RSUITE_HYDRATION_RESULT__?: HydrationResult;
+  }
+}
+
+const container = document.getElementById('root');
+
+if (!container) {
+  throw new Error('Missing hydration root');
+}
+
+const errors: string[] = [];
+const initialMarkup = container.innerHTML;
+const originalConsoleError = console.error;
+
+console.error = (...args: unknown[]) => {
+  errors.push(args.map(String).join(' '));
+  originalConsoleError(...args);
+};
+
+hydrateRoot(container, <ImageHydrationFixture />, {
+  onRecoverableError(error) {
+    errors.push(error instanceof Error ? error.message : String(error));
+  }
+});
+
+requestAnimationFrame(() => {
+  requestAnimationFrame(() => {
+    window.__RSUITE_HYDRATION_RESULT__ = {
+      errors,
+      initialMarkup,
+      hydratedMarkup: container.innerHTML
+    };
+  });
+});

--- a/src/Image/test/ImageHydrationFixture.tsx
+++ b/src/Image/test/ImageHydrationFixture.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import CustomProvider from '@/CustomProvider';
+import Image from '../Image';
+
+export default function ImageHydrationFixture() {
+  return (
+    <CustomProvider>
+      <Image
+        alt="demo"
+        src="/demo.png"
+        srcSet="/demo.png 1x, /demo@2x.png 2x"
+        fit="cover"
+        position="top"
+        loading="lazy"
+      />
+    </CustomProvider>
+  );
+}

--- a/src/internals/Box/test/Box.spec.tsx
+++ b/src/internals/Box/test/Box.spec.tsx
@@ -62,6 +62,18 @@ describe('Box', () => {
     expect(cssRules).toContain('display: var(--rs-box-display)');
   });
 
+  it('Should apply supported CSS props without forwarding them to the DOM', () => {
+    render(<Box transform="scale(1)">Content</Box>);
+
+    const element = screen.getByText('Content');
+    const cssRules = vi.mocked(StyleManager.addRule).mock.calls[0][1];
+
+    expect(element).to.have.attr('data-rs', 'box');
+    expect(element).to.not.have.attr('transform');
+    expect(cssRules).toContain('--rs-box-transform: scale(1)');
+    expect(cssRules).toContain('transform: var(--rs-box-transform)');
+  });
+
   it('Should render with multiple props', () => {
     render(
       <Box showFrom="sm" hideFrom="md" display="flex" className="custom-class">

--- a/src/internals/Box/test/utils.spec.ts
+++ b/src/internals/Box/test/utils.spec.ts
@@ -1,0 +1,57 @@
+import camelCase from 'lodash/camelCase';
+import { describe, expect, it, vi } from 'vitest';
+import { cssSystemPropAlias } from '@/internals/styled-system/css-alias';
+import { supportedCSSProperties } from '@/internals/styled-system/css-properties';
+import { extractBoxProps, omitBoxProps } from '../utils';
+
+describe('Box prop utilities', () => {
+  it('recognizes all public CSS properties, aliases and canonical alias names', () => {
+    const props: Record<string, unknown> = {};
+
+    supportedCSSProperties.forEach(property => {
+      props[property] = 'initial';
+    });
+
+    Object.entries(cssSystemPropAlias).forEach(([alias, config]) => {
+      props[alias] = 'initial';
+      props[camelCase(config.property)] = 'initial';
+    });
+
+    expect(extractBoxProps(props)).toEqual(props);
+    expect(omitBoxProps(props)).toEqual({});
+  });
+
+  it('keeps native element props out of the styled system', () => {
+    const onLoad = vi.fn();
+    const nativeProps = {
+      src: '/demo.png',
+      srcSet: '/demo.png 1x, /demo@2x.png 2x',
+      loading: 'lazy',
+      alt: 'demo',
+      onLoad
+    };
+
+    expect(extractBoxProps(nativeProps)).toEqual({});
+    expect(omitBoxProps(nativeProps)).toEqual(nativeProps);
+  });
+
+  it('partitions defined props and omits undefined styled-system values', () => {
+    const props = {
+      transform: 'scale(1)',
+      overflow: 'hidden',
+      objectFit: 'cover',
+      p: 8,
+      src: '/demo.png',
+      alt: 'demo',
+      cursor: undefined
+    };
+
+    expect(extractBoxProps(props)).toEqual({
+      transform: 'scale(1)',
+      overflow: 'hidden',
+      objectFit: 'cover',
+      p: 8
+    });
+    expect(omitBoxProps(props)).toEqual({ src: '/demo.png', alt: 'demo' });
+  });
+});

--- a/src/internals/Box/utils.ts
+++ b/src/internals/Box/utils.ts
@@ -1,20 +1,15 @@
 import camelCase from 'lodash/camelCase';
-import { cssSystemPropAlias } from '@/internals/styled-system';
-import { isCSSProperty } from '@/internals/utils';
+import { cssSystemPropAlias } from '@/internals/styled-system/css-alias';
+import { supportedCSSProperties } from '@/internals/styled-system/css-properties';
 
-const getUsedPropKeys = () => {
-  const propSet = new Set<string>();
+const boxPropKeys = new Set<string>(supportedCSSProperties);
 
-  Object.entries(cssSystemPropAlias).forEach(([key, prop]) => {
-    const { property } = prop;
-    const propName = camelCase(property);
+Object.entries(cssSystemPropAlias).forEach(([key, prop]) => {
+  boxPropKeys.add(key);
+  boxPropKeys.add(camelCase(prop.property));
+});
 
-    propSet.add(key);
-    propSet.add(propName);
-  });
-
-  return Array.from(propSet);
-};
+const isBoxProp = (key: string) => boxPropKeys.has(key);
 
 /**
  * Extract box properties from props
@@ -22,14 +17,11 @@ const getUsedPropKeys = () => {
  * @returns Object containing only box properties
  */
 export const extractBoxProps = (props: Record<string, any>): Record<string, any> => {
-  const boxPropKeys = getUsedPropKeys();
   const boxProps: Record<string, any> = {};
 
   // Extract only box related properties
   Object.keys(props).forEach(key => {
-    if (boxPropKeys.includes(key) && props[key] !== undefined) {
-      boxProps[key] = props[key];
-    } else if (isCSSProperty(key)) {
+    if (isBoxProp(key) && props[key] !== undefined) {
       boxProps[key] = props[key];
     }
   });
@@ -43,12 +35,11 @@ export const extractBoxProps = (props: Record<string, any>): Record<string, any>
  * @returns New object without layout properties
  */
 export const omitBoxProps = (props: Record<string, any>): Record<string, any> => {
-  const boxPropKeys = getUsedPropKeys();
   const filteredProps: Record<string, any> = {};
 
   // Copy all properties except box related ones
   Object.keys(props).forEach(key => {
-    if (!boxPropKeys.includes(key)) {
+    if (!isBoxProp(key)) {
       filteredProps[key] = props[key];
     }
   });

--- a/src/internals/styled-system/css-alias.ts
+++ b/src/internals/styled-system/css-alias.ts
@@ -1,4 +1,5 @@
-import { getSizeValue, getColorValue } from '@/internals/utils';
+import { getColorValue } from '@/internals/utils/colours';
+import { getSizeValue } from '@/internals/utils/sizes';
 import type { CSSSystemProps, CSSProperty } from './types';
 
 const transformRadiusValue = (value: string) => getSizeValue('radius', value);

--- a/src/internals/styled-system/css-properties.ts
+++ b/src/internals/styled-system/css-properties.ts
@@ -1,3 +1,5 @@
+import camelCase from 'lodash/camelCase';
+
 /**
  * List of commonly used CSS properties in React components
  * Focused on layout, spacing, typography, and common UI patterns
@@ -129,3 +131,19 @@ export const supportedCSSProperties = [
 ] as const;
 
 export type SupportedCSSProperty = (typeof supportedCSSProperties)[number];
+
+const supportedCSSPropertySet = new Set<string>(supportedCSSProperties);
+
+/**
+ * Check whether a property is supported by the styled system.
+ *
+ * Unlike DOM-based CSS property detection, this check is deterministic in
+ * both server and browser environments.
+ */
+export function isSupportedCSSProperty(property: string): boolean {
+  return (
+    Boolean(property) &&
+    !property.startsWith('--') &&
+    supportedCSSPropertySet.has(camelCase(property))
+  );
+}

--- a/src/internals/styled-system/responsive.ts
+++ b/src/internals/styled-system/responsive.ts
@@ -1,8 +1,9 @@
 import camelCase from 'lodash/camelCase';
 import kebabCase from 'lodash/kebabCase';
-import { getCssValue, isCSSProperty } from '@/internals/utils';
+import { getCssValue } from '@/internals/utils';
 import { BREAKPOINTS } from '@/internals/constants';
 import { cssSystemPropAlias } from './css-alias';
+import { isSupportedCSSProperty } from './css-properties';
 import type { Breakpoints, ResponsiveValue, WithResponsive } from '@/internals/types';
 import type { CSSProperty, CSSPropertyValueType } from './types';
 
@@ -115,7 +116,7 @@ export const getCSSVariables = (
       cssVars[varName] = processResponsiveValue(value, val => {
         return transformer ? transformer(val) : transformCSSValue(val, type);
       });
-    } else if (isCSSProperty(cssName)) {
+    } else if (isSupportedCSSProperty(cssName)) {
       // For non-predefined CSS properties, directly process with getCssValue
       cssVars[varName] = processResponsiveValue(value, val => getCssValue(val));
     }

--- a/src/internals/styled-system/test/css-properties.spec.ts
+++ b/src/internals/styled-system/test/css-properties.spec.ts
@@ -1,0 +1,18 @@
+import kebabCase from 'lodash/kebabCase';
+import { describe, expect, it } from 'vitest';
+import { isSupportedCSSProperty, supportedCSSProperties } from '../css-properties';
+
+describe('isSupportedCSSProperty', () => {
+  it('recognizes every supported property in camelCase and kebab-case', () => {
+    supportedCSSProperties.forEach(property => {
+      expect(isSupportedCSSProperty(property)).toBe(true);
+      expect(isSupportedCSSProperty(kebabCase(property))).toBe(true);
+    });
+  });
+
+  it('does not classify native image props as styled-system props', () => {
+    ['src', 'srcSet', 'loading', 'alt', 'onLoad', '--object-fit'].forEach(property => {
+      expect(isSupportedCSSProperty(property)).toBe(false);
+    });
+  });
+});

--- a/src/internals/styled-system/test/responsive.spec.ts
+++ b/src/internals/styled-system/test/responsive.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { getCSSVariables } from '../responsive';
+
+describe('getCSSVariables', () => {
+  it('generates variables for supported properties without aliases', () => {
+    expect(
+      getCSSVariables(
+        {
+          transform: 'scale(1)',
+          overflow: 'hidden',
+          objectFit: 'cover',
+          src: '/demo.png'
+        },
+        '--rs-box-'
+      )
+    ).toEqual({
+      '--rs-box-transform': 'scale(1)',
+      '--rs-box-overflow': 'hidden',
+      '--rs-box-object-fit': 'cover'
+    });
+  });
+
+  it('generates responsive variables for supported properties without aliases', () => {
+    expect(
+      getCSSVariables(
+        {
+          transform: { xs: 'none', md: 'scale(1)' },
+          overflow: { sm: 'hidden', lg: 'auto' }
+        },
+        '--rs-box-'
+      )
+    ).toEqual({
+      '--rs-box-transform': { xs: 'none', md: 'scale(1)' },
+      '--rs-box-overflow': { sm: 'hidden', lg: 'auto' }
+    });
+  });
+});

--- a/src/internals/styled-system/test/useStyled.spec.tsx
+++ b/src/internals/styled-system/test/useStyled.spec.tsx
@@ -169,4 +169,31 @@ describe('useStyled', () => {
     expect(cssRules).toContain('--rs-box-m: 20px');
     expect(cssRules).toContain('margin: var(--rs-box-m)');
   });
+
+  it('should map supported properties without aliases', () => {
+    render(
+      <TestComponent
+        cssVars={{
+          '--rs-box-transform': 'scale(1)',
+          '--rs-box-overflow': 'hidden',
+          '--rs-box-object-fit': 'cover'
+        }}
+      />
+    );
+
+    const cssRules = vi.mocked(StyleManager.addRule).mock.calls[0][1];
+
+    expect(cssRules).toContain('transform: var(--rs-box-transform)');
+    expect(cssRules).toContain('overflow: var(--rs-box-overflow)');
+    expect(cssRules).toContain('object-fit: var(--rs-box-object-fit)');
+  });
+
+  it('should ignore variables that do not map to supported properties', () => {
+    render(<TestComponent cssVars={{ '--rs-box-src': '/demo.png' }} />);
+
+    const cssRules = vi.mocked(StyleManager.addRule).mock.calls[0][1];
+
+    expect(cssRules).toContain('--rs-box-src: /demo.png');
+    expect(cssRules).not.toContain('src: var(--rs-box-src)');
+  });
 });

--- a/src/internals/styled-system/useStyled.ts
+++ b/src/internals/styled-system/useStyled.ts
@@ -1,10 +1,10 @@
 import isEmpty from 'lodash/isEmpty';
 import { CSSProperties, useId, useContext } from 'react';
 import { useIsomorphicLayoutEffect } from '@/internals/hooks';
-import { isCSSProperty } from '@/internals/utils';
 import { CustomContext } from '@/internals/Provider/CustomContext';
 import { breakpointValues, isResponsiveValue } from './responsive';
 import { cssSystemPropAlias } from './css-alias';
+import { isSupportedCSSProperty } from './css-properties';
 import { StyleManager } from './style-manager';
 import type { Breakpoints, WithResponsive, ResponsiveValue } from '@/internals/types';
 
@@ -131,7 +131,7 @@ export function useStyled(options: UseStyledOptions): UseStyledResult {
       const cssProperty = cssSystemPropAlias[propName];
       if (cssProperty) {
         basePropRules += `${cssProperty.property}: var(${varName}); `;
-      } else if (isCSSProperty(propName)) {
+      } else if (isSupportedCSSProperty(propName)) {
         basePropRules += `${propName}: var(${varName}); `;
       }
     });
@@ -182,7 +182,7 @@ export function useStyled(options: UseStyledOptions): UseStyledResult {
             const cssProperty = cssSystemPropAlias[propName];
             if (cssProperty) {
               breakpointPropRules[bp] += `${cssProperty}: var(${varName}); `;
-            } else if (isCSSProperty(propName)) {
+            } else if (isSupportedCSSProperty(propName)) {
               breakpointPropRules[bp] += `${propName}: var(${varName}); `;
             }
           }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,10 @@ const { M, F, RUN_ENV, VITEST_RUNNING_POSTBUILD } = process.env;
 let testPatterns: string;
 let testMainDescription: string;
 
-if (M) {
+if (RUN_ENV === 'ssr') {
+  testPatterns = 'src/**/*.ssr.test.+(js|ts|tsx)';
+  testMainDescription = `SSR tests: ${testPatterns}`;
+} else if (M) {
   testPatterns = `src/${M}/test/*.spec.+(js|ts|tsx)`;
   testMainDescription = `Module tests: ${testPatterns}`;
 } else if (F) {
@@ -49,7 +52,7 @@ async function createConfig() {
     },
     test: {
       include: [testPatterns],
-      setupFiles: ['vitest.setup.ts'],
+      setupFiles: RUN_ENV === 'ssr' ? [] : ['vitest.setup.ts'],
       coverage: {
         provider: 'istanbul',
         exclude: [
@@ -71,6 +74,13 @@ async function createConfig() {
       config.test.include = ['test/validateBuilds.spec.ts'];
       config.test.environment = 'node';
       config.test.browser = { enabled: false }; // Explicitly disable browser mode
+    }
+  } else if (RUN_ENV === 'ssr') {
+    if (config.test) {
+      config.test.environment = 'node';
+      config.test.browser = { enabled: false };
+      config.test.hookTimeout = 30000;
+      config.test.testTimeout = 30000;
     }
   } else {
     // Default browser configuration for other test runs


### PR DESCRIPTION
## Summary

- replace DOM-dependent styled-system property detection with a deterministic static allow-list
- keep native image attributes such as `src`, `srcSet`, and `loading` out of Box styling while preserving all public CSS system props
- add a real Node SSR to Chromium hydration regression test and run it for React 18 and React 19 in CI

## Testing

- `npm run test:ssr`
- `npm run test:component -- --browser.name=chromium --browser.headless --no-file-parallelism` (5299 passed, 4 skipped)
- `npm run lint`
- `npm run format:check`
- `npm run build:types`

Fixes #4597
